### PR TITLE
Make razor roslyn compilation work on mono

### DIFF
--- a/src/Common/PlatformHelper.cs
+++ b/src/Common/PlatformHelper.cs
@@ -4,7 +4,7 @@ namespace Microsoft.AspNet.Mvc
 {
     internal static class PlatformHelper
     {
-        private static Lazy<bool> _isMono = new Lazy<bool>(() => Type.GetType("Mono.Runtime") != null);
+        private static readonly Lazy<bool> _isMono = new Lazy<bool>(() => Type.GetType("Mono.Runtime") != null);
 
         public static bool IsMono
         {

--- a/src/Microsoft.AspNet.Mvc.Razor/Compilation/RoslynCompilationService.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Compilation/RoslynCompilationService.cs
@@ -14,10 +14,11 @@ namespace Microsoft.AspNet.Mvc.Razor.Compilation
 {
     public class RoslynCompilationService : ICompilationService
     {
+        private static readonly ConcurrentDictionary<string, MetadataReference> _metadataFileCache = new ConcurrentDictionary<string, MetadataReference>(StringComparer.OrdinalIgnoreCase);
+        
         private readonly ILibraryManager _libraryManager;
         private readonly IApplicationEnvironment _environment;
         private readonly IAssemblyLoaderEngine _loader;
-        private static readonly ConcurrentDictionary<string, MetadataReference> _metadataFileCache = new ConcurrentDictionary<string, MetadataReference>(StringComparer.OrdinalIgnoreCase);
 
         public RoslynCompilationService(IApplicationEnvironment environment,
                                         IAssemblyLoaderEngine loaderEngine,


### PR DESCRIPTION
- Added a metadata cache (we need this for core clr). Will consider
  moving this into the core
- Skip pdb generation on mono

This pull request was sent from a mac :smile: 
