### PR TITLE
Restore the TextWriter to ViewContext

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/ViewResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/ViewResult.cs
@@ -36,7 +36,9 @@ namespace Microsoft.AspNet.Mvc
                     var viewContext = new ViewContext(_serviceProvider, context.HttpContext, context.RouteValues, ViewData)
                     {
                         Url = new UrlHelper(context.HttpContext, context.Router, context.RouteValues),
+                        Writer = writer,
                     };
+
                     await view.RenderAsync(viewContext, writer);
                 }
             }

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorView.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorView.cs
@@ -31,7 +31,20 @@ namespace Microsoft.AspNet.Mvc.Razor
             using (var bodyWriter = new StringWriter(contentBuilder))
             {
                 Output = bodyWriter;
-                await ExecuteAsync();
+
+                // The writer for the body is passed through the ViewContext, allowing things like HtmlHelpers
+                // and ViewComponents to reference it.
+                var oldWriter = context.Writer;
+                context.Writer = bodyWriter;
+
+                try
+                {
+                    await ExecuteAsync();
+                }
+                finally
+                {
+                    context.Writer = oldWriter;
+                }
             }
 
             var bodyContent = contentBuilder.ToString();

--- a/src/Microsoft.AspNet.Mvc.Rendering/View/ViewContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Rendering/View/ViewContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.AspNet.Abstractions;
 
 namespace Microsoft.AspNet.Mvc.Rendering
@@ -23,5 +24,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         public ViewData ViewData { get; private set; }
 
         public IDictionary<string, object> ViewEngineContext { get; private set; }
+
+        public TextWriter Writer { get; set; }
     }
 }


### PR DESCRIPTION
This will be needed for Components, and Partials.

Basically anything that wants to write directly to a page, can do so by holding on the ViewContext, then it will have the appropriate writer for the current part of the page that's being rendered.

This design is consistent with what we have in the legacy code. Discussed with @davidfowl  and agreed to resurrect it for right now.
