### PR TITLE
Fix stylecop in Microsoft.AspNet.Mvc

### DIFF
--- a/Settings.StyleCop
+++ b/Settings.StyleCop
@@ -259,6 +259,11 @@
     </Analyzer>
     <Analyzer AnalyzerId="StyleCop.CSharp.ReadabilityRules">
       <Rules>
+        <Rule Name="OpeningParenthesisMustBeOnDeclarationLine">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
         <Rule Name="ParameterMustNotSpanMultipleLines">
           <RuleSettings>
             <BooleanProperty Name="Enabled">False</BooleanProperty>

--- a/src/Microsoft.AspNet.Mvc/BuilderExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc/BuilderExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNet.Builder
             return app.UseMvc(routes =>
             {
                 // Action style actions
-                routes.MapRoute(null, "{controller}/{action}/{id?}", new { controller = "Home" , action = "Index" });
+                routes.MapRoute(null, "{controller}/{action}/{id?}", new { controller = "Home", action = "Index" });
 
                 // Rest style actions
                 routes.MapRoute(null, "{controller}/{id?}");


### PR DESCRIPTION
The new rule that's deactivated is for cases like this:

```
yield return describe.Transient<INestedProvider<ActionDescriptorProviderContext>,
                                ReflectedRouteConstraintsActionDescriptorProvider>();
```

It's too long of a line if you put it all together, but there's no good way to break it up that this rule is happy with, so we should chuck it out.
