### PR TITLE
Created in memory tests for the MvcSample.

### DIFF
--- a/WebFx.sln
+++ b/WebFx.sln
@@ -29,6 +29,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "MvcSample.Web", "samples\Mv
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.Mvc.Razor.Host", "src\Microsoft.AspNet.Mvc.Razor.Host\Microsoft.AspNet.Mvc.Razor.Host.kproj", "{520B3AA4-363A-497C-8C15-80423C5AFC85}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "MvcSample.Web.Tests", "test\MvcSample.Web.Tests\MvcSample.Web.Tests.kproj", "{09B868DC-4C72-4C97-A587-E6651D6424B0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -139,6 +141,16 @@ Global
 		{520B3AA4-363A-497C-8C15-80423C5AFC85}.Release|Mixed Platforms.Build.0 = Release|x86
 		{520B3AA4-363A-497C-8C15-80423C5AFC85}.Release|x86.ActiveCfg = Release|x86
 		{520B3AA4-363A-497C-8C15-80423C5AFC85}.Release|x86.Build.0 = Release|x86
+		{09B868DC-4C72-4C97-A587-E6651D6424B0}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{09B868DC-4C72-4C97-A587-E6651D6424B0}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{09B868DC-4C72-4C97-A587-E6651D6424B0}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{09B868DC-4C72-4C97-A587-E6651D6424B0}.Debug|x86.ActiveCfg = Debug|x86
+		{09B868DC-4C72-4C97-A587-E6651D6424B0}.Debug|x86.Build.0 = Debug|x86
+		{09B868DC-4C72-4C97-A587-E6651D6424B0}.Release|Any CPU.ActiveCfg = Release|x86
+		{09B868DC-4C72-4C97-A587-E6651D6424B0}.Release|Mixed Platforms.ActiveCfg = Release|x86
+		{09B868DC-4C72-4C97-A587-E6651D6424B0}.Release|Mixed Platforms.Build.0 = Release|x86
+		{09B868DC-4C72-4C97-A587-E6651D6424B0}.Release|x86.ActiveCfg = Release|x86
+		{09B868DC-4C72-4C97-A587-E6651D6424B0}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -154,5 +166,6 @@ Global
 		{A8AA326E-8EE8-4F11-B750-23028E0949D7} = {3BA657BF-28B1-42DA-B5B0-1C4601FCF7B1}
 		{FBB2B86E-972B-4185-9FF2-62CAB5F8388F} = {DAAE4C74-D06F-4874-A166-33305D2643CE}
 		{520B3AA4-363A-497C-8C15-80423C5AFC85} = {32285FA4-6B46-4D6B-A840-2B13E4C8B58E}
+		{09B868DC-4C72-4C97-A587-E6651D6424B0} = {3BA657BF-28B1-42DA-B5B0-1C4601FCF7B1}
 	EndGlobalSection
 EndGlobal

--- a/global.json
+++ b/global.json
@@ -1,3 +1,3 @@
 {
-    "sources": ["src"]
+    "sources": ["src", "samples"]
 }

--- a/samples/MvcSample.Web/Startup.cs
+++ b/samples/MvcSample.Web/Startup.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNet.Abstractions;
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.AspNet.Abstractions;
 using Microsoft.AspNet.DependencyInjection;
 using Microsoft.AspNet.DependencyInjection.Fallback;
 using Microsoft.AspNet.Mvc;
@@ -11,12 +13,22 @@ namespace MvcSample.Web
     {
         public void Configuration(IBuilder builder)
         {
+            // This is a temporary change until we figure out a way to replace services already configured.
+            var services = CreateServices();
+            var serviceProvider = services.BuildServiceProvider(builder.ServiceProvider);
+            ConfigurationCore(builder, serviceProvider);
+        }
+
+        public ServiceCollection CreateServices()
+        {
             var services = new ServiceCollection();
             services.Add(MvcServices.GetDefaultServices());
             services.AddSingleton<PassThroughAttribute, PassThroughAttribute>();
+            return services;
+        }
 
-            var serviceProvider = services.BuildServiceProvider(builder.ServiceProvider);
-
+        public void ConfigurationCore(IBuilder builder, IServiceProvider serviceProvider)
+        {
             var routes = new RouteCollection()
             {
                 DefaultHandler = new MvcApplication(serviceProvider),

--- a/test/MvcSample.Web.Tests/MvcSample.Web.Tests.kproj
+++ b/test/MvcSample.Web.Tests/MvcSample.Web.Tests.kproj
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">12.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\ProjectK\Microsoft.Web.ProjectK.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>09b868dc-4c72-4c97-a587-e6651d6424b0</ProjectGuid>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'" Label="Configuration">
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Content Include="Project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MvcSampleTests.cs" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\ProjectK\Microsoft.Web.ProjectK.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/MvcSample.Web.Tests/MvcSampleTests.cs
+++ b/test/MvcSample.Web.Tests/MvcSampleTests.cs
@@ -1,0 +1,177 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.Versioning;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Abstractions;
+using Microsoft.AspNet.DependencyInjection;
+using Microsoft.AspNet.DependencyInjection.Fallback;
+using Microsoft.AspNet.Mvc;
+using Microsoft.AspNet.TestHost;
+using Microsoft.Net.Runtime;
+using Xunit;
+using System.Collections.Generic;
+
+namespace MvcSample.Web.Tests
+{
+    public class MvcSampleTests
+    {
+        private readonly IServiceProvider _provider;
+
+        public MvcSampleTests()
+        {
+            _provider = new ServiceCollection()
+                .AddSingleton<IApplicationEnvironment, MockApplicationEnvironment>()
+                .BuildServiceProvider();
+        }
+
+        Action<IBuilder> app = app =>
+            {
+                var startup = new Startup();
+                var mockAssemblyProvider = new ControllerAssemblyProvider(typeof(Startup).GetTypeInfo().Assembly);
+
+                var services = startup.CreateServices();
+                services.AddInstance<IControllerAssemblyProvider>(mockAssemblyProvider);
+                startup.ConfigurationCore(app, services.BuildServiceProvider(app.ServiceProvider));
+            };
+
+        [Theory]
+        [InlineData("http://localhost/Link/", "http://localhost/?action=Details#CoolBeans!")]
+        [InlineData("http://localhost/Link/Link1", "/")]
+        [InlineData("http://localhost/Link/Link2", "/Link/Link2")]
+        [InlineData("http://localhost/Link/About", "/Link/About")]
+        public async Task LinkController_Works(string url, string result)
+        {
+            // Arrange
+            var testServer = TestServer.Create(_provider, app);
+
+            // When we have HttpClient we'll only need to substitute this line for new HttpClient(testServer.Handler)
+            // the rest of the API will be equivalent.
+            var client = testServer.Handler;
+
+            // Act
+            var response = await client.GetStringAsync(url);
+
+            // Assert
+            Assert.Equal(result, response);
+        }
+
+        [Theory]
+        [InlineData("http://localhost/Overload/", "Get()")]
+        [InlineData("http://localhost/Overload?id=1", "Get(id)")]
+        [InlineData("http://localhost/Overload?id=1&name=Ryan", "Get(id, name)")]
+        public async Task OverloadController_Works(string url, string responseContent)
+        {
+            // Arrange
+            var testServer = TestServer.Create(_provider, app);
+            var client = testServer.Handler;
+
+            // Act
+            var response = await client.GetStringAsync(url);
+
+            // Assert
+            Assert.Equal(responseContent, response);
+        }
+
+        [Fact]
+        public async Task SimplePocoController_Works()
+        {
+            // Arrange
+            var testServer = TestServer.Create(_provider, app);
+            var client = testServer.Handler;
+
+            // Act
+            var response = await client.GetStringAsync("http://localhost:12345/SimplePoco/");
+
+            // Assert
+            Assert.Equal("Hello world", response);
+        }
+
+        [Fact]
+        public async Task SimpleRest_Works()
+        {
+            // Arrange
+            var testServer = TestServer.Create(_provider, app);
+            var client = testServer.Handler;
+
+            // Act
+            var response = await client.GetStringAsync("http://localhost:12345/SimpleRest/");
+
+            // Assert
+            Assert.Equal("Get method", response);
+        }
+
+        [Theory]
+        [InlineData("http://localhost:12345/Home/Something", "Hello World From Content")]
+        [InlineData("http://localhost:12345/Home/Hello", "Hello World")]
+        [InlineData("http://localhost:12345/Home/Raw", "Hello World raw")]
+        [InlineData("http://localhost:12345/Home/User", @"{""Name"":""My name"",""Address"":""My address"",""Age"":13,""GPA"":13.37,""Dependent"":{""Name"":""Dependents name"",""Address"":""Dependents address"",""Age"":0,""GPA"":0.0,""Dependent"":null,""Alive"":false,""Password"":null},""Alive"":true,""Password"":""Secure string""}")]
+        public async Task HomeController_Works_NonViewActions(string url, string result)
+        {
+            // Arrange
+            var testServer = TestServer.Create(_provider, app);
+            var client = testServer.Handler;
+
+            // Act
+            var response = await client.GetStringAsync(url);
+
+            // Assert
+            Assert.Equal(result, response);
+        }
+
+        [Theory]
+        [InlineData("http://localhost:12345/Home2/", "Hello World: my namespace is MvcSample.Web.RandomNameSpace")]
+        [InlineData("http://localhost:12345/Home2/Something", "Hello World From Content")]
+        [InlineData("http://localhost:12345/Home2/Hello", "Hello World")]
+        [InlineData("http://localhost:12345/Home2/Raw", "Hello World raw")]
+        [InlineData("http://localhost:12345/Home2/UserJson", @"{""Name"":""User Name"",""Address"":""Home Address"",""Age"":0,""GPA"":0.0,""Dependent"":null,""Alive"":false,""Password"":null}")]
+        [InlineData("http://localhost:12345/Home2/User", @"{""Name"":""User Name"",""Address"":""Home Address"",""Age"":0,""GPA"":0.0,""Dependent"":null,""Alive"":false,""Password"":null}")]
+        public async Task Home2Controller_Works(string url, string result)
+        {
+            // Arrange
+            var testServer = TestServer.Create(_provider, app);
+            var client = testServer.Handler;
+
+            // Act
+            var response = await client.GetStringAsync(url);
+
+            // Assert
+            Assert.Equal(result, response);
+        }
+
+        public class ControllerAssemblyProvider : IControllerAssemblyProvider
+        {
+            private Assembly _assembly;
+            public ControllerAssemblyProvider([NotNull]Assembly assembly)
+            {
+                _assembly = assembly;
+            }
+            public IEnumerable<Assembly> CandidateAssemblies
+            {
+                get { yield return _assembly; }
+            }
+        }
+
+        private class MockApplicationEnvironment : IApplicationEnvironment
+        {
+            public string ApplicationName
+            {
+                get { return "Test"; }
+            }
+
+            public string Version
+            {
+                get { return "1.0.0.0"; }
+            }
+
+            public string ApplicationBasePath
+            {
+                get { return "."; }
+            }
+
+            public FrameworkName TargetFramework
+            {
+                get { return new FrameworkName(".NETFramework", new Version(4, 5)); }
+            }
+        }
+    }
+}

--- a/test/MvcSample.Web.Tests/Project.json
+++ b/test/MvcSample.Web.Tests/Project.json
@@ -1,0 +1,53 @@
+﻿{
+  "version" : "0.1-alpha-*",
+  "dependencies": {
+    "Common": "",
+    "TestCommon": "",
+    "MvcSample.Web": "",
+    "Xunit.KRunner": "0.1-alpha-*",
+    "xunit.abstractions": "2.0.0-aspnet-*",
+    "xunit.assert": "2.0.0-aspnet-*",
+    "xunit.core": "2.0.0-aspnet-*",
+    "xunit.execution": "2.0.0-aspnet-*",
+    "Microsoft.AspNet.Abstractions": "0.1-alpha-*",
+    "Microsoft.AspNet.ConfigurationModel": "0.1-alpha-*",
+    "Microsoft.AspNet.DependencyInjection": "0.1-alpha-*",
+    "Microsoft.AspNet.FeatureModel": "0.1-alpha-*",
+    "Microsoft.AspNet.Hosting": "0.1-alpha-*",
+    "Microsoft.AspNet.TestHost": "0.1-alpha-*",
+    "Microsoft.AspNet.HttpFeature": "0.1-alpha-*",
+    "Microsoft.AspNet.RequestContainer": "0.1-alpha-*",
+    "Microsoft.AspNet.Routing": "0.1-alpha-*",
+    "Microsoft.AspNet.Mvc": "",
+    "Microsoft.AspNet.Mvc.Core": "",
+    "Microsoft.AspNet.Mvc.ModelBinding": "",
+    "Microsoft.AspNet.Mvc.Razor": "",
+    "Microsoft.AspNet.Mvc.Razor.Host": "",
+    "Microsoft.AspNet.PipelineCore": "0.1-alpha-*",
+    "Microsoft.AspNet.Security.DataProtection": "0.1-alpha-*",
+    "Microsoft.ComponentModel.DataAnnotations": "4.0.10.0"
+  },
+  "commands": {
+    "test": "Xunit.KRunner"
+  },
+  "configurations": {
+    "k10": {
+        "dependencies": {
+            "System.Runtime": "4.0.20.0",
+            "System.Runtime.Extensions": "4.0.10.0",
+            "System.Reflection": "4.0.10.0",
+            "System.Reflection.Extensions": "4.0.0.0"
+        }
+    },
+    "net45": {
+        "dependencies": {
+            "System.Reflection": "4.0.10.0",
+            "System.Runtime": "4.0.20.0",
+            "System.Runtime.Extensions": "4.0.10.0",
+            "System.Threading": "4.0.0.0",
+            "System.Threading.Tasks": "4.0.10.0",
+            "System.Threading.Thread": "4.0.0.0"
+        }
+    }
+  }
+}


### PR DESCRIPTION
1. Created a new project to hold in memory tests for the MvcSample.
2. Refactored MvcSample startup to enable mocking IControllerAssemblyProvider until we have a way to replace already configured services.
3. Automated all the endpoints in the MvcSample that don't return views.
