### PR TITLE
Fix build issues with Injector

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/Injector.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Injector.cs
@@ -32,7 +32,12 @@ namespace Microsoft.AspNet.Mvc
         {
             var type = obj.GetType();
 
-            var property = type.GetProperty(propertyName);
+            var property = type.GetRuntimeProperty(propertyName);
+            if (property == null)
+            {
+                return;
+            }
+
             if (property.PropertyType.IsAssignableFrom(typeof(TProperty)))
             {
                 property.SetValue(obj, value);
@@ -43,7 +48,12 @@ namespace Microsoft.AspNet.Mvc
         {
             var type = obj.GetType();
 
-            var property = type.GetProperty(propertyName);
+            var property = type.GetRuntimeProperty(propertyName);
+            if (property == null)
+            {
+                return;
+            }
+
             if (property.PropertyType.IsAssignableFrom(typeof(TProperty)))
             {
                 property.SetValue(obj, services.GetService<TProperty>());


### PR DESCRIPTION
This was causing intellisense failures in VS. It looks like the
commandline is able to accidentally pick up the compatability extensions
from the model binding assembly, but this is not the case in VS.

Changed this code not to rely on compatability extensions.
