### PR TITLE
Modify JsonResult to generate results in UTF8 without BOM by default

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/JsonResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/JsonResult.cs
@@ -11,7 +11,8 @@ namespace Microsoft.AspNet.Mvc
     public class JsonResult : ActionResult
     {
         private const int BufferSize = 1024;
-        private static readonly Encoding UTF8EncodingWithoutBOM = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        private static readonly Encoding UTF8EncodingWithoutBOM 
+            = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
         private readonly object _returnValue;
 
         private JsonSerializerSettings _jsonSerializerSettings;

--- a/test/Microsoft.AspNet.Mvc.Core.Test/JsonResultTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/JsonResultTest.cs
@@ -16,7 +16,8 @@ namespace Microsoft.AspNet.Mvc
 {
     public class JsonResultTest
     {
-        private static readonly byte[] _abcdUTF8Bytes = new byte[] { 123, 34, 102, 111, 111, 34, 58, 34, 97, 98, 99, 100, 34, 125 };
+        private static readonly byte[] _abcdUTF8Bytes 
+            = new byte[] { 123, 34, 102, 111, 111, 34, 58, 34, 97, 98, 99, 100, 34, 125 };
 
         [Fact]
         public async Task ExecuteResult_GeneratesResultsWithoutBOMByDefault()


### PR DESCRIPTION
Fixes #577

<!---
@huboard:{"order":582.0,"custom_state":""}
-->
