### PR TITLE
Catch up with previous `ActionNameAttribute` addition

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/Microsoft.AspNet.Mvc.Core.kproj
+++ b/src/Microsoft.AspNet.Mvc.Core/Microsoft.AspNet.Mvc.Core.kproj
@@ -29,6 +29,7 @@
     <Compile Include="ActionInvokerFactory.cs" />
     <Compile Include="ActionInvokerProviderContext.cs" />
     <Compile Include="ActionMethodSelectorAttribute.cs" />
+    <Compile Include="ActionNameAttribute.cs" />
     <Compile Include="ActionResultFactory.cs" />
     <Compile Include="ActionResultHelper.cs" />
     <Compile Include="ActionResults\ContentResult.cs" />


### PR DESCRIPTION
Sending out as a FYI; will push to dev immediately
- note only .\build.cmd corrects these files; VS doesn't know anything about new or renamed files
