### PR TITLE
Removing AdditionalInfo from CompilationResult since we can't always pass it into exception thrown

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/Compilation/CompilationResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Compilation/CompilationResult.cs
@@ -40,18 +40,6 @@ namespace Microsoft.AspNet.Mvc.Razor
         public IEnumerable<CompilationMessage> Messages { get; private set; }
 
         /// <summary>
-        /// Gets additional information from compilation.
-        /// </summary>
-        /// <remarks>
-        /// In the event of a compilation failure, values from this dictionary are copied to the
-        /// <see cref="Exception.Data"/> property of the <see cref="Exception"/> thrown.
-        /// </remarks>
-        public IDictionary<string, object> AdditionalInfo
-        {
-            get; private set;
-        }
-
-        /// <summary>
         /// Gets the generated C# content that was compiled.
         /// </summary>
         public string CompiledContent { get; private set; }
@@ -81,19 +69,16 @@ namespace Microsoft.AspNet.Mvc.Razor
         /// <param name="fileInfo">The <see cref="IFileInfo"/> for the Razor file that was compiled.</param>
         /// <param name="compilationContent">The generated C# content to be compiled.</param>
         /// <param name="messages">The sequence of failure messages encountered during compilation.</param>
-        /// <param name="additionalInfo">Additional info about the compilation.</param>
         /// <returns>A CompilationResult instance representing a failure.</returns>
         public static CompilationResult Failed([NotNull] IFileInfo file,
                                                [NotNull] string compilationContent,
-                                               [NotNull] IEnumerable<CompilationMessage> messages,
-                                               IDictionary<string, object> additionalInfo)
+                                               [NotNull] IEnumerable<CompilationMessage> messages)
         {
             return new CompilationResult
             {
                 File = file,
                 CompiledContent = compilationContent,
                 Messages = messages,
-                AdditionalInfo = additionalInfo
             };
         }
 
@@ -113,16 +98,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         private CompilationFailedException CreateCompilationFailedException()
         {
             var fileContent = ReadContent(File);
-            var exception = new CompilationFailedException(FilePath, fileContent, CompiledContent, Messages);
-            if (AdditionalInfo != null)
-            {
-                foreach (var item in AdditionalInfo)
-                {
-                    exception.Data.Add(item.Key, item.Value);
-                }
-            }
-
-            return exception;
+            return new CompilationFailedException(FilePath, fileContent, CompiledContent, Messages);
         }
 
         private static string ReadContent(IFileInfo file)

--- a/src/Microsoft.AspNet.Mvc.Razor/Compilation/RoslynCompilationService.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Compilation/RoslynCompilationService.cs
@@ -22,7 +22,6 @@ namespace Microsoft.AspNet.Mvc.Razor.Compilation
     /// </summary>
     public class RoslynCompilationService : ICompilationService
     {
-        public static readonly string CompilationResultDiagnosticsKey = "Diagnostics";
         private static readonly ConcurrentDictionary<string, MetadataReference> _metadataFileCache =
             new ConcurrentDictionary<string, MetadataReference>(StringComparer.OrdinalIgnoreCase);
 
@@ -85,11 +84,7 @@ namespace Microsoft.AspNet.Mvc.Razor.Compilation
                                              .Select(d => GetCompilationMessage(formatter, d))
                                              .ToList();
 
-                        var additionalInfo = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
-                        {
-                            { CompilationResultDiagnosticsKey, result.Diagnostics }
-                        };
-                        return CompilationResult.Failed(fileInfo, compilationContent, messages, additionalInfo);
+                        return CompilationResult.Failed(fileInfo, compilationContent, messages);
                     }
 
                     Assembly assembly;

--- a/src/Microsoft.AspNet.Mvc.Razor/Razor/RazorCompilationService.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Razor/RazorCompilationService.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNet.Mvc.Razor
             if (!results.Success)
             {
                 var messages = results.ParserErrors.Select(e => new CompilationMessage(e.Message));
-                return CompilationResult.Failed(file, results.GeneratedCode, messages, additionalInfo: null);
+                return CompilationResult.Failed(file, results.GeneratedCode, messages);
             }
 
             return _baseCompilationService.Compile(file, results.GeneratedCode);

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/Compilation/CompilationResultTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/Compilation/CompilationResultTest.cs
@@ -38,8 +38,7 @@ world";
             };
             var result = CompilationResult.Failed(fileInfo.Object,
                                                  "<h1>hello world</h1>",
-                                                 messages,
-                                                 additionalInfo);
+                                                 messages);
 
             // Act and Assert
             var ex = Assert.Throws<CompilationFailedException>(() => result.CompiledType);


### PR DESCRIPTION
All values in Exception.Data need to be serializable which is not true for
the diagnostics. Removing this property since we can't pass it through.
