### PR TITLE
RazorViewEngine.CreateFoundResult to protected virtual

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/RazorViewEngine.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorViewEngine.cs
@@ -108,7 +108,7 @@ namespace Microsoft.AspNet.Mvc.Razor
             }
         }
 
-        private ViewEngineResult CreateFoundResult(IRazorPage page, string viewName, bool partial)
+        protected virtual ViewEngineResult CreateFoundResult(IRazorPage page, string viewName, bool partial)
         {
             var view = _typeActivator.CreateInstance<RazorView>(_serviceProvider, page);
             view.ExecuteViewHierarchy = !partial;


### PR DESCRIPTION
Currently it seems that if you want to implement your own `RazorView` for some custom functionality, you cannot just replace the current `RazorViewEngine` with a custom implementation of `RazorViewEngine` to use your custom `RazorView`. By making `CreateFoundResult` as protected virtual, this would allow devs to inherit from `RazorViewEngine` to return a custom implementation of `RazorView`.

In the current ASP.Net, `RazorViewEngine` allows overriding the methods: CreatePartialView & CreateView to achieve this result, would be very nice to have the same ability with vNext. I realize you could probably do this by implementing a custom `ITypeActivator` but that seems like a rather large hack to make this work.
