### PR TITLE
Made some changes to the MvcApplication class

### DIFF
--- a/samples/MvcSample.Web/Startup.cs
+++ b/samples/MvcSample.Web/Startup.cs
@@ -19,7 +19,7 @@ namespace MvcSample.Web
 
             var routes = new RouteCollection()
             {
-                DefaultHandler = new MvcApplication(serviceProvider),
+                DefaultHandler = new MvcRouteHandler(),
             };
 
             // TODO: Add support for route constraints, so we can potentially constrain by existing routes

--- a/src/Microsoft.AspNet.Mvc.Core/Microsoft.AspNet.Mvc.Core.kproj
+++ b/src/Microsoft.AspNet.Mvc.Core/Microsoft.AspNet.Mvc.Core.kproj
@@ -113,7 +113,7 @@
     <Compile Include="IParameterDescriptorFactory.cs" />
     <Compile Include="IUrlHelper.cs" />
     <Compile Include="JsonOutputFormatter.cs" />
-    <Compile Include="MvcApplication.cs" />
+    <Compile Include="MvcRouteHandler.cs" />
     <Compile Include="NonActionAttribute.cs" />
     <Compile Include="ParameterBindingInfo.cs" />
     <Compile Include="ParameterBinding\ActionBindingContext.cs" />

--- a/src/Microsoft.AspNet.Mvc.Core/MvcRouteHandler.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/MvcRouteHandler.cs
@@ -11,15 +11,8 @@ using Microsoft.AspNet.Routing;
 
 namespace Microsoft.AspNet.Mvc
 {
-    public class MvcApplication : IRouter
+    public class MvcRouteHandler : IRouter
     {
-        private readonly IServiceProvider _serviceProvider;
-
-        public MvcApplication([NotNull] IServiceProvider serviceProvider)
-        {
-            _serviceProvider = serviceProvider;
-        }
-
         public string GetVirtualPath([NotNull] VirtualPathContext context)
         {
             // The contract of this method is to check that the values coming in from the route are valid;
@@ -81,7 +74,7 @@ namespace Microsoft.AspNet.Mvc
                 return null;
             }
 
-            var applicationServices = httpContext.ApplicationServices ?? _serviceProvider;
+            var applicationServices = httpContext.ApplicationServices;
 
             var scopeFactory = applicationServices.GetService<IServiceScopeFactory>();
             var scope = scopeFactory.CreateScope();


### PR DESCRIPTION
- Renamed it to MvcRouteHandler
- Removed required IServiceProvider ctor param.
- The HttpContext flows the application services through to MVC. This does
  require a call to app.UseContainer in order for things to work but that should be fine.
  This will be the pattern we use for all frameworks going forward and we'll need to have some
  good error handling around this area when things aren't wired up properly.

/cc @Praburaj @victorhurdugaci 

This will require changes to the samples we have
#258 #257
