### PR TITLE
Fix #118

### DIFF
--- a/samples/MvcSample.Web/Views/Home/Create.cshtml
+++ b/samples/MvcSample.Web/Views/Home/Create.cshtml
@@ -1,24 +1,23 @@
 ﻿@using MvcSample.Web.Models
 @model User
 @{
-    string nullValue = null;
     ViewBag.Title = (Model == null) ? "Create Page" : "Edit Page";
-    if (ViewData["Gift"] == null)
+    if (ViewBag.Gift == null)
     {
         ViewBag.Gift = "nothing";
     }
 }
 
 <div class="row">
-    <h2 title="@ViewBag.Title" class="@nullValue">@ViewBag.Title</h2>
-    <h3 title="Thanks" class="@nullValue">Thanks for @ViewBag.Gift</h3>
+    <h2 title="@ViewBag.Title" class="@ViewBag.NullValue">@ViewBag.Title</h2>
+    <h3 title="Thanks" class="@ViewBag.NullValue">Thanks for @ViewBag.Gift</h3>
     @if (Model == null)
     {
-        <h4 title ="Null Model" class="@nullValue">Howdy, your model is null.</h4>
+        <h4 title ="Null Model" class="@ViewBag.NullValue">Howdy, your model is null.</h4>
     }
     else
     {
-        <h4 title="@Model.Name" class="@nullValue">Hello @Model.Name! Happy @Model.Age birthday.</h4>
+        <h4 title="@Model.Name" class="@ViewBag.NullValue">Hello @Model.Name! Happy @Model.Age birthday.</h4>
     }
 
     @{

--- a/src/Microsoft.AspNet.Mvc.Rendering/View/ViewData.cs
+++ b/src/Microsoft.AspNet.Mvc.Rendering/View/ViewData.cs
@@ -55,8 +55,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             get
             {
                 dynamic result;
-
-                _data.TryGetValue(index, out result);
+                TryGetValue(index, out result);
 
                 return result;
             }
@@ -93,18 +92,15 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
         public override bool TryGetMember(GetMemberBinder binder, out object result)
         {
-            result = _data[binder.Name];
+            result = this[binder.Name];
 
-            // We return true here because ViewDataDictionary returns null if the key is not
-            // in the dictionary, so we simply pass on the returned value.
+            // Indexer's result will be null when TryGetValue fails. Never return false; that confuses the runtime.
             return true;
         }
 
         public override bool TrySetMember(SetMemberBinder binder, object value)
         {
-            // This cast should always succeed.
-            dynamic v = value;
-            _data[binder.Name] = v;
+            this[binder.Name] = value;
             return true;
         }
 
@@ -115,7 +111,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 throw new ArgumentException("Invalid number of indexes");
             }
 
-            object index = indexes[0];
+            var index = indexes[0];
+
+            // This cast should always succeed.
             result = this[(string)index];
             return true;
         }
@@ -127,11 +125,16 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 throw new ArgumentException("Invalid number of indexes");
             }
 
-            object index = indexes[0];
+            var index = indexes[0];
 
             // This cast should always succeed.
             this[(string)index] = value;
             return true;
+        }
+
+        public bool TryGetValue(string key, out dynamic value)
+        {
+            return _data.TryGetValue(key, out value);
         }
 
         // This method will execute before the derived type's instance constructor executes. Derived types must


### PR DESCRIPTION
- avoid throwing in `TryGetMember()`: work through the `ViewData` indexer
- do same in `TryGetMember()` for consistency with other `DynamicObject`
  overrides
- new `TryGetValue()` will be used more when we add `@Html.Value()`...
- also use `var` more in rest of `ViewData` class

(split from my `@Html.TextBox` prototype because I found it fixed this issue)
