### PR TITLE
Run unit tests during builds

### DIFF
--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/project.json
@@ -4,11 +4,20 @@
     "Microsoft.AspNet.Abstractions": "0.1-alpha-*",
     "Microsoft.AspNet.PipelineCore": "0.1-alpha-*",
     "Microsoft.AspNet.Mvc.ModelBinding" : "",
-    "Moq": "4.0.10827",
-    "Xunit": "1.9.1",
-    "Xunit.extensions": "1.9.1"
+    "Xunit.KRunner": "0.1-alpha-*",
+    "xunit.abstractions": "3.0.0-alpha-*",
+    "xunit2": "0.1-alpha-*",
+    "xunit2.assert": "0.1-alpha-*"
+  },
+  "commands": {
+    "test": "Xunit.KRunner"
   },
   "configurations": {
-    "net45": { }
+    "net45": {
+      "dependencies": {
+        "Moq": "4.2.1312.1622",
+        "System.Runtime": ""
+      }
+    }
   }
 }

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/project.json
@@ -3,11 +3,20 @@
   "dependencies": {
     "Microsoft.AspNet.Razor" : "0.1-alpha-*",
     "Microsoft.AspNet.Mvc.Razor.Host" : "",
-    "Moq": "4.0.10827",
-    "Xunit": "1.9.1",
-    "Xunit.extensions": "1.9.1"
+    "Xunit.KRunner": "0.1-alpha-*",
+    "xunit.abstractions": "3.0.0-alpha-*",
+    "xunit2": "0.1-alpha-*",
+    "xunit2.assert": "0.1-alpha-*"
+  },
+  "commands": {
+    "test": "Xunit.KRunner"
   },
   "configurations": {
-    "net45": { }
+    "net45": {
+      "dependencies": {
+        "Moq": "4.2.1312.1622",
+        "System.Runtime": ""
+      }
+    }
   }
 }


### PR DESCRIPTION
- Dirty read since migration from XUnit 1.9.1 to XUnit 2.0 currently breaks testing in VS
- Note this commit builds on PR #58, "Fix 4 unit test failures"
