### PR TITLE
Trim Razor.Host dependencies.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor.Host/project.json
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/project.json
@@ -5,13 +5,7 @@
   },
   "dependencies": {
     "Common": "",
-    "Microsoft.AspNet.FileSystems": "0.1-alpha-*",
-    "Microsoft.AspNet.Http": "0.1-alpha-*",
-    "Microsoft.AspNet.Mvc.Core" : "",
-    "Microsoft.AspNet.Mvc.ModelBinding" : "",
-    "Microsoft.AspNet.Razor": "0.1-alpha-*",
-    "Microsoft.Framework.DependencyInjection": "0.1-alpha-*",
-    "Microsoft.Framework.Runtime.Interfaces":  "0.1-alpha-*"
+    "Microsoft.AspNet.Razor": "0.1-alpha-*"
   },
   "configurations": {
     "net45": {


### PR DESCRIPTION
Several dependencies were added to the Razor.Host project that weren't needed.  Removed them in order to reduce the dependency chain for tooling.
