### PR TITLE
Sample should be built in VS

### DIFF
--- a/WebFx.sln
+++ b/WebFx.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30327.0
+VisualStudioVersion = 12.0.30408.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{DAAE4C74-D06F-4874-A166-33305D2643CE}"
 EndProject
@@ -119,6 +119,7 @@ Global
 		{A8AA326E-8EE8-4F11-B750-23028E0949D7}.Release|x86.Build.0 = Release|x86
 		{FBB2B86E-972B-4185-9FF2-62CAB5F8388F}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{FBB2B86E-972B-4185-9FF2-62CAB5F8388F}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{FBB2B86E-972B-4185-9FF2-62CAB5F8388F}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{FBB2B86E-972B-4185-9FF2-62CAB5F8388F}.Debug|x86.ActiveCfg = Debug|x86
 		{FBB2B86E-972B-4185-9FF2-62CAB5F8388F}.Debug|x86.Build.0 = Debug|x86
 		{FBB2B86E-972B-4185-9FF2-62CAB5F8388F}.Release|Any CPU.ActiveCfg = Release|x86


### PR DESCRIPTION
- catches errors because some methods are used only from views or controllers

@davidfowl the sample stopped building when you checked in your tooling changes.  But it works fine to have that project building in VS.  Any objection to this change?
