### PR TITLE
Modifying the Default Action convention to have verb only methods

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/DefaultActionDiscoveryConventions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/DefaultActionDiscoveryConventions.cs
@@ -13,8 +13,6 @@ namespace Microsoft.AspNet.Mvc
             "POST", 
             "PUT", 
             "DELETE", 
-            "HEAD", 
-            "OPTIONS", 
             "PATCH",
         };
 
@@ -56,7 +54,7 @@ namespace Microsoft.AspNet.Mvc
 
             for (var i = 0; i < _supportedHttpMethodsByConvention.Length; i++)
             {
-                if (methodInfo.Name.StartsWith(_supportedHttpMethodsByConvention[i], StringComparison.OrdinalIgnoreCase))
+                if (methodInfo.Name.Equals(_supportedHttpMethodsByConvention[i], StringComparison.OrdinalIgnoreCase))
                 {
                     return new [] {
                         new ActionInfo()


### PR DESCRIPTION
-   Action names that match the list of specific http verb have no action name associate with them by default. This also means that “verb only methods” cannot be reached by browsing to for example {controller}/Get (i.e even if there is a template {controller}/{action},  {controller}/Get is not reachable). The comparison is case insensitive.
-   The accepted verbs are: GET, POST, PUT, DELETE, PATCH.
  (No Head or Options).
