### PR TITLE
Update namespace generation in RazorCompilationService to use root relative paths.

### DIFF
--- a/samples/MvcSample/Home2Controller.cs
+++ b/samples/MvcSample/Home2Controller.cs
@@ -1,6 +1,6 @@
-﻿using System.Text;
-using Microsoft.AspNet.Abstractions;
+﻿using Microsoft.AspNet.Abstractions;
 using Microsoft.AspNet.Mvc;
+using MvcSample.Models;
 
 namespace MvcSample
 {

--- a/samples/MvcSample/HomeController.cs
+++ b/samples/MvcSample/HomeController.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.AspNet.Mvc;
-using Microsoft.Owin;
+using MvcSample.Models;
 
 namespace MvcSample
 {

--- a/samples/MvcSample/Models/User.cs
+++ b/samples/MvcSample/Models/User.cs
@@ -1,4 +1,4 @@
-﻿namespace MvcSample
+﻿namespace MvcSample.Models
 {
     public class User
     {

--- a/samples/MvcSample/Views/Home/MyView.cshtml
+++ b/samples/MvcSample/Views/Home/MyView.cshtml
@@ -1,4 +1,4 @@
-﻿
+﻿@using MvcSample.Models
 @{
     Layout = "/Views/Shared/_Layout.cshtml";
     ViewBag.Title = "Home Page";
@@ -9,9 +9,11 @@
     <p class="lead">ASP.NET is a free web framework for building great Web sites and Web applications using HTML, CSS and JavaScript.</p>
     <p><a href="http://asp.net" class="btn btn-primary btn-large">Learn more &raquo;</a></p>
 </div>
-
+@{
+    var user = new User { Name = "Test user" };
+}
 <div class="row">
-    <h3>Hello!</h3>
+    <h3>Hello @user.Name!</h3>
     <div class="col-md-4">
         <h2>Getting started</h2>
         <p>
@@ -32,4 +34,3 @@
         <p><a class="btn btn-default" href="http://go.microsoft.com/fwlink/?LinkId=301867">Learn more &raquo;</a></p>
     </div>
 </div>
-

--- a/src/Microsoft.AspNet.Mvc.Razor/Compilation/CscBasedCompilationService.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Compilation/CscBasedCompilationService.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.AspNet.FileSystems;
 
 namespace Microsoft.AspNet.Mvc.Razor
 {
@@ -118,8 +117,6 @@ namespace Microsoft.AspNet.Mvc.Razor
 
             return process;
         }
-
-
     }
 }
 #endif

--- a/src/Microsoft.AspNet.Mvc.Razor/Razor/IRazorCompilationService.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Razor/IRazorCompilationService.cs
@@ -5,6 +5,6 @@ namespace Microsoft.AspNet.Mvc.Razor
 {
     public interface IRazorCompilationService
     {
-        Task<CompilationResult> Compile(IFileInfo fileInfo);
+        Task<CompilationResult> Compile(string appRoot, IFileInfo fileInfo);
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Razor/Razor/RazorCompilationService.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Razor/RazorCompilationService.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using System.Diagnostics.Contracts;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNet.FileSystems;
 using Microsoft.AspNet.Razor;
@@ -20,17 +20,25 @@ namespace Microsoft.AspNet.Mvc.Razor
             _razorHost = razorHost;
         }
 
-        public Task<CompilationResult> Compile(IFileInfo file)
+        public Task<CompilationResult> Compile(string appRoot, IFileInfo file)
         {
-            return _cache.GetOrAdd(file, () => CompileCore(file));
+            return _cache.GetOrAdd(file, () => CompileCore(appRoot, file));
         }
 
-        private async Task<CompilationResult> CompileCore(IFileInfo file)
+        private async Task<CompilationResult> CompileCore(string appRoot, IFileInfo file)
         {
             GeneratorResults results;
             using (Stream inputStream = file.CreateReadStream())
             {
-                results = _razorHost.GenerateCode(file.PhysicalPath, inputStream);
+                Contract.Assert(file.PhysicalPath.StartsWith(appRoot, StringComparison.OrdinalIgnoreCase));
+                // Remove the app name segment so that it appears as part of the root relative path: 
+                // work/src/myapp/ -> work/src
+                // root relative path: myapp/views/home/index.cshtml
+                // TODO: The root namespace might be a property we'd have to read via configuration since it 
+                // affects other things such as resx files.
+                appRoot = Path.GetDirectoryName(appRoot.TrimEnd(Path.DirectorySeparatorChar));
+                string rootRelativePath = file.PhysicalPath.Substring(appRoot.Length).TrimStart(Path.DirectorySeparatorChar);
+                results = _razorHost.GenerateCode(rootRelativePath, inputStream);
             }
 
             if (!results.Success)

--- a/src/Microsoft.AspNet.Mvc.Razor/ViewEngine/PathBasedViewFactory.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/ViewEngine/PathBasedViewFactory.cs
@@ -17,10 +17,12 @@ namespace Microsoft.AspNet.Mvc.Razor
 
         public async Task<IView> CreateInstance(string virtualPath)
         {
+            // TODO: We need to glean the approot from HttpContext
+            var appRoot = ((PhysicalFileSystem)_fileSystem).Root;
             IFileInfo fileInfo;
             if (_fileSystem.TryGetFileInfo(virtualPath, out fileInfo))
             {
-                CompilationResult result = await _compilationService.Compile(fileInfo);
+                CompilationResult result = await _compilationService.Compile(appRoot, fileInfo);
                 return (IView)Activator.CreateInstance(result.CompiledType);
             }
 


### PR DESCRIPTION
We need to mangle either the generated type name or the namespace for views based on paths to avoid name collisions. Removing the VirtualFileSystem caused us to start using absolute paths when mangling namespaces. This change fixes the issue by using the app root for figuring out the app relative path.
