### PR TITLE
Take advantage of nameof to improve our usage of MemberData

### DIFF
--- a/test/Microsoft.AspNet.Mvc.Core.Test/ActionResults/ObjectContentResultTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ActionResults/ObjectContentResultTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test.ActionResults
         }
 
         [Theory]
-        [MemberData("ContentTypes")]
+        [MemberData(nameof(ContentTypes))]
         public async Task ObjectResult_WithMultipleContentTypesAndAcceptHeaders_PerformsContentNegotiation(
             IEnumerable<string> contentTypes, string acceptHeader, string expectedHeader)
         {

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ActionResults/RedirectToRouteResultTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ActionResults/RedirectToRouteResultTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNet.Mvc.Core
     public class RedirectToRouteResultTest
     {
         [Theory]
-        [MemberData("RedirectToRouteData")]
+        [MemberData(nameof(RedirectToRouteData))]
         public async void RedirectToRoute_Execute_PassesCorrectValuesToRedirect(object values)
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ControllerTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ControllerTests.cs
@@ -180,7 +180,7 @@ namespace Microsoft.AspNet.Mvc.Test
         }
 
         [Theory]
-        [MemberData("RedirectTestData")]
+        [MemberData(nameof(RedirectTestData))]
         public void RedirectToAction_WithParameterActionControllerRouteValues_SetsResultProperties(object routeValues)
         {
             // Arrange
@@ -198,7 +198,7 @@ namespace Microsoft.AspNet.Mvc.Test
         }
 
         [Theory]
-        [MemberData("RedirectTestData")]
+        [MemberData(nameof(RedirectTestData))]
         public void RedirectToActionPermanent_WithParameterActionControllerRouteValues_SetsResultProperties(
             object routeValues)
         {
@@ -220,7 +220,7 @@ namespace Microsoft.AspNet.Mvc.Test
         }
 
         [Theory]
-        [MemberData("RedirectTestData")]
+        [MemberData(nameof(RedirectTestData))]
         public void RedirectToAction_WithParameterActionAndRouteValues_SetsResultProperties(object routeValues)
         {
             // Arrange
@@ -237,7 +237,7 @@ namespace Microsoft.AspNet.Mvc.Test
         }
 
         [Theory]
-        [MemberData("RedirectTestData")]
+        [MemberData(nameof(RedirectTestData))]
         public void RedirectToActionPermanent_WithParameterActionAndRouteValues_SetsResultProperties(
             object routeValues)
         {
@@ -255,7 +255,7 @@ namespace Microsoft.AspNet.Mvc.Test
         }
 
         [Theory]
-        [MemberData("RedirectTestData")]
+        [MemberData(nameof(RedirectTestData))]
         public void RedirectToRoute_WithParameterRouteValues_SetsResultEqualRouteValues(object routeValues)
         {
             // Arrange
@@ -271,7 +271,7 @@ namespace Microsoft.AspNet.Mvc.Test
         }
 
         [Theory]
-        [MemberData("RedirectTestData")]
+        [MemberData(nameof(RedirectTestData))]
         public void RedirectToRoutePermanent_WithParameterRouteValues_SetsResultEqualRouteValuesAndPermanent(
             object routeValues)
         {
@@ -320,7 +320,7 @@ namespace Microsoft.AspNet.Mvc.Test
         }
 
         [Theory]
-        [MemberData("RedirectTestData")]
+        [MemberData(nameof(RedirectTestData))]
         public void RedirectToRoute_WithParameterRouteNameAndRouteValues_SetsResultSameRouteNameAndRouteValues(
             object routeValues)
         {
@@ -339,7 +339,7 @@ namespace Microsoft.AspNet.Mvc.Test
         }
 
         [Theory]
-        [MemberData("RedirectTestData")]
+        [MemberData(nameof(RedirectTestData))]
         public void RedirectToRoutePermanent_WithParameterRouteNameAndRouteValues_SetsResultProperties(
             object routeValues)
         {
@@ -372,7 +372,7 @@ namespace Microsoft.AspNet.Mvc.Test
         }
 
         [Theory]
-        [MemberData("PublicNormalMethodsFromController")]
+        [MemberData(nameof(PublicNormalMethodsFromController))]
         public void NonActionAttribute_IsOnEveryPublicNormalMethodFromController(MethodInfo method)
         {
             // Arrange & Act & Assert

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ExpiringFileInfoCacheTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ExpiringFileInfoCacheTest.cs
@@ -203,7 +203,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
         }
 
         [Theory]
-        [MemberData("ImmediateExpirationTimespans")]
+        [MemberData(nameof(ImmediateExpirationTimespans))]
         public void GettingFileInfoReturnsNewDataWithCustomImmediateExpiration(TimeSpan expiration)
         {
             // Arrange
@@ -244,7 +244,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
         }
 
         [Theory]
-        [MemberData("CustomExpirationTimespans")]
+        [MemberData(nameof(CustomExpirationTimespans))]
         public void GettingFileInfoReturnsNewDataWithCustomExpiration(TimeSpan expiration)
         {
             // Arrange
@@ -270,7 +270,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
         }
 
         [Theory]
-        [MemberData("CustomExpirationTimespans")]
+        [MemberData(nameof(CustomExpirationTimespans))]
         public void GettingFileInfoReturnsSameDataWithCustomExpiration(TimeSpan expiration)
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/JsonInputFormatterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/JsonInputFormatterTest.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNet.Mvc
         }
 
         [Theory]
-        [MemberData("JsonFormatterReadSimpleTypesData")]
+        [MemberData(nameof(JsonFormatterReadSimpleTypesData))]
         public async Task JsonFormatterReadsSimpleTypes(string content, Type type, object expected)
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/NoContentFormatterTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/NoContentFormatterTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNet.Mvc.Test
         }
 
         [Theory]
-        [MemberData("OutputFormatterContextValues_CanWriteType")]
+        [MemberData(nameof(OutputFormatterContextValues_CanWriteType))]
         public void CanWriteResult_ReturnsTrueOnlyIfTheValueIsNull(object value,
                                                                    bool declaredTypeAsString,
                                                                    bool expectedCanwriteResult,

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/OutputFormatterTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/OutputFormatterTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNet.Mvc.Test
         }
 
         [Theory]
-        [MemberData("SelectResponseCharacterEncodingData")]
+        [MemberData(nameof(SelectResponseCharacterEncodingData))]
         public void SelectResponseCharacterEncoding_SelectsEncoding(string acceptCharsetHeaders,
                                                                     string requestEncoding,
                                                                     string[] supportedEncodings,

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/TextPlainFormatterTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/TextPlainFormatterTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNet.Mvc
         }
 
         [Theory]
-        [MemberData("OutputFormatterContextValues")]
+        [MemberData(nameof(OutputFormatterContextValues))]
         public void CanWriteResult_ReturnsTrueForStringTypes(object value, bool useDeclaredTypeAsString, bool expectedCanWriteResult)
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.Core.Test/HttpMethodProviderAttributesTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/HttpMethodProviderAttributesTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNet.Mvc
     public class HttpMethodProviderAttributesTests
     {
         [Theory]
-        [MemberData("HttpMethodProviderTestData")]
+        [MemberData(nameof(HttpMethodProviderTestData))]
         public void HttpMethodProviderAttributes_ReturnsCorrectHttpMethodSequence(
             IActionHttpMethodProvider httpMethodProvider,
             IEnumerable<string> expectedHttpMethods)

--- a/test/Microsoft.AspNet.Mvc.Core.Test/MediaTypeWithQualityHeaderValueTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/MediaTypeWithQualityHeaderValueTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
         }
 
         [Theory]
-        [MemberData("SortValues")]
+        [MemberData(nameof(SortValues))]
         public void SortMediaTypeWithQualityHeaderValuesByQFactor_SortsCorrectly(IEnumerable<string> unsorted, IEnumerable<string> expectedSorted)
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ReflectedActionInvokerTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ReflectedActionInvokerTest.cs
@@ -1261,7 +1261,7 @@ namespace Microsoft.AspNet.Mvc
         }
 
         [Theory]
-        [MemberData("CreateActionResult_ReturnsObjectContentResultData")]
+        [MemberData(nameof(CreateActionResult_ReturnsObjectContentResultData))]
         public void CreateActionResult_ReturnsObjectContentResult(Type type, object input)
         {
             // Arrange & Act

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ReflectedModelBuilder/ReflectedAttributeRouteModelTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ReflectedModelBuilder/ReflectedAttributeRouteModelTests.cs
@@ -102,7 +102,7 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder
         }
 
         [Theory]
-        [MemberData("ReplaceTokens_ValueValuesData")]
+        [MemberData(nameof(ReplaceTokens_ValueValuesData))]
         public void ReplaceTokens_ValidValues(string template, object values, string expected)
         {
             // Arrange
@@ -120,7 +120,7 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder
         }
 
         [Theory]
-        [MemberData("ReplaceTokens_InvalidFormatValuesData")]
+        [MemberData(nameof(ReplaceTokens_InvalidFormatValuesData))]
         public void ReplaceTokens_InvalidFormat(string template, object values, string reason)
         {
             // Arrange
@@ -169,7 +169,7 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder
         }
 
         [Theory]
-        [MemberData("CombineOrdersTestData")]
+        [MemberData(nameof(CombineOrdersTestData))]
         public void Combine_Orders(
             ReflectedAttributeRouteModel left,
             ReflectedAttributeRouteModel right,
@@ -184,7 +184,7 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder
         }
 
         [Theory]
-        [MemberData("ValidReflectedAttributeRouteModelsTestData")]
+        [MemberData(nameof(ValidReflectedAttributeRouteModelsTestData))]
         public void Combine_ValidReflectedAttributeRouteModels(
             ReflectedAttributeRouteModel left,
             ReflectedAttributeRouteModel right,
@@ -199,7 +199,7 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder
         }
 
         [Theory]
-        [MemberData("NullOrNullTemplateReflectedAttributeRouteModelTestData")]
+        [MemberData(nameof(NullOrNullTemplateReflectedAttributeRouteModelTestData))]
         public void Combine_NullOrNullTemplateReflectedAttributeRouteModels(
             ReflectedAttributeRouteModel left,
             ReflectedAttributeRouteModel right)
@@ -212,7 +212,7 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder
         }
 
         [Theory]
-        [MemberData("RightOverridesReflectedAttributeRouteModelTestData")]
+        [MemberData(nameof(RightOverridesReflectedAttributeRouteModelTestData))]
         public void Combine_RightOverridesReflectedAttributeRouteModel(
             ReflectedAttributeRouteModel left,
             ReflectedAttributeRouteModel right)
@@ -230,7 +230,7 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder
         }
 
         [Theory]
-        [MemberData("CombineNamesTestData")]
+        [MemberData(nameof(CombineNamesTestData))]
         public void Combine_Names(
             ReflectedAttributeRouteModel left,
             ReflectedAttributeRouteModel right,

--- a/test/Microsoft.AspNet.Mvc.Core.Test/RouteTemplateProviderAttributesTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/RouteTemplateProviderAttributesTests.cs
@@ -6,7 +6,7 @@ namespace Microsoft.AspNet.Mvc
     public class RouteTemplateProviderAttributesTest
     {
         [Theory]
-        [MemberData("RouteTemplateProvidersTestData")]
+        [MemberData(nameof(RouteTemplateProvidersTestData))]
         public void Order_Defaults_ToNull(IRouteTemplateProvider routeTemplateProvider)
         {
             // Act & Assert

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ViewEngineTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ViewEngineTests.cs
@@ -53,7 +53,7 @@ ViewWithNestedLayout-Content
         }
 
         [Theory]
-        [MemberData("RazorView_ExecutesPageAndLayoutData")]
+        [MemberData(nameof(RazorView_ExecutesPageAndLayoutData))]
         public async Task RazorView_ExecutesPageAndLayout(string actionName, string expected)
         {
             var server = TestServer.Create(_provider, _app);

--- a/test/Microsoft.AspNet.Mvc.HeaderValueAbstractions.Test/MediaTypeHeaderValueParsingTests.cs
+++ b/test/Microsoft.AspNet.Mvc.HeaderValueAbstractions.Test/MediaTypeHeaderValueParsingTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.AspNet.Mvc.HeaderValueAbstractions
         }
 
         [Theory]
-        [MemberData("GetValidMediaTypeWithQualityHeaderValues")]
+        [MemberData(nameof(GetValidMediaTypeWithQualityHeaderValues))]
         public void MediaTypeWithQualityHeaderValue_ParseSuccessfully(string mediaType,
                                          string mediaSubType,
                                          string charset,

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Internal/TypeExtensionTests.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Internal/TypeExtensionTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNet.Mvc
         }
 
         [Theory]
-        [MemberData("TypesWithValues")]
+        [MemberData(nameof(TypesWithValues))]
         public void IsCompatibleWithReturnsTrue_IfValueIsAssignable(Type type, object value)
         {
             // Act

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/CachedDataAnnotationsMetadataAttributesTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/CachedDataAnnotationsMetadataAttributesTest.cs
@@ -53,7 +53,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         }
 
         [Theory]
-        [MemberData("ExpectedAttributeData")]
+        [MemberData(nameof(ExpectedAttributeData))]
         public void Constructor_FindsExpectedAttribute(
             Attribute attribute,
             Func<CachedDataAnnotationsMetadataAttributes, Attribute> accessor)

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/CachedDataAnnotationsModelMetadataTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/CachedDataAnnotationsModelMetadataTest.cs
@@ -92,7 +92,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         }
 
         [Theory]
-        [MemberData("ExpectedAttributeDataStrings")]
+        [MemberData(nameof(ExpectedAttributeDataStrings))]
         public void AttributesOverrideMetadataStrings(Attribute attribute, Func<ModelMetadata, string> accessor)
         {
             // Arrange
@@ -184,7 +184,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         }
 
         [Theory]
-        [MemberData("ExpectedAttributeDataBooleans")]
+        [MemberData(nameof(ExpectedAttributeDataBooleans))]
         public void AttributesOverrideMetadataBooleans(
             Attribute attribute,
             Func<ModelMetadata, bool> accessor,

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/ModelMetadataTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/ModelMetadataTest.cs
@@ -269,7 +269,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         }
 
         [Theory]
-        [MemberData("MetadataModifierData")]
+        [MemberData(nameof(MetadataModifierData))]
         public void PropertiesPropertyChangesPersist(
             Action<ModelMetadata> setter,
             Func<ModelMetadata, object> getter,
@@ -398,7 +398,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         }
 
         [Theory]
-        [MemberData("SimpleDisplayTextData")]
+        [MemberData(nameof(SimpleDisplayTextData))]
         public void TestSimpleDisplayText(Func<object> modelAccessor, Type modelType, string expectedResult)
         {
             // Arrange
@@ -426,7 +426,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         }
 
         [Theory]
-        [MemberData("MetadataModifierData")]
+        [MemberData(nameof(MetadataModifierData))]
         public void PropertyChangesPersist(
             Action<ModelMetadata> setter,
             Func<ModelMetadata, object> getter,

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Validation/DataAnnotationsModelValidatorProviderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Validation/DataAnnotationsModelValidatorProviderTest.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         }
 
         [Theory]
-        [MemberData("DataAnnotationAdapters")]
+        [MemberData(nameof(DataAnnotationAdapters))]
         public void AdapterFactory_RegistersAdapters_ForDataAnnotationAttributes(ValidationAttribute attribute,
                                                                                  Type expectedAdapterType)
         {
@@ -122,7 +122,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         }
 
         [Theory]
-        [MemberData("DataTypeAdapters")]
+        [MemberData(nameof(DataTypeAdapters))]
         public void AdapterFactory_RegistersAdapters_ForDataTypeAttributes(ValidationAttribute attribute,
                                                                            string expectedRuleName)
         {

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Validation/DataAnnotationsModelValidatorTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Validation/DataAnnotationsModelValidatorTest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
 #if NET45
         [Theory]
-        [MemberData("ValidateSetsMemberNamePropertyDataSet")]
+        [MemberData(nameof(ValidateSetsMemberNamePropertyDataSet))]
         public void ValidateSetsMemberNamePropertyOfValidationContextForProperties(ModelMetadata metadata,
                                                                                    string expectedMemberName)
         {

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/ValueProviders/ValueProviderResultTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/ValueProviders/ValueProviderResultTest.cs
@@ -373,7 +373,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         }
 
         [Theory]
-        [MemberData("IntrinsicConversionData")]
+        [MemberData(nameof(IntrinsicConversionData))]
         public void ConvertToCanConvertIntrinsics<T>(object initialValue, T expectedValue)
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/ViewStartUtilityTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/ViewStartUtilityTest.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         }
 
         [Theory]
-        [MemberData("GetViewStartLocations_ReturnsPotentialViewStartLocationsData")]
+        [MemberData(nameof(GetViewStartLocations_ReturnsPotentialViewStartLocationsData))]
         public void GetViewStartLocations_ReturnsPotentialViewStartLocations(string appPath,
                                                                              string viewPath,
                                                                              IEnumerable<string> expected)

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/BufferEntryCollectionTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/BufferEntryCollectionTest.cs
@@ -83,7 +83,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         }
 
         [Theory]
-        [MemberData("AddWithChar_RepresentsStringsAsChunkedEntriesData")]
+        [MemberData(nameof(AddWithChar_RepresentsStringsAsChunkedEntriesData))]
         public void AddWithChar_RepresentsStringsAsChunkedEntries(char[] value, int index, int count, IList<object> expected)
         {
             // Arrange
@@ -150,7 +150,7 @@ namespace Microsoft.AspNet.Mvc.Razor
 
 
         [Theory]
-        [MemberData("Enumerator_TraversesThroughBufferData")]
+        [MemberData(nameof(Enumerator_TraversesThroughBufferData))]
         public void Enumerator_TraversesThroughBuffer(BufferEntryCollection buffer, string[] expected)
         {
             // Act and Assert

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/RazorViewEngineTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/RazorViewEngineTest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNet.Mvc.Razor.Test
         }
 
         [Theory]
-        [MemberData("InvalidViewNameValues")]
+        [MemberData(nameof(InvalidViewNameValues))]
         public void FindView_WithFullPathReturnsNotFound_WhenPathDoesNotMatchExtension(string viewName)
         {
             // Arrange
@@ -51,7 +51,7 @@ namespace Microsoft.AspNet.Mvc.Razor.Test
         }
 
         [Theory]
-        [MemberData("InvalidViewNameValues")]
+        [MemberData(nameof(InvalidViewNameValues))]
         public void FindViewFullPathSucceedsWithCshtmlEnding(string viewName)
         {
             // Arrange
@@ -68,7 +68,7 @@ namespace Microsoft.AspNet.Mvc.Razor.Test
         }
 
         [Theory]
-        [MemberData("InvalidViewNameValues")]
+        [MemberData(nameof(InvalidViewNameValues))]
         public void FindPartialView_WithFullPathReturnsNotFound_WhenPathDoesNotMatchExtension(string partialViewName)
         {
             // Arrange
@@ -83,7 +83,7 @@ namespace Microsoft.AspNet.Mvc.Razor.Test
         }
 
         [Theory]
-        [MemberData("InvalidViewNameValues")]
+        [MemberData(nameof(InvalidViewNameValues))]
         public void FindPartialViewFullPathSucceedsWithCshtmlEnding(string partialViewName)
         {
             // Arrange


### PR DESCRIPTION
Substituted all instances of [MemberData("PropertyName")] for [MemberData(nameof(PropertyName))]
This change enables us to take advantage of IDE features like Navigate to source,
find all references, etc. When using Visual Studio.
