### PR TITLE
Optimize action selection 

### DIFF
--- a/perfrun-config.json
+++ b/perfrun-config.json
@@ -1,0 +1,3 @@
+{
+    "TestNames": ["Memory_BasicMvc_IIS_Desktop", "Memory_MvcRouting_IIS_Desktop", "Throughput_BasicMvc_IIS_Desktop", "Throughput_MvcRouting_IIS_Desktop"]
+}

--- a/src/Microsoft.AspNet.Mvc.Core/DefaultActionSelector.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/DefaultActionSelector.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc.Core;
 using Microsoft.AspNet.Mvc.Logging;
 using Microsoft.AspNet.Mvc.ModelBinding;
+using Microsoft.AspNet.Mvc.Routing;
 using Microsoft.AspNet.Routing;
 using Microsoft.Framework.Logging;
 
@@ -16,14 +17,18 @@ namespace Microsoft.AspNet.Mvc
     public class DefaultActionSelector : IActionSelector
     {
         private readonly IActionDescriptorsCollectionProvider _actionDescriptorsCollectionProvider;
+        private readonly ActionSelectorDecisionTreeProvider _decisionTreeProvider;
         private readonly IActionBindingContextProvider _bindingProvider;
         private ILogger _logger;
 
-        public DefaultActionSelector(IActionDescriptorsCollectionProvider actionDescriptorsCollectionProvider,
-                                     IActionBindingContextProvider bindingProvider,
-                                     [NotNull] ILoggerFactory loggerFactory)
+        public DefaultActionSelector(
+            [NotNull] IActionDescriptorsCollectionProvider actionDescriptorsCollectionProvider,
+            [NotNull] ActionSelectorDecisionTreeProvider decisionTreeProvider, 
+            [NotNull] IActionBindingContextProvider bindingProvider,
+            [NotNull] ILoggerFactory loggerFactory)
         {
             _actionDescriptorsCollectionProvider = actionDescriptorsCollectionProvider;
+            _decisionTreeProvider = decisionTreeProvider;
             _bindingProvider = bindingProvider;
             _logger = loggerFactory.Create<DefaultActionSelector>();
         }
@@ -32,11 +37,8 @@ namespace Microsoft.AspNet.Mvc
         {
             using (_logger.BeginScope("DefaultActionSelector.SelectAsync"))
             {
-                var allDescriptors = GetActions();
-
-                var matchingRouteConstraints =
-                    allDescriptors.Where(ad =>
-                        MatchRouteConstraints(ad, context)).ToList();
+                var tree = _decisionTreeProvider.DecisionTree;
+                var matchingRouteConstraints = tree.Select(context.RouteData.Values);
 
                 var matchingRouteAndMethodConstraints =
                     matchingRouteConstraints.Where(ad =>
@@ -101,12 +103,6 @@ namespace Microsoft.AspNet.Mvc
                     return selectedAction;
                 }
             }
-        }
-
-        private bool MatchRouteConstraints(ActionDescriptor descriptor, RouteContext context)
-        {
-            return descriptor.RouteConstraints == null ||
-                    descriptor.RouteConstraints.All(c => c.Accept(context));
         }
 
         private bool MatchMethodConstraints(ActionDescriptor descriptor, RouteContext context)

--- a/src/Microsoft.AspNet.Mvc.Core/Internal/DecisionTree/DecisionCriterion.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Internal/DecisionTree/DecisionCriterion.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNet.Mvc.Internal.DecisionTree
+{
+    public class DecisionCriterion<T, U>
+    {
+        public string Key { get; set; }
+
+        public Dictionary<U, DecisionTreeNode<T, U>> Branches { get; set; }
+
+        public DecisionTreeNode<T, U> Fallback { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Internal/DecisionTree/DecisionCriterionValue.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Internal/DecisionTree/DecisionCriterionValue.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNet.Mvc
+{
+    public struct DecisionCriterionValue<U>
+    {
+        private readonly bool _isCatchAll;
+        private readonly U _value;
+
+        public DecisionCriterionValue(U value, bool isCatchAll)
+        {
+            _value = value;
+            _isCatchAll = isCatchAll;
+        }
+
+        public bool IsCatchAll
+        {
+            get { return _isCatchAll; }
+        }
+
+        public U Value
+        {
+            get { return _value; }
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Internal/DecisionTree/DecisionCriterionValueEqualityComparer.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Internal/DecisionTree/DecisionCriterionValueEqualityComparer.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNet.Mvc
+{
+    public class DecisionCriterionValueEqualityComparer<U> : IEqualityComparer<DecisionCriterionValue<U>>
+    {
+        public DecisionCriterionValueEqualityComparer(IEqualityComparer<U> innerComparer)
+        {
+            InnerComparer = innerComparer;
+        }
+
+        public IEqualityComparer<U> InnerComparer { get; private set; }
+
+        public bool Equals(DecisionCriterionValue<U> x, DecisionCriterionValue<U> y)
+        {
+            return x.IsCatchAll == y.IsCatchAll || InnerComparer.Equals(x.Value, y.Value);
+        }
+
+        public int GetHashCode(DecisionCriterionValue<U> obj)
+        {
+            if (obj.IsCatchAll)
+            {
+                return 0;
+            }
+            else
+            {
+                return InnerComparer.GetHashCode(obj.Value);
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Internal/DecisionTree/DecisionTreeBuilder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Internal/DecisionTree/DecisionTreeBuilder.cs
@@ -1,0 +1,231 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.AspNet.Mvc.Internal.DecisionTree
+{
+    // This code generates a minimal tree of decision criteria that map known categorical data 
+    // (key-value-pairs) to a set of inputs. Action Selection is the best example of how this 
+    // can be used, so the comments  here will describe the process from the point-of-view, 
+    // though the decision tree is generally applicable to like-problems.
+    //
+    // Care has been taken here to keep the performance of building the data-structure at a
+    // reasonable level, as this has an impact on startup cost for action selection. Additionally
+    // we want to hold on to the minimal amount of memory needed once we've built the tree.
+    //
+    // Ex:
+    //  Given actions like the following, create a decision tree that will help action
+    //  selection work efficiently.
+    //
+    //  Given any set of route data it should be possible to traverse the tree using the
+    //  presence our route data keys (like action), and whether or not they match any of
+    //  the known values for that route data key, to find the set of actions that match
+    //  the route data.
+    //
+    // Actions:
+    //
+    //  { controller = "Home", action = "Index" }
+    //  { controller = "Products", action = "Index" }
+    //  { controller = "Products", action = "Buy" }
+    //  { area = "Admin", controller = "Users", action = "AddUser" }
+    //
+    // The generated tree looks like this (json-like-notation):
+    //
+    //  { 
+    //      action : {
+    //          "AddUser" : {
+    //              controller : {
+    //                  "Users" : {
+    //                      area : {
+    //                          "Admin" : match { area = "Admin", controller = "Users", action = "AddUser" }
+    //                      }
+    //                  }
+    //              }
+    //          },
+    //          "Buy" : {
+    //              controller : {
+    //                  "Products" : {
+    //                      area : {
+    //                          null : match { controller = "Products", action = "Buy" }
+    //                      }
+    //                  }
+    //              }
+    //          },
+    //          "Index" : {
+    //              controller : {
+    //                  "Home" : {
+    //                      area : {
+    //                          null : match { controller = "Home", action = "Index" }
+    //                      }
+    //                  }
+    //                  "Products" : {
+    //                      area : {
+    //                          "null" : match { controller = "Products", action = "Index" }
+    //                      }
+    //                  }
+    //              }
+    //          }
+    //      }
+    //  }
+    public static class DecisionTreeBuilder<T, U>
+    {
+        public static DecisionTreeNode<T, U> GenerateTree(IReadOnlyList<T> items, IClassifier<T, U> classifier)
+        {
+            var itemDescriptors = new List<ItemDescriptor<T, U>>();
+            for (var i = 0; i < items.Count; i++)
+            {
+                itemDescriptors.Add(new ItemDescriptor<T, U>()
+                {
+                    Criteria = classifier.GetCriteria(items[i]),
+                    Index = i,
+                    Item = items[i],
+                });
+            }
+
+            var comparer = new DecisionCriterionValueEqualityComparer<U>(classifier.ValueComparer);
+            return GenerateNode(
+                new TreeBuilderContext(), 
+                comparer, 
+                itemDescriptors);
+        }
+
+        private static DecisionTreeNode<T, U> GenerateNode(
+            TreeBuilderContext context,
+            DecisionCriterionValueEqualityComparer<U> comparer,
+            IList<ItemDescriptor<T, U>> items)
+        {
+            // The extreme use of generics here is intended to reduce the number of intermediate 
+            // allocations of wrapper classes. Performance testing found that building these trees allocates
+            // significant memory that we can avoid and that it has a real impact on startup.
+            //
+            // Explanation:
+            //  This is a dictionary of string-key -> criteria.
+            //  Each criterion is a dictionary of value-key -> branch.
+            //  Each branch is a list of items that match these criteria
+            var criteria = 
+                new Dictionary<string, Dictionary<DecisionCriterionValue<U>, List<ItemDescriptor<T, U>>>>(StringComparer.OrdinalIgnoreCase);
+
+            // Matches are items that have no remaining criteria - at this point in the tree
+            // they are considered accepted.
+            var matches = new List<T>();
+
+            // For each item in the working set, we want to map it to it's possible criteria-branch
+            // pairings, then reduce that tree to the minimal set.
+            foreach (var item in items)
+            {
+                var unsatisfiedCriteria = 0;
+
+                foreach (var kvp in item.Criteria)
+                {
+                    // context.CurrentCriteria is the logical 'stack' of criteria that we've already processed
+                    // on this branch of the tree.
+                    if (context.CurrentCriteria.Contains(kvp.Key))
+                    {
+                        continue;
+                    }
+
+                    unsatisfiedCriteria++;
+
+                    Dictionary<DecisionCriterionValue<U>, List<ItemDescriptor<T, U>>> criterion;
+                    if (!criteria.TryGetValue(kvp.Key, out criterion))
+                    {
+                        criterion = new Dictionary<DecisionCriterionValue<U>, List<ItemDescriptor<T, U>>>(comparer);
+                        criteria.Add(kvp.Key, criterion);
+                    }
+
+                    List<ItemDescriptor<T, U>> branch;
+                    if (!criterion.TryGetValue(kvp.Value, out branch))
+                    {
+                        branch = new List<ItemDescriptor<T, U>>();
+                        criterion.Add(kvp.Value, branch);
+                    }
+
+                    branch.Add(item);
+                }
+
+                // If all of the criteria on item are satisfied by the 'stack' then this item is a match.
+                if (unsatisfiedCriteria == 0)
+                {
+                    matches.Add(item.Item);
+                }
+            }
+
+            // Iterate criteria in order of branchiness to determine which one to explore next. If a criterion
+            // has no 'new' matches under it then we can just eliminate that part of the tree.
+            var reducedCriteria = new List<DecisionCriterion<T, U>>();
+            foreach (var criterion in criteria.OrderByDescending(c => c.Value.Count))
+            {
+                var reducedBranches = new Dictionary<U, DecisionTreeNode<T, U>>(comparer.InnerComparer);
+                DecisionTreeNode<T, U> fallback = null;
+
+                foreach (var branch in criterion.Value)
+                {
+                    var reducedItems = new List<ItemDescriptor<T, U>>();
+                    foreach (var item in branch.Value)
+                    {
+                        if (context.MatchedItems.Add(item))
+                        {
+                            reducedItems.Add(item);
+                        }
+                    }
+
+                    if (reducedItems.Count > 0)
+                    {
+                        var childContext = new TreeBuilderContext(context);
+                        childContext.CurrentCriteria.Add(criterion.Key);
+
+                        var newBranch = GenerateNode(childContext, comparer, branch.Value);
+                        if (branch.Key.IsCatchAll)
+                        {
+                            fallback = newBranch;
+                        }
+                        else
+                        {
+                            reducedBranches.Add(branch.Key.Value, newBranch);
+                        }
+                    }
+                }
+
+                if (reducedBranches.Count > 0 || fallback != null)
+                {
+                    var newCriterion = new DecisionCriterion<T, U>()
+                    {
+                        Key = criterion.Key,
+                        Branches = reducedBranches,
+                        Fallback = fallback,
+                    };
+
+                    reducedCriteria.Add(newCriterion);
+                }
+            }
+
+            return new DecisionTreeNode<T, U>()
+            {
+                Criteria = reducedCriteria.ToList(),
+                Matches = matches,
+            };
+        }
+
+        private class TreeBuilderContext
+        {
+            public TreeBuilderContext()
+            {
+                CurrentCriteria = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                MatchedItems = new HashSet<ItemDescriptor<T, U>>();
+            }
+
+            public TreeBuilderContext(TreeBuilderContext other)
+            {
+                CurrentCriteria = new HashSet<string>(other.CurrentCriteria, StringComparer.OrdinalIgnoreCase);
+                MatchedItems = new HashSet<ItemDescriptor<T, U>>();
+            }
+
+            public HashSet<string> CurrentCriteria { get; private set; }
+
+            public HashSet<ItemDescriptor<T, U>> MatchedItems { get; private set; }
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Internal/DecisionTree/DecisionTreeNode.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Internal/DecisionTree/DecisionTreeNode.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNet.Mvc.Internal.DecisionTree
+{
+    public class DecisionTreeNode<T, U>
+    {
+        public List<T> Matches { get; set; }
+
+        public List<DecisionCriterion<T, U>> Criteria { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Internal/DecisionTree/IClassifier.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Internal/DecisionTree/IClassifier.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNet.Mvc.Internal.DecisionTree
+{
+    public interface IClassifier<T, U>
+    {
+        IDictionary<string, DecisionCriterionValue<U>> GetCriteria(T item);
+
+        IEqualityComparer<U> ValueComparer { get; }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Internal/DecisionTree/ItemDescriptor.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Internal/DecisionTree/ItemDescriptor.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNet.Mvc.Internal.DecisionTree
+{
+    public class ItemDescriptor<T, U>
+    {
+        public IDictionary<string, DecisionCriterionValue<U>> Criteria { get; set; }
+
+        public int Index { get; set; }
+
+        public T Item { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Microsoft.AspNet.Mvc.Core.kproj
+++ b/src/Microsoft.AspNet.Mvc.Core/Microsoft.AspNet.Mvc.Core.kproj
@@ -31,6 +31,8 @@
     <Compile Include="ActionDescriptorsCollection.cs" />
     <Compile Include="ActionResults\HttpNotFoundResult.cs" />
     <Compile Include="Formatters\TextPlainFormatter.cs" />
+    <Compile Include="Internal\DecisionTree\DecisionCriterionValue.cs" />
+    <Compile Include="Internal\DecisionTree\DecisionCriterionValueEqualityComparer.cs" />
     <Compile Include="Logging\AttributeRouteRouteAsyncValues.cs" />
     <Compile Include="Logging\LoggerExtensions.cs" />
     <Compile Include="Logging\MvcRouteHandlerRouteAsyncValues.cs" />
@@ -60,6 +62,17 @@
     <Compile Include="OptionDescriptors\ViewEngineDescriptor.cs" />
     <Compile Include="OptionDescriptors\ViewEngineDescriptorExtensions.cs" />
     <Compile Include="ParameterBinding\ModelBindingHelper.cs" />
+    <Compile Include="Internal\DecisionTree\DecisionTreeBuilder.cs" />
+    <Compile Include="Internal\DecisionTree\DecisionCriterion.cs" />
+    <Compile Include="Internal\DecisionTree\DecisionTreeNode.cs" />
+    <Compile Include="Internal\DecisionTree\IClassifier.cs" />
+    <Compile Include="Internal\DecisionTree\ItemDescriptor.cs" />
+    <Compile Include="ReflectedActionDescriptor.cs" />
+    <Compile Include="ReflectedActionDescriptorProvider.cs" />
+    <Compile Include="ReflectedModelBuilder\IReflectedApplicationModelConvention.cs" />
+    <Compile Include="ReflectedModelBuilder\ReflectedActionModel.cs" />
+    <Compile Include="ReflectedModelBuilder\ReflectedControllerModel.cs" />
+    <Compile Include="ReflectedModelBuilder\ReflectedApplicationModel.cs" />
     <Compile Include="ActionInvokerFactory.cs" />
     <Compile Include="ActionInvokerProviderContext.cs" />
     <Compile Include="ActionMethodSelectorAttribute.cs" />
@@ -246,6 +259,8 @@
     <Compile Include="RouteConstraintAttribute.cs" />
     <Compile Include="RouteDataActionConstraint.cs" />
     <Compile Include="RouteKeyHandling.cs" />
+    <Compile Include="Routing\ActionSelectorDecisionTree.cs" />
+    <Compile Include="Routing\ActionSelectorDecisionTreeProvider.cs" />
     <Compile Include="Routing\AttributeRoute.cs" />
     <Compile Include="Routing\AttributeRouteLinkGenerationEntry.cs" />
     <Compile Include="Routing\AttributeRouteMatchingEntry.cs" />
@@ -253,6 +268,7 @@
     <Compile Include="Routing\AttributeRouteTemplate.cs" />
     <Compile Include="Routing\AttributeRouting.cs" />
     <Compile Include="Routing\IRouteTemplateProvider.cs" />
+    <Compile Include="Routing\RouteValueEqualityComparer.cs" />
     <Compile Include="TemplateInfo.cs" />
     <Compile Include="UrlHelper.cs" />
     <Compile Include="UrlHelperExtensions.cs" />

--- a/src/Microsoft.AspNet.Mvc.Core/RouteDataActionConstraint.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/RouteDataActionConstraint.cs
@@ -43,7 +43,6 @@ namespace Microsoft.AspNet.Mvc
         {
             switch (keyHandling)
             {
-                case RouteKeyHandling.AcceptAlways:
                 case RouteKeyHandling.CatchAll:
                 case RouteKeyHandling.DenyKey:
                 case RouteKeyHandling.RequireKey:
@@ -81,9 +80,6 @@ namespace Microsoft.AspNet.Mvc
             object value;
             switch (KeyHandling)
             {
-                case RouteKeyHandling.AcceptAlways:
-                    return true;
-
                 case RouteKeyHandling.CatchAll:
                     return routeValues.ContainsKey(RouteKey);
 

--- a/src/Microsoft.AspNet.Mvc.Core/RouteKeyHandling.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/RouteKeyHandling.cs
@@ -21,10 +21,5 @@ namespace Microsoft.AspNet.Mvc
         /// Requires that the key will be in the route values, but ignore the content.
         /// </summary>
         CatchAll,
-
-        /// <summary>
-        /// Always accept.
-        /// </summary>
-        AcceptAlways,
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/Routing/ActionSelectorDecisionTree.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Routing/ActionSelectorDecisionTree.cs
@@ -1,0 +1,188 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using Microsoft.AspNet.Mvc.Internal.DecisionTree;
+
+namespace Microsoft.AspNet.Mvc.Routing
+{
+    /// <summary>
+    /// A data structure that retrieves a list of <see cref="ActionDescriptor"/> matches based on the values
+    /// supplied for the current request by <see cref="Microsoft.AspNet.Routing.RouteData.Values"/>.
+    /// </summary>
+    public class ActionSelectionDecisionTree
+    {
+        private readonly DecisionTreeNode<ActionDescriptor, object> _root;
+
+        /// <summary>
+        /// Creates a new <see cref="ActionSelectionDecisionTree"/>.
+        /// </summary>
+        /// <param name="actions">The <see cref="ActionDescriptorsCollection"/>.</param>
+        public ActionSelectionDecisionTree(ActionDescriptorsCollection actions)
+        {
+            Version = actions.Version;
+
+            _root = DecisionTreeBuilder<ActionDescriptor, object>.GenerateTree(
+                actions.Items,
+                new ActionDescriptorClassifier());
+        }
+
+        /// <summary>
+        /// Gets the version. The same as the value of <see cref="ActionDescriptorsCollection.Version"/>.
+        /// </summary>
+        public int Version { get; private set; }
+
+        /// <summary>
+        /// Retrieves a set of <see cref="ActionDescriptor"/> based on the route values supplied by
+        /// <paramref name="routeValues"/>/
+        /// </summary>
+        /// <param name="routeValues">The route values for the current request.</param>
+        /// <returns>A set of <see cref="ActionDescriptor"/> matching the route values.</returns>
+        public IList<ActionDescriptor> Select(IDictionary<string, object> routeValues)
+        {
+            var results = new List<ActionDescriptor>();
+            Walk(results, routeValues, _root);
+
+            // If we have a match that isn't using catch-all, then it's considered better than matches with catch all
+            // so filter those out.
+            var hasNonCatchAll = false;
+
+            // The common case for MVC has no catch-alls, so avoid allocating.
+            List<ActionDescriptor> filtered = null;
+
+            foreach (var action in results)
+            {
+                var actionHasCatchAll = false;
+                if (action.RouteConstraints != null)
+                {
+                    foreach (var constraint in action.RouteConstraints)
+                    {
+                        if (constraint.KeyHandling == RouteKeyHandling.CatchAll)
+                        {
+                            actionHasCatchAll = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (hasNonCatchAll && actionHasCatchAll)
+                {
+                    // Do nothing - we've already found a better match.
+                }
+                else if (actionHasCatchAll)
+                {
+                    if (filtered == null)
+                    {
+                        filtered = new List<ActionDescriptor>();
+                    }
+
+                    filtered.Add(action);
+                }
+                else if (hasNonCatchAll)
+                {
+                    Contract.Assert(filtered != null);
+                    filtered.Add(action);
+                }
+                else
+                {
+                    // This is the first non-catch-all we've found.
+                    hasNonCatchAll = true;
+
+                    if (filtered == null)
+                    {
+                        filtered = new List<ActionDescriptor>();
+                    }
+                    else
+                    {
+                        filtered.Clear();
+                    }
+
+                    filtered.Add(action);
+                }
+            }
+
+            return filtered ?? results;
+        }
+
+        private void Walk(
+            List<ActionDescriptor> results,
+            IDictionary<string, object> routeValues,
+            DecisionTreeNode<ActionDescriptor, object> node)
+        {
+            for (var i = 0; i < node.Matches.Count; i++)
+            {
+                results.Add(node.Matches[i]);
+            }
+
+            for (var i = 0; i < node.Criteria.Count; i++)
+            {
+                var criterion = node.Criteria[i];
+                var key = criterion.Key;
+
+                object value;
+                var hasValue = routeValues.TryGetValue(key, out value);
+
+                DecisionTreeNode<ActionDescriptor, object> branch;
+                if (criterion.Branches.TryGetValue(value ?? string.Empty, out branch))
+                {
+                    Walk(results, routeValues, branch);
+                }
+
+                // If there's a fallback node we always need to process it when we have a value. We'll prioritize 
+                // non-fallback matches later in the process.
+                if (hasValue && criterion.Fallback != null)
+                {
+                    Walk(results, routeValues, criterion.Fallback);
+                }
+            }
+        }
+
+        private class ActionDescriptorClassifier : IClassifier<ActionDescriptor, object>
+        {
+            public ActionDescriptorClassifier()
+            {
+                ValueComparer = new RouteValueEqualityComparer();
+            }
+
+            public IEqualityComparer<object> ValueComparer { get; private set; }
+
+            public IDictionary<string, DecisionCriterionValue<object>> GetCriteria(ActionDescriptor item)
+            {
+                var results = new Dictionary<string, DecisionCriterionValue<object>>(StringComparer.OrdinalIgnoreCase);
+
+                if (item.RouteConstraints != null)
+                {
+                    foreach (var constraint in item.RouteConstraints)
+                    {
+                        DecisionCriterionValue<object> value;
+                        if (constraint.KeyHandling == RouteKeyHandling.CatchAll)
+                        {
+                            value = new DecisionCriterionValue<object>(value: null, isCatchAll: true);
+                        }
+                        else if (constraint.KeyHandling == RouteKeyHandling.DenyKey)
+                        {
+                            // null and string.Empty are equivalent for route values, so just treat nulls as
+                            // string.Empty.
+                            value = new DecisionCriterionValue<object>(value: string.Empty, isCatchAll: false);
+                        }
+                        else if (constraint.KeyHandling == RouteKeyHandling.RequireKey)
+                        {
+                            value = new DecisionCriterionValue<object>(value: constraint.RouteValue, isCatchAll: false);
+                        }
+                        else
+                        {
+                            Contract.Assert(false, "Unknown value of RouteKeyHandling.");
+                            continue;
+                        }
+
+                        results.Add(constraint.RouteKey, value);
+                    }
+                }
+
+                return results;
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Routing/ActionSelectorDecisionTreeProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Routing/ActionSelectorDecisionTreeProvider.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNet.Mvc.Core;
+
+namespace Microsoft.AspNet.Mvc.Routing
+{
+    /// <summary>
+    /// Stores an <see cref="ActionSelectionDecisionTree"/> for the current value of 
+    /// <see cref="IActionDescriptorsCollectionProvider.ActionDescriptors"/>.
+    /// </summary>
+    public class ActionSelectorDecisionTreeProvider
+    {
+        private readonly IActionDescriptorsCollectionProvider _actionDescriptorsCollectionProvider;
+        private ActionSelectionDecisionTree _decisionTree;
+
+        /// <summary>
+        /// Creates a new <see cref="ActionSelectorDecisionTreeProvider"/>.
+        /// </summary>
+        /// <param name="actionDescriptorsCollectionProvider">
+        /// The <see cref="IActionDescriptorsCollectionProvider"/>.
+        /// </param>
+        public ActionSelectorDecisionTreeProvider(
+            IActionDescriptorsCollectionProvider actionDescriptorsCollectionProvider)
+        {
+            _actionDescriptorsCollectionProvider = actionDescriptorsCollectionProvider;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IActionDescriptorsCollectionProvider"/>.
+        /// </summary>
+        public ActionSelectionDecisionTree DecisionTree
+        {
+            get
+            {
+                var descriptors = _actionDescriptorsCollectionProvider.ActionDescriptors;
+                if (descriptors == null)
+                {
+                    throw new InvalidOperationException(
+                        Resources.FormatPropertyOfTypeCannotBeNull(
+                            "ActionDescriptors",
+                            _actionDescriptorsCollectionProvider.GetType()));
+                }
+
+                if (_decisionTree == null || descriptors.Version != _decisionTree.Version)
+                {
+                    _decisionTree = new ActionSelectionDecisionTree(descriptors);
+                }
+
+                return _decisionTree;
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Routing/RouteValueEqualityComparer.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Routing/RouteValueEqualityComparer.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Microsoft.AspNet.Mvc.Routing
+{
+    /// <summary>
+    /// An <see cref="IEqualityComparer{object}"/> implementation that compares objects as-if
+    /// they were route value strings.
+    /// </summary>
+    /// <remarks>
+    /// Values that are are not strings are converted to strings using 
+    /// <c>Convert.ToString(x, CultureInfo.InvariantCulture)</c>. <c>null</c> values are converted
+    /// to the empty string.
+    /// 
+    /// strings are compared using <see cref="StringComparison.OrdinalIgnoreCase"/>.
+    /// </remarks>
+    public class RouteValueEqualityComparer : IEqualityComparer<object>
+    {
+        /// <inheritdoc />
+        public new bool Equals(object x, object y)
+        {
+            var stringX = x as string ?? Convert.ToString(x, CultureInfo.InvariantCulture);
+            var stringY = y as string ?? Convert.ToString(y, CultureInfo.InvariantCulture);
+
+            if (string.IsNullOrEmpty(stringX) && string.IsNullOrEmpty(stringY))
+            {
+                return true;
+            }
+            else
+            {
+                return string.Equals(stringX, stringY, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        /// <inheritdoc />
+        public int GetHashCode(object obj)
+        {
+            var stringObj = obj as string ?? Convert.ToString(obj, CultureInfo.InvariantCulture);
+            if (string.IsNullOrEmpty(stringObj))
+            {
+                return StringComparer.OrdinalIgnoreCase.GetHashCode(string.Empty);
+            }
+            else
+            {
+                return StringComparer.OrdinalIgnoreCase.GetHashCode(stringObj);
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc/MvcServices.cs
+++ b/src/Microsoft.AspNet.Mvc/MvcServices.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNet.Mvc.OptionDescriptors;
 using Microsoft.AspNet.Mvc.Razor;
 using Microsoft.AspNet.Mvc.Razor.Compilation;
 using Microsoft.AspNet.Mvc.Rendering;
+using Microsoft.AspNet.Mvc.Routing;
 using Microsoft.AspNet.Security;
 using Microsoft.Framework.ConfigurationModel;
 using Microsoft.Framework.DependencyInjection;
@@ -32,7 +33,10 @@ namespace Microsoft.AspNet.Mvc
 
             yield return describe.Transient<IControllerFactory, DefaultControllerFactory>();
             yield return describe.Singleton<IControllerActivator, DefaultControllerActivator>();
+
+            yield return describe.Singleton<ActionSelectorDecisionTreeProvider, ActionSelectorDecisionTreeProvider>();
             yield return describe.Scoped<IActionSelector, DefaultActionSelector>();
+
             yield return describe.Transient<IActionInvokerFactory, ActionInvokerFactory>();
             yield return describe.Transient<IControllerAssemblyProvider, DefaultControllerAssemblyProvider>();
             yield return describe.Transient<IActionDiscoveryConventions, DefaultActionDiscoveryConventions>();

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ActionAttributeTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ActionAttributeTests.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
+using Microsoft.AspNet.Mvc.Routing;
 using Microsoft.AspNet.Routing;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.NestedProviders;
@@ -195,12 +196,15 @@ namespace Microsoft.AspNet.Mvc
                                         descriptorProvider);
 
             var actionCollectionDescriptorProvider = new DefaultActionDescriptorsCollectionProvider(serviceContainer);
+            var decisionTreeProvider = new ActionSelectorDecisionTreeProvider(actionCollectionDescriptorProvider);
 
             var bindingProvider = new Mock<IActionBindingContextProvider>();
 
-            var defaultActionSelector = new DefaultActionSelector(actionCollectionDescriptorProvider,
-                                                                  bindingProvider.Object,
-                                                                  NullLoggerFactory.Instance);
+            var defaultActionSelector = new DefaultActionSelector(
+                actionCollectionDescriptorProvider, 
+                decisionTreeProvider,
+                bindingProvider.Object,
+                NullLoggerFactory.Instance);
 
             return await defaultActionSelector.SelectAsync(context);
         }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/DefaultActionDiscoveryConventionsActionSelectionTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/DefaultActionDiscoveryConventionsActionSelectionTests.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
+using Microsoft.AspNet.Mvc.Routing;
 using Microsoft.AspNet.Routing;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.NestedProviders;
@@ -174,12 +175,15 @@ namespace Microsoft.AspNet.Mvc
                                         descriptorProvider);
 
             var actionCollectionDescriptorProvider = new DefaultActionDescriptorsCollectionProvider(serviceContainer);
+            var decisionTreeProvider = new ActionSelectorDecisionTreeProvider(actionCollectionDescriptorProvider);
 
             var bindingProvider = new Mock<IActionBindingContextProvider>();
 
-            var defaultActionSelector = new DefaultActionSelector(actionCollectionDescriptorProvider,
-                                                                  bindingProvider.Object,
-                                                                  NullLoggerFactory.Instance);
+            var defaultActionSelector = new DefaultActionSelector(
+                actionCollectionDescriptorProvider,
+                decisionTreeProvider,
+                bindingProvider.Object,
+                NullLoggerFactory.Instance);
 
             return await defaultActionSelector.SelectAsync(context);
         }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/DefaultActionSelectorTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/DefaultActionSelectorTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
+using Microsoft.AspNet.Mvc.Routing;
 using Microsoft.AspNet.Routing;
 using Microsoft.AspNet.Mvc.Logging;
 using Microsoft.Framework.Logging;
@@ -215,12 +216,14 @@ namespace Microsoft.AspNet.Mvc
             actionProvider
                 .Setup(p => p.ActionDescriptors).Returns(new ActionDescriptorsCollection(actions, 0));
 
+            var decisionTreeProvider = new ActionSelectorDecisionTreeProvider(actionProvider.Object);
+
             var bindingProvider = new Mock<IActionBindingContextProvider>(MockBehavior.Strict);
             bindingProvider
                 .Setup(bp => bp.GetActionBindingContextAsync(It.IsAny<ActionContext>()))
                 .Returns(Task.FromResult<ActionBindingContext>(null));
 
-            return new DefaultActionSelector(actionProvider.Object, bindingProvider.Object, loggerFactory);
+            return new DefaultActionSelector(actionProvider.Object, decisionTreeProvider, bindingProvider.Object, loggerFactory);
         }
 
         private static VirtualPathContext CreateContext(object routeValues)

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Internal/DecisionTree/DecisionTreeBuilderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Internal/DecisionTree/DecisionTreeBuilderTest.cs
@@ -1,0 +1,285 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.AspNet.Mvc.Internal.DecisionTree
+{
+    public class DecisionTreeBuilderTest
+    {
+        [Fact]
+        public void BuildTree_Empty()
+        {
+            // Arrange
+            var items = new List<Item>();
+
+            // Act
+            var tree = DecisionTreeBuilder<Item, string>.GenerateTree(items, new ItemClassifier());
+
+            // Assert
+            Assert.Empty(tree.Criteria);
+            Assert.Empty(tree.Matches);
+        }
+
+        [Fact]
+        public void BuildTree_TrivialMatch()
+        {
+            // Arrange
+            var items = new List<Item>();
+
+            var item = new Item();
+            items.Add(item);
+
+            // Act
+            var tree = DecisionTreeBuilder<Item, string>.GenerateTree(items, new ItemClassifier());
+
+            // Assert
+            Assert.Empty(tree.Criteria);
+            Assert.Same(item, Assert.Single(tree.Matches));
+        }
+
+        [Fact]
+        public void BuildTree_WithMultipleCriteria()
+        {
+            // Arrange
+            var items = new List<Item>();
+
+            var item = new Item();
+            item.Criteria.Add("area", new DecisionCriterionValue<string>(value: "Admin", isCatchAll: false));
+            item.Criteria.Add("controller", new DecisionCriterionValue<string>(value: "Users", isCatchAll: false));
+            item.Criteria.Add("action", new DecisionCriterionValue<string>(value: "AddUser", isCatchAll: false));
+            items.Add(item);
+
+            // Act
+            var tree = DecisionTreeBuilder<Item, string>.GenerateTree(items, new ItemClassifier());
+
+            // Assert
+            Assert.Empty(tree.Matches);
+
+            var area = Assert.Single(tree.Criteria);
+            Assert.Equal("area", area.Key);
+            Assert.Null(area.Fallback);
+
+            var admin = Assert.Single(area.Branches);
+            Assert.Equal("Admin", admin.Key);
+            Assert.Empty(admin.Value.Matches);
+
+            var controller = Assert.Single(admin.Value.Criteria);
+            Assert.Equal("controller", controller.Key);
+            Assert.Null(controller.Fallback);
+
+            var users = Assert.Single(controller.Branches);
+            Assert.Equal("Users", users.Key);
+            Assert.Empty(users.Value.Matches);
+
+            var action = Assert.Single(users.Value.Criteria);
+            Assert.Equal("action", action.Key);
+            Assert.Null(action.Fallback);
+
+            var addUser = Assert.Single(action.Branches);
+            Assert.Equal("AddUser", addUser.Key);
+            Assert.Empty(addUser.Value.Criteria);
+            Assert.Same(item, Assert.Single(addUser.Value.Matches));
+        }
+
+        [Fact]
+        public void BuildTree_WithMultipleItems()
+        {
+            // Arrange
+            var items = new List<Item>();
+
+            var item1 = new Item();
+            item1.Criteria.Add("controller", new DecisionCriterionValue<string>(value: "Store", isCatchAll: false));
+            item1.Criteria.Add("action", new DecisionCriterionValue<string>(value: "Buy", isCatchAll: false));
+            items.Add(item1);
+
+            var item2 = new Item();
+            item2.Criteria.Add("controller", new DecisionCriterionValue<string>(value: "Store", isCatchAll: false));
+            item2.Criteria.Add("action", new DecisionCriterionValue<string>(value: "Checkout", isCatchAll: false));
+            items.Add(item2);
+
+            // Act
+            var tree = DecisionTreeBuilder<Item, string>.GenerateTree(items, new ItemClassifier());
+
+            // Assert
+            Assert.Empty(tree.Matches);
+
+            var action = Assert.Single(tree.Criteria);
+            Assert.Equal("action", action.Key);
+            Assert.Null(action.Fallback);
+
+            var buy = action.Branches["Buy"];
+            Assert.Empty(buy.Matches);
+
+            var controller = Assert.Single(buy.Criteria);
+            Assert.Equal("controller", controller.Key);
+            Assert.Null(controller.Fallback);
+
+            var store = Assert.Single(controller.Branches);
+            Assert.Equal("Store", store.Key);
+            Assert.Empty(store.Value.Criteria);
+            Assert.Same(item1, Assert.Single(store.Value.Matches));
+
+            var checkout = action.Branches["Checkout"];
+            Assert.Empty(checkout.Matches);
+
+            controller = Assert.Single(checkout.Criteria);
+            Assert.Equal("controller", controller.Key);
+            Assert.Null(controller.Fallback);
+
+            store = Assert.Single(controller.Branches);
+            Assert.Equal("Store", store.Key);
+            Assert.Empty(store.Value.Criteria);
+            Assert.Same(item2, Assert.Single(store.Value.Matches));
+        }
+
+        [Fact]
+        public void BuildTree_WithInteriorMatch()
+        {
+            // Arrange
+            var items = new List<Item>();
+
+            var item1 = new Item();
+            item1.Criteria.Add("controller", new DecisionCriterionValue<string>(value: "Store", isCatchAll: false));
+            item1.Criteria.Add("action", new DecisionCriterionValue<string>(value: "Buy", isCatchAll: false));
+            items.Add(item1);
+
+            var item2 = new Item();
+            item2.Criteria.Add("controller", new DecisionCriterionValue<string>(value: "Store", isCatchAll: false));
+            item2.Criteria.Add("action", new DecisionCriterionValue<string>(value: "Checkout", isCatchAll: false));
+            items.Add(item2);
+
+            var item3 = new Item();
+            item3.Criteria.Add("action", new DecisionCriterionValue<string>(value: "Buy", isCatchAll: false));
+            items.Add(item3);
+
+            // Act
+            var tree = DecisionTreeBuilder<Item, string>.GenerateTree(items, new ItemClassifier());
+
+            // Assert
+            Assert.Empty(tree.Matches);
+
+            var action = Assert.Single(tree.Criteria);
+            Assert.Equal("action", action.Key);
+            Assert.Null(action.Fallback);
+
+            var buy = action.Branches["Buy"];
+            Assert.Same(item3, Assert.Single(buy.Matches));
+        }
+
+        [Fact]
+        public void BuildTree_WithCatchAll()
+        {
+            // Arrange
+            var items = new List<Item>();
+
+            var item1 = new Item();
+            item1.Criteria.Add("country", new DecisionCriterionValue<string>(value: "CA", isCatchAll: false));
+            item1.Criteria.Add("controller", new DecisionCriterionValue<string>(value: "Store", isCatchAll: false));
+            item1.Criteria.Add("action", new DecisionCriterionValue<string>(value: "Checkout", isCatchAll: false));
+            items.Add(item1);
+
+            var item2 = new Item();
+            item2.Criteria.Add("country", new DecisionCriterionValue<string>(value: "US", isCatchAll: false));
+            item2.Criteria.Add("controller", new DecisionCriterionValue<string>(value: "Store", isCatchAll: false));
+            item2.Criteria.Add("action", new DecisionCriterionValue<string>(value: "Checkout", isCatchAll: false));
+            items.Add(item2);
+
+            var item3 = new Item();
+            item3.Criteria.Add("country", new DecisionCriterionValue<string>(value: null, isCatchAll: true));
+            item3.Criteria.Add("controller", new DecisionCriterionValue<string>(value: "Store", isCatchAll: false));
+            item3.Criteria.Add("action", new DecisionCriterionValue<string>(value: "Checkout", isCatchAll: false));
+            items.Add(item3);
+
+            // Act
+            var tree = DecisionTreeBuilder<Item, string>.GenerateTree(items, new ItemClassifier());
+
+            // Assert
+            Assert.Empty(tree.Matches);
+
+            var country = Assert.Single(tree.Criteria);
+            Assert.Equal("country", country.Key);
+
+            var fallback = country.Fallback;
+            Assert.NotNull(fallback);
+
+            var controller = Assert.Single(fallback.Criteria);
+            Assert.Equal("controller", controller.Key);
+            Assert.Null(controller.Fallback);
+
+            var store = Assert.Single(controller.Branches);
+            Assert.Equal("Store", store.Key);
+            Assert.Empty(store.Value.Matches);
+
+            var action = Assert.Single(store.Value.Criteria);
+            Assert.Equal("action", action.Key);
+            Assert.Null(action.Fallback);
+
+            var checkout = Assert.Single(action.Branches);
+            Assert.Equal("Checkout", checkout.Key);
+            Assert.Empty(checkout.Value.Criteria);
+            Assert.Same(item3, Assert.Single(checkout.Value.Matches));           
+        }
+
+        [Fact]
+        public void BuildTree_WithDivergentCriteria()
+        {
+            // Arrange
+            var items = new List<Item>();
+
+            var item1 = new Item();
+            item1.Criteria.Add("controller", new DecisionCriterionValue<string>(value: "Store", isCatchAll: false));
+            item1.Criteria.Add("action", new DecisionCriterionValue<string>(value: "Buy", isCatchAll: false));
+            items.Add(item1);
+
+            var item2 = new Item();
+            item2.Criteria.Add("controller", new DecisionCriterionValue<string>(value: "Store", isCatchAll: false));
+            item2.Criteria.Add("action", new DecisionCriterionValue<string>(value: "Checkout", isCatchAll: false));
+            items.Add(item2);
+
+            var item3 = new Item();
+            item3.Criteria.Add("stub", new DecisionCriterionValue<string>(value: "Bleh", isCatchAll: false));
+            items.Add(item3);
+
+            // Act
+            var tree = DecisionTreeBuilder<Item, string>.GenerateTree(items, new ItemClassifier());
+
+            // Assert
+            Assert.Empty(tree.Matches);
+
+            var action = tree.Criteria[0];
+            Assert.Equal("action", action.Key);
+
+            var stub = tree.Criteria[1];
+            Assert.Equal("stub", stub.Key);
+        }
+
+        private class Item
+        {
+            public Item()
+            {
+                Criteria = new Dictionary<string, DecisionCriterionValue<string>>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            public Dictionary<string, DecisionCriterionValue<string>> Criteria { get; private set; }
+        }
+
+        private class ItemClassifier : IClassifier<Item, string>
+        {
+            public IEqualityComparer<string> ValueComparer
+            {
+                get
+                {
+                    return StringComparer.OrdinalIgnoreCase;
+                }
+            }
+
+            public IDictionary<string, DecisionCriterionValue<string>> GetCriteria(Item item)
+            {
+                return item.Criteria;
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Microsoft.AspNet.Mvc.Core.Test.kproj
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Microsoft.AspNet.Mvc.Core.Test.kproj
@@ -35,6 +35,7 @@
     <Compile Include="Formatters\OutputFormatterTests.cs" />
     <Compile Include="Formatters\TextPlainFormatterTests.cs" />
     <Compile Include="DefaultViewComponentActivatorTests.cs" />
+    <Compile Include="Internal\DecisionTree\DecisionTreeBuilderTest.cs" />
     <Compile Include="Logging\BeginScopeContext.cs" />
     <Compile Include="Logging\TestLoggerFactory.cs" />
     <Compile Include="Logging\WriteCoreContext.cs" />


### PR DESCRIPTION
Here's a PR for discussion of the general pattern. 

We're still figuring out the best way to measure this because:
- We need to consider working set
- Our current perf test is too small to show any real delta
- We'd like to create (and run in the lab) a focused benchmark for this code

The idea is that we generate a tree of dictionaries, and make decisions at each node which patch to take based on a key-value-pair in route data. The ordering of decisions is based on the branchiest-first, and the tree is then reduced - you won't find any AD in two places in the tree.

We need to walk the entire tree to deal with the possibility of partial matches (which is supported by our action selection system). That's a case like:

```
Action1 = { controller = "Home", action = "Index" }
Action2 = { controller = "Home", action = "Index", foo = "bar" }

Values = { controller = "Home", action = "Index" }
```

In this case both of these match.

So while average time is closer to log-k(n), you can build parasitic cases that will be closer to log(n) where n is the number of nodes in the decision tree (sum of all values for all constraints).
