### PR TITLE
Return a copy of the route values in functional tests.

### DIFF
--- a/test/WebSites/RoutingWebSite/TestResponseGenerator.cs
+++ b/test/WebSites/RoutingWebSite/TestResponseGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNet.Mvc;
 using Microsoft.Framework.DependencyInjection;
@@ -40,7 +41,7 @@ namespace RoutingWebSite
             {
                 expectedUrls = expectedUrls,
                 actualUrl = _actionContext.HttpContext.Request.Path.Value,
-                routeValues = _actionContext.RouteData.Values,
+                routeValues = new Dictionary<string, object>(_actionContext.RouteData.Values),
 
                 action = _actionContext.ActionDescriptor.Name,
                 controller = ((ReflectedActionDescriptor)_actionContext.ActionDescriptor).ControllerDescriptor.Name,


### PR DESCRIPTION
This is a workaround for a Json.Net + CoreCLR issue.
