### PR TITLE
Made razor compilation more robust

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/Compilation/RoslynCompilationService.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Compilation/RoslynCompilationService.cs
@@ -119,6 +119,9 @@ namespace Microsoft.AspNet.Mvc.Razor.Compilation
 
             foreach (var metadataReference in export.MetadataReferences)
             {
+                // Taken from  https://github.com/aspnet/KRuntime/blob/757ba9bfdf80bd6277e715d6375969a7f44370ee/src/Microsoft.Framework.Runtime.Roslyn/RoslynCompiler.cs#L164
+                // We don't want to take a dependency on the Roslyn bit directly since it pulls in more dependencies
+                // than the view engine needs (Microsoft.Framework.Runtime) for example
                 references.Add(ConvertMetadataReference(metadataReference));
             }
 


### PR DESCRIPTION
- Support other kinds of references when compiling razor views
- Cache application references since they can't change throughout the lifetime
  of the running application

/cc @pranavkm 
