### PR TITLE
Fix #522, [MusicStore]: Html.BeginForm() while generating the action url...

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/HtmlHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/HtmlHelper.cs
@@ -769,7 +769,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 // parameters. Also reachable in the even-more-unusual case that user called another BeginForm()
                 // overload with default argument values.
                 var request = ViewContext.HttpContext.Request;
-                formAction = request.PathBase.Add(request.Path).Add(request.QueryString);
+                formAction = request.PathBase + request.Path + request.QueryString;
             }
             else
             {


### PR DESCRIPTION
 should consider the application base path
- `request.BasePath` was indeed ignored
- also simplify `formAction` calculation using the higher-level
  `PathString.Add()` overloads
