### PR TITLE
Reviving support for IValidatableObject in CoreCLR

### DIFF
--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Validation/DataAnnotationsModelValidatorProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Validation/DataAnnotationsModelValidatorProvider.cs
@@ -33,11 +33,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         private static Dictionary<Type, DataAnnotationsModelValidationFactory> AttributeFactories =
             new Dictionary<Type, DataAnnotationsModelValidationFactory>();
 
-#if NET45
         // Factories for IValidatableObject models
         private static DataAnnotationsValidatableObjectAdapterFactory DefaultValidatableFactory =
             () => new ValidatableObjectAdapter();
-#endif
 
         private static Dictionary<Type, DataAnnotationsValidatableObjectAdapterFactory> ValidatableFactories =
             new Dictionary<Type, DataAnnotationsValidatableObjectAdapterFactory>();
@@ -63,7 +61,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 results.Add(factory(attribute));
             }
 
-#if NET45
             // Produce a validator if the type supports IValidatableObject
             if (typeof(IValidatableObject).IsAssignableFrom(metadata.ModelType))
             {
@@ -74,7 +71,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 }
                 results.Add(factory());
             }
-#endif
 
             return results;
         }

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Validation/ValidatableObjectAdapter.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Validation/ValidatableObjectAdapter.cs
@@ -1,5 +1,4 @@
-﻿#if NET45
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
@@ -57,4 +56,3 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         }
     }
 }
-#endif

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Validation/DataAnnotationsModelValidatorProviderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Validation/DataAnnotationsModelValidatorProviderTest.cs
@@ -37,8 +37,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         }
 
         // Default IValidatableObject adapter factory
-
-#if NET45
         [Fact]
         public void IValidatableObjectGetsAValidator()
         {
@@ -53,7 +51,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             // Assert
             Assert.Single(validators);
         }
-#endif
 
         // Integration with metadata system
 


### PR DESCRIPTION
These were made Net45 specific at one point when DataAnnotations in CoreCLR did not have this interface. Reviving this ahead of WebFX-98
