### PR TITLE
[Fixes #888] Revive BadRequest()

### DIFF
--- a/samples/MvcSample.Web/HomeController.cs
+++ b/samples/MvcSample.Web/HomeController.cs
@@ -34,6 +34,11 @@ namespace MvcSample.Web
             return HttpNotFound();
         }
 
+        public ActionResult BadRequest()
+        {
+            return HttpBadRequest();
+        }
+
         public bool IsDefaultNameSpace()
         {
             var namespaceToken = ActionContext.RouteData.DataTokens["NameSpace"] as string;

--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/HttpBadRequestResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/HttpBadRequestResult.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNet.Mvc
+{
+    /// <summary>
+    /// Represents an <see cref="HttpStatusCodeResult"/> that when
+    /// executed will produce a Bad Request (400) response.
+    /// </summary>
+    public class HttpBadRequestResult : HttpStatusCodeResult
+    {
+        /// <summary>
+        /// Creates a new <see cref="HttpBadRequestResult"/> instance.
+        /// </summary>
+        public HttpBadRequestResult() : base(400)
+        {
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Controller.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Controller.cs
@@ -426,6 +426,16 @@ namespace Microsoft.AspNet.Mvc
         }
 
         /// <summary>
+        /// Creates an <see cref="HttpBadRequestResult"/> that produces a Bad Request (400) response.
+        /// </summary>
+        /// <returns>The created <see cref="HttpBadRequestResult"/> for the response.</returns>
+        [NonAction]
+        public virtual HttpBadRequestResult HttpBadRequest()
+        {
+            return new HttpBadRequestResult();
+        }
+
+        /// <summary>
         /// Called before the action method is invoked.
         /// </summary>
         /// <param name="context">The action executing context.</param>

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ActionResults/HttpBadRequestResultTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ActionResults/HttpBadRequestResultTest.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Xunit;
+
+namespace Microsoft.AspNet.Mvc.Test
+{
+    public class HttpBadRequestResultTest
+    {
+        [Fact]
+        public void HttpBadRequestResult_InitializesStatusCode()
+        {
+            // Arrange & act
+            var notFound = new HttpBadRequestResult();
+
+            // Assert
+            Assert.Equal(400, notFound.StatusCode);
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ControllerTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ControllerTests.cs
@@ -371,6 +371,20 @@ namespace Microsoft.AspNet.Mvc.Test
             Assert.Equal(404, result.StatusCode);
         }
 
+        [Fact]
+        public void HttpBadRequest_SetsStatusCode()
+        {
+            // Arrange
+            var controller = new Controller();
+
+            // Act
+            var result = controller.HttpBadRequest();
+
+            // Assert
+            Assert.IsType<HttpBadRequestResult>(result);
+            Assert.Equal(400, result.StatusCode);
+        }
+
         [Theory]
         [MemberData("PublicNormalMethodsFromController")]
         public void NonActionAttribute_IsOnEveryPublicNormalMethodFromController(MethodInfo method)


### PR DESCRIPTION
1. Added an HttpBadRequest() method on Controller.
2. Added an HttpBadRequestResult class that extends HttpStatusCodeResult
   and sets the status code to 400 following the similar pattern we do in
   HttpNotFoundResult.
3. Added a sample in MvcSample.Web and unit tests.
