### PR TITLE
[Fixes #1035] RouteGroupConstraint should only be added once for non attribute routed actions

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/Routing/ActionSelectorDecisionTree.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Routing/ActionSelectorDecisionTree.cs
@@ -168,19 +168,15 @@ namespace Microsoft.AspNet.Mvc.Routing
                             // would throw.
 #if NET45
                             throw new InvalidEnumArgumentException(
-                                "item", 
-                                (int)constraint.KeyHandling, 
+                                "item",
+                                (int)constraint.KeyHandling,
                                 typeof(RouteKeyHandling));
 #else
                             throw new ArgumentOutOfRangeException("item");
 #endif
                         }
 
-                        // Workaround for Javier's cool bug.
-                        if (!results.ContainsKey(constraint.RouteKey))
-                        {
-                            results.Add(constraint.RouteKey, value);
-                        }
+                        results.Add(constraint.RouteKey, value);
                     }
                 }
 


### PR DESCRIPTION
attribute routed actions
1. Changed ReflectedActionDescriptorProvider to add RouteGroupConstraint only once
   for non attribute routed actions.
2. Added tests to cover the scenario.
