### PR TITLE
Add friendly name to action descriptor. Issue #820

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ActionDescriptor.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionDescriptor.cs
@@ -34,5 +34,10 @@ namespace Microsoft.AspNet.Mvc
         public List<ParameterDescriptor> Parameters { get; set; }
 
         public List<FilterDescriptor> FilterDescriptors { get; set; }
+
+        /// <summary>
+        /// A friendly name for this action.
+        /// </summary>
+        public virtual string DisplayName { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ReflectedActionDescriptor.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ReflectedActionDescriptor.cs
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using System.Reflection;
 
 namespace Microsoft.AspNet.Mvc
 {
-    [DebuggerDisplay("CA {ControllerName}:{Name}(RC-{RouteConstraints.Count})")]
+    [DebuggerDisplay("CA {DisplayName}(RC-{RouteConstraints.Count})")]
     public class ReflectedActionDescriptor : ActionDescriptor
     {
         public string ControllerName
@@ -20,5 +21,31 @@ namespace Microsoft.AspNet.Mvc
         public MethodInfo MethodInfo { get; set; }
 
         public ControllerDescriptor ControllerDescriptor { get; set; }
+
+        public override string DisplayName
+        {
+            get
+            {
+                if (base.DisplayName == null && MethodInfo != null)
+                {
+                    base.DisplayName = string.Format(
+                        "{0}.{1}",
+                        MethodInfo.DeclaringType.FullName,
+                        MethodInfo.Name);
+                }
+
+                return base.DisplayName;
+            }
+
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException("value");
+                }
+
+                base.DisplayName = value;
+            }
+        }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ReflectedActionDescriptorProviderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ReflectedActionDescriptorProviderTests.cs
@@ -189,6 +189,26 @@ namespace Microsoft.AspNet.Mvc.Test
             Assert.Same(filter, Assert.Single(filters));
         }
 
+        [Fact]
+        public void GetDescriptor_SetsDisplayName()
+        {
+            // Arrange
+            var provider = GetProvider(typeof(PersonController).GetTypeInfo());
+
+            // Act
+            var descriptors = provider.GetDescriptors();
+            var displayNames = descriptors.Select(ad => ad.DisplayName);
+
+            // Assert
+            Assert.Equal(
+                new[]
+                {
+                    "Microsoft.AspNet.Mvc.Test.ReflectedActionDescriptorProviderTests+PersonController.GetPerson",
+                    "Microsoft.AspNet.Mvc.Test.ReflectedActionDescriptorProviderTests+PersonController.ListPeople",
+                },
+                displayNames);
+        }
+
         private ReflectedActionDescriptorProvider GetProvider(
             TypeInfo controllerTypeInfo, 
             IEnumerable<IFilter> filters = null)


### PR DESCRIPTION
Used in error messages for various attribute routing pieces, and anywhere
that you need a display name for an AD.
