### PR TITLE
Passing additional data on the ViewContext for resolving views.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/ViewResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/ViewResult.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNet.Mvc
                 context.HttpContext.Response.ContentType = "text/html";
                 using (var writer = new StreamWriter(context.HttpContext.Response.Body, Encoding.UTF8, 1024, leaveOpen: true))
                 {
-                    var viewContext = new ViewContext(context.HttpContext, ViewData, _serviceProvider)
+                    var viewContext = new ViewContext(_serviceProvider, context.HttpContext, context.RouteValues, ViewData)
                     {
                         Url = new UrlHelper(context.HttpContext, context.Router, context.RouteValues),
                     };

--- a/src/Microsoft.AspNet.Mvc.Rendering/View/ViewContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Rendering/View/ViewContext.cs
@@ -1,15 +1,17 @@
 ﻿using System;
+using System.Collections.Generic;
 using Microsoft.AspNet.Abstractions;
 
 namespace Microsoft.AspNet.Mvc.Rendering
 {
     public class ViewContext
     {
-        public ViewContext(HttpContext context, ViewData viewData, IServiceProvider serviceProvider)
+        public ViewContext(IServiceProvider serviceProvider, HttpContext httpContext, IDictionary<string, object> viewEngineContext, ViewData viewData)
         {
-            HttpContext = context;
-            ViewData = viewData;
             ServiceProvider = serviceProvider;
+            HttpContext = httpContext;
+            ViewEngineContext = viewEngineContext;
+            ViewData = viewData;
         }
 
         public HttpContext HttpContext { get; private set; }
@@ -19,5 +21,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         public IUrlHelper Url { get; set; }
 
         public ViewData ViewData { get; private set; }
+
+        public IDictionary<string, object> ViewEngineContext { get; private set; }
     }
 }


### PR DESCRIPTION
This will be necessary for partials, and for Components.

Basically, the view engine uses a dictionary of data to find the top level
view (for an action) - after we do that, we want this context to be
sticky, which means we need to pass it around. This ensures that partials
and components will be resolved under the same paths as the main view.

Currently this 'data' is just the route values - and there is an ongoing
discussing about the right design here. The data that's being passed WILL
change in the future.
