### PR TITLE
Updating tests using Moq to workaround Roslyn changes

### DIFF
--- a/test/Microsoft.AspNet.Mvc.Core.Test/DefaultActionSelectorTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/DefaultActionSelectorTests.cs
@@ -218,7 +218,7 @@ namespace Microsoft.AspNet.Mvc
             var bindingProvider = new Mock<IActionBindingContextProvider>(MockBehavior.Strict);
             bindingProvider
                 .Setup(bp => bp.GetActionBindingContextAsync(It.IsAny<ActionContext>()))
-                .Returns(() => Task.FromResult<ActionBindingContext>(null));
+                .Returns(Task.FromResult<ActionBindingContext>(null));
 
             return new DefaultActionSelector(actionProvider.Object, bindingProvider.Object, loggerFactory);
         }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Filters/ActionFilterAttributeTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Filters/ActionFilterAttributeTests.cs
@@ -71,7 +71,11 @@ namespace Microsoft.AspNet.Mvc.Test
 
             mock.As<IActionFilter>()
                 .Setup(f => f.OnActionExecuting(It.IsAny<ActionExecutingContext>()))
-                .Callback<ActionExecutingContext>(c => c.Result = new NoOpResult());
+                .Callback<ActionExecutingContext>(c =>
+                {
+                    mock.ToString();
+                    c.Result = new NoOpResult();
+                });
 
             mock.As<IActionFilter>()
                 .Setup(f => f.OnActionExecuted(It.IsAny<ActionExecutedContext>()))
@@ -154,7 +158,11 @@ namespace Microsoft.AspNet.Mvc.Test
 
             mock.As<IResultFilter>()
                 .Setup(f => f.OnResultExecuting(It.IsAny<ResultExecutingContext>()))
-                .Callback<ResultExecutingContext>(c => c.Result = new NoOpResult());
+                .Callback<ResultExecutingContext>(c =>
+                {
+                    mock.ToString();
+                    c.Result = new NoOpResult();
+                });
 
             mock.As<IResultFilter>()
                 .Setup(f => f.OnResultExecuted(It.IsAny<ResultExecutedContext>()))
@@ -188,7 +196,11 @@ namespace Microsoft.AspNet.Mvc.Test
 
             mock.As<IResultFilter>()
                 .Setup(f => f.OnResultExecuting(It.IsAny<ResultExecutingContext>()))
-                .Callback<ResultExecutingContext>(c => c.Cancel = true);
+                .Callback<ResultExecutingContext>(c =>
+                {
+                    mock.ToString();
+                    c.Cancel = true;
+                });
 
             mock.As<IResultFilter>()
                 .Setup(f => f.OnResultExecuted(It.IsAny<ResultExecutedContext>()))

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ReflectedActionInvokerTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ReflectedActionInvokerTest.cs
@@ -146,6 +146,7 @@ namespace Microsoft.AspNet.Mvc
                 .Setup(f => f.OnException(It.IsAny<ExceptionContext>()))
                 .Callback<ExceptionContext>(context =>
                 {
+                    filter2.ToString();
                     context.Exception = null;
                 })
                 .Verifiable();
@@ -172,6 +173,7 @@ namespace Microsoft.AspNet.Mvc
                 .Setup(f => f.OnExceptionAsync(It.IsAny<ExceptionContext>()))
                 .Callback<ExceptionContext>(context =>
                 {
+                    filter2.ToString();
                     context.Exception = null;
                 })
                 .Returns<ExceptionContext>((context) => Task.FromResult<object>(null))
@@ -860,7 +862,11 @@ namespace Microsoft.AspNet.Mvc
             var filter2 = new Mock<IResultFilter>(MockBehavior.Strict);
             filter2
                 .Setup(f => f.OnResultExecuting(It.IsAny<ResultExecutingContext>()))
-                .Callback<ResultExecutingContext>(c => c.Cancel = true)
+                .Callback<ResultExecutingContext>(c =>
+                {
+                    filter2.ToString();
+                    c.Cancel = true;
+                })
                 .Verifiable();
 
             var filter3 = new Mock<IResultFilter>(MockBehavior.Strict);

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Rendering/DefaultTemplatesUtilities.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Rendering/DefaultTemplatesUtilities.cs
@@ -145,6 +145,7 @@ namespace Microsoft.AspNet.Mvc.Core
                 .Setup(v => v.RenderAsync(It.IsAny<ViewContext>()))
                 .Callback(async (ViewContext v) =>
                 {
+                    view.ToString();
                     await v.Writer.WriteAsync(FormatOutput(v.ViewData.ModelMetadata));
                 })
                 .Returns(Task.FromResult(0));

--- a/test/Microsoft.AspNet.Mvc.Core.Test/UrlHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/UrlHelperTest.cs
@@ -540,7 +540,11 @@ namespace Microsoft.AspNet.Mvc.Core.Test
             var target = new Mock<IRouter>(MockBehavior.Strict);
             target
                 .Setup(e => e.GetVirtualPath(It.IsAny<VirtualPathContext>()))
-                .Callback<VirtualPathContext>(c => c.IsBound = true)
+                .Callback<VirtualPathContext>(c =>
+                {
+                    rt.ToString();
+                    c.IsBound = true;
+                })
                 .Returns<VirtualPathContext>(rc => null);
             rt.DefaultHandler = target.Object;
             var serviceProviderMock = new Mock<IServiceProvider>();

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ViewResultTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ViewResultTest.cs
@@ -28,6 +28,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
             view.Setup(v => v.RenderAsync(It.IsAny<ViewContext>()))
                  .Callback((ViewContext v) =>
                  {
+                     view.ToString();
                      v.Writer.Write("abcd");
                  })
                  .Returns(Task.FromResult(0));
@@ -78,6 +79,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
             view.Setup(v => v.RenderAsync(It.IsAny<ViewContext>()))
                  .Callback((ViewContext v) =>
                  {
+                     view.ToString();
                      v.Writer.Write("abcd");
                  })
                  .Returns(Task.FromResult(0));
@@ -139,6 +141,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
             view.Setup(v => v.RenderAsync(It.IsAny<ViewContext>()))
                  .Callback((ViewContext v) =>
                  {
+                     view.ToString();
                      v.Writer.Write(longString);
                      throw new Exception();
                  });

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Validation/AssociatedValidatorProviderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Validation/AssociatedValidatorProviderTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var provider = new Mock<TestableAssociatedValidatorProvider> { CallBase = true };
             provider.Setup(p => p.AbstractGetValidators(metadata, It.IsAny<IEnumerable<Attribute>>()))
                     .Callback<ModelMetadata, IEnumerable<Attribute>>((m, attributes) => callbackAttributes = attributes)
-                    .Returns(() => null)
+                    .Returns((IEnumerable<IModelValidator>)null)
                     .Verifiable();
 
             // Act
@@ -44,7 +44,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             Mock<TestableAssociatedValidatorProvider> provider = new Mock<TestableAssociatedValidatorProvider> { CallBase = true };
             provider.Setup(p => p.AbstractGetValidators(metadata, It.IsAny<IEnumerable<Attribute>>()))
                     .Callback<ModelMetadata, IEnumerable<Attribute>>((m, attributes) => callbackAttributes = attributes)
-                    .Returns(() => null)
+                    .Returns((IEnumerable<IModelValidator>)null)
                     .Verifiable();
 
             // Act
@@ -64,7 +64,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             Mock<TestableAssociatedValidatorProvider> provider = new Mock<TestableAssociatedValidatorProvider> { CallBase = true };
             provider.Setup(p => p.AbstractGetValidators(metadata, It.IsAny<IEnumerable<Attribute>>()))
                     .Callback<ModelMetadata, IEnumerable<Attribute>>((m, attributes) => callbackAttributes = attributes)
-                    .Returns(() => null)
+                    .Returns((IEnumerable<IModelValidator>)null)
                     .Verifiable();
 
             // Act


### PR DESCRIPTION
https://roslyn.codeplex.com/workitem/246 affects usage of code with the
latest build of Roslyn with Moq v4.2. The workaround involves ensuring a
closure is created. Updating affected tests to make ToString() calls on
local variables to create these closures.
