### PR TITLE
Reintroduce `IHtmlHelper` and use it everywhere possible

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/Controller.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Controller.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNet.Mvc
 
         public IUrlHelper Url { get; set; }
 
-        public ViewDataDictionary<object> ViewData { get; set; }
+        public ViewDataDictionary ViewData { get; set; }
 
         public dynamic ViewBag
         {

--- a/src/Microsoft.AspNet.Mvc.Core/DefaultControllerFactory.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/DefaultControllerFactory.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNet.Mvc
         {
             Injector.InjectProperty(controller, "ActionContext", actionContext);
 
-            var viewData = new ViewDataDictionary<object>(
+            var viewData = new ViewDataDictionary(
                 _serviceProvider.GetService<IModelMetadataProvider>(),
                 actionContext.ModelState);
             Injector.InjectProperty(controller, "ViewData", viewData);

--- a/src/Microsoft.AspNet.Mvc.Core/Microsoft.AspNet.Mvc.Core.kproj
+++ b/src/Microsoft.AspNet.Mvc.Core/Microsoft.AspNet.Mvc.Core.kproj
@@ -182,6 +182,7 @@
     <Compile Include="Rendering\Html\TemplateRenderer.cs" />
     <Compile Include="Rendering\Html\ValidationHelpers.cs" />
     <Compile Include="Rendering\ICanHasViewContext.cs" />
+    <Compile Include="Rendering\IHtmlHelper.cs" />
     <Compile Include="Rendering\IHtmlHelperOfT.cs" />
     <Compile Include="Rendering\IView.cs" />
     <Compile Include="Rendering\IViewEngine.cs" />

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/DefaultDisplayTemplates.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/DefaultDisplayTemplates.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
 {
     public static class DefaultDisplayTemplates
     {
-        public static string BooleanTemplate(IHtmlHelper<object> html)
+        public static string BooleanTemplate(IHtmlHelper html)
         {
             bool? value = null;
             if (html.ViewData.Model != null)
@@ -39,7 +39,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return inputTag.ToString(TagRenderMode.SelfClosing);
         }
 
-        private static string BooleanTemplateDropDownList(IHtmlHelper<object> html, bool? value)
+        private static string BooleanTemplateDropDownList(IHtmlHelper html, bool? value)
         {
             var selectTag = new TagBuilder("select");
             selectTag.AddCssClass("list-box");
@@ -86,7 +86,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             };
         }
 
-        public static string CollectionTemplate(IHtmlHelper<object> html)
+        public static string CollectionTemplate(IHtmlHelper html)
         {
             var model = html.ViewData.ModelMetadata.Model;
             if (model == null)
@@ -158,7 +158,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             }
         }
 
-        public static string DecimalTemplate(IHtmlHelper<object> html)
+        public static string DecimalTemplate(IHtmlHelper html)
         {
             if (html.ViewData.TemplateInfo.FormattedModelValue == html.ViewData.ModelMetadata.Model)
             {
@@ -169,7 +169,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return StringTemplate(html);
         }
 
-        public static string EmailAddressTemplate(IHtmlHelper<object> html)
+        public static string EmailAddressTemplate(IHtmlHelper html)
         {
             var uriString = "mailto:" + ((html.ViewData.Model == null) ? string.Empty : html.ViewData.Model.ToString());
             var linkedText = (html.ViewData.TemplateInfo.FormattedModelValue == null) ?
@@ -179,18 +179,18 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return HyperlinkTemplate(uriString, linkedText);
         }
 
-        public static string HiddenInputTemplate(IHtmlHelper<object> html)
+        public static string HiddenInputTemplate(IHtmlHelper html)
         {
             // TODO: add ModelMetadata.HideSurroundingHtml and use here (return string.Empty)
             return StringTemplate(html);
         }
 
-        public static string HtmlTemplate(IHtmlHelper<object> html)
+        public static string HtmlTemplate(IHtmlHelper html)
         {
             return html.ViewData.TemplateInfo.FormattedModelValue.ToString();
         }
 
-        public static string ObjectTemplate(IHtmlHelper<object> html)
+        public static string ObjectTemplate(IHtmlHelper html)
         {
             var viewData = html.ViewData;
             var templateInfo = viewData.TemplateInfo;
@@ -261,12 +261,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 !templateInfo.Visited(metadata);
         }
 
-        public static string StringTemplate(IHtmlHelper<object> html)
+        public static string StringTemplate(IHtmlHelper html)
         {
             return html.Encode(html.ViewData.TemplateInfo.FormattedModelValue);
         }
 
-        public static string UrlTemplate(IHtmlHelper<object> html)
+        public static string UrlTemplate(IHtmlHelper html)
         {
             var uriString = (html.ViewData.Model == null) ? string.Empty : html.ViewData.Model.ToString();
             var linkedText = (html.ViewData.TemplateInfo.FormattedModelValue == null) ?

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/HtmlHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/HtmlHelper.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
     /// <summary>
     /// Default implementation of non-generic portions of <see cref="IHtmlHelper{T}">.
     /// </summary>
-    public class HtmlHelper : ICanHasViewContext
+    public class HtmlHelper : IHtmlHelper, ICanHasViewContext
     {
         public static readonly string ValidationInputCssClassName = "input-validation-error";
         public static readonly string ValidationInputValidCssClassName = "input-validation-valid";
@@ -52,8 +52,10 @@ namespace Microsoft.AspNet.Mvc.Rendering
             IdAttributeDotReplacement = "_";
         }
 
+        /// <inheritdoc />
         public string IdAttributeDotReplacement { get; set; }
 
+        /// <inheritdoc />
         public ViewContext ViewContext
         {
             get
@@ -71,6 +73,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             }
         }
 
+        /// <inheritdoc />
         public dynamic ViewBag
         {
             get
@@ -79,6 +82,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             }
         }
 
+        /// <inheritdoc />
         public ViewDataDictionary ViewData
         {
             get
@@ -89,6 +93,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
         protected IModelMetadataProvider MetadataProvider { get; private set; }
 
+        /// <inheritdoc />
         public HtmlString ActionLink(
             [NotNull] string linkText, 
             string actionName, 
@@ -161,11 +166,13 @@ namespace Microsoft.AspNet.Mvc.Rendering
             ViewContext = viewContext;
         }
 
+        /// <inheritdoc />
         public HtmlString AntiForgeryToken()
         {
             return _antiForgeryInstance.GetHtml(ViewContext.HttpContext);
         }
 
+        /// <inheritdoc />
         public MvcForm BeginForm(string actionName, string controllerName, object routeValues, FormMethod method,
                                  object htmlAttributes)
         {
@@ -179,37 +186,44 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return GenerateForm(actionName, controllerName, routeValues, method, htmlAttributeDictionary);
         }
 
+        /// <inheritdoc />
         public void EndForm()
         {
             var mvcForm = CreateForm();
             mvcForm.EndForm();
         }
 
+        /// <inheritdoc />
         public HtmlString CheckBox(string name, bool? isChecked, object htmlAttributes)
         {
             return GenerateCheckBox(metadata: null, name: name, isChecked: isChecked, htmlAttributes: htmlAttributes);
         }
 
+        /// <inheritdoc />
         public string Encode(string value)
         {
             return (!string.IsNullOrEmpty(value)) ? WebUtility.HtmlEncode(value) : string.Empty;
         }
 
+        /// <inheritdoc />
         public string Encode(object value)
         {
             return value != null ? WebUtility.HtmlEncode(value.ToString()) : string.Empty;
         }
 
+        /// <inheritdoc />
         public string FormatValue(object value, string format)
         {
             return ViewDataDictionary.FormatValue(value, format);
         }
 
+        /// <inheritdoc />
         public string GenerateIdFromName([NotNull] string name)
         {
             return TagBuilder.CreateSanitizedId(name, IdAttributeDotReplacement);
         }
 
+        /// <inheritdoc />
         public HtmlString Display(string expression,
                                   string templateName,
                                   string htmlFieldName,
@@ -223,6 +237,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                                    additionalViewData);
         }
 
+        /// <inheritdoc />
         public HtmlString DisplayForModel(string templateName,
                                           string htmlFieldName,
                                           object additionalViewData)
@@ -232,7 +247,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
                                    templateName,
                                    additionalViewData);
         }
-        
+
+        /// <inheritdoc />
         public HtmlString DisplayName(string expression)
         {
             var modelMetadata = string.IsNullOrEmpty(expression) ?
@@ -245,6 +261,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
 
+        /// <inheritdoc />
         public HtmlString DropDownList(string name, IEnumerable<SelectListItem> selectList, string optionLabel,
             object htmlAttributes)
         {
@@ -256,13 +273,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 htmlAttributes: htmlAttributes);
         }
 
+        /// <inheritdoc />
         public HtmlString Hidden(string name, object value, object htmlAttributes)
         {
             return GenerateHidden(metadata: null, name: name, value: value, useViewData: (value == null),
                 htmlAttributes: htmlAttributes);
         }
-        
 
+        /// <inheritdoc />
         public HtmlString Label(string expression, string labelText, object htmlAttributes)
         {
             var modelMetadata = string.IsNullOrEmpty(expression)?
@@ -278,12 +296,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
                             htmlAttributes);
         }
 
+        /// <inheritdoc />
         public virtual HtmlString Name(string name)
         {
             var fullName = ViewData.TemplateInfo.GetFullHtmlFieldName(name);
             return new HtmlString(Encode(fullName));
         }
 
+        /// <inheritdoc />
         public async Task<HtmlString> PartialAsync([NotNull] string partialViewName, object model,
                                                    ViewDataDictionary viewData)
         {
@@ -295,6 +315,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             }
         }
 
+        /// <inheritdoc />
         public Task RenderPartialAsync([NotNull] string partialViewName, object model, ViewDataDictionary viewData)
         {
             return RenderPartialCoreAsync(partialViewName, model, viewData, ViewContext.Writer);
@@ -351,27 +372,32 @@ namespace Microsoft.AspNet.Mvc.Rendering
             }
         }
 
+        /// <inheritdoc />
         public HtmlString Password(string name, object value, object htmlAttributes)
         {
             return GeneratePassword(metadata: null, name: name, value: value, htmlAttributes: htmlAttributes);
         }
 
+        /// <inheritdoc />
         public HtmlString RadioButton(string name, object value, bool? isChecked, object htmlAttributes)
         {
             return GenerateRadioButton(metadata: null, name: name, value: value, isChecked: isChecked,
                 htmlAttributes: htmlAttributes);
         }
 
+        /// <inheritdoc />
         public HtmlString Raw(string value)
         {
             return new HtmlString(value);
         }
 
+        /// <inheritdoc />
         public HtmlString Raw(object value)
         {
             return new HtmlString(value == null ? null : value.ToString());
         }
 
+        /// <inheritdoc />
         public virtual HtmlString ValidationSummary(bool excludePropertyErrors, string message, IDictionary<string, object> htmlAttributes)
         {
             var formContext = ViewContext.ClientValidationEnabled ? ViewContext.FormContext : null;
@@ -481,12 +507,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
             }
         }
 
+        /// <inheritdoc />
         public HtmlString TextBox(string name, object value, string format, IDictionary<string, object> htmlAttributes)
         {
             return GenerateTextBox(metadata: null, name: name, value: value, format: format,
                 htmlAttributes: htmlAttributes);
         }
 
+        /// <inheritdoc />
         public HtmlString Value([NotNull] string name, string format)
         {
             return GenerateValue(name, value: null, format: format, useViewData: true);
@@ -589,7 +617,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 format: null,
                 htmlAttributes: htmlAttributeDictionary);
         }
-        
+
         protected virtual HtmlString GenerateDisplayName([NotNull] ModelMetadata metadata, string htmlFieldName)
         {
             // We don't call ModelMetadata.GetDisplayName here because 
@@ -603,7 +631,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                                                                     string.Empty :
                                                                     htmlFieldName.Split('.').Last();
             }
-            
+
             return new HtmlString(Encode(resolvedDisplayName));
         }
 
@@ -695,7 +723,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 format: null,
                 htmlAttributes: htmlAttributeDictionary);
         }
-        
+
         protected virtual HtmlString GenerateLabel([NotNull] ModelMetadata metadata, 
                                                     string htmlFieldName,
                                                     string labelText,

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/HtmlHelperOfT.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/HtmlHelperOfT.cs
@@ -91,7 +91,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <inheritdoc />
-        public HtmlString DisplayNameForInnerType<TInnerModel, TValue>(Expression<Func<TInnerModel, TValue>> expression)
+        public HtmlString DisplayNameForInnerType<TInnerModel, TValue>(
+            [NotNull] Expression<Func<TInnerModel, TValue>> expression)
         {
             var metadata = ExpressionMetadataProvider.
                                             FromLambdaExpression<TInnerModel, TValue>(
@@ -175,7 +176,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <inheritdoc />
-        public HtmlString ValueFor<TProperty>(Expression<Func<TModel, TProperty>> expression, string format)
+        public HtmlString ValueFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression, string format)
         {
             var metadata = GetModelMetadata(expression);
             return GenerateValue(ExpressionHelper.GetExpressionText(expression), metadata.Model, format,

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/TemplateBuilder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/TemplateBuilder.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 return string.Empty;
             }
 
-            var viewData = new ViewDataDictionary<object>(_viewData)
+            var viewData = new ViewDataDictionary(_viewData)
             {
                 Model = _metadata.Model,
                 ModelMetadata = _metadata

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/TemplateRenderer.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/TemplateRenderer.cs
@@ -14,8 +14,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         private static readonly string DisplayTemplateViewPath = "DisplayTemplates";
         private static readonly string EditorTemplateViewPath = "EditorTemplates";
 
-        private static readonly Dictionary<string, Func<IHtmlHelper<object>, string>> _defaultDisplayActions =
-            new Dictionary<string, Func<IHtmlHelper<object>, string>>(StringComparer.OrdinalIgnoreCase)
+        private static readonly Dictionary<string, Func<IHtmlHelper, string>> _defaultDisplayActions =
+            new Dictionary<string, Func<IHtmlHelper, string>>(StringComparer.OrdinalIgnoreCase)
             {
                 { "EmailAddress", DefaultDisplayTemplates.EmailAddressTemplate },
                 { "HiddenInput", DefaultDisplayTemplates.HiddenInputTemplate },
@@ -30,16 +30,17 @@ namespace Microsoft.AspNet.Mvc.Rendering
             };
 
         private ViewContext _viewContext;
-        private ViewDataDictionary<object> _viewData;
+        private ViewDataDictionary _viewData;
         private IViewEngine _viewEngine;
         private string _templateName;
         private bool _readOnly;
 
-        public TemplateRenderer([NotNull] IViewEngine viewEngine, 
-                                [NotNull] ViewContext viewContext,
-                                [NotNull] ViewDataDictionary<object> viewData,
-                                string templateName, 
-                                bool readOnly)
+        public TemplateRenderer(
+            [NotNull] IViewEngine viewEngine,
+            [NotNull] ViewContext viewContext,
+            [NotNull] ViewDataDictionary viewData,
+            string templateName,
+            bool readOnly)
         {
             _viewEngine = viewEngine;
             _viewContext = viewContext;
@@ -75,7 +76,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                     }
                 }
 
-                Func<IHtmlHelper<object>, string> defaultAction;
+                Func<IHtmlHelper, string> defaultAction;
                 if (defaultActions.TryGetValue(viewName, out defaultAction))
                 {
                     return defaultAction(MakeHtmlHelper(_viewContext, _viewData));
@@ -86,7 +87,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 Resources.FormatTemplateHelpers_NoTemplate(_viewData.ModelMetadata.RealModelType.FullName));
         }
 
-        private Dictionary<string, Func<IHtmlHelper<object>, string>> GetDefaultActions()
+        private Dictionary<string, Func<IHtmlHelper, string>> GetDefaultActions()
         {
             if (_readOnly)
             {
@@ -170,9 +171,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
             }
         }
 
-        private static IHtmlHelper<object> MakeHtmlHelper(ViewContext viewContext, ViewDataDictionary<object> viewData)
+        private static IHtmlHelper MakeHtmlHelper(ViewContext viewContext, ViewDataDictionary viewData)
         {
-            var newHelper = viewContext.HttpContext.RequestServices.GetService<IHtmlHelper<object>>();
+            var newHelper = viewContext.HttpContext.RequestServices.GetService<IHtmlHelper>();
 
             var contextable = newHelper as ICanHasViewContext;
             if (contextable != null)

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperDisplayExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperDisplayExtensions.cs
@@ -5,39 +5,42 @@ namespace Microsoft.AspNet.Mvc.Rendering
 {
     public static class HtmlHelperDisplayExtensions
     {
-        public static HtmlString Display<TModel>([NotNull] this IHtmlHelper<TModel> html,
-                                                 string expression)
+        public static HtmlString Display([NotNull] this IHtmlHelper html, string expression)
         {
             return html.Display(expression, templateName: null, htmlFieldName: null, additionalViewData: null);
         }
 
-        public static HtmlString Display<TModel>([NotNull] this IHtmlHelper<TModel> html,
-                                                 string expression,
-                                                 object additionalViewData)
+        public static HtmlString Display(
+            [NotNull] this IHtmlHelper html,
+            string expression,
+            object additionalViewData)
         {
             return html.Display(expression, templateName: null, htmlFieldName: null,
                 additionalViewData: additionalViewData);
         }
 
-        public static HtmlString Display<TModel>([NotNull] this IHtmlHelper<TModel> html,
-                                                 string expression,
-                                                 string templateName)
+        public static HtmlString Display(
+            [NotNull] this IHtmlHelper html,
+            string expression,
+            string templateName)
         {
             return html.Display(expression, templateName, htmlFieldName: null, additionalViewData: null);
         }
 
-        public static HtmlString Display<TModel>([NotNull] this IHtmlHelper<TModel> html,
-                                                 string expression,
-                                                 string templateName,
-                                                 object additionalViewData)
+        public static HtmlString Display(
+            [NotNull] this IHtmlHelper html,
+            string expression,
+            string templateName,
+            object additionalViewData)
         {
             return html.Display(expression, templateName, htmlFieldName: null, additionalViewData: additionalViewData);
         }
 
-        public static HtmlString Display<TModel>([NotNull] this IHtmlHelper<TModel> html,
-                                                 string expression,
-                                                 string templateName,
-                                                 string htmlFieldName)
+        public static HtmlString Display(
+            [NotNull] this IHtmlHelper html,
+            string expression,
+            string templateName,
+            string htmlFieldName)
         {
             return html.Display(expression, templateName, htmlFieldName, additionalViewData: null);
         }
@@ -82,34 +85,34 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 additionalViewData: null);
         }
 
-        public static HtmlString DisplayForModel<TModel>([NotNull] this IHtmlHelper<TModel> html)
+        public static HtmlString DisplayForModel([NotNull] this IHtmlHelper html)
         {
             return html.DisplayForModel(templateName: null, htmlFieldName: null, additionalViewData: null);
         }
 
-        public static HtmlString DisplayForModel<TModel>([NotNull] this IHtmlHelper<TModel> html,
-                                                         object additionalViewData)
+        public static HtmlString DisplayForModel([NotNull] this IHtmlHelper html, object additionalViewData)
         {
             return html.DisplayForModel(templateName: null, htmlFieldName: null,
                 additionalViewData: additionalViewData);
         }
 
-        public static HtmlString DisplayForModel<TModel>([NotNull] this IHtmlHelper<TModel> html,
-                                                         string templateName)
+        public static HtmlString DisplayForModel([NotNull] this IHtmlHelper html, string templateName)
         {
             return html.DisplayForModel(templateName, htmlFieldName: null, additionalViewData: null);
         }
 
-        public static HtmlString DisplayForModel<TModel>([NotNull] this IHtmlHelper<TModel> html,
-                                                         string templateName,
-                                                         object additionalViewData)
+        public static HtmlString DisplayForModel(
+            [NotNull] this IHtmlHelper html,
+            string templateName,
+            object additionalViewData)
         {
             return html.DisplayForModel(templateName, htmlFieldName: null, additionalViewData: additionalViewData);
         }
 
-        public static HtmlString DisplayForModel<TModel>([NotNull] this IHtmlHelper<TModel> html,
-                                                         string templateName,
-                                                         string htmlFieldName)
+        public static HtmlString DisplayForModel(
+            [NotNull] this IHtmlHelper html,
+            string templateName,
+            string htmlFieldName)
         {
             return html.DisplayForModel(templateName, htmlFieldName, additionalViewData: null);
         }

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperDisplayNameExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperDisplayNameExtensions.cs
@@ -1,7 +1,7 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+
 namespace Microsoft.AspNet.Mvc.Rendering
 {
     /// <summary>
@@ -12,9 +12,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <summary>
         /// Gets the display name for the current model.
         /// </summary>
-        /// <param name="htmlHelper">The <see cref="IHtmlHelper{T}"/> instance that this method extends.</param>
         /// <returns>An <see cref="HtmlString"/> that represents HTML markup.</returns>
-        public static HtmlString DisplayNameForModel<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper)
+        public static HtmlString DisplayNameForModel([NotNull] this IHtmlHelper htmlHelper)
         {
             return htmlHelper.DisplayName(string.Empty);
         }
@@ -27,8 +26,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <returns>
         /// The display name for the model.
         /// </returns>
-        public static HtmlString DisplayNameFor<TInnerModel,TValue>(this IHtmlHelper<IEnumerable<TInnerModel>> htmlHelper,
-                                                                      Expression<Func<TInnerModel, TValue>> expression)
+        public static HtmlString DisplayNameFor<TInnerModel,TValue>(
+            [NotNull] this IHtmlHelper<IEnumerable<TInnerModel>> htmlHelper,
+            [NotNull] Expression<Func<TInnerModel, TValue>> expression)
         {
             return htmlHelper.DisplayNameForInnerType<TInnerModel, TValue>(expression);
         }

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperFormExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperFormExtensions.cs
@@ -3,62 +3,80 @@ namespace Microsoft.AspNet.Mvc.Rendering
 {
     public static class HtmlHelperFormExtensions
     {
-        public static MvcForm BeginForm<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper)
+        public static MvcForm BeginForm([NotNull] this IHtmlHelper htmlHelper)
         {
             // Generates <form action="{current url}" method="post">.
             return htmlHelper.BeginForm(actionName: null, controllerName: null, routeValues: null,
                                         method: FormMethod.Post, htmlAttributes: null);
         }
 
-        public static MvcForm BeginForm<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, FormMethod method)
+        public static MvcForm BeginForm([NotNull] this IHtmlHelper htmlHelper, FormMethod method)
         {
             return htmlHelper.BeginForm(actionName: null, controllerName: null, routeValues: null,
                                         method: method, htmlAttributes: null);
         }
 
-        public static MvcForm BeginForm<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, FormMethod method,
-                                                object htmlAttributes)
+        public static MvcForm BeginForm(
+            [NotNull] this IHtmlHelper htmlHelper,
+            FormMethod method,
+            object htmlAttributes)
         {
             return htmlHelper.BeginForm(actionName: null, controllerName: null, routeValues: null,
                                         method: method, htmlAttributes: htmlAttributes);
         }
 
-        public static MvcForm BeginForm<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, object routeValues)
+        public static MvcForm BeginForm([NotNull] this IHtmlHelper htmlHelper, object routeValues)
         {
             return htmlHelper.BeginForm(actionName: null, controllerName: null, routeValues: routeValues,
                                         method: FormMethod.Post, htmlAttributes: null);
         }
 
-        public static MvcForm BeginForm<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string actionName,
-                                                string controllerName)
+        public static MvcForm BeginForm(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string actionName,
+            string controllerName)
         {
             return htmlHelper.BeginForm(actionName, controllerName, routeValues: null,
                                         method: FormMethod.Post, htmlAttributes: null);
         }
 
-        public static MvcForm BeginForm<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string actionName,
-                                                string controllerName, object routeValues)
+        public static MvcForm BeginForm(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string actionName,
+            string controllerName,
+            object routeValues)
         {
             return htmlHelper.BeginForm(actionName, controllerName, routeValues,
                                         FormMethod.Post, htmlAttributes: null);
         }
 
-        public static MvcForm BeginForm<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string actionName,
-                                                string controllerName, FormMethod method)
+        public static MvcForm BeginForm(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string actionName,
+            string controllerName,
+            FormMethod method)
         {
             return htmlHelper.BeginForm(actionName, controllerName, routeValues: null,
                                         method: method, htmlAttributes: null);
         }
 
-        public static MvcForm BeginForm<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string actionName,
-                                                string controllerName, object routeValues, FormMethod method)
+        public static MvcForm BeginForm(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string actionName,
+            string controllerName,
+            object routeValues,
+            FormMethod method)
         {
             return htmlHelper.BeginForm(actionName, controllerName, routeValues,
                                         method, htmlAttributes: null);
         }
 
-        public static MvcForm BeginForm<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string actionName,
-                                                string controllerName, FormMethod method, object htmlAttributes)
+        public static MvcForm BeginForm(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string actionName,
+            string controllerName,
+            FormMethod method,
+            object htmlAttributes)
         {
             return htmlHelper.BeginForm(actionName, controllerName, routeValues: null,
                                         method: method, htmlAttributes: htmlAttributes);

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperInputExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperInputExtensions.cs
@@ -6,18 +6,22 @@ namespace Microsoft.AspNet.Mvc.Rendering
 {
     public static class HtmlHelperInputExtensions
     {
-        public static HtmlString CheckBox<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string name)
+        public static HtmlString CheckBox([NotNull] this IHtmlHelper htmlHelper, string name)
         {
             return htmlHelper.CheckBox(name, isChecked: null, htmlAttributes: null);
         }
 
-        public static HtmlString CheckBox<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string name,
+        public static HtmlString CheckBox(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string name,
             bool isChecked)
         {
             return htmlHelper.CheckBox(name, isChecked, htmlAttributes: null);
         }
 
-        public static HtmlString CheckBox<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string name,
+        public static HtmlString CheckBox(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string name,
             object htmlAttributes)
         {
             return htmlHelper.CheckBox(name, isChecked: null, htmlAttributes: htmlAttributes);
@@ -29,12 +33,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return htmlHelper.CheckBoxFor(expression, htmlAttributes: null);
         }
 
-        public static HtmlString Hidden<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string name)
+        public static HtmlString Hidden([NotNull] this IHtmlHelper htmlHelper, string name)
         {
             return htmlHelper.Hidden(name, value: null, htmlAttributes: null);
         }
 
-        public static HtmlString Hidden<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string name,
+        public static HtmlString Hidden(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string name,
             object value)
         {
             return htmlHelper.Hidden(name, value, htmlAttributes: null);
@@ -46,12 +52,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return htmlHelper.HiddenFor(expression, htmlAttributes: null);
         }
 
-        public static HtmlString Password<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string name)
+        public static HtmlString Password([NotNull] this IHtmlHelper htmlHelper, string name)
         {
             return htmlHelper.Password(name, value: null, htmlAttributes: null);
         }
 
-        public static HtmlString Password<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string name,
+        public static HtmlString Password(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string name,
             object value)
         {
             return htmlHelper.Password(name, value, htmlAttributes: null);
@@ -63,20 +71,28 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return htmlHelper.PasswordFor(expression, htmlAttributes: null);
         }
 
-        public static HtmlString RadioButton<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string name,
+        public static HtmlString RadioButton(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string name,
             object value)
         {
             return htmlHelper.RadioButton(name, value, isChecked: null, htmlAttributes: null);
         }
 
-        public static HtmlString RadioButton<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string name,
-            object value, object htmlAttributes)
+        public static HtmlString RadioButton(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string name,
+            object value,
+            object htmlAttributes)
         {
             return htmlHelper.RadioButton(name, value, isChecked: null, htmlAttributes: htmlAttributes);
         }
 
-        public static HtmlString RadioButton<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string name,
-            object value, bool isChecked)
+        public static HtmlString RadioButton(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string name,
+            object value,
+            bool isChecked)
         {
             return htmlHelper.RadioButton(name, value, isChecked, htmlAttributes: null);
         }
@@ -87,38 +103,53 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return htmlHelper.RadioButtonFor(expression, value, htmlAttributes: null);
         }
 
-        public static HtmlString TextBox<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string name)
+        public static HtmlString TextBox([NotNull] this IHtmlHelper htmlHelper, string name)
         {
             return TextBox(htmlHelper, name, value: null);
         }
 
-        public static HtmlString TextBox<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string name,
+        public static HtmlString TextBox(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string name,
             object value)
         {
             return TextBox(htmlHelper, name, value, format: null);
         }
 
-        public static HtmlString TextBox<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string name,
-            object value, string format)
+        public static HtmlString TextBox(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string name,
+            object value,
+            string format)
         {
             return TextBox(htmlHelper, name, value, format, htmlAttributes: null);
         }
 
-        public static HtmlString TextBox<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string name,
-            object value, object htmlAttributes)
+        public static HtmlString TextBox(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string name,
+            object value,
+            object htmlAttributes)
         {
             return TextBox(htmlHelper, name, value, format: null, htmlAttributes: htmlAttributes);
         }
 
-        public static HtmlString TextBox<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string name,
-            object value, string format, object htmlAttributes)
+        public static HtmlString TextBox(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string name,
+            object value,
+            string format,
+            object htmlAttributes)
         {
             return htmlHelper.TextBox(name, value, format,
                 HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes));
         }
 
-        public static HtmlString TextBox<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string name,
-            object value, IDictionary<string, object> htmlAttributes)
+        public static HtmlString TextBox(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string name,
+            object value,
+            IDictionary<string, object> htmlAttributes)
         {
             return htmlHelper.TextBox(name, value, format: null, htmlAttributes: htmlAttributes);
         }

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperLabelExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperLabelExtensions.cs
@@ -5,16 +5,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
 {
     public static class HtmlHelperLabelExtensions
     {
-        public static HtmlString Label<TModel>([NotNull] this IHtmlHelper<TModel> html, string expression)
+        public static HtmlString Label([NotNull] this IHtmlHelper html, string expression)
         {
             return html.Label(expression,
                              labelText: null,
                              htmlAttributes: null);
         }
 
-        public static HtmlString Label<TModel>([NotNull] this IHtmlHelper<TModel> html,
-                                               string expression,
-                                               string labelText)
+        public static HtmlString Label([NotNull] this IHtmlHelper html, string expression, string labelText)
         {
             return html.Label(expression, labelText, htmlAttributes: null);
         }
@@ -39,25 +37,25 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return html.LabelFor<TValue>(expression, labelText: null, htmlAttributes: htmlAttributes);
         }
 
-        public static HtmlString LabelForModel<TModel>([NotNull] this IHtmlHelper<TModel> html)
+        public static HtmlString LabelForModel([NotNull] this IHtmlHelper html)
         {
             return LabelForModel(html, labelText: null);
         }
 
-        public static HtmlString LabelForModel<TModel>([NotNull] this IHtmlHelper<TModel> html, string labelText)
+        public static HtmlString LabelForModel([NotNull] this IHtmlHelper html, string labelText)
         {
             return html.Label(expression: string.Empty, labelText: labelText, htmlAttributes: null);
         }
 
-        public static HtmlString LabelForModel<TModel>([NotNull] this IHtmlHelper<TModel> html,
-                                                        object htmlAttributes)
+        public static HtmlString LabelForModel([NotNull] this IHtmlHelper html, object htmlAttributes)
         {
             return html.Label(expression: string.Empty, labelText: null, htmlAttributes: htmlAttributes);
         }
 
-        public static HtmlString LabelForModel<TModel>([NotNull] this IHtmlHelper<TModel> html,
-                                                        string labelText,
-                                                        object htmlAttributes)
+        public static HtmlString LabelForModel(
+            [NotNull] this IHtmlHelper html,
+            string labelText,
+            object htmlAttributes)
         {
             return html.Label(expression: string.Empty, labelText: labelText, htmlAttributes: htmlAttributes);
         }

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperLinkExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperLinkExtensions.cs
@@ -3,9 +3,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
 {
     public static class HtmlHelperLinkExtensions
     {
-        public static HtmlString ActionLink<TModel>(
-            [NotNull] this IHtmlHelper<TModel> helper, 
-            [NotNull] string linkText, 
+        public static HtmlString ActionLink(
+            [NotNull] this IHtmlHelper helper,
+            [NotNull] string linkText,
             string actionName)
         {
             return helper.ActionLink(
@@ -19,10 +19,10 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 htmlAttributes: null);
         }
 
-        public static HtmlString ActionLink<TModel>(
-            [NotNull] this IHtmlHelper<TModel> helper, 
-            [NotNull] string linkText, 
-            string actionName, 
+        public static HtmlString ActionLink(
+            [NotNull] this IHtmlHelper helper,
+            [NotNull] string linkText,
+            string actionName,
             object routeValues)
         {
             return helper.ActionLink(
@@ -36,11 +36,11 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 htmlAttributes: null);
         }
 
-        public static HtmlString ActionLink<TModel>(
-            [NotNull] this IHtmlHelper<TModel> helper, 
-            [NotNull] string linkText, 
-            string actionName, 
-            object routeValues, 
+        public static HtmlString ActionLink(
+            [NotNull] this IHtmlHelper helper,
+            [NotNull] string linkText,
+            string actionName,
+            object routeValues,
             object htmlAttributes)
         {
             return helper.ActionLink(
@@ -54,10 +54,10 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 htmlAttributes: htmlAttributes);
         }
 
-        public static HtmlString ActionLink<TModel>(
-            [NotNull] this IHtmlHelper<TModel> helper, 
-            [NotNull] string linkText, 
-            string actionName, 
+        public static HtmlString ActionLink(
+            [NotNull] this IHtmlHelper helper,
+            [NotNull] string linkText,
+            string actionName,
             string controllerName)
         {
             return helper.ActionLink(
@@ -71,8 +71,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 htmlAttributes: null);
         }
 
-        public static HtmlString ActionLink<TModel>(
-            [NotNull] this IHtmlHelper<TModel> helper,
+        public static HtmlString ActionLink(
+            [NotNull] this IHtmlHelper helper,
             [NotNull] string linkText,
             string actionName,
             string controllerName,
@@ -89,12 +89,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 htmlAttributes: null);
         }
 
-        public static HtmlString ActionLink<TModel>(
-            [NotNull] this IHtmlHelper<TModel> helper, 
-            [NotNull] string linkText, 
-            string actionName, 
-            string controllerName, 
-            object routeValues, 
+        public static HtmlString ActionLink(
+            [NotNull] this IHtmlHelper helper,
+            [NotNull] string linkText,
+            string actionName,
+            string controllerName,
+            object routeValues,
             object htmlAttributes)
         {
             return helper.ActionLink(

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperNameExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperNameExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </summary>
         /// <param name="htmlHelper">The <see cref="HtmlHelper"/> instance that this method extends.</param>
         /// <returns>An <see cref="HtmlString"/> that represents HTML markup.</returns>
-        public static HtmlString NameForModel<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper)
+        public static HtmlString NameForModel([NotNull] this IHtmlHelper htmlHelper)
         {
             return htmlHelper.Name(string.Empty);
         }

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperPartialExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperPartialExtensions.cs
@@ -7,13 +7,13 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <summary>
         /// Renders the partial view with the parent's view data and model to a string.
         /// </summary>
-        /// <typeparam name="T">The <see cref="Type"/> of the model.</typeparam>
         /// <param name="htmlHelper">The <see cref="HtmlHelper"/> instance that this method extends.</param>
         /// <param name="partialViewName">The name of the partial view to render.</param>
         /// <returns>
         /// A <see cref="Task{T}"/> that represents when rendering to the <see cref="HtmlString"/> has completed.
         /// </returns>
-        public static Task<HtmlString> PartialAsync<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper,
+        public static Task<HtmlString> PartialAsync(
+            [NotNull] this IHtmlHelper htmlHelper,
             [NotNull] string partialViewName)
         {
             return htmlHelper.PartialAsync(partialViewName, htmlHelper.ViewData.Model, viewData: null);
@@ -22,7 +22,6 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <summary>
         /// Renders the partial view with the given view data and, implicitly, the given view data's model to a string.
         /// </summary>
-        /// <typeparam name="T">The <see cref="Type"/> of the model.</typeparam>
         /// <param name="htmlHelper">The <see cref="HtmlHelper"/> instance that this method extends.</param>
         /// <param name="partialViewName">The name of the partial view to render.</param>
         /// <param name="viewData">
@@ -31,8 +30,10 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <returns>
         /// A <see cref="Task{T}"/> that represents when rendering to the <see cref="HtmlString"/> has completed.
         /// </returns>
-        public static Task<HtmlString> PartialAsync<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            [NotNull] string partialViewName, ViewDataDictionary viewData)
+        public static Task<HtmlString> PartialAsync(
+            [NotNull] this IHtmlHelper htmlHelper,
+            [NotNull] string partialViewName,
+            ViewDataDictionary viewData)
         {
             return htmlHelper.PartialAsync(partialViewName, htmlHelper.ViewData.Model, viewData: viewData);
         }
@@ -40,15 +41,16 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <summary>
         /// Renders the partial view with an empty view data and the given model to a string.
         /// </summary>
-        /// <typeparam name="T">The <see cref="Type"/> of the model.</typeparam>
         /// <param name="htmlHelper">The <see cref="HtmlHelper"/> instance that this method extends.</param>
         /// <param name="partialViewName">The name of the partial view to render.</param>
         /// <param name="model">The model to provide to the partial view that will be rendered.</param>
         /// <returns>
         /// A <see cref="Task{T}"/> that represents when rendering to the <see cref="HtmlString"/> has completed.
         /// </returns>
-        public static Task<HtmlString> PartialAsync<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            [NotNull] string partialViewName, object model)
+        public static Task<HtmlString> PartialAsync(
+            [NotNull] this IHtmlHelper htmlHelper,
+            [NotNull] string partialViewName,
+            object model)
         {
             return htmlHelper.PartialAsync(partialViewName, model, viewData: null);
         }
@@ -56,11 +58,11 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <summary>
         /// Renders the partial view with the parent's view data and model.
         /// </summary>
-        /// <typeparam name="T">The <see cref="Type"/> of the model.</typeparam>
         /// <param name="htmlHelper">The <see cref="HtmlHelper"/> instance that this method extends.</param>
         /// <param name="partialViewName">The name of the partial view to render.</param>
         /// <returns>A <see cref="Task"/> that represents when rendering has completed.</returns>
-        public static Task RenderPartialAsync<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper,
+        public static Task RenderPartialAsync(
+            [NotNull] this IHtmlHelper htmlHelper,
             [NotNull] string partialViewName)
         {
             return htmlHelper.RenderPartialAsync(partialViewName, htmlHelper.ViewData.Model,
@@ -70,15 +72,16 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <summary>
         /// Renders the partial view with the given view data and, implicitly, the given view data's model.
         /// </summary>
-        /// <typeparam name="T">The <see cref="Type"/> of the model.</typeparam>
         /// <param name="htmlHelper">The <see cref="HtmlHelper"/> instance that this method extends.</param>
         /// <param name="partialViewName">The name of the partial view to render.</param>
         /// <param name="viewData">
         /// The <see cref="ViewDataDictionary"/> that is provided to the partial view that will be rendered.
         /// </param>
         /// <returns>A <see cref="Task"/> that represents when rendering has completed.</returns>
-        public static Task RenderPartialAsync<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            [NotNull] string partialViewName, ViewDataDictionary viewData)
+        public static Task RenderPartialAsync(
+            [NotNull] this IHtmlHelper htmlHelper,
+            [NotNull] string partialViewName,
+            ViewDataDictionary viewData)
         {
             return htmlHelper.RenderPartialAsync(partialViewName, htmlHelper.ViewData.Model, viewData: viewData);
         }
@@ -86,13 +89,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <summary>
         /// Renders the partial view with an empty view data and the given model.
         /// </summary>
-        /// <typeparam name="T">The <see cref="Type"/> of the model.</typeparam>
         /// <param name="htmlHelper">The <see cref="HtmlHelper"/> instance that this method extends.</param>
         /// <param name="partialViewName">The name of the partial view to render.</param>
         /// <param name="model">The model to provide to the partial view that will be rendered.</param>
         /// <returns>A <see cref="Task"/> that represents when rendering has completed.</returns>
-        public static Task RenderPartialAsync<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            [NotNull] string partialViewName, object model)
+        public static Task RenderPartialAsync(
+            [NotNull] this IHtmlHelper htmlHelper,
+            [NotNull] string partialViewName,
+            object model)
         {
             return htmlHelper.RenderPartialAsync(partialViewName, model, htmlHelper.ViewData);
         }

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperSelectExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperSelectExtensions.cs
@@ -6,31 +6,38 @@ namespace Microsoft.AspNet.Mvc.Rendering
 {
     public static class SelectExtensions
     {
-        public static HtmlString DropDownList<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string name)
+        public static HtmlString DropDownList([NotNull] this IHtmlHelper htmlHelper, string name)
         {
             return htmlHelper.DropDownList(name, selectList: null, optionLabel: null, htmlAttributes: null);
         }
 
-        public static HtmlString DropDownList<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string name,
-            string optionLabel)
+        public static HtmlString DropDownList([NotNull] this IHtmlHelper htmlHelper, string name, string optionLabel)
         {
             return htmlHelper.DropDownList(name, selectList: null, optionLabel: optionLabel, htmlAttributes: null);
         }
 
-        public static HtmlString DropDownList<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string name,
+        public static HtmlString DropDownList(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string name,
             IEnumerable<SelectListItem> selectList)
         {
             return htmlHelper.DropDownList(name, selectList, optionLabel: null, htmlAttributes: null);
         }
 
-        public static HtmlString DropDownList<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string name,
-            IEnumerable<SelectListItem> selectList, object htmlAttributes)
+        public static HtmlString DropDownList(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string name,
+            IEnumerable<SelectListItem> selectList,
+            object htmlAttributes)
         {
             return htmlHelper.DropDownList(name, selectList, optionLabel: null, htmlAttributes: htmlAttributes);
         }
 
-        public static HtmlString DropDownList<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string name,
-            IEnumerable<SelectListItem> selectList, string optionLabel)
+        public static HtmlString DropDownList(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string name,
+            IEnumerable<SelectListItem> selectList,
+            string optionLabel)
         {
             return htmlHelper.DropDownList(name, selectList, optionLabel, htmlAttributes: null);
         }

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperValidationExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperValidationExtensions.cs
@@ -4,46 +4,53 @@ namespace Microsoft.AspNet.Mvc.Rendering
 {
     public static class HtmlHelperValidationExtensions
     {
-        public static HtmlString ValidationSummary<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper)
+        public static HtmlString ValidationSummary([NotNull] this IHtmlHelper htmlHelper)
         {
             return ValidationSummary(htmlHelper, excludePropertyErrors: false);
         }
 
-        public static HtmlString ValidationSummary<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            bool excludePropertyErrors)
+        public static HtmlString ValidationSummary([NotNull] this IHtmlHelper htmlHelper, bool excludePropertyErrors)
         {
             return ValidationSummary(htmlHelper, excludePropertyErrors, message: null);
         }
 
-        public static HtmlString ValidationSummary<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            string message)
+        public static HtmlString ValidationSummary([NotNull] this IHtmlHelper htmlHelper, string message)
         {
             return ValidationSummary(htmlHelper, excludePropertyErrors: false, message: message,
                 htmlAttributes: (object)null);
         }
 
-        public static HtmlString ValidationSummary<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            bool excludePropertyErrors, string message)
+        public static HtmlString ValidationSummary(
+            [NotNull] this IHtmlHelper htmlHelper,
+            bool excludePropertyErrors,
+            string message)
         {
             return ValidationSummary(htmlHelper, excludePropertyErrors, message, htmlAttributes: (object)null);
         }
 
-        public static HtmlString ValidationSummary<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            string message, object htmlAttributes)
+        public static HtmlString ValidationSummary(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string message,
+            object htmlAttributes)
         {
             return ValidationSummary(htmlHelper, excludePropertyErrors: false, message: message,
                 htmlAttributes: HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes));
         }
 
-        public static HtmlString ValidationSummary<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            bool excludePropertyErrors, string message, object htmlAttributes)
+        public static HtmlString ValidationSummary(
+            [NotNull] this IHtmlHelper htmlHelper,
+            bool excludePropertyErrors,
+            string message,
+            object htmlAttributes)
         {
             return htmlHelper.ValidationSummary(excludePropertyErrors, message,
                 HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes));
         }
 
-        public static HtmlString ValidationSummary<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            string message, IDictionary<string, object> htmlAttributes)
+        public static HtmlString ValidationSummary(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string message,
+            IDictionary<string, object> htmlAttributes)
         {
             return htmlHelper.ValidationSummary(excludePropertyErrors: false, message: message,
                 htmlAttributes: htmlAttributes);

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperValueExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperValueExtensions.cs
@@ -5,22 +5,24 @@ namespace Microsoft.AspNet.Mvc.Rendering
 {
     public static class HtmlHelperValueExtensions
     {
-        public static HtmlString Value<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string name)
+        public static HtmlString Value([NotNull] this IHtmlHelper htmlHelper, string name)
         {
             return htmlHelper.Value(name, format: null);
         }
 
-        public static HtmlString ValueFor<TModel, TProperty>([NotNull] this IHtmlHelper<TModel> htmlHelper, Expression<Func<TModel, TProperty>> expression)
+        public static HtmlString ValueFor<TModel, TProperty>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TProperty>> expression)
         {
             return htmlHelper.ValueFor(expression, format: null);
         }
 
-        public static HtmlString ValueForModel<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper)
+        public static HtmlString ValueForModel([NotNull] this IHtmlHelper htmlHelper)
         {
-            return ValueForModel<TModel>(htmlHelper, format: null);
+            return ValueForModel(htmlHelper, format: null);
         }
 
-        public static HtmlString ValueForModel<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper, string format)
+        public static HtmlString ValueForModel([NotNull] this IHtmlHelper htmlHelper, string format)
         {
             return htmlHelper.Value(string.Empty, format);
         }

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/IHtmlHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/IHtmlHelper.cs
@@ -1,0 +1,358 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNet.Mvc.Rendering
+{
+    /// <summary>
+    /// Base HTML helpers.
+    /// </summary>
+    public interface IHtmlHelper
+    {
+        /// <summary>
+        /// Gets or sets the character that replaces periods in the ID attribute of an element.
+        /// </summary>
+        string IdAttributeDotReplacement { get; set; }
+
+        /// <summary>
+        /// Gets the view bag.
+        /// </summary>
+        dynamic ViewBag { get; }
+
+        /// <summary>
+        /// Gets the context information about the view.
+        /// </summary>
+        ViewContext ViewContext { get; }
+
+        /// <summary>
+        /// Gets the current view data.
+        /// </summary>
+        ViewDataDictionary ViewData { get; }
+
+        /// <summary>
+        /// Returns an anchor element (a element) that contains a URL path to the specified action.
+        /// </summary>
+        /// <param name="linkText">The inner text of the anchor element.</param>
+        /// <param name="actionName">The name of the action.</param>
+        /// <param name="controllerName">The name of the controller.</param>
+        /// <param name="protocol">The protocol for the URL, such as &quot;http&quot; or &quot;https&quot;.</param>
+        /// <param name="hostname">The host name for the URL.</param>
+        /// <param name="fragment">The URL fragment name (the anchor name).</param>
+        /// <param name="routeValues">
+        /// An object that contains the parameters for a route. The parameters are retrieved through reflection by
+        /// examining the properties of the object. This object is typically created using object initializer syntax.
+        /// Alternatively, an <see cref="IDictionary{string, object}"/> instance containing the route parameters.
+        /// </param>
+        /// <param name="htmlAttributes">
+        /// An object that contains the HTML attributes to set for the element. Alternatively, an
+        /// <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
+        /// </param>
+        /// <returns>
+        /// An anchor element (a element).
+        /// </returns>
+        HtmlString ActionLink(
+            [NotNull] string linkText,
+            string actionName,
+            string controllerName,
+            string protocol,
+            string hostname,
+            string fragment,
+            object routeValues,
+            object htmlAttributes);
+
+        /// <summary>
+        /// Generates a hidden form field (anti-forgery token) that is validated when the form is submitted.
+        /// </summary>
+        /// <returns>
+        /// The generated form field (anti-forgery token).
+        /// </returns>
+        HtmlString AntiForgeryToken();
+
+        /// <summary>
+        /// Writes an opening <form> tag to the response. When the user submits the form,
+        /// the request will be processed by an action method.
+        /// </summary>
+        /// <param name="actionName">The name of the action method.</param>
+        /// <param name="controllerName">The name of the controller.</param>
+        /// <param name="routeValues">An object that contains the parameters for a route. The parameters are retrieved
+        /// through reflection by examining the properties of the object. This object is typically created using object
+        /// initializer syntax. Alternatively, an <see cref="IDictionary{string, object}"/> instance containing the
+        /// route parameters.</param>
+        /// <param name="method">The HTTP method for processing the form, either GET or POST.</param>
+        /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the element.
+        /// Alternatively, an <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
+        /// </param>
+        /// <returns>An <see cref="MvcForm"/> instance which emits the closing {form} tag when disposed.</returns>
+        MvcForm BeginForm(
+            string actionName,
+            string controllerName,
+            object routeValues,
+            FormMethod method,
+            object htmlAttributes);
+
+        /// <summary>
+        /// Render an input element of type "checkbox" with value "true" and an input element of type "hidden" with
+        /// value "false".
+        /// </summary>
+        /// <param name="name">
+        /// Rendered element's name. Also use this name to find value in submitted data or view data. Use view data
+        /// only if value is not in submitted data and <paramref name="value"/> is <c>null</c>.
+        /// </param>
+        /// <param name="isChecked">
+        /// If <c>true</c>, checkbox is initially checked. Ignore if named value is found in submitted data. Finally
+        /// fall back to an existing "checked" value in <paramref name="htmlAttributes"/>.
+        /// </param>
+        /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the element.
+        /// Alternatively, an <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
+        /// </param>
+        /// <returns>New <see cref="HtmlString"/> containing the rendered HTML.</returns>
+        HtmlString CheckBox(string name, bool? isChecked, object htmlAttributes);
+
+        /// <summary>
+        /// Returns HTML markup for each property in the object that is represented by the expression, using the
+        /// specified template, HTML field ID, and additional view data.
+        /// </summary>
+        /// <param name="expression">An expression that identifies the object that contains the properties to display.
+        /// </param>
+        /// <param name="templateName">The name of the template that is used to render the object.</param>
+        /// <param name="htmlFieldName">
+        /// A string that is used to disambiguate the names of HTML input elements that are rendered for properties
+        /// that have the same name.
+        /// </param>
+        /// <param name="additionalViewData">
+        /// An anonymous object or dictionary that can contain additional view data that will be merged into the
+        /// <see cref="ViewDataDictionary{TModel}"/> instance that is created for the template.
+        /// </param>
+        /// <returns>The HTML markup for each property in the object that is represented by the expression.</returns>
+        HtmlString Display(
+            string expression,
+            string templateName,
+            string htmlFieldName,
+            object additionalViewData);
+
+        /// <summary>
+        /// Returns HTML markup for each property in the model, using the specified template, an HTML field ID, and
+        /// additional view data.
+        /// </summary>
+        /// <param name="templateName">The name of the template that is used to render the object.</param>
+        /// <param name="htmlFieldName">
+        /// A string that is used to disambiguate the names of HTML input elements that are rendered for properties
+        /// that have the same name.
+        /// </param>
+        /// <param name="additionalViewData">
+        /// An anonymous object or dictionary that can contain additional view data that will be merged into the
+        /// <see cref="ViewDataDictionary{TModel}"/> instance that is created for the template.
+        /// </param>
+        /// <returns>The HTML markup for each property in the model.</returns>
+        HtmlString DisplayForModel(string templateName, string htmlFieldName, object additionalViewData);
+
+        /// <summary>
+        /// Gets the display name.
+        /// </summary>
+        /// <param name="expression">An expression that identifies the object that contains the display name.</param>
+        /// <returns>
+        /// The display name.
+        /// </returns>
+        HtmlString DisplayName(string expression);
+
+        /// <summary>
+        /// Returns a single-selection HTML {select} element using the specified name of the form field,
+        /// list items, option label, and HTML attributes.
+        /// </summary>
+        /// <param name="name">The name of the form field to return.</param>
+        /// <param name="selectList">A collection of <see href="SelectListItem"/> objects that are used to populate the
+        /// drop-down list.</param>
+        /// <param name="optionLabel">The text for a default empty item. This parameter can be null.</param>
+        /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the {select} element.
+        /// Alternatively, an <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
+        /// </param>
+        /// <returns>An HTML {select} element with an {option} subelement for each item in the list.</returns>
+        HtmlString DropDownList(
+            string name,
+            IEnumerable<SelectListItem> selectList,
+            string optionLabel,
+            object htmlAttributes);
+
+        /// <summary>
+        /// Converts the value of the specified object to an HTML-encoded string.
+        /// </summary>
+        /// <param name="value">The object to encode.</param>
+        /// <returns>The HTML-encoded string.</returns>
+        string Encode(object value);
+
+        /// <summary>
+        /// Converts the specified string to an HTML-encoded string.
+        /// </summary>
+        /// <param name="value">The string to encode.</param>
+        /// <returns>The HTML-encoded string.</returns>
+        string Encode(string value);
+
+        /// <summary>
+        /// Renders the closing </form> tag to the response.
+        /// </summary>
+        void EndForm();
+
+        /// <summary>
+        /// Formats the value.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <param name="format">The format string.</param>
+        /// <returns>The formatted value.</returns>
+        string FormatValue(object value, string format);
+
+        /// <summary>
+        /// Creates an HTML element ID using the specified element name.
+        /// </summary>
+        /// <param name="name">The name of the HTML element.</param>
+        /// <returns>The ID of the HTML element.</returns>
+        string GenerateIdFromName(string name);
+
+        /// <summary>
+        /// Render an input element of type "hidden".
+        /// </summary>
+        /// <param name="name">
+        /// Rendered element's name. Also use this name to find value in submitted data or view data. Use view data
+        /// only if value is not in submitted data and <paramref name="value"/> is <c>null</c>.
+        /// </param>
+        /// <param name="value">
+        /// If non-<c>null</c>, value to include in the element. Ignore if named value is found in submitted data.
+        /// </param>
+        /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the element.
+        /// Alternatively, an <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
+        /// </param>
+        /// <returns>New <see cref="HtmlString"/> containing the rendered HTML.</returns>
+        HtmlString Hidden(string name, object value, object htmlAttributes);
+
+        /// <summary>
+        /// Returns an HTML label element and the property name of the property that is represented by the specified
+        /// expression.
+        /// </summary>
+        /// <param name="expression">An expression that identifies the property to display.</param>
+        /// <param name="labelText">The label text.</param>
+        /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the element.</param>
+        /// <returns>
+        /// An HTML label element and the property name of the property that is represented by the expression.
+        /// </returns>
+        HtmlString Label(string expression, string labelText, object htmlAttributes);
+
+        /// <summary>
+        /// Gets the full HTML field name for the given expression <paramref name="name"/>.
+        /// </summary>
+        /// <param name="name">Name of an expression, relative to the current model.</param>
+        /// <returns>An <see cref="HtmlString"/> that represents HTML markup.</returns>
+        HtmlString Name(string name);
+
+        /// <summary>
+        /// Returns a partial view in string format.
+        /// </summary>
+        /// <param name="partialViewName">The name of the partial view to render and return.</param>
+        /// <param name="model">A model to pass into the partial view.</param>
+        /// <param name="viewData">A <see cref="ViewDataDictionary"/> to pass into the partial view.</param>
+        /// <returns>A task that represents when rendering of the partial view into a string has completed.</returns>
+        Task<HtmlString> PartialAsync([NotNull] string partialViewName, object model, ViewDataDictionary viewData);
+
+        /// <summary>
+        /// Render an input element of type "password".
+        /// </summary>
+        /// <param name="name">
+        /// Rendered element's name. Also use this name to find value in view data. Use view data
+        /// only if value is not in submitted data and <paramref name="value"/> is <c>null</c>.
+        /// </param>
+        /// <param name="value">
+        /// If non-<c>null</c>, value to include in the element.
+        /// </param>
+        /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the element.
+        /// Alternatively, an <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
+        /// </param>
+        /// <returns>New <see cref="HtmlString"/> containing the rendered HTML.</returns>
+        HtmlString Password(string name, object value, object htmlAttributes);
+
+        /// <summary>
+        /// Render an input element of type "radio".
+        /// </summary>
+        /// <param name="name">
+        /// Rendered element's name. Also use this name to find value in submitted data or view data. Use view data
+        /// only if value is not in submitted data and <paramref name="value"/> is <c>null</c>.
+        /// </param>
+        /// <param name="value">
+        /// If non-<c>null</c>, value to include in the element. May be <c>null</c> only if
+        /// <paramref name="isChecked"/> is also <c>null</c>. Also compared to value in submitted data or view data to
+        /// determine <paramref name="isChecked"/> if that parameter is <c>null</c>. Ignore if named value is found in
+        /// submitted data.
+        /// </param>
+        /// <param name="isChecked">
+        /// If <c>true</c>, radio button is initially selected. Ignore if named value is found in submitted data. Fall
+        /// back to comparing <paramref name="value"/> with view data if this parameter is <c>null</c>. Finally
+        /// fall back to an existing "checked" value in <paramref name="htmlAttributes"/>.
+        /// </param>
+        /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the element.
+        /// Alternatively, an <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
+        /// </param>
+        /// <returns>New <see cref="HtmlString"/> containing the rendered HTML.</returns>
+        HtmlString RadioButton(string name, object value, bool? isChecked, object htmlAttributes);
+
+        /// <summary>
+        /// Wraps HTML markup in an <see cref="HtmlString"/>, which will enable HTML markup to be
+        /// rendered to the output without getting HTML encoded.
+        /// </summary>
+        /// <param name="value">HTML markup string.</param>
+        /// <returns>An <see cref="HtmlString"/> that represents HTML markup.</returns>
+        HtmlString Raw(string value);
+
+        /// <summary>
+        /// Wraps HTML markup from the string representation of an object in an <see cref="HtmlString"/>,
+        /// which will enable HTML markup to be rendered to the output without getting HTML encoded.
+        /// </summary>
+        /// <param name="value">object with string representation as HTML markup.</param>
+        /// <returns>An <see cref="HtmlString"/> that represents HTML markup.</returns>
+        HtmlString Raw(object value);
+
+        /// <summary>
+        /// Renders a partial view.
+        /// </summary>
+        /// <param name="partialViewName">The name of the partial view to render.</param>
+        /// <param name="model">A model to pass into the partial view.</param>
+        /// <param name="viewData">A <see cref="ViewDataDictionary"/> to pass into the partial view.</param>
+        /// <returns>A task that represents when rendering has completed.</returns>
+        Task RenderPartialAsync([NotNull] string partialViewName, object model, ViewDataDictionary viewData);
+
+        /// <summary>
+        /// Render an input element of type "text".
+        /// </summary>
+        /// <param name="name">
+        /// Rendered element's name. Also use this name to find value in submitted data or view data. Use view data
+        /// only if value is not in submitted data and <paramref name="value"/> is <c>null</c>.
+        /// </param>
+        /// <param name="value">
+        /// If non-<c>null</c>, value to include in the element. Ignore if named value is found in submitted data.
+        /// </param>
+        /// <param name="format"></param>
+        /// <param name="htmlAttributes">
+        /// <see cref="IDictionary{string, object}"/> containing additional HTML attributes.
+        /// </param>
+        /// <returns>New <see cref="HtmlString"/> containing the rendered HTML.</returns>
+        HtmlString TextBox(string name, object value, string format, IDictionary<string, object> htmlAttributes);
+
+        /// <summary>
+        /// Returns an unordered list (ul element) of validation messages that are in the
+        /// <see cref="ModelStateDictionary"/> object.
+        /// </summary>
+        /// <param name="excludePropertyErrors">true to have the summary display model-level errors only, or false to
+        /// have the summary display all errors.</param>
+        /// <param name="message">The message to display with the validation summary.</param>
+        /// <param name="htmlAttributes">A dictionary that contains the HTML attributes for the element.</param>
+        /// <returns>An <see cref="HtmlString"/> that contains an unordered list (ul element) of validation messages.
+        /// </returns>
+        HtmlString ValidationSummary(
+            bool excludePropertyErrors,
+            string message,
+            IDictionary<string, object> htmlAttributes);
+
+        /// <summary>
+        /// Returns the model value for the given expression <paramref name="name"/>.
+        /// </summary>
+        /// <param name="name">Name of an expression, relative to the current model.</param>
+        /// <param name="format">The optional format string to apply to the value.</param>
+        /// <returns>An <see cref="HtmlString"/> that represents HTML markup.</returns>
+        HtmlString Value([NotNull] string name, string format);
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/IHtmlHelperOfT.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/IHtmlHelperOfT.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using System.Threading.Tasks;
 
 namespace Microsoft.AspNet.Mvc.Rendering
 {
@@ -9,107 +8,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
     /// An <see cref="IHtmlHelper"/> for Linq expressions.
     /// </summary>
     /// <typeparam name="TModel">The <see cref="Type"/> of the model.</typeparam>
-    public interface IHtmlHelper<TModel>
+    public interface IHtmlHelper<TModel> : IHtmlHelper
     {
-        /// <summary>
-        /// Gets or sets the character that replaces periods in the ID attribute of an element.
-        /// </summary>
-        string IdAttributeDotReplacement { get; set; }
-
-        /// <summary>
-        /// Gets the view bag.
-        /// </summary>
-        dynamic ViewBag { get; }
-
-        /// <summary>
-        /// Gets the context information about the view.
-        /// </summary>
-        ViewContext ViewContext { get; }
-
         /// <summary>
         /// Gets the current view data.
         /// </summary>
-        ViewDataDictionary<TModel> ViewData { get; }
-
-        /// <summary>
-        /// Returns an anchor element (a element) that contains a URL path to the specified action.
-        /// </summary>
-        /// <param name="linkText">The inner text of the anchor element.</param>
-        /// <param name="actionName">The name of the action.</param>
-        /// <param name="controllerName">The name of the controller.</param>
-        /// <param name="protocol">The protocol for the URL, such as &quot;http&quot; or &quot;https&quot;.</param>
-        /// <param name="hostname">The host name for the URL.</param>
-        /// <param name="fragment">The URL fragment name (the anchor name).</param>
-        /// <param name="routeValues">
-        /// An object that contains the parameters for a route. The parameters are retrieved through reflection by 
-        /// examining the properties of the object. This object is typically created using object initializer syntax. 
-        /// Alternatively, an <see cref="IDictionary{string, object}"/> instance containing the route parameters.
-        /// </param>
-        /// <param name="htmlAttributes">
-        /// An object that contains the HTML attributes to set for the element. Alternatively, an 
-        /// <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
-        /// </param>
-        /// <returns>
-        /// An anchor element (a element).
-        /// </returns>
-        HtmlString ActionLink(
-            [NotNull] string linkText,
-            string actionName,
-            string controllerName,
-            string protocol,
-            string hostname,
-            string fragment,
-            object routeValues,
-            object htmlAttributes);
-
-        /// <summary>
-        /// Generates a hidden form field (anti-forgery token) that is validated when the form is submitted.
-        /// </summary>
-        /// <returns>
-        /// The generated form field (anti-forgery token).
-        /// </returns>
-        HtmlString AntiForgeryToken();
-
-        /// <summary>
-        /// Writes an opening <form> tag to the response. When the user submits the form,
-        /// the request will be processed by an action method.
-        /// </summary>
-        /// <param name="actionName">The name of the action method.</param>
-        /// <param name="controllerName">The name of the controller.</param>
-        /// <param name="routeValues">An object that contains the parameters for a route. The parameters are retrieved
-        /// through reflection by examining the properties of the object. This object is typically created using object
-        /// initializer syntax. Alternatively, an <see cref="IDictionary{string, object}"/> instance containing the
-        /// route parameters.</param>
-        /// <param name="method">The HTTP method for processing the form, either GET or POST.</param>
-        /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the element.
-        /// Alternatively, an <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
-        /// </param>
-        /// <returns>An <see cref="MvcForm"/> instance which emits the closing {form} tag when disposed.</returns>
-        MvcForm BeginForm(string actionName, string controllerName, object routeValues, FormMethod method,
-                          object htmlAttributes);
-
-        /// <summary>
-        /// Renders the closing </form> tag to the response.
-        /// </summary>
-        void EndForm();
-
-        /// <summary>
-        /// Render an input element of type "checkbox" with value "true" and an input element of type "hidden" with
-        /// value "false".
-        /// </summary>
-        /// <param name="name">
-        /// Rendered element's name. Also use this name to find value in submitted data or view data. Use view data
-        /// only if value is not in submitted data and <paramref name="value"/> is <c>null</c>.
-        /// </param>
-        /// <param name="isChecked">
-        /// If <c>true</c>, checkbox is initially checked. Ignore if named value is found in submitted data. Finally
-        /// fall back to an existing "checked" value in <paramref name="htmlAttributes"/>.
-        /// </param>
-        /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the element.
-        /// Alternatively, an <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
-        /// </param>
-        /// <returns>New <see cref="HtmlString"/> containing the rendered HTML.</returns>
-        HtmlString CheckBox(string name, bool? isChecked, object htmlAttributes);
+        new ViewDataDictionary<TModel> ViewData { get; }
 
         /// <summary>
         /// Render an input element of type "checkbox" with value "true" and an input element of type "hidden" with
@@ -125,70 +29,26 @@ namespace Microsoft.AspNet.Mvc.Rendering
         HtmlString CheckBoxFor([NotNull] Expression<Func<TModel, bool>> expression, object htmlAttributes);
 
         /// <summary>
-        /// Returns HTML markup for each property in the object that is represented by the expression, using the specified 
-        /// template, HTML field ID, and additional view data.
-        /// </summary>
-        /// <param name="expression">An expression that identifies the object that contains the properties to display.</param>
-        /// <param name="templateName">The name of the template that is used to render the object.</param>
-        /// <param name="htmlFieldName">
-        /// A string that is used to disambiguate the names of HTML input elements that are rendered for properties that have 
-        /// the same name.
-        /// </param>
-        /// <param name="additionalViewData">
-        /// An anonymous object or dictionary that can contain additional view data that will be merged into the 
-        /// <see cref="ViewDataDictionary{TModel}"/> instance that is created for the template.
-        /// </param>
-        /// <returns>The HTML markup for each property in the object that is represented by the expression.</returns>
-        HtmlString Display(string expression,
-                           string templateName,
-                           string htmlFieldName,
-                           object additionalViewData);
-
-        /// <summary>
-        /// Returns HTML markup for each property in the object that is represented by the specified expression, using the 
-        /// template, an HTML field ID, and additional view data.
+        /// Returns HTML markup for each property in the object that is represented by the specified expression, using
+        /// the template, an HTML field ID, and additional view data.
         /// </summary>
         /// <typeparam name="TValue">The type of the value.</typeparam>
-        /// <param name="expression">An expression that identifies the object that contains the properties to display.</param>
+        /// <param name="expression">An expression that identifies the object that contains the properties to display.
+        /// </param>
         /// <param name="templateName">The name of the template that is used to render the object.</param>
         /// <param name="htmlFieldName">
-        /// A string that is used to disambiguate the names of HTML input elements that are rendered for properties that have 
-        /// the same name.
+        /// A string that is used to disambiguate the names of HTML input elements that are rendered for properties
+        /// that have the same name.
         /// </param>
         /// <param name="additionalViewData">
-        /// An anonymous object or dictionary that can contain additional view data that will be merged into the 
+        /// An anonymous object or dictionary that can contain additional view data that will be merged into the
         /// <see cref="ViewDataDictionary{TModel}"/> instance that is created for the template.
         /// </param>
         /// <returns>The HTML markup for each property in the object that is represented by the expression.</returns>
-        HtmlString DisplayFor<TValue>(Expression<Func<TModel, TValue>> expression,
+        HtmlString DisplayFor<TValue>([NotNull] Expression<Func<TModel, TValue>> expression,
                                       string templateName,
                                       string htmlFieldName,
                                       object additionalViewData);
-
-        /// <summary>
-        /// Returns HTML markup for each property in the model, using the specified template, an HTML field ID, and additional 
-        /// view data.
-        /// </summary>
-        /// <param name="templateName">The name of the template that is used to render the object.</param>
-        /// <param name="htmlFieldName">
-        /// A string that is used to disambiguate the names of HTML input elements that are rendered for properties that have the 
-        /// same name.
-        /// </param>
-        /// <param name="additionalViewData">
-        /// An anonymous object or dictionary that can contain additional view data that will be merged into the 
-        /// <see cref="ViewDataDictionary{TModel}"/> instance that is created for the template.
-        /// </param>
-        /// <returns>The HTML markup for each property in the model.</returns>
-        HtmlString DisplayForModel(string templateName, string htmlFieldName, object additionalViewData);
-
-        /// <summary>
-        /// Gets the display name.
-        /// </summary>
-        /// <param name="expression">An expression that identifies the object that contains the display name.</param>
-        /// <returns>
-        /// The display name.
-        /// </returns>
-        HtmlString DisplayName(string expression);
 
         /// <summary>
         /// Gets the display name for the model.
@@ -198,7 +58,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <returns>
         /// The display name for the model.
         /// </returns>
-        HtmlString DisplayNameFor<TValue>(Expression<Func<TModel, TValue>> expression);
+        HtmlString DisplayNameFor<TValue>([NotNull] Expression<Func<TModel, TValue>> expression);
 
         /// <summary>
         /// Gets the display name for the inner model if the current model represents a collection.
@@ -207,25 +67,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <typeparam name="TValue">The type of the value.</typeparam>
         /// <param name="expression">An expression that identifies the object that contains the display name.</param>
         /// <returns>The display name for the inner model.</returns>
-        HtmlString DisplayNameForInnerType<TInnerModel, TValue>(Expression<Func<TInnerModel, TValue>> expression);
-
-        /// <summary>
-        /// Returns a single-selection HTML {select} element using the specified name of the form field,
-        /// list items, option label, and HTML attributes.
-        /// </summary>
-        /// <param name="name">The name of the form field to return.</param>
-        /// <param name="selectList">A collection of <see href="SelectListItem"/> objects that are used to populate the
-        /// drop-down list.</param>
-        /// <param name="optionLabel">The text for a default empty item. This parameter can be null.</param>
-        /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the {select} element.
-        /// Alternatively, an <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
-        /// </param>
-        /// <returns>An HTML {select} element with an {option} subelement for each item in the list.</returns>
-        HtmlString DropDownList(
-            string name,
-            IEnumerable<SelectListItem> selectList,
-            string optionLabel,
-            object htmlAttributes);
+        HtmlString DisplayNameForInnerType<TInnerModel, TValue>(
+            [NotNull] Expression<Func<TInnerModel, TValue>> expression);
 
         /// <summary>
         /// Returns a single-selection HTML {select} element for the object that is represented
@@ -247,51 +90,6 @@ namespace Microsoft.AspNet.Mvc.Rendering
             object htmlAttributes);
 
         /// <summary>
-        /// Converts the value of the specified object to an HTML-encoded string.
-        /// </summary>
-        /// <param name="value">The object to encode.</param>
-        /// <returns>The HTML-encoded string.</returns>
-        string Encode(object value);
-
-        /// <summary>
-        /// Converts the specified string to an HTML-encoded string.
-        /// </summary>
-        /// <param name="value">The string to encode.</param>
-        /// <returns>The HTML-encoded string.</returns>
-        string Encode(string value);
-
-        /// <summary>
-        /// Formats the value.
-        /// </summary>
-        /// <param name="value">The value.</param>
-        /// <param name="format">The format string.</param>
-        /// <returns>The formatted value.</returns>
-        string FormatValue(object value, string format);
-
-        /// <summary>
-        /// Creates an HTML element ID using the specified element name.
-        /// </summary>
-        /// <param name="name">The name of the HTML element.</param>
-        /// <returns>The ID of the HTML element.</returns>
-        string GenerateIdFromName(string name);
-
-        /// <summary>
-        /// Render an input element of type "hidden".
-        /// </summary>
-        /// <param name="name">
-        /// Rendered element's name. Also use this name to find value in submitted data or view data. Use view data
-        /// only if value is not in submitted data and <paramref name="value"/> is <c>null</c>.
-        /// </param>
-        /// <param name="value">
-        /// If non-<c>null</c>, value to include in the element. Ignore if named value is found in submitted data.
-        /// </param>
-        /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the element.
-        /// Alternatively, an <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
-        /// </param>
-        /// <returns>New <see cref="HtmlString"/> containing the rendered HTML.</returns>
-        HtmlString Hidden(string name, object value, object htmlAttributes);
-
-        /// <summary>
         /// Render an input element of type "hidden".
         /// </summary>
         /// <param name="expression">
@@ -305,35 +103,18 @@ namespace Microsoft.AspNet.Mvc.Rendering
             object htmlAttributes);
 
         /// <summary>
-        /// Returns an HTML label element and the property name of the property that is represented by the specified expression.
-        /// </summary>
-        /// <param name="expression">An expression that identifies the property to display.</param>
-        /// <param name="labelText">The label text.</param>
-        /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the element.</param>
-        /// <returns>
-        /// An HTML label element and the property name of the property that is represented by the expression.
-        /// </returns>
-        HtmlString Label(string expression, string labelText, object htmlAttributes);
-
-        /// <summary>
-        /// Returns an HTML label element and the property name of the property that is represented by the specified expression.
+        /// Returns an HTML label element and the property name of the property that is represented by the specified
+        /// expression.
         /// </summary>
         /// <param name="expression">An expression that identifies the property to display.</param>
         /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the element.</param>
-        /// <typeparam name="TValue">The type of the value.</typeparam> 
+        /// <typeparam name="TValue">The type of the value.</typeparam>
         /// <returns>
         /// An HTML label element and the property name of the property that is represented by the expression.
         /// </returns>
-        HtmlString LabelFor<TValue>(Expression<Func<TModel, TValue>> expression,
+        HtmlString LabelFor<TValue>([NotNull] Expression<Func<TModel, TValue>> expression,
                                     string labelText,
                                     object htmlAttributes);
-
-        /// <summary>
-        /// Gets the full HTML field name for the given expression <paramref name="name"/>.
-        /// </summary>
-        /// <param name="name">Name of an expression, relative to the current model.</param>
-        /// <returns>An <see cref="HtmlString"/> that represents HTML markup.</returns>
-        HtmlString Name(string name);
 
         /// <summary>
         /// Gets the full HTML field name for the given <paramref name="expression"/>.
@@ -342,22 +123,6 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <param name="expression">An expression, relative to the current model.</param>
         /// <returns>An <see cref="HtmlString"/> that represents HTML markup.</returns>
         HtmlString NameFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression);
-
-        /// <summary>
-        /// Render an input element of type "password".
-        /// </summary>
-        /// <param name="name">
-        /// Rendered element's name. Also use this name to find value in view data. Use view data
-        /// only if value is not in submitted data and <paramref name="value"/> is <c>null</c>.
-        /// </param>
-        /// <param name="value">
-        /// If non-<c>null</c>, value to include in the element.
-        /// </param>
-        /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the element.
-        /// Alternatively, an <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
-        /// </param>
-        /// <returns>New <see cref="HtmlString"/> containing the rendered HTML.</returns>
-        HtmlString Password(string name, object value, object htmlAttributes);
 
         /// <summary>
         /// Render an input element of type "password".
@@ -371,30 +136,6 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <returns>New <see cref="HtmlString"/> containing the rendered HTML.</returns>
         HtmlString PasswordFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression,
             object htmlAttributes);
-
-        /// <summary>
-        /// Render an input element of type "radio".
-        /// </summary>
-        /// <param name="name">
-        /// Rendered element's name. Also use this name to find value in submitted data or view data. Use view data
-        /// only if value is not in submitted data and <paramref name="value"/> is <c>null</c>.
-        /// </param>
-        /// <param name="value">
-        /// If non-<c>null</c>, value to include in the element. May be <c>null</c> only if
-        /// <paramref name="isChecked"/> is also <c>null</c>. Also compared to value in submitted data or view data to
-        /// determine <paramref name="isChecked"/> if that parameter is <c>null</c>. Ignore if named value is found in
-        /// submitted data.
-        /// </param>
-        /// <param name="isChecked">
-        /// If <c>true</c>, radio button is initially selected. Ignore if named value is found in submitted data. Fall
-        /// back to comparing <paramref name="value"/> with view data if this parameter is <c>null</c>. Finally
-        /// fall back to an existing "checked" value in <paramref name="htmlAttributes"/>.
-        /// </param>
-        /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the element.
-        /// Alternatively, an <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
-        /// </param>
-        /// <returns>New <see cref="HtmlString"/> containing the rendered HTML.</returns>
-        HtmlString RadioButton(string name, object value, bool? isChecked, object htmlAttributes);
 
         /// <summary>
         /// Render an input element of type "radio".
@@ -414,57 +155,6 @@ namespace Microsoft.AspNet.Mvc.Rendering
             object htmlAttributes);
 
         /// <summary>
-        /// Wraps HTML markup in an <see cref="HtmlString"/>, which will enable HTML markup to be
-        /// rendered to the output without getting HTML encoded.
-        /// </summary>
-        /// <param name="value">HTML markup string.</param>
-        /// <returns>An <see cref="HtmlString"/> that represents HTML markup.</returns>
-        HtmlString Raw(string value);
-
-        /// <summary>
-        /// Wraps HTML markup from the string representation of an object in an <see cref="HtmlString"/>,
-        /// which will enable HTML markup to be rendered to the output without getting HTML encoded.
-        /// </summary>
-        /// <param name="value">object with string representation as HTML markup.</param>
-        /// <returns>An <see cref="HtmlString"/> that represents HTML markup.</returns>
-        HtmlString Raw(object value);
-
-        /// <summary>
-        /// Returns a partial view in string format.
-        /// </summary>
-        /// <param name="partialViewName">The name of the partial view to render and return.</param>
-        /// <param name="model">A model to pass into the partial view.</param>
-        /// <param name="viewData">A <see cref="ViewDataDictionary"/> to pass into the partial view.</param>
-        /// <returns>A task that represents when rendering of the partial view into a string has completed.</returns>
-        Task<HtmlString> PartialAsync([NotNull] string partialViewName, object model, ViewDataDictionary viewData);
-
-        /// <summary>
-        /// Renders a partial view.
-        /// </summary>
-        /// <param name="partialViewName">The name of the partial view to render.</param>
-        /// <param name="model">A model to pass into the partial view.</param>
-        /// <param name="viewData">A <see cref="ViewDataDictionary"/> to pass into the partial view.</param>
-        /// <returns>A task that represents when rendering has completed.</returns>
-        Task RenderPartialAsync([NotNull] string partialViewName, object model, ViewDataDictionary viewData);
-
-        /// <summary>
-        /// Render an input element of type "text".
-        /// </summary>
-        /// <param name="name">
-        /// Rendered element's name. Also use this name to find value in submitted data or view data. Use view data
-        /// only if value is not in submitted data and <paramref name="value"/> is <c>null</c>.
-        /// </param>
-        /// <param name="value">
-        /// If non-<c>null</c>, value to include in the element. Ignore if named value is found in submitted data.
-        /// </param>
-        /// <param name="format"></param>
-        /// <param name="htmlAttributes">
-        /// <see cref="IDictionary{string, object}"/> containing additional HTML attributes.
-        /// </param>
-        /// <returns>New <see cref="HtmlString"/> containing the rendered HTML.</returns>
-        HtmlString TextBox(string name, object value, string format, IDictionary<string, object> htmlAttributes);
-
-        /// <summary>
         /// Render an input element of type "text".
         /// </summary>
         /// <param name="expression">
@@ -477,27 +167,6 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <returns>New <see cref="HtmlString"/> containing the rendered HTML.</returns>
         HtmlString TextBoxFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression, string format,
             IDictionary<string, object> htmlAttributes);
-
-        /// <summary>
-        /// Returns an unordered list (ul element) of validation messages that are in the
-        /// <see cref="ModelStateDictionary"/> object.
-        /// </summary>
-        /// <param name="excludePropertyErrors">true to have the summary display model-level errors only, or false to
-        /// have the summary display all errors.</param>
-        /// <param name="message">The message to display with the validation summary.</param>
-        /// <param name="htmlAttributes">A dictionary that contains the HTML attributes for the element.</param>
-        /// <returns>An <see cref="HtmlString"/> that contains an unordered list (ul element) of validation messages.
-        /// </returns>
-        HtmlString ValidationSummary(bool excludePropertyErrors, string message,
-                                     IDictionary<string, object> htmlAttributes);
-
-        /// <summary>
-        /// Returns the model value for the given expression <paramref name="name"/>.
-        /// </summary>
-        /// <param name="name">Name of an expression, relative to the current model.</param>
-        /// <param name="format">The optional format string to apply to the value.</param>
-        /// <returns>An <see cref="HtmlString"/> that represents HTML markup.</returns>
-        HtmlString Value([NotNull] string name, string format);
 
         /// <summary>
         /// Returns the model value for the given expression <paramref name="expression"/>.

--- a/src/Microsoft.AspNet.Mvc/MvcServices.cs
+++ b/src/Microsoft.AspNet.Mvc/MvcServices.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNet.Mvc.Razor;
 using Microsoft.AspNet.Mvc.Razor.Compilation;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Security.Authorization;
-using Microsoft.AspNet.Security.DataProtection;
 
 namespace Microsoft.AspNet.Mvc
 {
@@ -97,6 +96,7 @@ namespace Microsoft.AspNet.Mvc
                     implementationInstance: null,
                     lifecycle: LifecycleKind.Transient);
 
+            yield return describe.Transient<IHtmlHelper, HtmlHelper>();
             yield return
                 describe.Describe(
                     typeof(IHtmlHelper<>),


### PR DESCRIPTION
- no more `IHtmlHelper<object>` in `DefaultDisplayTemplates` and also no
  need for `ViewDataDictionary<object>` in a few places
- mostly removals from `IHtmlHelper<TModel>` but did cleanup comments and
  add `[NotNull]` for `DisplayFor()`, `DisplayNameFor()`,
  `DisplayNameForInnerType()`, and `LabelFor()`
- also add `[NotNull]` for `this` and `Expression` parameters in some
  extension methods

Fixes #262 and makes @Eilon happy.
