### PR TITLE
Remove reduncant `ArgumentNullOrEmpty` resource from Core project

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Properties/Resources.Designer.cs
@@ -315,22 +315,6 @@ namespace Microsoft.AspNet.Mvc.Core
         }
 
         /// <summary>
-        /// The argument must not be null or empty.
-        /// </summary>
-        internal static string ArgumentNullOrEmpty
-        {
-            get { return GetString("ArgumentNullOrEmpty"); }
-        }
-
-        /// <summary>
-        /// The argument must not be null or empty.
-        /// </summary>
-        internal static string FormatArgumentNullOrEmpty()
-        {
-            return GetString("ArgumentNullOrEmpty");
-        }
-
-        /// <summary>
         /// Property '{0}' is of type '{1}', but this method requires a value of type '{2}'.
         /// </summary>
         internal static string ArgumentPropertyUnexpectedType
@@ -511,7 +495,7 @@ namespace Microsoft.AspNet.Mvc.Core
             var value = _resourceManager.GetString(name);
 
             System.Diagnostics.Debug.Assert(value != null);
-
+    
             if (formatterNames != null)
             {
                 for (var i = 0; i < formatterNames.Length; i++)

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/HtmlHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/HtmlHelper.cs
@@ -502,7 +502,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             var fullName = ViewData.TemplateInfo.GetFullHtmlFieldName(name);
             if (string.IsNullOrEmpty(fullName))
             {
-                throw new ArgumentException(Resources.ArgumentNullOrEmpty, "name");
+                throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, "name");
             }
 
             var tagBuilder = new TagBuilder("input");

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/TagBuilder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/TagBuilder.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         {
             if (string.IsNullOrEmpty(tagName))
             {
-                throw new ArgumentException(Resources.ArgumentNullOrEmpty, "tagName");
+                throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, "tagName");
             }
 
             TagName = tagName;
@@ -114,7 +114,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         {
             if (string.IsNullOrEmpty(key))
             {
-                throw new ArgumentException(Resources.ArgumentNullOrEmpty, "key");
+                throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, "key");
             }
 
             if (replaceExisting || !Attributes.ContainsKey(key))

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/View/ViewDataDictionary.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/View/ViewDataDictionary.cs
@@ -160,7 +160,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         {
             if (string.IsNullOrEmpty(expression))
             {
-                throw new ArgumentException(Resources.ArgumentNullOrEmpty, "expression");
+                throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, "expression");
             }
 
             return ViewDataEvaluator.Eval(this, expression);

--- a/src/Microsoft.AspNet.Mvc.Core/Resources.resx
+++ b/src/Microsoft.AspNet.Mvc.Core/Resources.resx
@@ -174,9 +174,6 @@
   <data name="ActionSelector_GetCandidateActionsIsAmbiguous" xml:space="preserve">
     <value>The supplied route values are ambiguous and can select multiple sets of actions.</value>
   </data>
-  <data name="ArgumentNullOrEmpty" xml:space="preserve">
-    <value>The argument must not be null or empty.</value>
-  </data>
   <data name="ArgumentPropertyUnexpectedType" xml:space="preserve">
     <value>Property '{0}' is of type '{1}', but this method requires a value of type '{2}'.</value>
   </data>

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/AssociatedMetadataProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/AssociatedMetadataProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         {
             if (string.IsNullOrEmpty(propertyName))
             {
-                throw new ArgumentException(Resources.FormatArgumentNullOrEmpty("propertyName"), "propertyName");
+                throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, "propertyName");
             }
 
             var typeInfo = GetTypeInformation(containerType);

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Properties/Resources.Designer.cs
@@ -11,19 +11,19 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             = new ResourceManager("Microsoft.AspNet.Mvc.ModelBinding.Resources", typeof(Resources).GetTypeInfo().Assembly);
 
         /// <summary>
-        /// The argument '{0}' is null or empty.
+        /// The value cannot be null or empty.
         /// </summary>
-        internal static string ArgumentNullOrEmpty
+        internal static string ArgumentCannotBeNullOrEmpty
         {
-            get { return GetString("ArgumentNullOrEmpty"); }
+            get { return GetString("ArgumentCannotBeNullOrEmpty"); }
         }
 
         /// <summary>
-        /// The argument '{0}' is null or empty.
+        /// The value cannot be null or empty.
         /// </summary>
-        internal static string FormatArgumentNullOrEmpty(object p0)
+        internal static string FormatArgumentCannotBeNullOrEmpty()
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("ArgumentNullOrEmpty"), p0);
+            return GetString("ArgumentCannotBeNullOrEmpty");
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Resources.resx
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Resources.resx
@@ -117,8 +117,8 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ArgumentNullOrEmpty" xml:space="preserve">
-    <value>The argument '{0}' is null or empty.</value>
+  <data name="ArgumentCannotBeNullOrEmpty" xml:space="preserve">
+    <value>The value cannot be null or empty.</value>
   </data>
   <data name="Common_PropertyNotFound" xml:space="preserve">
     <value>The property {0}.{1} could not be found.</value>

--- a/src/Microsoft.AspNet.Mvc.Razor/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Properties/Resources.Designer.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNet.Mvc.Razor
             = new ResourceManager("Microsoft.AspNet.Mvc.Razor.Resources", typeof(Resources).GetTypeInfo().Assembly);
 
         /// <summary>
-        /// Value cannot be null or empty.
+        /// The value cannot be null or empty.
         /// </summary>
         internal static string ArgumentCannotBeNullOrEmpty
         {
@@ -19,7 +19,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         }
 
         /// <summary>
-        /// Value cannot be null or empty.
+        /// The value cannot be null or empty.
         /// </summary>
         internal static string FormatArgumentCannotBeNullOrEmpty()
         {

--- a/src/Microsoft.AspNet.Mvc.Razor/Resources.resx
+++ b/src/Microsoft.AspNet.Mvc.Razor/Resources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ArgumentCannotBeNullOrEmpty" xml:space="preserve">
-    <value>Value cannot be null or empty.</value>
+    <value>The value cannot be null or empty.</value>
   </data>
   <data name="LayoutCannotBeLocated" xml:space="preserve">
     <value>The layout view '{0}' could not be located.</value>

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/AssociatedMetadataProviderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/AssociatedMetadataProviderTest.cs
@@ -83,11 +83,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test.Binders
             ExceptionAssert.ThrowsArgument(
                 () => provider.GetMetadataForProperty(modelAccessor: null, containerType: typeof(object), propertyName: null),
                 "propertyName",
-                "The argument 'propertyName' is null or empty.");
+                "The value cannot be null or empty.");
             ExceptionAssert.ThrowsArgument(
                 () => provider.GetMetadataForProperty(modelAccessor: null, containerType: typeof(object), propertyName: String.Empty),
                 "propertyName",
-                "The argument 'propertyName' is null or empty.");
+                "The value cannot be null or empty.");
         }
 
         [Fact]


### PR DESCRIPTION
Part 3 in Ryan's thrilling N part series!
- came from Rendering but Core already had `ArgumentCannotBeNullOrEmpty`
- moved wording from "argument must not be" to "value cannot be"

Also make similar resources consistent in this repo
- adjust Razor's `ArgumentCannotBeNullOrEmpty` resource to use same wording
  as Core, adding "The"
- update ModelBinding to also have `ArgumentCannotBeNullOrEmpty` and to use
  it consistently with Core and Razor
