### PR TITLE
Adding support for Render Section

### DIFF
--- a/samples/MvcSample.Web/Views/Shared/MyView.cshtml
+++ b/samples/MvcSample.Web/Views/Shared/MyView.cshtml
@@ -11,6 +11,29 @@
     };
 }
 
+@section header {
+    <style type="text/css">
+        #qux {
+            display: none;
+        }
+
+        #qux.foo {
+            color: red;
+        }
+    </style>
+}
+
+@section footer {
+    <script src="//ajax.aspnetcdn.com/ajax/jQuery/jquery-2.1.0.min.js"></script>
+    <script>
+        $(function () {
+            $("#qux").fadeIn(3000, function () {
+                $(this).addClass("foo")
+            });
+        });
+    </script>
+}
+
 @functions {
     public async Task<string> AsyncValueRetrieval()
     {
@@ -31,7 +54,7 @@
 </div>
 <div class="row">
     <h3 title="@Model.Name" class="@nullValue">Hello @Model.Name! Happy @Model.Age birthday.</h3>
-    <h3>This value was retrieved asynchronously: @(await AsyncValueRetrieval())</h3>
+    <h3 id ="qux">This value was retrieved asynchronously: @(await AsyncValueRetrieval())</h3>
     <h3>Partial Async: @await Html.PartialAsync("HelloWorldPartial", Model)</h3>
     <h3>Render Partial Async (Custom model): @{ await RenderHelloWorldPartial(new User()
                                                 {

--- a/samples/MvcSample.Web/Views/Shared/_Layout.cshtml
+++ b/samples/MvcSample.Web/Views/Shared/_Layout.cshtml
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>@ViewBag.Title - My ASP.NET Application</title>
     <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css" />
+    @RenderSection("header")
 </head>
 <body>
     <div class="navbar navbar-inverse navbar-fixed-top">
@@ -36,5 +37,6 @@
             <p>&copy; @DateTime.Now.Year - My ASP.NET Application</p>
         </footer>
     </div>
+    @RenderSection("footer")
 </body>
 </html>

--- a/src/Microsoft.AspNet.Mvc.Razor/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Properties/Resources.Designer.cs
@@ -59,6 +59,38 @@ namespace Microsoft.AspNet.Mvc.Razor
         }
 
         /// <summary>
+        /// Section '{0}' is already defined.
+        /// </summary>
+        internal static string SectionAlreadyDefined
+        {
+            get { return GetString("SectionAlreadyDefined"); }
+        }
+
+        /// <summary>
+        /// Section '{0}' is already defined.
+        /// </summary>
+        internal static string FormatSectionAlreadyDefined(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("SectionAlreadyDefined"), p0);
+        }
+
+        /// <summary>
+        /// Section '{0}' is not defined.
+        /// </summary>
+        internal static string SectionNotDefined
+        {
+            get { return GetString("SectionNotDefined"); }
+        }
+
+        /// <summary>
+        /// Section '{0}' is not defined.
+        /// </summary>
+        internal static string FormatSectionNotDefined(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("SectionNotDefined"), p0);
+        }
+
+        /// <summary>
         /// The partial view '{0}' was not found. The following locations were searched:{1}
         /// </summary>
         internal static string ViewEngine_PartialViewNotFound

--- a/src/Microsoft.AspNet.Mvc.Razor/Resources.resx
+++ b/src/Microsoft.AspNet.Mvc.Razor/Resources.resx
@@ -126,6 +126,12 @@
   <data name="RenderBodyCannotBeCalled" xml:space="preserve">
     <value>RenderBody can only be called from a layout page.</value>
   </data>
+  <data name="SectionAlreadyDefined" xml:space="preserve">
+    <value>Section '{0}' is already defined.</value>
+  </data>
+  <data name="SectionNotDefined" xml:space="preserve">
+    <value>Section '{0}' is not defined.</value>
+  </data>
   <data name="ViewEngine_PartialViewNotFound" xml:space="preserve">
     <value>The partial view '{0}' was not found. The following locations were searched:{1}</value>
   </data>

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/RazorViewTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/RazorViewTest.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Mvc.Rendering;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNet.Mvc.Razor.Test
+{
+    public class RazorViewTest
+    {
+        private const string LayoutPath = "~/Shared/_Layout.cshtml";
+
+        [Fact]
+        public async Task DefineSection_ThrowsIfSectionIsAlreadyDefined()
+        {
+            // Arrange
+            Exception ex = null;
+            var view = CreateView(v => {
+                v.DefineSection("foo", new HelperResult(action: null));
+
+                ex = Assert.Throws<InvalidOperationException>(
+                        () => v.DefineSection("foo", new HelperResult(action: null)));
+            });
+            var viewContext = CreateViewContext(layoutView: null);
+
+            // Act
+            await view.RenderAsync(viewContext);
+
+            // Assert
+            Assert.Equal("Section 'foo' is already defined.", ex.Message);
+        }
+
+        [Fact]
+        public async Task RenderSection_RendersSectionFromPreviousPage()
+        {
+            // Arrange
+            var expected = new HelperResult(action: null);
+            HelperResult actual = null;
+            var view = CreateView(v =>
+            {
+                v.DefineSection("bar", expected);
+                v.Layout = LayoutPath;
+            });
+            var layoutView = CreateView(v =>
+            {
+                actual = v.RenderSection("bar");
+            });
+            var viewContext = CreateViewContext(layoutView);
+
+            // Act
+            await view.RenderAsync(viewContext);
+
+            // Assert
+            Assert.Same(actual, expected);
+        }
+
+        [Fact]
+        public async Task RenderSection_ThrowsIfRequiredSectionIsNotFound()
+        {
+            // Arrange
+            var expected = new HelperResult(action: null);
+            Exception ex = null;
+            var view = CreateView(v =>
+            {
+                v.DefineSection("baz", expected);
+                v.Layout = LayoutPath;
+            });
+            var layoutView = CreateView(v =>
+            {
+                ex = Assert.Throws<InvalidOperationException>(
+                        () => v.RenderSection("bar"));
+            });
+            var viewContext = CreateViewContext(layoutView);
+
+            // Act
+            await view.RenderAsync(viewContext);
+
+            // Assert
+            Assert.Equal("Section 'bar' is not defined.", ex.Message);
+        }
+
+        public static RazorView CreateView(Action<RazorView> executeAction)
+        {
+            var view = new Mock<RazorView> { CallBase = true };
+            if (executeAction != null)
+            {
+                view.Setup(v => v.ExecuteAsync())
+                    .Callback(() => executeAction(view.Object))
+                    .Returns(Task.FromResult(0));
+            }
+
+            return view.Object;
+        }
+
+        private static ViewContext CreateViewContext(IView layoutView)
+        {
+            var viewFactory = new Mock<IVirtualPathViewFactory>();
+            viewFactory.Setup(v => v.CreateInstance(LayoutPath))
+                       .Returns(Task.FromResult(layoutView));
+            var serviceProvider = new Mock<IServiceProvider>();
+            serviceProvider.Setup(f => f.GetService(typeof(IVirtualPathViewFactory)))
+                            .Returns(viewFactory.Object);
+            return new ViewContext(serviceProvider.Object, httpContext: null, viewEngineContext: null)
+            {
+                Writer = new StringWriter()
+            };
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/project.json
@@ -1,10 +1,12 @@
 {
   "version" : "0.1-alpha-*",
   "dependencies": {
+    "Microsoft.AspNet.Abstractions": "0.1-alpha-*",
     "Microsoft.AspNet.FileSystems": "0.1-alpha-*",
     "Microsoft.AspNet.Razor": "0.1-alpha-*",
     "Microsoft.AspNet.Mvc.Razor" : "",
     "Microsoft.AspNet.Mvc.Razor.Host" : "",
+    "Microsoft.AspNet.Mvc.Rendering" : "",
     "Microsoft.AspNet.Testing" : "0.1-alpha-*",
     "Xunit.KRunner": "0.1-alpha-*",
     "xunit.abstractions": "2.0.0-aspnet-*",


### PR DESCRIPTION
Initial draft for DefineSection \ RenderSection. This change is based on
changes to the Razor parser to enable Razor to generate HelperResults for
section instead of void delegates.

Changes to Razor are available here: https://github.com/aspnet/Razor/compare/Sections?expand=1.
Not sending that as a PR until we figure out if the final design makes sense.
