### PR TITLE
Remove HttpContext hanging off of ModelBindingContext

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ReflectedActionInvoker.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ReflectedActionInvoker.cs
@@ -309,7 +309,6 @@ namespace Microsoft.AspNet.Mvc
                         ValueProvider = actionBindingContext.ValueProvider,
                         ValidatorProviders = actionBindingContext.ValidatorProviders,
                         MetadataProvider = metadataProvider,
-                        HttpContext = actionBindingContext.ActionContext.HttpContext,
                         FallbackToEmptyPrefix = true
                     };
                     if (await actionBindingContext.ModelBinder.BindModelAsync(modelBindingContext))

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/CompositeModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/CompositeModelBinder.cs
@@ -123,7 +123,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 ValidatorProviders = oldBindingContext.ValidatorProviders,
                 MetadataProvider = oldBindingContext.MetadataProvider,
                 ModelBinder = oldBindingContext.ModelBinder,
-                HttpContext = oldBindingContext.HttpContext
             };
 
             // validation is expensive to create, so copy it over if we can

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/ModelBindingContext.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/ModelBindingContext.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.AspNet.Http;
 
 namespace Microsoft.AspNet.Mvc.ModelBinding
 {
@@ -30,7 +29,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 MetadataProvider = bindingContext.MetadataProvider;
                 ModelBinder = bindingContext.ModelBinder;
                 ValidatorProviders = bindingContext.ValidatorProviders;
-                HttpContext = bindingContext.HttpContext;
             }
         }
 
@@ -86,8 +84,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         }
 
         public bool FallbackToEmptyPrefix { get; set; }
-
-        public HttpContext HttpContext { get; set; }
 
         public IValueProvider ValueProvider
         {


### PR DESCRIPTION
Came up as part of #415. It's unused apart from the assignment. We can revive it if we find a use for it.
