### PR TITLE
Test for XML documentation errors

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -5,3 +5,6 @@ var AUTHORS='Microsoft Open Technologies, Inc.'
 
 use-standard-lifecycle
 k-standard-goals
+
+#xml-docs-test target='test'
+  k-xml-docs-test


### PR DESCRIPTION
- can't be done as a unit test because `k.cmd test` doesn't write assemblies for referenced projects
- instead extend the "test" target in our build

Example output with one syntax error and one invalid reference:

```
info: Target xml-docs-test
warn: Invalid documentation syntax in src\Microsoft.AspNet.Mvc.Core\bin\debug\net45\Microsoft.AspNet.Mvc.Core.xml
  3170: <!-- Badly formed XML comment ignored for member "T:Microsoft.AspNet.Mvc.Rendering.HtmlHelper" -->
  3203: If the object is already an <see cref="!:IDictionaries&lt;string, object&gt;"/> instance, then it is
verbose: Stack trace:
   at View93f35e50188e4f2789d17251483ea9de.<RenderViewLevel0>b__45() in c:\Users\dougbu\AppData\Local\Temp\12926eb597854e3f86a9ff4dab39711b-1.cs:line 5674
   at Sake.Engine.Builder.BuilderBase`1.CallTarget(String name)
   at Sake.Engine.SakeEngine.Execute(Options options)
   at Sake.Engine.SakeEngine.Execute(String[] args)
   at Sake.Program.Main(String[] args)
```
