### PR TITLE
Modify search location for views.

### DIFF
--- a/test/Microsoft.AspNet.Mvc.Razor.Test/Microsoft.AspNet.Mvc.Razor.Test.kproj
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/Microsoft.AspNet.Mvc.Razor.Test.kproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <Compile Include="MvcRazorCodeParserTest.cs" />
     <Compile Include="RazorCompilationServiceTest.cs" />
+    <Compile Include="RazorViewEngineTest.cs" />
     <Compile Include="RazorViewTest.cs" />
     <Compile Include="SpanFactory.cs" />
   </ItemGroup>

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/RazorViewEngineTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/RazorViewEngineTest.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.AspNet.Mvc.Rendering;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNet.Mvc.Razor.Test
+{
+    public class RazorViewEngineTest
+    {
+        private static readonly Dictionary<string, object> _areaTestContext = new Dictionary<string, object>()
+        {
+            {"area", "foo"},
+            {"controller", "bar"},
+        };
+
+        private static readonly Dictionary<string, object> _controllerTestContext = new Dictionary<string, object>()
+        {
+            {"controller", "bar"},
+        };
+
+        [Fact]
+        public void FindPartialViewFailureSearchesCorrectLocationsWithAreas()
+        {
+            // Arrange
+            var searchedLocations = new List<string>();
+            var viewEngine = CreateSearchLocationViewEngineTester();
+
+            // Act
+            var result = viewEngine.FindPartialView(_areaTestContext, "partial");
+            
+            // Assert
+            Assert.False(result.Success);
+            Assert.Equal(new[] { 
+                "/Areas/foo/Views/bar/partial.cshtml", 
+                "/Areas/foo/Views/Shared/partial.cshtml", 
+                "/Views/Shared/partial.cshtml",
+            }, result.SearchedLocations);
+        }
+
+        [Fact]
+        public void FindPartialViewFailureSearchesCorrectLocationsWithoutAreas()
+        {
+            // Arrange
+            var viewEngine = CreateSearchLocationViewEngineTester();
+
+            // Act
+            var result = viewEngine.FindPartialView(_controllerTestContext, "partialNoArea");
+
+            // Assert
+            Assert.False(result.Success);
+            Assert.Equal(new[] { 
+                "/Views/bar/partialNoArea.cshtml", 
+                "/Views/Shared/partialNoArea.cshtml",
+            }, result.SearchedLocations);
+        }
+
+        [Fact]
+        public void FindViewFailureSearchesCorrectLocationsWithAreas()
+        {
+            // Arrange
+            var viewEngine = CreateSearchLocationViewEngineTester();
+
+            // Act
+            var result = viewEngine.FindView(_areaTestContext, "full");
+
+            // Assert
+            Assert.False(result.Success);
+            Assert.Equal(new[] { 
+                "/Areas/foo/Views/bar/full.cshtml", 
+                "/Areas/foo/Views/Shared/full.cshtml", 
+                "/Views/Shared/full.cshtml",
+            }, result.SearchedLocations);
+        }
+
+        [Fact]
+        public void FindViewFailureSearchesCorrectLocationsWithoutAreas()
+        {
+            // Arrange
+            var viewEngine = CreateSearchLocationViewEngineTester();
+
+            // Act
+            var result = viewEngine.FindView(_controllerTestContext, "fullNoArea");
+
+            // Assert
+            Assert.False(result.Success);
+            Assert.Equal(new[] { 
+                "/Views/bar/fullNoArea.cshtml", 
+                "/Views/Shared/fullNoArea.cshtml",
+            }, result.SearchedLocations);
+        }
+
+        private IViewEngine CreateSearchLocationViewEngineTester()
+        {
+            var virtualPathFactory = new Mock<IVirtualPathViewFactory>();
+            virtualPathFactory.Setup(vpf => vpf.CreateInstance(It.IsAny<string>())).Returns<IView>(null);
+
+            var viewEngine = new RazorViewEngine(virtualPathFactory.Object);
+
+            return viewEngine;
+        }
+    }
+}


### PR DESCRIPTION
When areas are not provided area locations are not searched for views.

This is in reference to https://github.com/aspnet/WebFx/issues/206.  It does not enable non ".cshtml" extensions to be used but it does fix the search locations that are displayed when invalid views are requested.
