### PR TITLE
Catch MVC up with Helios rename

### DIFF
--- a/samples/MvcSample.Web/project.json
+++ b/samples/MvcSample.Web/project.json
@@ -3,13 +3,13 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "Helios": "1.0.0-*",
     "Microsoft.AspNet.Http": "1.0.0-*",
     "Microsoft.AspNet.Mvc": "",
     "Microsoft.AspNet.Mvc.Core": "",
     "Microsoft.AspNet.Mvc.ModelBinding": "",
     "Microsoft.AspNet.Mvc.Razor": "",
     "Microsoft.AspNet.Routing": "1.0.0-*",
+    "Microsoft.AspNet.Server.IIS": "1.0.0-*",
     "Microsoft.AspNet.Server.WebListener": "1.0.0-*",
     "Microsoft.DataAnnotations": "1.0.0-*",
     "Microsoft.Framework.ConfigurationModel": "1.0.0-*",

--- a/test/WebSites/BasicWebSite/project.json
+++ b/test/WebSites/BasicWebSite/project.json
@@ -1,7 +1,7 @@
 ﻿{
     "dependencies": {
-        "Helios": "1.0.0-*",
-        "Microsoft.AspNet.Mvc": ""
+        "Microsoft.AspNet.Mvc": "",
+        "Microsoft.AspNet.Server.IIS": "1.0.0-*"
     },
     "configurations": {
         "net45": { },

--- a/test/WebSites/InlineConstraintsWebSite/project.json
+++ b/test/WebSites/InlineConstraintsWebSite/project.json
@@ -1,7 +1,7 @@
 ﻿{
     "dependencies": {
-        "Helios": "1.0.0-*",
         "Microsoft.AspNet.Mvc": "",
+        "Microsoft.AspNet.Server.IIS": "1.0.0-*",
         "Microsoft.Framework.ConfigurationModel.Json": "1.0.0-*"
     },
     "configurations": {


### PR DESCRIPTION
- allows builds to succeed after cleaning your repo (without NuGet.org source)

@GrabYourPitchforks @davidfowl @Eilon @pranavkm any better if we start in release?  Note the test/WebSites/ActivatorWebSite/project.json file doesn't exist in release and will need to be manually changed in dev.
