### PR TITLE
Add the ability to correctly determine if a particular field has been validated

### DIFF
--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/MutableObjectModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/MutableObjectModelBinder.cs
@@ -113,7 +113,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 var validationNode = (ModelValidationNode)sender;
                 var modelState = e.ValidationContext.ModelState;
 
-                if (modelState.IsValidField(validationNode.ModelStateKey))
+                if (modelState.IsValidField(validationNode.ModelStateKey) == null)
                 {
                     // TODO: Revive ModelBinderConfig
                     // string errorMessage =  ModelBinderConfig.ValueRequiredErrorMessageProvider(e.ValidationContext, modelMetadata, incomingValue);
@@ -266,7 +266,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             if (value == null)
             {
                 var modelStateKey = dtoResult.ValidationNode.ModelStateKey;
-                if (bindingContext.ModelState.IsValidField(modelStateKey))
+                if (bindingContext.ModelState.IsValidField(modelStateKey) == null)
                 {
                     if (requiredValidator != null)
                     {
@@ -295,7 +295,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                         ex = targetInvocationException.InnerException;
                     }
                     var modelStateKey = dtoResult.ValidationNode.ModelStateKey;
-                    if (bindingContext.ModelState.IsValidField(modelStateKey))
+                    if (bindingContext.ModelState.IsValidField(modelStateKey) == null)
                     {
                         bindingContext.ModelState.AddModelError(modelStateKey, ex);
                     }
@@ -305,7 +305,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             {
                 // trying to set a non-nullable value type to null, need to make sure there's a message
                 var modelStateKey = dtoResult.ValidationNode.ModelStateKey;
-                if (bindingContext.ModelState.IsValidField(modelStateKey))
+                if (bindingContext.ModelState.IsValidField(modelStateKey) == null)
                 {
                     dtoResult.ValidationNode.Validated += CreateNullCheckFailedHandler(propertyMetadata, value);
                 }
@@ -326,6 +326,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 bindingContext.ModelState.AddModelError(modelStateKey, validationResult.Message);
                 addedError = true;
             }
+
+            if (!addedError)
+            {
+                bindingContext.ModelState.MarkFieldValid(modelStateKey);
+            }
+
             return addedError;
         }
 

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/ModelState.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/ModelState.cs
@@ -11,5 +11,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         {
             get { return _errors; }
         }
+
+        public bool? IsValid { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Properties/Resources.Designer.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         }
 
         /// <summary>
-        /// No encoding found for media type formatter '{0}'. There must be at least one supported encoding registered in order for the media type formatter to read or write content.
+        /// No encoding found for input formatter '{0}'. There must be at least one supported encoding registered in order for the formatter to read content.
         /// </summary>
         internal static string MediaTypeFormatterNoEncoding
         {
@@ -67,12 +67,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         }
 
         /// <summary>
-        /// No encoding found for media type formatter '{0}'. There must be at least one supported encoding registered in order for the media type formatter to read or write content.
+        /// No encoding found for input formatter '{0}'. There must be at least one supported encoding registered in order for the formatter to read content.
         /// </summary>
         internal static string FormatMediaTypeFormatterNoEncoding(object p0)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("MediaTypeFormatterNoEncoding"), p0);
         }
+
+        /// <summary>
         /// Property '{0}' on type '{1}' is invalid. Value-typed properties marked as [Required] must also be marked with [DataMember(IsRequired=true)] to be recognized as required. Consider attributing the declaring type with [DataContract] and the property with [DataMember(IsRequired=true)].
         /// </summary>
         internal static string MissingDataMemberIsRequired
@@ -262,6 +264,22 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         internal static string FormatValidationAttributeOnNonPublicProperty(object p0, object p1)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("ValidationAttributeOnNonPublicProperty"), p0, p1);
+        }
+
+        /// <summary>
+        /// A field previously marked invalid should not be marked valid.
+        /// </summary>
+        internal static string Validation_InvalidFieldCannotBeReset
+        {
+            get { return GetString("Validation_InvalidFieldCannotBeReset"); }
+        }
+
+        /// <summary>
+        /// A field previously marked invalid should not be marked valid.
+        /// </summary>
+        internal static string FormatValidation_InvalidFieldCannotBeReset()
+        {
+            return GetString("Validation_InvalidFieldCannotBeReset");
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Resources.resx
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Resources.resx
@@ -165,6 +165,9 @@
   <data name="ValidationAttributeOnNonPublicProperty" xml:space="preserve">
     <value>Non-public property '{0}' on type '{1}' is attributed with one or more validation attributes. Validation attributes on non-public properties are not supported. Consider using a public property for validation instead.</value>
   </data>
+  <data name="Validation_InvalidFieldCannotBeReset" xml:space="preserve">
+    <value>A field previously marked invalid should not be marked valid.</value>
+  </data>
   <data name="Validation_ValueNotFound" xml:space="preserve">
     <value>A value is required but was not present in the request.</value>
   </data>

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Binders/CompositeModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Binders/CompositeModelBinderTest.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             Assert.Equal(42, bindingContext.Model);
             
             Assert.True(validationCalled);
-            Assert.True(bindingContext.ModelState.IsValid);
+            Assert.Equal(true, bindingContext.ModelState.IsValid);
         }
 
         [Fact]
@@ -106,7 +106,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             Assert.True(isBound);
             Assert.Equal(expectedModel, bindingContext.Model);
             Assert.True(validationCalled);
-            Assert.True(bindingContext.ModelState.IsValid);
+            Assert.Equal(true, bindingContext.ModelState.IsValid);
         }
 
         [Fact]
@@ -132,7 +132,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             // Assert
             Assert.False(isBound);
             Assert.Null(bindingContext.Model);
-            Assert.True(bindingContext.ModelState.IsValid);
+            Assert.Equal(true, bindingContext.ModelState.IsValid);
             mockListBinder.Verify();
         }
 

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Binders/MutableObjectModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Binders/MutableObjectModelBinderTest.cs
@@ -319,7 +319,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             // Assert
             var modelStateDictionary = bindingContext.ModelState;
-            Assert.False(modelStateDictionary.IsValid);
+            Assert.Equal(false, modelStateDictionary.IsValid);
             Assert.Equal(1, modelStateDictionary.Count);
 
             // Check Age error.
@@ -377,13 +377,19 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             // Assert
             var modelStateDictionary = bindingContext.ModelState;
-            Assert.False(modelStateDictionary.IsValid);
-            Assert.Equal(1, modelStateDictionary.Count);
+            Assert.Equal(false, modelStateDictionary.IsValid);
+            Assert.Equal(2, modelStateDictionary.Count);
+
+            // Check Name field
+            ModelState modelState;
+            Assert.True(modelStateDictionary.TryGetValue("theModel.Name", out modelState));
+            Assert.Equal(0, modelState.Errors.Count);
+            Assert.Equal(true, modelState.IsValid);
 
             // Check Age error.
-            ModelState modelState;
             Assert.True(modelStateDictionary.TryGetValue("theModel.Age", out modelState));
             Assert.Equal(1, modelState.Errors.Count);
+            Assert.Equal(false, modelState.IsValid);
 
             var modelError = modelState.Errors[0];
             Assert.Null(modelError.Exception);
@@ -409,7 +415,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             // Assert
             var modelStateDictionary = bindingContext.ModelState;
-            Assert.False(modelStateDictionary.IsValid);
+            Assert.Equal(false, modelStateDictionary.IsValid);
             Assert.Equal(2, modelStateDictionary.Count);
 
             // Check Age error.
@@ -457,7 +463,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             // Assert
             var modelStateDictionary = bindingContext.ModelState;
-            Assert.False(modelStateDictionary.IsValid);
+            Assert.Equal(false, modelStateDictionary.IsValid);
             Assert.Equal(1, modelStateDictionary.Count);
 
             // Check City error.
@@ -488,7 +494,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             // Assert
             var modelStateDictionary = bindingContext.ModelState;
-            Assert.False(modelStateDictionary.IsValid);
+            Assert.Equal(false, modelStateDictionary.IsValid);
             Assert.Equal(1, modelStateDictionary.Count);
 
             // Check ValueTypeRequired error.
@@ -524,7 +530,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             // Assert
             ModelStateDictionary modelStateDictionary = bindingContext.ModelState;
-            Assert.False(modelStateDictionary.IsValid);
+            Assert.Equal(false, modelStateDictionary.IsValid);
             Assert.Equal(1, modelStateDictionary.Count);
 
             // Check ValueTypeRequired error.
@@ -568,7 +574,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             Assert.Equal("John", model.FirstName);
             Assert.Equal("Doe", model.LastName);
             Assert.Equal(dob, model.DateOfBirth);
-            Assert.True(bindingContext.ModelState.IsValid);
+            Assert.Equal(true, bindingContext.ModelState.IsValid);
         }
 
         [Fact]
@@ -593,7 +599,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             // Assert
             var person = Assert.IsType<Person>(bindingContext.Model);
             Assert.Equal(123.456m, person.PropertyWithDefaultValue);
-            Assert.True(bindingContext.ModelState.IsValid);
+            Assert.Equal(true, bindingContext.ModelState.IsValid);
         }
 
         [Fact]
@@ -637,7 +643,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             // Assert
             validationNode.Validate(validationContext);
-            Assert.True(bindingContext.ModelState.IsValid);
+            Assert.Equal(true, bindingContext.ModelState.IsValid);
             Assert.Equal(new DateTime(2001, 1, 1), model.DateOfBirth);
         }
 
@@ -684,9 +690,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             testableBinder.SetPropertyPublic(bindingContext, propertyMetadata, dtoResult, requiredValidator);
 
             // Assert
-            Assert.True(bindingContext.ModelState.IsValid);
+            Assert.Equal(true, bindingContext.ModelState.IsValid);
             validationNode.Validate(validationContext, bindingContext.ValidationNode);
-            Assert.False(bindingContext.ModelState.IsValid);
+            Assert.Equal(false, bindingContext.ModelState.IsValid);
         }
 
         [Fact]
@@ -706,7 +712,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             testableBinder.SetPropertyPublic(bindingContext, propertyMetadata, dtoResult, requiredValidator);
 
             // Assert
-            Assert.False(bindingContext.ModelState.IsValid);
+            Assert.Equal(false, bindingContext.ModelState.IsValid);
             Assert.Equal("Sample message", bindingContext.ModelState["foo.ValueTypeRequired"].Errors[0].ErrorMessage);
         }
 
@@ -728,7 +734,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             testableBinder.SetPropertyPublic(bindingContext, propertyMetadata, dtoResult, requiredValidator);
 
             // Assert
-            Assert.False(bindingContext.ModelState.IsValid);
+            Assert.Equal(false, bindingContext.ModelState.IsValid);
             Assert.Equal(1, bindingContext.ModelState["foo.NameNoAttribute"].Errors.Count);
             Assert.Equal("This is a different exception." + Environment.NewLine
                        + "Parameter name: value",
@@ -752,7 +758,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             testableBinder.SetPropertyPublic(bindingContext, propertyMetadata, dtoResult, requiredValidator);
 
             // Assert
-            Assert.False(bindingContext.ModelState.IsValid);
+            Assert.Equal(false, bindingContext.ModelState.IsValid);
             Assert.Equal(1, bindingContext.ModelState["foo.Name"].Errors.Count);
             Assert.Equal("This message comes from the [Required] attribute.", bindingContext.ModelState["foo.Name"].Errors[0].ErrorMessage);
         }

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Binders/TypeConverterModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Binders/TypeConverterModelBinderTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             // Assert
             Assert.False(retVal);
             Assert.Null(bindingContext.Model);
-            Assert.False(bindingContext.ModelState.IsValid);
+            Assert.Equal(false, bindingContext.ModelState.IsValid);
             Assert.Equal("Input string was not in a correct format.", bindingContext.ModelState["theModelName"].Errors[0].ErrorMessage);
         }
 


### PR DESCRIPTION
There are several portions of model validation that attempt to avoid
revalidating if a field has been validated. However the behavior of
ModelStateDictionary makes it difficult to distinguish between an
unvalidated field and a field without validation errors. This change
resolves this issue by letting the caller distinguish between the two
cases.
