### PR TITLE
Unblocking the CI

### DIFF
--- a/src/Microsoft.AspNet.Mvc.ModelBinding/project.json
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/project.json
@@ -34,6 +34,7 @@
         "System.Reflection.Emit.Lightweight": "4.0.0.0",
         "System.Reflection.Extensions": "4.0.0.0",
         "System.Reflection.Primitives": "4.0.0.0",
+        "System.Reflection.TypeExtensions": "4.0.0.0",
         "System.Resources.ResourceManager": "4.0.0.0",
         "System.Runtime": "4.0.20.0",
         "System.Runtime.Extensions": "4.0.10.0",


### PR DESCRIPTION
DataAnnotations used to reference System.Reflection.Compatibility, which
was giving us a reference to some methods "for free". Really we should
have been pulling in this package all along.
