### PR TITLE
Fix for issue #131

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/DefaultActionSelector.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/DefaultActionSelector.cs
@@ -35,10 +35,6 @@ namespace Microsoft.AspNet.Mvc
             {
                 return null;
             }
-            else if (matching.Count == 1)
-            {
-                return matching[0];
-            }
             else
             {
                 return await SelectBestCandidate(context, matching);


### PR DESCRIPTION
The problem is that we weren't running the parameter-based part of action
selection when we have one candidate. It needs to run because it finds the
'best' action and filters actions at the same time.
