### PR TITLE
Refactor FindView to always take a viewName (no null support)

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/Controller.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Controller.cs
@@ -31,8 +31,7 @@ namespace Microsoft.AspNet.Mvc
 
         public IActionResult View(string view)
         {
-            object model = null;
-            return View(view, model);
+            return View(view, model: (object)null);
         }
 
         public IActionResult View<TModel>(TModel model)

--- a/src/Microsoft.AspNet.Mvc.Razor/ViewEngine/RazorViewEngine.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/ViewEngine/RazorViewEngine.cs
@@ -28,27 +28,8 @@ namespace Microsoft.AspNet.Mvc.Razor
             get { return _viewLocationFormats; }
         }
 
-        public async Task<ViewEngineResult> FindView(object context, string viewName)
+        public async Task<ViewEngineResult> FindView([NotNull] IDictionary<string, object> context,[NotNull] string viewName)
         {
-            var actionContext = (ActionContext)context;
-
-            var actionDescriptor = actionContext.ActionDescriptor;
-            
-            if (actionDescriptor == null)
-            {
-                return null;
-            }
-            
-            if (string.IsNullOrEmpty(viewName))
-            {
-                viewName = actionDescriptor.Name;
-            }
-
-            if (string.IsNullOrEmpty(viewName))
-            {
-                throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, "viewName");
-            }
-
             var nameRepresentsPath = IsSpecificPath(viewName);
 
             if (nameRepresentsPath)
@@ -59,8 +40,8 @@ namespace Microsoft.AspNet.Mvc.Razor
             }
             else
             {
-                var controllerName = actionContext.RouteValues.GetValueOrDefault<string>("controller");
-                var areaName = actionContext.RouteValues.GetValueOrDefault<string>("area");
+                var controllerName = context.GetValueOrDefault<string>("controller");
+                var areaName = context.GetValueOrDefault<string>("area");
 
                 var searchedLocations = new List<string>(_viewLocationFormats.Length);
                 for (int i = 0; i < _viewLocationFormats.Length; i++)
@@ -73,6 +54,7 @@ namespace Microsoft.AspNet.Mvc.Razor
                     }
                     searchedLocations.Add(path);
                 }
+
                 return ViewEngineResult.NotFound(searchedLocations);
             }
         }

--- a/src/Microsoft.AspNet.Mvc.Rendering/Html/HtmlHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Rendering/Html/HtmlHelper.cs
@@ -83,26 +83,6 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return value != null ? WebUtility.HtmlEncode(value.ToString()) : string.Empty;
         }
 
-        internal static IView FindPartialView([NotNull] ViewContext viewContext, string partialViewName,
-            [NotNull] IViewEngine viewEngine)
-        {
-            ViewEngineResult result = viewEngine.FindView(viewContext, partialViewName).Result;
-            if (result.View != null)
-            {
-                return result.View;
-            }
-
-            StringBuilder locationsText = new StringBuilder();
-            foreach (string location in result.SearchedLocations)
-            {
-                locationsText.AppendLine();
-                locationsText.Append(location);
-            }
-
-            throw new InvalidOperationException(Resources.FormatCommon_PartialViewNotFound(partialViewName,
-                locationsText));
-        }
-
         public string GenerateIdFromName([NotNull] string name)
         {
             return TagBuilder.CreateSanitizedId(name, IdAttributeDotReplacement);

--- a/src/Microsoft.AspNet.Mvc.Rendering/View/IViewEngine.cs
+++ b/src/Microsoft.AspNet.Mvc.Rendering/View/IViewEngine.cs
@@ -1,10 +1,10 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Microsoft.AspNet.Mvc.Rendering
 {
     public interface IViewEngine
     {
-        // TODO: Relayer to allow this to be ActionContext. We probably need the common MVC assembly
-        Task<ViewEngineResult> FindView(object actionContext, string viewName);
+        Task<ViewEngineResult> FindView([NotNull] IDictionary<string, object> context, [NotNull] string viewName);
     }
 }


### PR DESCRIPTION
and only use RouteValues (or generically just Dictionary<string, object>).

This is temporary and will change once we get Partials (which are currently just dead code)

For now this will unblock ViewComponents
