### PR TITLE
Renames to prepare for action selection PR

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/ViewEngine/RazorViewEngine.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/ViewEngine/RazorViewEngine.cs
@@ -12,10 +12,11 @@ namespace Microsoft.AspNet.Mvc.Razor
             "/Views/{1}/{0}.cshtml",
             "/Views/Shared/{0}.cshtml",
         };
-        private readonly IRouteContextProvider _actionDescriptorProvider;
+
+        private readonly IActionDescriptorProvider _actionDescriptorProvider;
         private readonly IVirtualPathViewFactory _virtualPathFactory;
 
-        public RazorViewEngine(IRouteContextProvider actionDescriptorProvider, 
+        public RazorViewEngine(IActionDescriptorProvider actionDescriptorProvider, 
                                IVirtualPathViewFactory virtualPathFactory)
         {
             _actionDescriptorProvider = actionDescriptorProvider;
@@ -29,7 +30,9 @@ namespace Microsoft.AspNet.Mvc.Razor
 
         public async Task<ViewEngineResult> FindView(RequestContext requestContext, string viewName)
         {
-            var actionDescriptor = _actionDescriptorProvider.CreateDescriptor(requestContext) as ControllerActionRouteContext;
+            // TODO: We plan to change this on the next CR, so we don't have a strong depenedency directly on the specific
+            // type of the action descriptor
+            var actionDescriptor = _actionDescriptorProvider.CreateDescriptor(requestContext) as TypeMethodBasedActionDescriptor;
             
             if (actionDescriptor == null)
             {

--- a/src/Microsoft.AspNet.Mvc.Startup/MvcServices.cs
+++ b/src/Microsoft.AspNet.Mvc.Startup/MvcServices.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNet.Mvc.Startup
             Add<IActionInvokerFactory, ActionInvokerFactory>();
             Add<IActionResultHelper, ActionResultHelper>();
             Add<IActionResultFactory, ActionResultFactory>();
-            Add<IRouteContextProvider, ControllerActionBasedRouteContextProvider>();
+            Add<IActionDescriptorProvider, TypeMethodBasedActionDescriptorProvider>();
             Add<IActionInvokerProvider, ActionInvokerProvider>();
 
             // need singleton support here.

--- a/src/Microsoft.AspNet.Mvc/ActionInvokerFactory.cs
+++ b/src/Microsoft.AspNet.Mvc/ActionInvokerFactory.cs
@@ -7,10 +7,10 @@ namespace Microsoft.AspNet.Mvc
     {
         private readonly IActionResultFactory _actionResultFactory;
         private readonly IActionInvokerProvider _actionInvokerProvider;
-        private readonly IRouteContextProvider _routeContextProvider;
+        private readonly IActionDescriptorProvider _routeContextProvider;
 
         public ActionInvokerFactory(IActionResultFactory actionResultFactory,
-                                    IRouteContextProvider actionDescriptorProvider, 
+                                    IActionDescriptorProvider actionDescriptorProvider, 
                                     IActionInvokerProvider actionInvokerProvider)
         {
             _actionResultFactory = actionResultFactory;
@@ -20,7 +20,7 @@ namespace Microsoft.AspNet.Mvc
 
         public IActionInvoker CreateInvoker(RequestContext requestContext)
         {
-            RouteContext routeContext = _routeContextProvider.CreateDescriptor(requestContext);
+            ActionDescriptor routeContext = _routeContextProvider.CreateDescriptor(requestContext);
             if (routeContext == null)
             {
                 return null;

--- a/src/Microsoft.AspNet.Mvc/ActionInvokerProvider.cs
+++ b/src/Microsoft.AspNet.Mvc/ActionInvokerProvider.cs
@@ -18,15 +18,15 @@ namespace Microsoft.AspNet.Mvc
             _serviceProvider = serviceProvider;
         }
 
-        public IActionInvoker GetInvoker(RequestContext requestContext, RouteContext routeContext)
+        public IActionInvoker GetInvoker(RequestContext requestContext, ActionDescriptor actionDescriptor)
         {
-            var controllerActionDescriptor = routeContext as ControllerActionRouteContext;
+            var ad = actionDescriptor as TypeMethodBasedActionDescriptor;
 
-            if (controllerActionDescriptor != null)
+            if (ad != null)
             {
-                return new ControllerActionInvoker(
+                return new TypeMethodBasedActionInvoker(
                     requestContext,
-                    controllerActionDescriptor,
+                    ad,
                     _actionResultFactory,
                     _controllerFactory,
                     _serviceProvider);

--- a/src/Microsoft.AspNet.Mvc/ControllerBasedActionDescriptor.cs
+++ b/src/Microsoft.AspNet.Mvc/ControllerBasedActionDescriptor.cs
@@ -1,9 +1,0 @@
-﻿namespace Microsoft.AspNet.Mvc
-{
-    public class ControllerActionRouteContext : RouteContext
-    {
-        public string ControllerName { get; set; }
-
-        public string ActionName { get; set; }
-    }
-}

--- a/src/Microsoft.AspNet.Mvc/IActionDescriptorProvider.cs
+++ b/src/Microsoft.AspNet.Mvc/IActionDescriptorProvider.cs
@@ -2,8 +2,8 @@
 
 namespace Microsoft.AspNet.Mvc
 {
-    public interface IRouteContextProvider
+    public interface IActionDescriptorProvider
     {
-        RouteContext CreateDescriptor(RequestContext requestContext);
+        ActionDescriptor CreateDescriptor(RequestContext requestContext);
     }
 }

--- a/src/Microsoft.AspNet.Mvc/IActionInvokerProvider.cs
+++ b/src/Microsoft.AspNet.Mvc/IActionInvokerProvider.cs
@@ -3,6 +3,6 @@ namespace Microsoft.AspNet.Mvc
 {
     public interface IActionInvokerProvider
     {
-        IActionInvoker GetInvoker(RequestContext requestContext, RouteContext routeContext);
+        IActionInvoker GetInvoker(RequestContext requestContext, ActionDescriptor routeContext);
     }
 }

--- a/src/Microsoft.AspNet.Mvc/RouteContext.cs
+++ b/src/Microsoft.AspNet.Mvc/RouteContext.cs
@@ -1,6 +1,6 @@
 ﻿namespace Microsoft.AspNet.Mvc
 {
-    public class RouteContext
+    public class ActionDescriptor
     {
     }
 }

--- a/src/Microsoft.AspNet.Mvc/TypeMethodBasedActionDescriptor.cs
+++ b/src/Microsoft.AspNet.Mvc/TypeMethodBasedActionDescriptor.cs
@@ -1,0 +1,12 @@
+﻿namespace Microsoft.AspNet.Mvc
+{
+    public class TypeMethodBasedActionDescriptor : ActionDescriptor
+    {
+        // TODO:
+        // In the next PR the content of the descriptor is changing, and the string below will
+        // be represented as route constraints, so for now leaving as is.
+        public string ControllerName { get; set; }
+
+        public string ActionName { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc/TypeMethodBasedActionDescriptorProvider.cs
+++ b/src/Microsoft.AspNet.Mvc/TypeMethodBasedActionDescriptorProvider.cs
@@ -1,13 +1,13 @@
 ﻿namespace Microsoft.AspNet.Mvc
 {
-    public class ControllerActionBasedRouteContextProvider : IRouteContextProvider
+    public class TypeMethodBasedActionDescriptorProvider : IActionDescriptorProvider
     {
-        public RouteContext CreateDescriptor(RequestContext requestContext)
+        public ActionDescriptor CreateDescriptor(RequestContext requestContext)
         {
             var controllerName = (string)requestContext.RouteValues["controller"];
             var actionName = (string)requestContext.RouteValues["action"];
 
-            return new ControllerActionRouteContext
+            return new TypeMethodBasedActionDescriptor()
             {
                 ControllerName = controllerName,
                 ActionName = actionName

--- a/src/Microsoft.AspNet.Mvc/TypeMethodBasedActionInvoker.cs
+++ b/src/Microsoft.AspNet.Mvc/TypeMethodBasedActionInvoker.cs
@@ -6,16 +6,16 @@ using Microsoft.AspNet.Abstractions;
 
 namespace Microsoft.AspNet.Mvc
 {
-    public class ControllerActionInvoker : IActionInvoker
+    public class TypeMethodBasedActionInvoker : IActionInvoker
     {
         private readonly RequestContext _requestContext;
-        private readonly ControllerActionRouteContext _descriptor;
+        private readonly TypeMethodBasedActionDescriptor _descriptor;
         private readonly IActionResultFactory _actionResultFactory;
         private readonly IServiceProvider _serviceProvider;
         private readonly IControllerFactory _controllerFactory;
 
-        public ControllerActionInvoker(RequestContext requestContext,
-                                       ControllerActionRouteContext descriptor,
+        public TypeMethodBasedActionInvoker(RequestContext requestContext,
+                                       TypeMethodBasedActionDescriptor descriptor,
                                        IActionResultFactory actionResultFactory,
                                        IControllerFactory controllerFactory,
                                        IServiceProvider serviceProvider)


### PR DESCRIPTION
This is to rename the types such that the action selection PR will focus on the functional and structural changes rather than names.
