### PR TITLE
Adding support for GetCodeTree to IMvcRazorHost

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor.Host/IMvcRazorHost.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/IMvcRazorHost.cs
@@ -1,13 +1,24 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.IO;
 using Microsoft.AspNet.Razor;
+using Microsoft.AspNet.Razor.Generator.Compiler;
 
 namespace Microsoft.AspNet.Mvc.Razor
 {
     public interface IMvcRazorHost
     {
         GeneratorResults GenerateCode(string rootRelativePath, Stream inputStream);
+
+        /// <summary>
+        /// Parses the contents represented by the stream and provides a list of 
+        /// <see cref="Chunk"/> for the parsed content.
+        /// </summary>
+        /// <param name="rootRelativePath">The path of the file relative to the root of application.</param>
+        /// <param name="inputStream">The stream to parse.</param>
+        /// <returns>A list of Chunks parsed from the tree.</returns>
+        IList<Chunk> GetCodeTree(string rootRelativePath, Stream inputStream);
     }
 }

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/MvcRazorHostTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/MvcRazorHostTest.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Text;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNet.Mvc.Razor.Host.Test
+{
+    public class MvcRazorHostTest
+    {
+        [Fact]
+        public void GetCodeTree_ReturnsParsedCodeTree()
+        {
+            // Arrange
+            var content = @"
+@model Foo
+@inject IHtmlHelper Foo
+@{
+    Layout = ""/Layout.cshtml"";
+}
+";
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+            var host = new MvcRazorHost("someBasetype");
+
+            // Act
+            var result = host.GetCodeTree("/views/home/view.cshtml", stream);
+
+            // Assert
+            Assert.IsType<ModelChunk>(result[1]);
+            Assert.IsType<InjectChunk>(result[2]);
+        }
+
+        [Fact]
+        public void GetCodeTree_DoesNotCloseStream()
+        {
+            // Arrange
+            var host = new MvcRazorHost("MyBaseType");
+            var stream = new Mock<MemoryStream> { CallBase = true };
+
+            // Act
+            host.GetCodeTree("somepath.cshtml", stream.Object);
+
+            // Assert
+            stream.Verify(s => s.Close(), Times.Never());
+        }
+
+        [Fact]
+        public void GenerateCode_DoesNotCloseStream()
+        {
+            // Arrange
+            var host = new MvcRazorHost("MyBaseType");
+            var stream = new Mock<MemoryStream> { CallBase = true };
+
+            // Act
+            host.GenerateCode("somepath.cshtml", stream.Object);
+
+            // Assert
+            stream.Verify(s => s.Close(), Times.Never());
+        }
+    }
+}


### PR DESCRIPTION
This would allow consumers to parse the code tree from files on disk.
