### PR TITLE
Get CoreCLR test builds compiling again

### DIFF
--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Validation/DataAnnotationsModelValidatorProviderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Validation/DataAnnotationsModelValidatorProviderTest.cs
@@ -37,6 +37,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         }
 
         // Default IValidatableObject adapter factory
+
+#if NET45
         [Fact]
         public void IValidatableObjectGetsAValidator()
         {
@@ -51,6 +53,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             // Assert
             Assert.Single(validators);
         }
+#endif
 
         // Integration with metadata system
 


### PR DESCRIPTION
- no Mock without .NET 4.5
- reverts part of "Reviving support for IValidatableObject in CoreCLR"
- that was commit 0f6df5405bb2d9acae42c094d61a0df8859ee3ad

@pranavkm can you have a look?
