### PR TITLE
Remove `using` for Microsoft.AspNet.Mvc.Razor namespace from views

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor.Host/MvcRazorHost.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/MvcRazorHost.cs
@@ -22,8 +22,7 @@ namespace Microsoft.AspNet.Mvc.Razor
             "System.Linq",
             "System.Collections.Generic",
             "Microsoft.AspNet.Mvc",
-            "Microsoft.AspNet.Mvc.Razor",
-            "Microsoft.AspNet.Mvc.Rendering"
+            "Microsoft.AspNet.Mvc.Rendering",
         };
 
         private readonly MvcRazorHostOptions _hostOptions;
@@ -51,7 +50,7 @@ namespace Microsoft.AspNet.Mvc.Razor
                 writeLiteralMethodName: "WriteLiteral",
                 writeToMethodName: "WriteTo",
                 writeLiteralToMethodName: "WriteLiteralTo",
-                templateTypeName: "HelperResult",
+                templateTypeName: "Microsoft.AspNet.Mvc.Razor.HelperResult",
                 defineSectionMethodName: "DefineSection")
             {
                 ResolveUrlMethodName = "Href"


### PR DESCRIPTION
- eventually will clean up IntelliSense -- removing classes users don't
  need when editing a view
- will _not_ cleanup IntelliSense 'til VS stops using a private copy of
  Microsoft.AspNet.Mvc.Razor.Host.dll or we update that copy
- all tests and MVC sample views still work fine
- issue #969
