### PR TITLE
Remove extra TextWriter parameter from IView

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/ViewResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/ViewResult.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNet.Mvc
                 using (var writer = new StreamWriter(context.HttpContext.Response.Body, Encoding.UTF8, 1024, leaveOpen: true))
                 {
                     var viewContext = CreateViewContext(context, writer);
-                    await view.RenderAsync(viewContext, writer);
+                    await view.RenderAsync(viewContext);
                 }
             }
         }

--- a/src/Microsoft.AspNet.Mvc.Core/ViewComponents/ViewViewComponentResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ViewComponents/ViewViewComponentResult.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNet.Mvc
             var view = await FindView(context.ViewContext.ViewEngineContext, qualifiedViewName);
             using (view as IDisposable)
             {
-                await view.RenderAsync(childViewContext, context.Writer);
+                await view.RenderAsync(childViewContext);
             }
         }
 

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorView.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorView.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNet.Mvc.Razor
 
         private string BodyContent { get; set; }
 
-        public virtual async Task RenderAsync([NotNull] ViewContext context, [NotNull] TextWriter writer)
+        public virtual async Task RenderAsync([NotNull] ViewContext context)
         {
             Context = context;
 
@@ -55,15 +55,15 @@ namespace Microsoft.AspNet.Mvc.Razor
             var bodyContent = contentBuilder.ToString();
             if (!string.IsNullOrEmpty(Layout))
             {
-                await RenderLayoutAsync(context, writer, bodyContent);
+                await RenderLayoutAsync(context, bodyContent);
             }
             else
             {
-                await writer.WriteAsync(bodyContent);
+                await context.Writer.WriteAsync(bodyContent);
             }
         }
 
-        private async Task RenderLayoutAsync(ViewContext context, TextWriter writer, string bodyContent)
+        private async Task RenderLayoutAsync(ViewContext context, string bodyContent)
         {
             var virtualPathFactory = context.ServiceProvider.GetService<IVirtualPathViewFactory>();
             var layoutView = (RazorView)(await virtualPathFactory.CreateInstance(Layout));
@@ -75,7 +75,7 @@ namespace Microsoft.AspNet.Mvc.Razor
             }
 
             layoutView.BodyContent = bodyContent;
-            await layoutView.RenderAsync(context, writer);
+            await layoutView.RenderAsync(context);
         }
 
         public abstract Task ExecuteAsync();

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorViewOfT.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorViewOfT.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNet.Mvc.Razor
 
         public HtmlHelper<TModel> Html { get; set; }
 
-        public override Task RenderAsync([NotNull] ViewContext context, [NotNull] TextWriter writer)
+        public override Task RenderAsync([NotNull] ViewContext context)
         {
             ViewData = context.ViewData as ViewData<TModel>;
             if (ViewData == null)
@@ -46,7 +46,7 @@ namespace Microsoft.AspNet.Mvc.Razor
 
             InitHelpers(context);
 
-            return base.RenderAsync(context, writer);
+            return base.RenderAsync(context);
         }
 
         private void InitHelpers(ViewContext context)

--- a/src/Microsoft.AspNet.Mvc.Rendering/View/IView.cs
+++ b/src/Microsoft.AspNet.Mvc.Rendering/View/IView.cs
@@ -5,6 +5,6 @@ namespace Microsoft.AspNet.Mvc.Rendering
 {
     public interface IView
     {
-        Task RenderAsync([NotNull] ViewContext context, [NotNull] TextWriter writer);
+        Task RenderAsync([NotNull] ViewContext context);
     }
 }


### PR DESCRIPTION
This was here in the legacy code for legacy reasons. We're passing the writer
as part of the ViewContext, so we can remove this extra parameter.
