### PR TITLE
Cleaning up more warnings

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/EmptyResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/EmptyResult.cs
@@ -11,9 +11,11 @@ namespace Microsoft.AspNet.Mvc
             get { return _singleton; }
         }
 
+        #pragma warning disable 1998
         public async Task ExecuteResultAsync(ActionContext context)
         {
             context.HttpContext.Response.StatusCode = 204;
         }
+        #pragma warning restore 1998
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/HttpStatusCodeResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/HttpStatusCodeResult.cs
@@ -11,9 +11,11 @@ namespace Microsoft.AspNet.Mvc
             _statusCode = statusCode;
         }
 
+        #pragma warning disable 1998
         public async Task ExecuteResultAsync(ActionContext context)
         {
             context.HttpContext.Response.StatusCode = _statusCode;
         }
+        #pragma warning restore 1998
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/JsonResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/JsonResult.cs
@@ -59,6 +59,7 @@ namespace Microsoft.AspNet.Mvc
             }
         }
 
+        #pragma warning disable 1998
         public async Task ExecuteResultAsync(ActionContext context)
         {
             HttpResponse response = context.HttpContext.Response;
@@ -76,5 +77,6 @@ namespace Microsoft.AspNet.Mvc
                 formatter.WriteObject(writer, _returnValue);
             }
         }
+        #pragma warning restore 1998
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/RedirectResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/RedirectResult.cs
@@ -27,6 +27,7 @@ namespace Microsoft.AspNet.Mvc
 
         public string Url { get; private set; }
 
+        #pragma warning disable 1998
         public async Task ExecuteResultAsync([NotNull] ActionContext context)
         {
             // It is redirected directly to the input URL.
@@ -34,5 +35,6 @@ namespace Microsoft.AspNet.Mvc
             // only when relative URLs are supported. (Issue - WEBFX-202)
             context.HttpContext.Response.Redirect(Url, Permanent);
         }
+        #pragma warning restore 1998
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/RedirectToActionResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/RedirectToActionResult.cs
@@ -33,6 +33,7 @@ namespace Microsoft.AspNet.Mvc
 
         public bool Permanent { get; private set; }
 
+        #pragma warning disable 1998
         public async Task ExecuteResultAsync([NotNull] ActionContext context)
         {
             var destinationUrl = UrlHelper.Action(ActionName, ControllerName, RouteValues);
@@ -44,5 +45,6 @@ namespace Microsoft.AspNet.Mvc
 
             context.HttpContext.Response.Redirect(destinationUrl, Permanent);
         }
+        #pragma warning restore 1998
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/RedirectToRouteResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/RedirectToRouteResult.cs
@@ -26,6 +26,7 @@ namespace Microsoft.AspNet.Mvc
 
         public bool Permanent { get; private set; }
 
+        #pragma warning disable 1998
         public async Task ExecuteResultAsync([NotNull] ActionContext context)
         {
             var destinationUrl = UrlHelper.RouteUrl(RouteValues);
@@ -37,5 +38,6 @@ namespace Microsoft.AspNet.Mvc
 
             context.HttpContext.Response.Redirect(destinationUrl, Permanent);
         }
+        #pragma warning restore 1998
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ViewComponents/JsonViewComponentResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ViewComponents/JsonViewComponentResult.cs
@@ -43,9 +43,11 @@ namespace Microsoft.AspNet.Mvc
             formatter.WriteObject(context.Writer, _value);
         }
 
+        #pragma warning disable 1998
         public async Task ExecuteAsync([NotNull] ViewComponentContext context)
         {
             Execute(context);
         }
+        #pragma warning restore 1998
     }
 }


### PR DESCRIPTION
These are the cases where an interface returns Task, but our
implementation is synchronous. In these cases we prefer to declare the
method as async and suppress, because this keeps the exception semantics
the same as a 'true' async method.
