### PR TITLE
Correct XML comment syntax

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ExpiringFileInfoCache.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ExpiringFileInfoCache.cs
@@ -10,7 +10,7 @@ using Microsoft.Framework.Runtime;
 namespace Microsoft.AspNet.Mvc.Core
 {
     /// <summary>
-    /// A default implementation for the <see cref="IFileInfoCache" interface./>
+    /// A default implementation for the <see cref="IFileInfoCache"/> interface.
     /// </summary>
     public class ExpiringFileInfoCache : IFileInfoCache
     {

--- a/src/Microsoft.AspNet.Mvc.Core/FormContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/FormContext.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.AspNet.Mvc.Rendering;
 
 namespace Microsoft.AspNet.Mvc
 {
@@ -14,8 +13,8 @@ namespace Microsoft.AspNet.Mvc
         private Dictionary<string, object> _formData;
 
         /// <summary>
-        /// Property bag for any information you wish to associate with a {form/} in an <see cref="IHtmlHelper"/>
-        /// implementation or extension method.
+        /// Property bag for any information you wish to associate with a &lt;form/&gt; in an
+        /// <see cref="Rendering.IHtmlHelper"/> implementation or extension method.
         /// </summary>
         public IDictionary<string, object> FormData
         {

--- a/src/Microsoft.AspNet.Mvc.Core/Formatters/MediaTypeWithQualityHeaderValueComparer.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Formatters/MediaTypeWithQualityHeaderValueComparer.cs
@@ -25,17 +25,15 @@ namespace Microsoft.AspNet.Mvc
             get { return _mediaTypeComparer; }
         }
 
-        /// <summary>
-        /// Compares two <see cref="MediaTypeWithQualityHeaderValue"/> based on their quality value 
-        /// (a.k.a their "q-value"). Values with identical q-values are considered equal (i.e the result is 0)
-        /// with the exception that sub-type wild-cards are considered less than specific media types and full
-        /// wild-cards are considered less than sub-type wild-cards. This allows to sort a sequence of 
-        /// <see cref="MediaTypeWithQualityHeaderValue"/> following their q-values in the order of specific 
-        /// media types, sub-type wildcards, and last any full wild-cards.
-        /// </summary>
-        /// <param name="mediaType1">The first <see cref="MediaTypeWithQualityHeaderValue"/> to compare.</param>
-        /// <param name="mediaType2">The second <see cref="MediaTypeWithQualityHeaderValue"/> to compare.</param>
-        /// <returns></returns>
+        /// <inheritdoc />
+        /// <remarks>
+        /// Performs comparisons based on the arguments' quality values
+        /// (aka their "q-value"). Values with identical q-values are considered equal (i.e. the result is 0)
+        /// with the exception that subtype wildcards are considered less than specific media types and full
+        /// wildcards are considered less than subtype wildcards. This allows callers to sort a sequence of
+        /// <see cref="MediaTypeWithQualityHeaderValue"/> following their q-values in the order of specific
+        /// media types, subtype wildcards, and last any full wildcards.
+        /// </remarks>
         public int Compare(MediaTypeWithQualityHeaderValue mediaType1, MediaTypeWithQualityHeaderValue mediaType2)
         {
             if (object.ReferenceEquals(mediaType1, mediaType2))

--- a/src/Microsoft.AspNet.Mvc.Core/IExpiringFileInfoCache.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/IExpiringFileInfoCache.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNet.Mvc.Core
         /// Returns a cached <see cref="IFileInfo" /> for a given path.
         /// </summary>
         /// <param name="virtualPath">The virtual path.</param>
-        /// <returns></returns>
+        /// <returns>The cached <see cref="IFileInfo"/>.</returns>
         IFileInfo GetFileInfo(string virtualPath);
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/MvcOptions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/MvcOptions.cs
@@ -50,9 +50,9 @@ namespace Microsoft.AspNet.Mvc
         }
 
         public List<OutputFormatterDescriptor> OutputFormatters { get; private set; }
-        
+
         /// <summary>
-        /// Provides programmatic configuration for the default <see cref="IViewEngine" />.
+        /// Provides programmatic configuration for the default <see cref="Rendering.IViewEngine" />.
         /// </summary>
         public RazorViewEngineOptions ViewEngineOptions
         {
@@ -75,17 +75,20 @@ namespace Microsoft.AspNet.Mvc
         }
 
         /// <summary>
-        /// Get a list of the <see cref="ModelBinderDescriptor" /> used by the <see cref="CompositeModelBinder" />.
+        /// Get a list of the <see cref="ModelBinderDescriptor" /> used by the
+        /// <see cref="ModelBinding.CompositeModelBinder" />.
         /// </summary>
         public List<ModelBinderDescriptor> ModelBinders { get; private set; }
 
         /// <summary>
-        /// Gets a list of descriptors that represent <see cref="IViewEngine"/> used by this application.
+        /// Gets a list of descriptors that represent <see cref="Rendering.IViewEngine"/> used
+        /// by this application.
         /// </summary>
         public List<ViewEngineDescriptor> ViewEngines { get; private set; }
 
         /// <summary>
-        /// Gets a list of descriptors that represent <see cref="IValueProviderFactory"/> used by this application.
+        /// Gets a list of descriptors that represent
+        /// <see cref="ModelBinding.IValueProviderFactory"/> used by this application.
         /// </summary>
         public List<ValueProviderFactoryDescriptor> ValueProviderFactories { get; private set; }
 

--- a/src/Microsoft.AspNet.Mvc.Core/OptionDescriptors/ModelBinderDescriptor.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/OptionDescriptors/ModelBinderDescriptor.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNet.Mvc.OptionDescriptors
         /// <summary>
         /// Creates a new instance of <see cref="ModelBinderDescriptor"/>.
         /// </summary>
-        /// <param name="type">A type that represents a <see cref="IModelBinder"/>.
+        /// <param name="type">A type that represents a <see cref="IModelBinder"/>.</param>
         public ModelBinderDescriptor([NotNull] Type type)
             : base(type)
         {
@@ -23,7 +23,7 @@ namespace Microsoft.AspNet.Mvc.OptionDescriptors
         /// <summary>
         /// Creates a new instance of <see cref="ModelBinderDescriptor"/> with the specified instance.
         /// </summary>
-        /// <param name="option">An instance of <see cref="IModelBinder"/>.
+        /// <param name="option">An instance of <see cref="IModelBinder"/>.</param>
         public ModelBinderDescriptor([NotNull] IModelBinder binder)
             : base(binder)
         {

--- a/src/Microsoft.AspNet.Mvc.Core/OptionDescriptors/OptionDescriptor.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/OptionDescriptors/OptionDescriptor.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNet.Mvc.OptionDescriptors
         /// <summary>
         /// Creates a new instance of <see cref="OptionDescriptor{TOption}"/>.
         /// </summary>
-        /// <param name="type">A type that represents <typeparamref name="TOption"/>.
+        /// <param name="type">A type that represents <typeparamref name="TOption"/>.</param>
         public OptionDescriptor([NotNull] Type type)
         {
             var optionType = typeof(TOption);
@@ -31,7 +31,7 @@ namespace Microsoft.AspNet.Mvc.OptionDescriptors
         /// <summary>
         /// Creates a new instance of <see cref="OptionDescriptor{TOption}"/> with the specified instance.
         /// </summary>
-        /// <param name="option">An instance of <typeparamref cref="TOption"/> that the descriptor represents.</param>
+        /// <param name="option">An instance of <typeparamref name="TOption"/> that the descriptor represents.</param>
         public OptionDescriptor([NotNull] TOption option)
         {
             Instance = option;
@@ -39,7 +39,7 @@ namespace Microsoft.AspNet.Mvc.OptionDescriptors
         }
 
         /// <summary>
-        /// Gets the type of the <typeparamref cref="TOption"/> described by this 
+        /// Gets the type of the <typeparamref name="TOption"/> described by this
         /// <see cref="OptionDescriptor{TOption}"/>.
         /// </summary>
         public Type OptionType
@@ -49,7 +49,7 @@ namespace Microsoft.AspNet.Mvc.OptionDescriptors
         }
 
         /// <summary>
-        /// Gets the instance of <typeparamref cref="TOption"/> described by this 
+        /// Gets the instance of <typeparamref name="TOption"/> described by this
         /// <see cref="OptionDescriptor{TOption}"/>.
         /// </summary>
         public TOption Instance

--- a/src/Microsoft.AspNet.Mvc.Core/OptionDescriptors/OutputFormatterDescriptor.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/OptionDescriptors/OutputFormatterDescriptor.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNet.Mvc.OptionDescriptors
         /// <summary>
         /// Creates a new instance of <see cref="OutputFormatterDescriptor"/>.
         /// </summary>
-        /// <param name="type">A <see cref="IOutputFormatter/> type that the descriptor represents.
+        /// <param name="type">A <see cref="IOutputFormatter"/> type that the descriptor represents.
         /// </param>
         public OutputFormatterDescriptor([NotNull] Type type)
             : base(type)

--- a/src/Microsoft.AspNet.Mvc.Core/OptionDescriptors/ValueProviderFactoryDescriptor.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/OptionDescriptors/ValueProviderFactoryDescriptor.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNet.Mvc.OptionDescriptors
         /// <summary>
         /// Creates a new instance of <see cref="ValueProviderFactoryDescriptor"/>.
         /// </summary>
-        /// <param name="type">The <see cref="IValueProviderFactory/> type that the descriptor represents.</param>
+        /// <param name="type">The <see cref="IValueProviderFactory"/> type that the descriptor represents.</param>
         public ValueProviderFactoryDescriptor([NotNull] Type type)
             : base(type)
         {

--- a/src/Microsoft.AspNet.Mvc.Core/OptionDescriptors/ViewEngineDescriptor.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/OptionDescriptors/ViewEngineDescriptor.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNet.Mvc.OptionDescriptors
         /// <summary>
         /// Creates a new instance of <see cref="ViewEngineDescriptor"/>.
         /// </summary>
-        /// <param name="type">The <see cref="IViewEngine/> type that the descriptor represents.</param>
+        /// <param name="type">The <see cref="IViewEngine"/> type that the descriptor represents.</param>
         public ViewEngineDescriptor([NotNull] Type type)
             : base(type)
         {

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/HtmlHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/HtmlHelper.cs
@@ -18,7 +18,7 @@ using Microsoft.AspNet.Mvc.Rendering.Expressions;
 namespace Microsoft.AspNet.Mvc.Rendering
 {
     /// <summary>
-    /// Default implementation of non-generic portions of <see cref="IHtmlHelper{T}">.
+    /// Default implementation of non-generic portions of <see cref="IHtmlHelper{TModel}"/>.
     /// </summary>
     public class HtmlHelper : IHtmlHelper, ICanHasViewContext
     {
@@ -125,11 +125,11 @@ namespace Microsoft.AspNet.Mvc.Rendering
         ///
         /// If the object is already an <see cref="IDictionary{string, object}"/> instance, then it is
         /// returned as-is.
-        /// </summary>
         /// <example>
         /// <c>new { property_name = "value" }</c> will translate to the entry <c>{ "property_name" , "value" }</c>
         /// in the resulting dictionary.
         /// </example>
+        /// </summary>
         /// <param name="obj">The object to be converted.</param>
         /// <returns>The created dictionary of property names and property values.</returns>
         public static IDictionary<string, object> ObjectToDictionary(object obj)
@@ -628,7 +628,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <summary>
-        /// Writes an opening <form> tag to the response. When the user submits the form,
+        /// Renders a &lt;form&gt; start tag to the response. When the user submits the form,
         /// the request will be processed by an action method.
         /// </summary>
         /// <param name="actionName">The name of the action method.</param>
@@ -640,7 +640,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <param name="method">The HTTP method for processing the form, either GET or POST.</param>
         /// <param name="htmlAttributes">An <see cref="IDictionary{string, object}"/> instance containing HTML
         /// attributes to set for the element.</param>
-        /// <returns>An <see cref="MvcForm"/> instance which emits the closing {form} tag when disposed.</returns>
+        /// <returns>
+        /// An <see cref="MvcForm"/> instance which emits the &lt;/form&gt; end tag when disposed.
+        /// </returns>
         protected virtual MvcForm GenerateForm(string actionName, string controllerName, object routeValues,
                                                FormMethod method, IDictionary<string, object> htmlAttributes)
         {

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperDisplayNameExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperDisplayNameExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// Returns the display name for the current model.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <returns>A <see langref="string"/> containing the display name.</returns>
+        /// <returns>A <see cref="String"/> containing the display name.</returns>
         public static string DisplayNameForModel([NotNull] this IHtmlHelper htmlHelper)
         {
             return htmlHelper.DisplayName(string.Empty);
@@ -27,12 +27,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// if the current model represents a collection.
         /// </summary>
         /// <param name="htmlHelper">
-        /// The <see cref="IHtmlHelper{IEnumerable<TModelItem>}"/> instance this method extends.
+        /// The <see cref="IHtmlHelper{IEnumerable{TModelItem}}"/> instance this method extends.
         /// </param>
         /// <param name="expression">The expression to be evaluated against an item in the current model.</param>
-        /// <typeparam name="TModelItem">The <see cref="Type"/> of items in the model collection.</typeparam>
-        /// <typeparam name="TValue">The <see cref="Type"/> of the <param name="expression"> result.</typeparam>
-        /// <returns>A <see langref="string"/> containing the display name.</returns>
+        /// <typeparam name="TModelItem">The type of items in the model collection.</typeparam>
+        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <returns>A <see cref="String"/> containing the display name.</returns>
         public static string DisplayNameFor<TModelItem, TValue>(
             [NotNull] this IHtmlHelper<IEnumerable<TModelItem>> htmlHelper,
             [NotNull] Expression<Func<TModelItem, TValue>> expression)

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperNameExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperNameExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// Returns the full HTML element name for the current model.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <returns>A <see langref="string"/> containing the element name.</returns>
+        /// <returns>A <see cref="System.String"/> containing the element name.</returns>
         public static string NameForModel([NotNull] this IHtmlHelper htmlHelper)
         {
             return htmlHelper.Name(string.Empty);
@@ -22,7 +22,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// Returns the HTML element Id for the current model.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <returns>A <see langref="string"/> containing the element Id.</returns>
+        /// <returns>A <see cref="System.String"/> containing the element Id.</returns>
         public static string IdForModel([NotNull] this IHtmlHelper htmlHelper)
         {
             return htmlHelper.Id(string.Empty);

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperValueExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperValueExtensions.cs
@@ -16,9 +16,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="name">Expression name, relative to the current model.</param>
-        /// <returns>A <see langref="string"/> containing the formatted value.</returns>
+        /// <returns>A <see cref="String"/> containing the formatted value.</returns>
         /// <remarks>
-        /// Converts the expression <paramref name="name"/> result to a <see langref="string"/> directly.
+        /// Converts the expression <paramref name="name"/> result to a <see cref="String"/> directly.
         /// </remarks>
         public static string Value([NotNull] this IHtmlHelper htmlHelper, string name)
         {
@@ -30,11 +30,11 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">The expression to be evaluated against the current model.</param>
-        /// <typeparam name="TModel">The <see cref="Type"/> of the model.</typeparam>
-        /// <typeparam name="TProperty">The <see cref="Type"/> of the <param name="expression"> result.</typeparam>
-        /// <returns>A <see langref="string"/> containing the formatted value.</returns>
+        /// <typeparam name="TModel">The type of the model.</typeparam>
+        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <returns>A <see cref="String"/> containing the formatted value.</returns>
         /// <remarks>
-        /// Converts the <paramref name="expression"/> result to a <see langref="string"/> directly.
+        /// Converts the <paramref name="expression"/> result to a <see cref="String"/> directly.
         /// </remarks>
         public static string ValueFor<TModel, TProperty>(
             [NotNull] this IHtmlHelper<TModel> htmlHelper,
@@ -47,9 +47,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// Returns the formatted value for the current model.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <returns>A <see langref="string"/> containing the formatted value.</returns>
+        /// <returns>A <see cref="String"/> containing the formatted value.</returns>
         /// <remarks>
-        /// Converts the model value to a <see langref="string"/> directly.
+        /// Converts the model value to a <see cref="String"/> directly.
         /// </remarks>
         public static string ValueForModel([NotNull] this IHtmlHelper htmlHelper)
         {
@@ -61,12 +61,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="format">
-        /// The composite format <see langref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx).
+        /// The composite format <see cref="String"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx).
         /// </param>
-        /// <returns>A <see langref="string"/> containing the formatted value.</returns>
+        /// <returns>A <see cref="String"/> containing the formatted value.</returns>
         /// <remarks>
-        /// Converts the model value to a <see langref="string"/> directly if
-        /// <paramref name="format"/> is <see langref="null"/> or empty.
+        /// Converts the model value to a <see cref="String"/> directly if
+        /// <paramref name="format"/> is <c>null</c> or empty.
         /// </remarks>
         public static string ValueForModel([NotNull] this IHtmlHelper htmlHelper, string format)
         {

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/IHtmlHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/IHtmlHelper.cs
@@ -13,9 +13,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
     public interface IHtmlHelper
     {
         /// <summary>
-        /// Set this property to <see cref="Mvc.Html5DateRenderingMode.Rfc3339"/> to have templated helpers such as
-        /// <see cref="Editor"/> and <see cref="EditorFor"/> render date and time values as RFC 3339 compliant strings.
-        /// By default these helpers render dates and times using the current culture.
+        /// Set this property to <see cref="Html5DateRenderingMode.Rfc3339"/> to have templated helpers such as
+        /// <see cref="Editor"/> and <see cref="IHtmlHelper{TModel}.EditorFor"/> render date and time values as RFC
+        /// 3339 compliant strings. By default these helpers render dates and times using the current culture.
         /// </summary>
         Html5DateRenderingMode Html5DateRenderingMode { get; set; }
 
@@ -84,7 +84,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         HtmlString AntiForgeryToken();
 
         /// <summary>
-        /// Writes an opening <form> tag to the response. When the user submits the form,
+        /// Renders a &lt;form&gt; start tag to the response. When the user submits the form,
         /// the request will be processed by an action method.
         /// </summary>
         /// <param name="actionName">The name of the action method.</param>
@@ -97,7 +97,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the element.
         /// Alternatively, an <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
         /// </param>
-        /// <returns>An <see cref="MvcForm"/> instance which emits the closing {form} tag when disposed.</returns>
+        /// <returns>
+        /// An <see cref="MvcForm"/> instance which renders the &lt;/form&gt; end tag when disposed.
+        /// </returns>
         MvcForm BeginForm(
             string actionName,
             string controllerName,
@@ -149,7 +151,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// Returns the display name for the specified expression <paramref name="expression"/>.
         /// </summary>
         /// <param name="expression">Expression name, relative to the current model.</param>
-        /// <returns>A <see langref="string"/> containing the display name.</returns>
+        /// <returns>A <see cref="System.String"/> containing the display name.</returns>
         string DisplayName(string expression);
 
         /// <summary>
@@ -157,23 +159,26 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </summary>
         /// <param name="name">Expression name, relative to the current model.</param>
         /// <returns>
-        /// A <see langref="string"/> containing the simple display text.
-        /// If the expression result is <see langref="null"/>, returns <see cref="ModelMetadata.NullDisplayText"/>.
+        /// A <see cref="System.String"/> containing the simple display text.
+        /// If the expression result is <c>null</c>, returns <see cref="ModelMetadata.NullDisplayText"/>.
         /// </returns>
         string DisplayText(string name);
 
         /// <summary>
-        /// Returns a single-selection HTML {select} element using the specified name of the form field,
+        /// Returns a single-selection HTML &lt;select&gt; element using the specified name of the form field,
         /// list items, option label, and HTML attributes.
         /// </summary>
         /// <param name="name">The name of the form field to return.</param>
-        /// <param name="selectList">A collection of <see href="SelectListItem"/> objects that are used to populate the
+        /// <param name="selectList">A collection of <see cref="SelectListItem"/> objects that are used to populate the
         /// drop-down list.</param>
         /// <param name="optionLabel">The text for a default empty item. This parameter can be null.</param>
-        /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the {select} element.
-        /// Alternatively, an <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
+        /// <param name="htmlAttributes">
+        /// An object that contains the HTML attributes to set for the &lt;select&gt; element. Alternatively, an
+        /// <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
         /// </param>
-        /// <returns>An HTML {select} element with an {option} subelement for each item in the list.</returns>
+        /// <returns>
+        /// An HTML &lt;select&gt; element with an &lt;option&gt; subelement for each item in the list.
+        /// </returns>
         HtmlString DropDownList(
             string name,
             IEnumerable<SelectListItem> selectList,
@@ -214,7 +219,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         string Encode(string value);
 
         /// <summary>
-        /// Renders the closing </form> tag to the response.
+        /// Renders the &lt;/form&gt; end tag to the response.
         /// </summary>
         void EndForm();
 
@@ -237,9 +242,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// Returns information about about client validation rules for the given <paramref name="metadata"/> or
         /// <paramref name="name"/>. Intended for use in <see cref="IHtmlHelper"/> extension methods.
         /// </summary>
-        /// <param name="metadata">Metadata about the <see langref="object"/> of interest.</param>
+        /// <param name="metadata">Metadata about the <see cref="System.Object"/> of interest.</param>
         /// <param name="name">Expression name, relative to the current model. Used to determine
-        /// <see cref="ModelMetadata"/> when <paramref name="metadata"/> is <see langref="null"/>; ignored
+        /// <see cref="ModelMetadata"/> when <paramref name="metadata"/> is <c>null</c>; ignored
         /// otherwise.</param>
         /// <returns>An <see cref="IEnumerable{ModelClientValidationRule}"/> containing the relevant rules.</returns>
         IEnumerable<ModelClientValidationRule> GetClientValidationRules(ModelMetadata metadata, string name);
@@ -264,7 +269,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// Returns the HTML element Id for the specified expression <paramref name="name"/>.
         /// </summary>
         /// <param name="name">Expression name, relative to the current model.</param>
-        /// <returns>A <see langref="string"/> containing the element Id.</returns>
+        /// <returns>A <see cref="System.String"/> containing the element Id.</returns>
         string Id(string name);
 
         /// <summary>
@@ -280,23 +285,25 @@ namespace Microsoft.AspNet.Mvc.Rendering
         HtmlString Label(string expression, string labelText, object htmlAttributes);
 
         /// <summary>
-        /// Returns a multi-selection HTML {select} element using the specified name of the form field,
+        /// Returns a multi-selection HTML &lt;select&gt; element using the specified name of the form field,
         /// list items, and HTML attributes.
         /// </summary>
         /// <param name="name">The name of the form field to return.</param>
-        /// <param name="selectList">A collection of <see href="SelectListItem"/> objects that are used to populate the
+        /// <param name="selectList">A collection of <see cref="SelectListItem"/> objects that are used to populate the
         /// drop-down list.</param>
         /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the element.
         /// Alternatively, an <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
         /// </param>
-        /// <returns>An HTML {select} element with an {option} subelement for each item in the list.</returns>
+        /// <returns>
+        /// An HTML &lt;select&gt; element with an &lt;option&gt; subelement for each item in the list.
+        /// </returns>
         HtmlString ListBox(string name, IEnumerable<SelectListItem> selectList, object htmlAttributes);
 
         /// <summary>
         /// Returns the full HTML element name for the specified expression <paramref name="name"/>.
         /// </summary>
         /// <param name="name">Expression name, relative to the current model.</param>
-        /// <returns>A <see langref="string"/> containing the element name.</returns>
+        /// <returns>A <see cref="System.String"/> containing the element name.</returns>
         string Name(string name);
 
         /// <summary>
@@ -476,12 +483,13 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </summary>
         /// <param name="name">Expression name, relative to the current model.</param>
         /// <param name="format">
-        /// The composite format <see langref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx).
+        /// The composite format <see cref="System.String"/>
+        /// (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx).
         /// </param>
-        /// <returns>A <see langref="string"/> containing the formatted value.</returns>
+        /// <returns>A <see cref="System.String"/> containing the formatted value.</returns>
         /// <remarks>
-        /// Converts the expression result to a <see langref="string"/> directly if
-        /// <paramref name="format"/> is <see langref="null"/> or empty.
+        /// Converts the expression result to a <see cref="System.String"/> directly if
+        /// <paramref name="format"/> is <c>null</c> or empty.
         /// </remarks>
         string Value([NotNull] string name, string format);
     }

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/IHtmlHelperOfT.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/IHtmlHelperOfT.cs
@@ -57,8 +57,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// Returns the display name for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="expression">The expression to be evaluated against the current model.</param>
-        /// <typeparam name="TValue">The type of the <param name="expression"> result.</typeparam>
-        /// <returns>A <see langref="string"/> containing the display name.</returns>
+        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <returns>A <see cref="String"/> containing the display name.</returns>
         string DisplayNameFor<TValue>([NotNull] Expression<Func<TModel, TValue>> expression);
 
         /// <summary>
@@ -67,8 +67,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </summary>
         /// <param name="expression">The expression to be evaluated against an item in the current model.</param>
         /// <typeparam name="TModelItem">The type of items in the model collection.</typeparam>
-        /// <typeparam name="TValue">The type of the <param name="expression"> result.</typeparam>
-        /// <returns>A <see langref="string"/> containing the display name.</returns>
+        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <returns>A <see cref="String"/> containing the display name.</returns>
         string DisplayNameForInnerType<TModelItem, TValue>(
             [NotNull] Expression<Func<TModelItem, TValue>> expression);
 
@@ -76,27 +76,30 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// Returns the simple display text for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="expression">The expression to be evaluated against the current model.</param>
-        /// <typeparam name="TValue">The type of the <param name="expression"> result.</typeparam>
+        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>
-        /// A <see langref="string"/> containing the simple display text.
-        /// If the <param name="expression"> result is <see langref="null"/>, returns
-        /// <see cref="ModelMetadata.NullDisplayText"/>.
+        /// A <see cref="String"/> containing the simple display text.
+        /// If the <paramref name="expression"/> result is <c>null</c>, returns
+        /// <see cref="ModelBinding.ModelMetadata.NullDisplayText"/>.
         /// </returns>
         string DisplayTextFor<TValue>([NotNull] Expression<Func<TModel, TValue>> expression);
 
         /// <summary>
-        /// Returns a single-selection HTML {select} element for the object that is represented
+        /// Returns a single-selection HTML &lt;select&gt; element for the object that is represented
         /// by the specified expression using the specified list items, option label, and HTML attributes.
         /// </summary>
         /// <typeparam name="TProperty">The type of the value.</typeparam>
         /// <param name="expression">An expression that identifies the value to display.</param>
-        /// <param name="selectList">A collection of <see href="SelectListItem"/> objects that are used to populate the
+        /// <param name="selectList">A collection of <see cref="SelectListItem"/> objects that are used to populate the
         /// drop-down list.</param>
         /// <param name="optionLabel">The text for a default empty item. This parameter can be null.</param>
-        /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the {select} element.
-        /// Alternatively, an <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
+        /// <param name="htmlAttributes">
+        /// An object that contains the HTML attributes to set for the &lt;select&gt; element. Alternatively, an
+        /// <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
         /// </param>
-        /// <returns>An HTML {select} element with an {option} subelement for each item in the list.</returns>
+        /// <returns>
+        /// An HTML &lt;select&gt; element with an &lt;option&gt; subelement for each item in the list.
+        /// </returns>
         HtmlString DropDownListFor<TProperty>(
             [NotNull] Expression<Func<TModel, TProperty>> expression,
             IEnumerable<SelectListItem> selectList,
@@ -143,8 +146,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// Returns the HTML element Id for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="expression">The expression to be evaluated against the current model.</param>
-        /// <typeparam name="TProperty">The type of the <param name="expression"> result.</typeparam>
-        /// <returns>A <see langref="string"/> containing the element Id.</returns>
+        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <returns>A <see cref="String"/> containing the element Id.</returns>
         string IdFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression);
 
         /// <summary>
@@ -162,18 +165,20 @@ namespace Microsoft.AspNet.Mvc.Rendering
                                     object htmlAttributes);
 
         /// <summary>
-        /// Returns a multi-selection HTML {select} element for the object that is represented by the specified
+        /// Returns a multi-selection HTML &lt;select&gt; element for the object that is represented by the specified
         /// expression using the specified list items and HTML attributes.
         /// </summary>
         /// <typeparam name="TProperty">The type of the property.</typeparam>
         /// <param name="expression">An expression that identifies the object that contains the properties to
         /// display.</param>
-        /// <param name="selectList">A collection of <see href="SelectListItem"/> objects that are used to populate the
+        /// <param name="selectList">A collection of <see cref="SelectListItem"/> objects that are used to populate the
         /// drop-down list.</param>
         /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the element.
         /// Alternatively, an <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
         /// </param>
-        /// <returns>An HTML {select} element with an {option} subelement for each item in the list.</returns>
+        /// <returns>
+        /// An HTML &lt;select&gt; element with an &lt;option&gt; subelement for each item in the list.
+        /// </returns>
         HtmlString ListBoxFor<TProperty>(
             [NotNull] Expression<Func<TModel, TProperty>> expression,
             IEnumerable<SelectListItem> selectList,
@@ -184,7 +189,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </summary>
         /// <param name="expression">The expression to be evaluated against the current model.</param>
         /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
-        /// <returns>A <see langref="string"/> containing the element name.</returns>
+        /// <returns>A <see cref="String"/> containing the element name.</returns>
         string NameFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression);
 
         /// <summary>
@@ -251,7 +256,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <param name="message">The message to be displayed. This will always be visible but client-side
         /// validation may update the associated CSS class.</param>
         /// <param name="htmlAttributes"> An object that contains the HTML attributes to set for the element.
-        /// Alternatively, an /// <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
+        /// Alternatively, an <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
         /// </param>
         /// <param name="tag">The tag to wrap the <paramref name="message"/> in the generated HTML.
         /// Its default value is <see cref="ViewContext.ValidationMessageElement" />.</param>
@@ -266,13 +271,13 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </summary>
         /// <param name="expression">The expression to be evaluated against the current model.</param>
         /// <param name="format">
-        /// The composite format <see langref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx).
+        /// The composite format <see cref="String"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx).
         /// </param>
-        /// <typeparam name="TProperty">The type of the <param name="expression"> result.</typeparam>
-        /// <returns>A <see langref="string"/> containing the formatted value.</returns>
+        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <returns>A <see cref="String"/> containing the formatted value.</returns>
         /// <remarks>
-        /// Converts the <paramref name="expression"/> result to a <see langref="string"/> directly if
-        /// <paramref name="format"/> is <see langref="null"/> or empty.
+        /// Converts the <paramref name="expression"/> result to a <see cref="String"/> directly if
+        /// <paramref name="format"/> is <c>null</c> or empty.
         /// </remarks>
         string ValueFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression, string format);
     }

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/MvcForm.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/MvcForm.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <summary>
-        /// Renders the closing </form> tag to the response.
+        /// Renders the &lt;/form&gt; end tag to the response.
         /// </summary>
         public void EndForm()
         {

--- a/src/Microsoft.AspNet.Mvc.Core/ViewDataDictionary.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ViewDataDictionary.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using Microsoft.AspNet.Mvc.Core;
 using Microsoft.AspNet.Mvc.ModelBinding;
-using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Mvc.Rendering.Expressions;
 
 namespace Microsoft.AspNet.Mvc
@@ -43,7 +42,7 @@ namespace Microsoft.AspNet.Mvc
 
         /// <summary>
         /// <see cref="ViewDataDictionary"/> copy constructor for use when model type may change. This avoids
-        /// exceptions a derived class may throw when <see cref="SetModel()"/> is called.
+        /// exceptions a derived class may throw when <see cref="SetModel"/> is called.
         /// </summary>
         public ViewDataDictionary([NotNull] ViewDataDictionary source, object model)
             : this(source.MetadataProvider)

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/GenericModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/GenericModelBinder.cs
@@ -79,10 +79,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         }
 
         /// <remarks>
-        /// Example: GetGenericBinder(typeof(IList<>), typeof(List<>), typeof(ListBinder<>), ...) means that the 
-        /// ListBinder<T> type can update models that implement IList<T>, and if for some reason the existing model
-        /// instance is not updatable the binder will create a List<T> object and bind to that instead. This method
-        /// will return ListBinder<T> or null, depending on whether the type and updatability checks succeed.
+        /// Example: <c>GetGenericBinderType(typeof(IList&lt;T&gt;), typeof(List&lt;T&gt;),
+        /// typeof(ListBinder&lt;T&gt;), ...)</c> means that the <c>ListBinder&lt;T&gt;</c> type can update models that
+        /// implement <see cref="IList{T}"/>, and if for some reason the existing model instance is not updatable the
+        /// binder will create a <see cref="List{T}"/> object and bind to that instead. This method will return
+        /// <c>ListBinder&lt;T&gt;</c> or <c>null</c>, depending on whether the type and updatability checks succeed.
         /// </remarks>
         private static Type GetGenericBinderType(Type supportedInterfaceType,
                                                  Type newInstanceType,

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/ModelMetadata.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/ModelMetadata.cs
@@ -140,7 +140,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         protected IModelMetadataProvider Provider { get; set; }
 
         /// <returns>
-        /// Gets TModel if ModelType is Nullable{TModel}, ModelType otherwise.
+        /// Gets <c>T</c> if <see cref="ModelType"/> is <see cref="Nullable{T}"/>;
+        /// <see cref="ModelType"/> otherwise.
         /// </returns>
         public Type RealModelType
         {

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Validation/DataAnnotationsModelValidatorProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Validation/DataAnnotationsModelValidatorProvider.cs
@@ -9,12 +9,12 @@ using System.Linq;
 namespace Microsoft.AspNet.Mvc.ModelBinding
 {
     /// <summary>
-    /// An implementation of <see cref="ModelValidatorProvider"/> which providers validators
+    /// An implementation of <see cref="IModelValidatorProvider"/> which providers validators
     /// for attributes which derive from <see cref="ValidationAttribute"/>. It also provides
     /// a validator for types which implement <see cref="IValidatableObject"/>. To support
     /// client side validation, you can either register adapters through the static methods
     /// on this class, or by having your validation attributes implement
-    /// <see cref="IClientValidatable"/>. The logic to support IClientValidatable
+    /// <see cref="IClientModelValidator"/>. The logic to support <see cref="IClientModelValidator"/>
     /// is implemented in <see cref="DataAnnotationsModelValidator"/>.
     /// </summary>
     public class DataAnnotationsModelValidatorProvider : AssociatedValidatorProvider

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Validation/DataMemberModelValidatorProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Validation/DataMemberModelValidatorProvider.cs
@@ -10,8 +10,8 @@ using System.Runtime.Serialization;
 namespace Microsoft.AspNet.Mvc.ModelBinding
 {
     /// <summary>
-    /// This <see cref="ModelValidatorProvider"/> provides a required ModelValidator for members marked
-    /// as [DataMember(IsRequired=true)].
+    /// This <see cref="IModelValidatorProvider"/> provides a required ModelValidator for members marked
+    /// as <c>[DataMember(IsRequired=true)]</c>.
     /// </summary>
     public class DataMemberModelValidatorProvider : AssociatedValidatorProvider
     {

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Validation/ModelClientValidationRule.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Validation/ModelClientValidationRule.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
         /// <summary>
         /// Identifier of the <see cref="ModelClientValidationRule"/>. If client-side validation is enabled, default
-        /// validation attribute generator uses this <see langref="string"/> as part of the generated "data-val"
+        /// validation attribute generator uses this <see cref="String"/> as part of the generated "data-val"
         /// attribute name. Must be unique in the set of enabled validation rules.
         /// </summary>
         public string ValidationType { get; private set; }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Rendering/HtmlHelperDisplayTextTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Rendering/HtmlHelperDisplayTextTest.cs
@@ -8,7 +8,8 @@ using Xunit;
 namespace Microsoft.AspNet.Mvc.Core
 {
     /// <summary>
-    /// Test the <see cref="IHtmlHelper.DisplayText"/> and <see cref="IHtmlHelper{T}.DisplayTextFor{TValue}"/> methods.
+    /// Test the <see cref="Rendering.IHtmlHelper.DisplayText"/> and
+    /// <see cref="Rendering.IHtmlHelper{TModel}.DisplayTextFor{TValue}"/> methods.
     /// </summary>
     public class HtmlHelperDisplayTextTest
     {

--- a/test/Microsoft.AspNet.Mvc.Core.Test/TestController.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/TestController.cs
@@ -67,9 +67,9 @@ namespace Microsoft.AspNet.Mvc.Core.Test
         }
 
         /// <summary>
-        /// Returns a Task<Task> instead of a Task. This should throw an InvalidOperationException.
+        /// Returns a <see cref="Task{TResult}"/> instead of a <see cref="Task"/>. This should throw an
+        /// <see cref="InvalidOperationException"/>.
         /// </summary>
-        /// <returns></returns>
         public Task UnwrappedTask(int i, string s)
         {
             return Task.Factory.StartNew(async () => await Task.Delay(50));


### PR DESCRIPTION
- fix problems at least with Roslyn compiler and VS IntelliSense or the Object Browser
  - `<see langref="keyword"/>` generates nothing
  - `<example>` at top level (outside `<summary>` or `<remarks>`) generates nothing
  - curly braces don't become angle brackets outside `<see cref="reference"/>` references
    - yeah, a point @yishaigalatzer asked about in a previous PR
- `<see href="reference"/>` is not valid
- correct some invalid use of angle brackets and remove useless empty elements
- add usings to help comment references resolve (unfortunately VS seems to get confused about these)

Few wording changes beyond
- `"opening </form> tag"` -> `"<form> start tag"`
- `"closing </form> tag"` -> `"</form> end tag"`

See #928 for one thing _not_ fixed in this PR.
