### PR TITLE
Fix for #617 - ViewResult can be constructed without a view engine

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/Controller.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Controller.cs
@@ -36,12 +36,6 @@ namespace Microsoft.AspNet.Mvc
         public ActionContext ActionContext { get; set; }
 
         [Activate]
-        public IServiceProvider ServiceProvider { get; set; }
-
-        [Activate]
-        public IViewEngine ViewEngine { get; set; }
-
-        [Activate]
         public IUrlHelper Url { get; set; }
 
         public IPrincipal User
@@ -122,7 +116,7 @@ namespace Microsoft.AspNet.Mvc
                 ViewData.Model = model;
             }
 
-            return new ViewResult(ServiceProvider, ViewEngine)
+            return new ViewResult()
             {
                 ViewName = viewName,
                 ViewData = ViewData,


### PR DESCRIPTION
We want result types to be constructable without services. This will simplify testing for end users and POCO controllers.
