### PR TITLE
Update RazorView.RenderAsync to be virtual

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/RazorView.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorView.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         public bool ExecuteViewHierarchy { get; set; }
 
         /// <inheritdoc />
-        public async Task RenderAsync([NotNull] ViewContext context)
+        public virtual async Task RenderAsync([NotNull] ViewContext context)
         {
             if (ExecuteViewHierarchy)
             {


### PR DESCRIPTION
Would be nice if this method is virtual so people can extend the RazorView easily, this functionality is available in the current MVC which I utilize.
