### PR TITLE
Modify AssociatedMetadataProvider to use PropertyHelper to create accessor

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Common/Microsoft.AspNet.Mvc.Common.kproj
+++ b/src/Microsoft.AspNet.Mvc.Common/Microsoft.AspNet.Mvc.Common.kproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <Compile Include="NotNullArgument.cs" />
     <Compile Include="PlatformHelper.cs" />
+    <Compile Include="PropertyHelper.cs" />
     <Compile Include="TypeExtensions.cs" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/src/Microsoft.AspNet.Mvc.Common/project.json
+++ b/src/Microsoft.AspNet.Mvc.Common/project.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "System.Linq": "4.0.0.0",
     "System.Reflection": "4.0.10.0",
+    "System.Reflection.Extensions": "4.0.0.0",
     "System.Runtime" : "4.0.20.0"
   },
   "configurations": {

--- a/src/Microsoft.AspNet.Mvc.Core/Microsoft.AspNet.Mvc.Core.kproj
+++ b/src/Microsoft.AspNet.Mvc.Core/Microsoft.AspNet.Mvc.Core.kproj
@@ -136,7 +136,6 @@
     <Compile Include="DefaultControllerActivator.cs" />
     <Compile Include="IControllerFactory.cs" />
     <Compile Include="Injector.cs" />
-    <Compile Include="Internal\PropertyHelper.cs" />
     <Compile Include="Internal\TypeHelper.cs" />
     <Compile Include="Internal\UTF8EncodingWithoutBOM.cs" />
     <Compile Include="IUrlHelper.cs" />

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlAttributePropertyHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlAttributePropertyHelper.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
         public static new PropertyHelper[] GetProperties(object instance)
         {
-            return GetProperties(instance, CreateInstance, ReflectionCache);
+            return GetProperties(instance.GetType(), CreateInstance, ReflectionCache);
         }
 
         private static PropertyHelper CreateInstance(PropertyInfo property)

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/AssociatedMetadataProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/AssociatedMetadataProvider.cs
@@ -4,10 +4,8 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Reflection;
-using System.Reflection.Emit;
 
 namespace Microsoft.AspNet.Mvc.ModelBinding
 {
@@ -67,8 +65,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 Func<object> modelAccessor = null;
                 if (container != null)
                 {
-                    var propertyGetter = propertyInfo.ValueAccessor;
-                    modelAccessor = () => propertyGetter(container);
+                    modelAccessor = () => propertyInfo.PropertyHelper.GetValue(container);
                 }
                 yield return CreatePropertyMetadata(modelAccessor, propertyInfo);
             }
@@ -113,13 +110,13 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                                                     propertyName: null)
             };
 
-            var properties = new Dictionary<string, PropertyInformation>();
-            foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            var properties = new Dictionary<string, PropertyInformation>(StringComparer.Ordinal);
+            foreach (var propertyHelper in PropertyHelper.GetProperties(type))
             {
                 // Avoid re-generating a property descriptor if one has already been generated for the property name
-                if (!properties.ContainsKey(property.Name))
+                if (!properties.ContainsKey(propertyHelper.Name))
                 {
-                    properties.Add(property.Name, CreatePropertyInformation(type, property));
+                    properties.Add(propertyHelper.Name, CreatePropertyInformation(type, propertyHelper));
                 }
             }
             info.Properties = properties;
@@ -127,87 +124,18 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             return info;
         }
 
-        private PropertyInformation CreatePropertyInformation(Type containerType, PropertyInfo property)
+        private PropertyInformation CreatePropertyInformation(Type containerType, PropertyHelper helper)
         {
+            var property = helper.Property;
             return new PropertyInformation
             {
-                ValueAccessor = CreatePropertyValueAccessor(property),
+                PropertyHelper = helper,
                 Prototype = CreateMetadataPrototype(property.GetCustomAttributes(),
                                                     containerType,
                                                     property.PropertyType,
                                                     property.Name),
                 IsReadOnly = !property.CanWrite || property.SetMethod.IsPrivate
             };
-        }
-
-        private static Func<object, object> CreatePropertyValueAccessor(PropertyInfo property)
-        {
-            var declaringType = property.DeclaringType;
-            var declaringTypeInfo = declaringType.GetTypeInfo();
-            if (declaringTypeInfo.IsVisible)
-            {
-                if (property.CanRead)
-                {
-                    var getMethodInfo = property.GetMethod;
-                    if (getMethodInfo != null)
-                    {
-                        return CreateDynamicValueAccessor(getMethodInfo, declaringType, property.Name);
-                    }
-                }
-            }
-
-            // If either the type isn't public or we can't find a public getter, use the slow Reflection path
-            return container => property.GetValue(container);
-        }
-
-        // Uses Lightweight Code Gen to generate a tiny delegate that gets the property value
-        // This is an optimization to avoid having to go through the much slower System.Reflection APIs
-        // e.g. generates (object o) => (Person)o.Id
-        private static Func<object, object> CreateDynamicValueAccessor(MethodInfo getMethodInfo,
-                                                                       Type declaringType,
-                                                                       string propertyName)
-        {
-            Contract.Assert(getMethodInfo != null && getMethodInfo.IsPublic && !getMethodInfo.IsStatic);
-
-            var declaringTypeInfo = declaringType.GetTypeInfo();
-            var propertyType = getMethodInfo.ReturnType;
-            var dynamicMethod = new DynamicMethod("Get" + propertyName + "From" + declaringType.Name,
-                                                  typeof(object),
-                                                  new[] { typeof(object) });
-            var ilg = dynamicMethod.GetILGenerator();
-
-            // Load the container onto the stack, convert from object => declaring type for the property
-            ilg.Emit(OpCodes.Ldarg_0);
-            if (declaringTypeInfo.IsValueType)
-            {
-                ilg.Emit(OpCodes.Unbox, declaringType);
-            }
-            else
-            {
-                ilg.Emit(OpCodes.Castclass, declaringType);
-            }
-
-            // if declaring type is value type, we use Call : structs don't have inheritance
-            // if get method is sealed or isn't virtual, we use Call : it can't be overridden
-            if (declaringTypeInfo.IsValueType || !getMethodInfo.IsVirtual || getMethodInfo.IsFinal)
-            {
-                ilg.Emit(OpCodes.Call, getMethodInfo);
-            }
-            else
-            {
-                ilg.Emit(OpCodes.Callvirt, getMethodInfo);
-            }
-
-            // Box if the property type is a value type, so it can be returned as an object
-            if (propertyType.GetTypeInfo().IsValueType)
-            {
-                ilg.Emit(OpCodes.Box, propertyType);
-            }
-
-            // Return property value
-            ilg.Emit(OpCodes.Ret);
-
-            return (Func<object, object>)dynamicMethod.CreateDelegate(typeof(Func<object, object>));
         }
 
         private sealed class TypeInformation
@@ -218,7 +146,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
         private sealed class PropertyInformation
         {
-            public Func<object, object> ValueAccessor { get; set; }
+            public PropertyHelper PropertyHelper { get; set; }
             public TModelMetadata Prototype { get; set; }
             public bool IsReadOnly { get; set; }
         }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/PropertyHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/PropertyHelperTest.cs
@@ -191,6 +191,23 @@ namespace Microsoft.AspNet.Mvc
         }
 
         [Fact]
+        public void GetProperties_ExcludesIndexersAndPropertiesWithoutPublicGetters()
+        {
+            // Arrange
+            var type = typeof(DerivedClassWithNonReadableProperties);
+
+
+            // Act
+            var result = PropertyHelper.GetProperties(type).ToArray();
+
+            // Assert
+            Assert.Equal(3, result.Length);
+            Assert.Equal("Visible", result[0].Name);
+            Assert.Equal("PropA", result[1].Name);
+            Assert.Equal("PropB", result[2].Name);
+        }
+
+        [Fact]
         public void MakeFastPropertySetter_SetsPropertyValues_ForPublicAndNobPublicProperties()
         {
             // Arrange
@@ -310,6 +327,28 @@ namespace Microsoft.AspNet.Mvc
                 get { return _value; }
                 set { _value = "Overriden" + value; }
             }
+        }
+
+        private class DerivedClassWithNonReadableProperties : BaseClassWithVirtual
+        {
+            public string this[int index]
+            {
+                get { return string.Empty; }
+                set { }
+            }
+
+            public int Visible { get; set; }
+
+            private string NotVisible { get; set; }
+
+            public string NotVisible2 { private get; set; }
+
+            public string NotVisible3
+            {
+                set { }
+            }
+
+            public static string NotVisible4 { get; set; }
         }
     }
 }


### PR DESCRIPTION
Additionally change it to use TypeExtensions.GetReadableProperties to get
property list. This causes it to ignore indexers which should not be
considered.

Fixes #595
