### PR TITLE
Added in memory tests to cover the MvcSample.

### DIFF
--- a/Mvc.sln
+++ b/Mvc.sln
@@ -29,6 +29,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "MvcSample.Web", "samples\Mv
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.Mvc.Razor.Host", "src\Microsoft.AspNet.Mvc.Razor.Host\Microsoft.AspNet.Mvc.Razor.Host.kproj", "{520B3AA4-363A-497C-8C15-80423C5AFC85}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "MvcSample.Web.Tests", "test\MvcSample.Web.Tests\MvcSample.Web.Tests.kproj", "{C1265868-D397-4ABD-A2B8-F2EBB32DB103}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -139,6 +141,16 @@ Global
 		{520B3AA4-363A-497C-8C15-80423C5AFC85}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{520B3AA4-363A-497C-8C15-80423C5AFC85}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{520B3AA4-363A-497C-8C15-80423C5AFC85}.Release|x86.ActiveCfg = Release|Any CPU
+		{C1265868-D397-4ABD-A2B8-F2EBB32DB103}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1265868-D397-4ABD-A2B8-F2EBB32DB103}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1265868-D397-4ABD-A2B8-F2EBB32DB103}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{C1265868-D397-4ABD-A2B8-F2EBB32DB103}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{C1265868-D397-4ABD-A2B8-F2EBB32DB103}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C1265868-D397-4ABD-A2B8-F2EBB32DB103}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C1265868-D397-4ABD-A2B8-F2EBB32DB103}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1265868-D397-4ABD-A2B8-F2EBB32DB103}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{C1265868-D397-4ABD-A2B8-F2EBB32DB103}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{C1265868-D397-4ABD-A2B8-F2EBB32DB103}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -154,5 +166,6 @@ Global
 		{A8AA326E-8EE8-4F11-B750-23028E0949D7} = {3BA657BF-28B1-42DA-B5B0-1C4601FCF7B1}
 		{FBB2B86E-972B-4185-9FF2-62CAB5F8388F} = {DAAE4C74-D06F-4874-A166-33305D2643CE}
 		{520B3AA4-363A-497C-8C15-80423C5AFC85} = {32285FA4-6B46-4D6B-A840-2B13E4C8B58E}
+		{C1265868-D397-4ABD-A2B8-F2EBB32DB103} = {3BA657BF-28B1-42DA-B5B0-1C4601FCF7B1}
 	EndGlobalSection
 EndGlobal

--- a/global.json
+++ b/global.json
@@ -1,3 +1,3 @@
 {
-    "sources": ["src"]
+    "sources": ["src", "samples"]
 }

--- a/samples/MvcSample.Web/Views/Shared/Components/Tags/Default.cshtml
+++ b/samples/MvcSample.Web/Views/Shared/Components/Tags/Default.cshtml
@@ -1,6 +1,6 @@
 ﻿@model string[]
 
-<div style="width: 300px; height: 250px; padding: 0px 10px;">
+<div style="width: 300px; height: 250px; padding: 0px 10px;" id="test-components">
     <h4>@ViewBag.Title</h4>
     @foreach (var tag in Model)
     {

--- a/samples/MvcSample.Web/Views/Shared/HelloWorldPartial.cshtml
+++ b/samples/MvcSample.Web/Views/Shared/HelloWorldPartial.cshtml
@@ -3,4 +3,4 @@
 
 <strong>Hello @Model.Name from Partial</strong>
 
-<a href="@Url.Action("Create", "Home")">Create Something!</a>
+<a id="@Model.Name" href="@Url.Action("Create", "Home")">Create Something!</a>

--- a/samples/MvcSample.Web/Views/Shared/MyView.cshtml
+++ b/samples/MvcSample.Web/Views/Shared/MyView.cshtml
@@ -13,7 +13,7 @@
 }
 
 @section header {
-    <style type="text/css">
+    <style id="test-style-header" type="text/css">
         #qux {
             display: none;
         }
@@ -25,7 +25,7 @@
 }
 
 @section footer {
-    <script src="//ajax.aspnetcdn.com/ajax/jQuery/jquery-2.1.0.min.js"></script>
+    <script id="test-script-footer" src="//ajax.aspnetcdn.com/ajax/jQuery/jquery-2.1.0.min.js"></script>
     <script>
         $(function () {
             $("#qux").fadeIn(3000, function () {
@@ -88,16 +88,16 @@
     <div style="float: left; border: 5px solid blue; margin: 5px; padding: 7px;">
         <table>
             <tr>
-                <td>
+                <td id="test-labelfor">
                     @Html.LabelForModel("ForModel")
                 </td>
-                <td>
+                <td id="test-displayname">
                     '@Html.DisplayNameForModel()'
                 </td>
-                <td>
+                <td id="test-namefor">
                     '@Html.NameForModel()'
                 </td>
-                <td>
+                <td id="test-valuefor">
                     '@Html.ValueForModel()'
                 </td>
             </tr>

--- a/samples/MvcSample.Web/Views/Shared/_Layout.cshtml
+++ b/samples/MvcSample.Web/Views/Shared/_Layout.cshtml
@@ -19,7 +19,7 @@
             </div>
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">
-                    <li><a href="/">Home</a></li>
+                    <li><a id="test-link-home" href="/">Home</a></li>
                 </ul>
             </div>
         </div>

--- a/test/MvcSample.Web.Tests/MvcSample.Web.Tests.kproj
+++ b/test/MvcSample.Web.Tests/MvcSample.Web.Tests.kproj
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">12.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\ProjectK\Microsoft.Web.ProjectK.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>c1265868-d397-4abd-a2b8-f2ebb32db103</ProjectGuid>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'" Label="Configuration">
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Content Include="Project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MvcSampleTests.cs" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\ProjectK\Microsoft.Web.ProjectK.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/MvcSample.Web.Tests/MvcSampleTests.cs
+++ b/test/MvcSample.Web.Tests/MvcSampleTests.cs
@@ -1,0 +1,333 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.Versioning;
+using System.Threading.Tasks;
+using HtmlAgilityPack;
+using Microsoft.AspNet.Builder;
+using Microsoft.AspNet.TestHost;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+using Microsoft.Framework.Runtime;
+using Microsoft.Framework.Runtime.Infrastructure;
+using Xunit;
+
+namespace MvcSample.Web.Tests
+{
+    public class MvcSampleTests
+    {
+        private readonly IServiceProvider _provider;
+        private readonly Action<IBuilder> _app = new Startup().Configure;
+
+        public MvcSampleTests()
+        {
+            var originalProvider = CallContextServiceLocator.Locator.ServiceProvider;
+
+            IApplicationEnvironment appEnvironment = originalProvider.GetService<IApplicationEnvironment>();
+
+            // When an application executes in a regular context, the application base path points to the root
+            // directory where the application is located, for example MvcSample.Web. However, when executing
+            // an aplication as part of a test, the ApplicationBasePath of the IApplicationEnvironment points
+            // to the root folder of the test project.
+            // To compensate for this, we need to calculate the original path and override the application
+            // environment value so that components like the view engine work properly in the context of the
+            // test.
+            string appBasePath = CalculateApplicationBasePath(appEnvironment);
+            _provider = new ServiceCollection()
+                .AddInstance(typeof(IApplicationEnvironment), new MockApplicationEnvironment(appEnvironment, appBasePath))
+                .BuildServiceProvider(originalProvider);
+        }
+
+        [Theory]
+        [InlineData("http://localhost/Link/", "http://localhost/Home/Create#CoolBeans!")]
+        [InlineData("http://localhost/Link/Link1", "/")]
+        [InlineData("http://localhost/Link/Link2", "/Link/Link2")]
+        [InlineData("http://localhost/Link/About", "/Link/About")]
+        public async Task LinkController_Works(string url, string result)
+        {
+            // Arrange
+            var testServer = TestServer.Create(_provider, _app);
+
+            // When we have HttpClient we'll only need to substitute this line for new HttpClient(testServer.Handler)
+            // the rest of the API will be equivalent.
+            var client = testServer.Handler;
+
+            // Act
+            var response = await client.GetStringAsync(url);
+
+            // Assert
+            Assert.Equal(result, response);
+        }
+
+        [Theory]
+        [InlineData("http://localhost/Overload/", "Get()")]
+        [InlineData("http://localhost/Overload?id=1", "Get(id)")]
+        [InlineData("http://localhost/Overload?id=1&name=Ryan", "Get(id, name)")]
+        public async Task OverloadController_Works(string url, string responseContent)
+        {
+            // Arrange
+            var testServer = TestServer.Create(_provider, _app);
+            var client = testServer.Handler;
+
+            // Act
+            var response = await client.GetStringAsync(url);
+
+            // Assert
+            Assert.Equal(responseContent, response);
+        }
+
+        [Fact]
+        public async Task SimplePocoController_Works()
+        {
+            // Arrange
+            var testServer = TestServer.Create(_provider, _app);
+            var client = testServer.Handler;
+
+            // Act
+            var response = await client.GetStringAsync("http://localhost:12345/SimplePoco/");
+
+            // Assert
+            Assert.Equal("Hello world", response);
+        }
+
+        [Fact]
+        public async Task SimpleRest_Works()
+        {
+            // Arrange
+            var testServer = TestServer.Create(_provider, _app);
+            var client = testServer.Handler;
+
+            // Act
+            var response = await client.GetStringAsync("http://localhost:12345/SimpleRest/");
+
+            // Assert
+            Assert.Equal("Get method", response);
+        }
+
+        [Theory]
+        [InlineData("http://localhost:12345/Home/Something", "Hello World From Content")]
+        [InlineData("http://localhost:12345/Home/Hello", "Hello World")]
+        [InlineData("http://localhost:12345/Home/Raw", "Hello World raw")]
+        [InlineData("http://localhost:12345/Home/CreateUser", "{\"Name\":\"My name\",\"Address\":\"My address\",\"Age\":13,\"GPA\":13.37,\"Dependent\":{\"Name\":\"Dependents name\",\"Address\":\"Dependents address\",\"Age\":0,\"GPA\":0.0,\"Dependent\":null,\"Alive\":false,\"Password\":null,\"Profession\":null,\"About\":null,\"Log\":null,\"OwnedAddresses\":[],\"ParentsAges\":[]},\"Alive\":true,\"Password\":\"Secure string\",\"Profession\":\"Software Engineer\",\"About\":\"I like playing Football\",\"Log\":null,\"OwnedAddresses\":[],\"ParentsAges\":[]}")]
+        public async Task HomeController_Works_NonViewActions(string url, string result)
+        {
+            // Arrange
+            var testServer = TestServer.Create(_provider, _app);
+            var client = testServer.Handler;
+
+            // Act
+            var response = await client.GetStringAsync(url);
+
+            // Assert
+            Assert.Equal(result, response);
+        }
+
+        [Theory]
+        [InlineData("http://localhost:12345/Home/Index")]
+        public async Task HomeController_Works_ViewActions(string url)
+        {
+            // Arrange
+            var testServer = TestServer.Create(_provider, _app);
+            var client = testServer.Handler;
+
+            // Act
+            var response = await client.GetAsync(url);
+
+            // Assert
+            Assert.Equal(200, response.StatusCode);
+            Assert.Equal("text/html; charset=utf-8", response.ContentType);
+            HomePage page = new HomePage(response.Body);
+            page.ValidateContent();
+        }
+
+        [Theory]
+        [InlineData("http://localhost:12345/Home2/", "Hello World: my namespace is MvcSample.Web.RandomNameSpace")]
+        [InlineData("http://localhost:12345/Home2/Something", "Hello World From Content")]
+        [InlineData("http://localhost:12345/Home2/Hello", "Hello World")]
+        [InlineData("http://localhost:12345/Home2/Raw", "Hello World raw")]
+        [InlineData("http://localhost:12345/Home2/UserJson", "{\"Name\":\"User Name\",\"Address\":\"Home Address\",\"Age\":0,\"GPA\":0.0,\"Dependent\":null,\"Alive\":false,\"Password\":null,\"Profession\":null,\"About\":null,\"Log\":null,\"OwnedAddresses\":[],\"ParentsAges\":[]}")]
+        [InlineData("http://localhost:12345/Home2/User", "{\"Name\":\"User Name\",\"Address\":\"Home Address\",\"Age\":0,\"GPA\":0.0,\"Dependent\":null,\"Alive\":false,\"Password\":null,\"Profession\":null,\"About\":null,\"Log\":null,\"OwnedAddresses\":[],\"ParentsAges\":[]}")]
+        public async Task Home2Controller_Works(string url, string result)
+        {
+            // Arrange
+            var testServer = TestServer.Create(_provider, _app);
+            var client = testServer.Handler;
+
+            // Act
+            var response = await client.GetStringAsync(url);
+
+            // Assert
+            Assert.Equal(result, response);
+        }
+
+        // Calculate the path relative to the current application base path.
+        private static string CalculateApplicationBasePath(IApplicationEnvironment appEnvironment)
+        {
+            // Mvc/test/MvcSample.Test
+            var appBase = appEnvironment.ApplicationBasePath;
+
+            // Mvc/test
+            var test = Path.GetDirectoryName(appBase);
+
+            // Mvc
+            var webFxPath = Path.GetDirectoryName(test);
+
+            // Mvc/Samples/MvcSample.Web
+            return Path.Combine(webFxPath, "Samples\\MvcSample.Web");
+        }
+
+        // Represents an application environment that overrides the base path of the original
+        // application environment in order to make it point to the folder of the original web
+        // aplication so that components like ViewEngines can find views as if they were executing
+        // in a regular context.
+        private class MockApplicationEnvironment : IApplicationEnvironment
+        {
+            private readonly IApplicationEnvironment _originalAppEnvironment;
+            private readonly string _applicationBasePath;
+
+            public MockApplicationEnvironment(IApplicationEnvironment originalAppEnvironment, string appBasePath)
+            {
+                _originalAppEnvironment = originalAppEnvironment;
+                _applicationBasePath = appBasePath;
+            }
+
+            public string ApplicationName
+            {
+                get { return _originalAppEnvironment.ApplicationName; }
+            }
+
+            public string Version
+            {
+                get { return _originalAppEnvironment.Version; }
+            }
+
+            public string ApplicationBasePath
+            {
+                get { return _applicationBasePath; }
+            }
+
+            public FrameworkName TargetFramework
+            {
+                get { return _originalAppEnvironment.TargetFramework; }
+            }
+        }
+
+        // Represents an abstraction over different elements of the rendered page we are interested to check for correctness.
+        private class HomePage
+        {
+            HtmlDocument _document;
+            public HomePage(Stream responseBody)
+            {
+                _document = new HtmlDocument();
+                _document.Load(responseBody);
+            }
+
+            public HtmlNode NavigationHomeItem
+            {
+                get
+                {
+                    return _document.GetElementbyId("test-link-home");
+                }
+            }
+
+            public HtmlNode HeaderStyleItem
+            {
+                get
+                {
+                    return _document.GetElementbyId("test-style-header");
+                }
+            }
+
+            public HtmlNode FooterScriptItem
+            {
+                get
+                {
+                    return _document.GetElementbyId("test-script-footer");
+                }
+            }
+
+            public HtmlNode AsyncValueItem
+            {
+                get
+                {
+                    return _document.GetElementbyId("qux");
+                }
+            }
+
+            public HtmlNode AsyncPartialItem
+            {
+                get
+                {
+                    return _document.GetElementbyId("Bob");
+                }
+            }
+
+            public HtmlNode LabelFor
+            {
+                get
+                {
+                    return _document.GetElementbyId("test-labelfor");
+                }
+            }
+
+            public HtmlNode DisplayNameFor
+            {
+                get
+                {
+                    return _document.GetElementbyId("test-displayname");
+                }
+            }
+
+            public HtmlNode ValueFor
+            {
+                get
+                {
+                    return _document.GetElementbyId("test-valuefor");
+                }
+            }
+            public HtmlNode NameFor
+            {
+                get
+                {
+                    return _document.GetElementbyId("test-namefor");
+                }
+            }
+
+            public HtmlNode Tags
+            {
+                get
+                {
+                    return _document.GetElementbyId("test-components");
+                }
+            }
+
+            // Checks for the presence of multiple elements inside the document contained in the response stream to 
+            // ensure that no component failed silently.
+            internal void ValidateContent()
+            {
+                // Check layout elements can be rendered
+                Assert.Equal("Home", NavigationHomeItem.InnerText);
+                Assert.Equal("text/css", HeaderStyleItem.GetAttributeValue("type", ""));
+                Assert.Equal("//ajax.aspnetcdn.com/ajax/jQuery/jquery-2.1.0.min.js", FooterScriptItem.GetAttributeValue("src", ""));
+
+                // Check async values can be retrieved.
+                Assert.Equal("This value was retrieved asynchronously: Hello World", AsyncValueItem.InnerText);
+
+                // Check partial views can be rendered.
+                Assert.Equal("Create Something!", AsyncPartialItem.InnerText);
+
+                // Check forms can be rendered.
+                Assert.Contains("ForModel", LabelFor.Descendants().Select(d => d.InnerText));
+                Assert.Contains("''", DisplayNameFor.Descendants().Select(d => d.InnerText.Trim()));
+                Assert.Contains("''", NameFor.Descendants().Select(d => d.InnerText.Trim()));
+                Assert.Contains("'MvcSample.Web.Models.User'", ValueFor.Descendants().Select(d => d.InnerText.Trim()));
+
+                // Check view components can be rendered.
+                Assert.Contains("15 Tags", Tags.InnerText);
+            }
+        }
+    }
+}

--- a/test/MvcSample.Web.Tests/Project.json
+++ b/test/MvcSample.Web.Tests/Project.json
@@ -1,0 +1,29 @@
+﻿{
+    "version": "0.1-alpha-*",
+    "dependencies": {
+        "Common": "",
+        "HtmlAgilityPack": "1.4.6",
+        "Microsoft.AspNet.Mvc": "",
+        "Microsoft.AspNet.TestHost": "0.1-alpha-*",
+        "MvcSample.Web": "",
+        "Xunit.KRunner": "0.1-alpha-*",
+        "xunit.abstractions": "2.0.0-aspnet-*",
+        "xunit.assert": "2.0.0-aspnet-*",
+        "xunit.core": "2.0.0-aspnet-*",
+        "xunit.execution": "2.0.0-aspnet-*"
+    },
+    "commands": {
+        "test": "Xunit.KRunner"
+    },
+    "configurations": {
+        "net45": { },
+        "k10": {
+            "dependencies": {
+                "System.Runtime": "4.0.20.0",
+                "System.Runtime.Extensions": "4.0.10.0",
+                "System.Reflection": "",
+                "System.Reflection.Extensions": "4.0.0.0"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This change adds some functional tests to cover the MvcSample in the
samples folder. The tests validate that the Mvc pipeline is correctly
integrated with the rest of the components like Hosting and Dependency
Injection and that no end to end scenario is regressed by a change.

The only thing we mock in the execution of the tests is the application
base path in order to make it match the application base path that the
sample would have if it was being executed in a regular context.

For testing views our approach is to use the HtmlAgility pack and check
some elements of the returned response in order to ensure that the
elements on the view get rendered properly and don't fail silently.
