### PR TITLE
Re-plumb ModelState.

### DIFF
--- a/samples/MvcSample.Web/Home2Controller.cs
+++ b/samples/MvcSample.Web/Home2Controller.cs
@@ -15,7 +15,15 @@ namespace MvcSample.Web.RandomNameSpace
 
         public IActionResultHelper Result { get; private set; }
 
-        public HttpContext Context { get; set; }
+        public HttpContext Context
+        {
+            get
+            {
+                return ActionContext.HttpContext;
+            }
+        }
+
+        public ActionContext ActionContext { get; set; }
 
         public string Index()
         {

--- a/src/Microsoft.AspNet.Mvc.Core/ActionContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionContext.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Microsoft.AspNet.Abstractions;
+using Microsoft.AspNet.Mvc.ModelBinding;
 using Microsoft.AspNet.Routing;
 
 namespace Microsoft.AspNet.Mvc
@@ -12,6 +13,7 @@ namespace Microsoft.AspNet.Mvc
             Router = router;
             RouteValues = routeValues;
             ActionDescriptor = actionDescriptor;
+            ModelState = new ModelStateDictionary();
         }
 
         public HttpContext HttpContext { get; private set; }
@@ -19,6 +21,8 @@ namespace Microsoft.AspNet.Mvc
         public IRouter Router { get; private set; }
 
         public IDictionary<string, object> RouteValues { get; private set; }
+
+        public ModelStateDictionary ModelState { get; private set; }
 
         public ActionDescriptor ActionDescriptor { get; private set; }
     }

--- a/src/Microsoft.AspNet.Mvc.Core/Controller.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Controller.cs
@@ -6,15 +6,30 @@ namespace Microsoft.AspNet.Mvc
 {
     public class Controller
     {
-        public void Initialize(IActionResultHelper actionResultHelper, IModelMetadataProvider metadataProvider)
+        public void Initialize(IActionResultHelper actionResultHelper)
         {
             Result = actionResultHelper;
-            ViewData = new ViewData<object>(metadataProvider);
         }
 
-        public IActionResultHelper Result { get; private set; }
+        public HttpContext Context
+        {
+            get
+            {
+                return ActionContext.HttpContext;
+            }
+        }
 
-        public HttpContext Context { get; set; }
+        public ModelStateDictionary ModelState
+        {
+            get
+            {
+                return ViewData.ModelState;
+            }
+        }
+
+        public ActionContext ActionContext { get; set; }
+
+        public IActionResultHelper Result { get; private set; }
 
         public IUrlHelper Url { get; set; }
 

--- a/src/Microsoft.AspNet.Mvc.Core/IControllerFactory.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/IControllerFactory.cs
@@ -1,11 +1,10 @@
 ﻿
-using Microsoft.AspNet.Mvc.ModelBinding;
 
 namespace Microsoft.AspNet.Mvc
 {
     public interface IControllerFactory
     {
-        object CreateController(ActionContext actionContext, ModelStateDictionary modelState);
+        object CreateController(ActionContext actionContext);
 
         void ReleaseController(object controller);
     }

--- a/src/Microsoft.AspNet.Mvc.Core/ReflectedActionInvoker.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ReflectedActionInvoker.cs
@@ -50,8 +50,7 @@ namespace Microsoft.AspNet.Mvc
 
             PreArrangeFiltersInPipeline(filterProviderContext);
 
-            var modelState = new ModelStateDictionary();
-            object controller = _controllerFactory.CreateController(_actionContext, modelState);
+            var controller = _controllerFactory.CreateController(_actionContext);
 
             if (controller == null)
             {
@@ -96,7 +95,7 @@ namespace Microsoft.AspNet.Mvc
 
                     if (actionResult == null)
                     {
-                        var parameterValues = await GetParameterValues(modelState);
+                        var parameterValues = await GetParameterValues(_actionContext.ModelState);
 
                         var actionFilterContext = new ActionFilterContext(_actionContext,
                                                                           filterMetaItems,

--- a/src/Microsoft.AspNet.Mvc.Rendering/View/ViewDataOfTModel.cs
+++ b/src/Microsoft.AspNet.Mvc.Rendering/View/ViewDataOfTModel.cs
@@ -14,6 +14,11 @@ namespace Microsoft.AspNet.Mvc.Rendering
         {
             _defaultModelMetadata = MetadataProvider.GetMetadataForType(null, typeof(TModel));
         }
+        
+        public ViewData([NotNull] IModelMetadataProvider metadataProvider, [NotNull] ModelStateDictionary modelState)
+            : base(metadataProvider, modelState)
+        {
+        }
 
         public ViewData(ViewData source)
             : base(source)

--- a/src/Microsoft.AspNet.Mvc.Rendering/project.json
+++ b/src/Microsoft.AspNet.Mvc.Rendering/project.json
@@ -10,6 +10,7 @@
     "net45": {},
     "k10": {
       "dependencies": {
+        "Microsoft.CSharp": "4.0.0.0",
         "System.Collections": "4.0.0.0",
         "System.ComponentModel": "4.0.0.0",
         "System.Diagnostics.Contracts": "4.0.0.0",
@@ -19,6 +20,7 @@
         "System.Globalization": "4.0.10.0",
         "System.IO": "4.0.0.0",
         "System.Linq": "4.0.0.0",
+        "System.Linq.Expressions": "4.0.0.0",
         "System.Reflection": "4.0.10.0",
         "System.Reflection.Extensions": "4.0.0.0",
         "System.Resources.ResourceManager": "4.0.0.0",


### PR DESCRIPTION
Modified ModelState to only ever be created on the ActionContext and then plumbed/exposed it on ViewData and Controller.  This will enable: ActionFilterContext's will have access to ModelState via its ActionContext member, allow HTMLHelpers to access ModelState via ViewData, and unify the locations of "source" model state.  In the old world we used to copy/replace/instantiate new model state all over unnecessarily.
