### PR TITLE
[Fixes #731] Add unit tests for ReflectedActionDescriptorProvider

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ReflectedActionDescriptorProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ReflectedActionDescriptorProvider.cs
@@ -112,12 +112,6 @@ namespace Microsoft.AspNet.Mvc
             return applicationModel;
         }
 
-        private bool HasConstraint(List<RouteDataActionConstraint> constraints, string routeKey)
-        {
-            return constraints.Any(
-                rc => string.Equals(rc.RouteKey, routeKey, StringComparison.OrdinalIgnoreCase));
-        }
-
         public List<ReflectedActionDescriptor> Build(ReflectedApplicationModel model)
         {
             var actions = new List<ReflectedActionDescriptor>();
@@ -132,161 +126,31 @@ namespace Microsoft.AspNet.Mvc
                 var controllerDescriptor = new ControllerDescriptor(controller.ControllerType);
                 foreach (var action in controller.Actions)
                 {
-                    var parameterDescriptors = new List<ParameterDescriptor>();
-                    foreach (var parameter in action.Parameters)
-                    {
-                        var isFromBody = parameter.Attributes.OfType<FromBodyAttribute>().Any();
+                    var actionDescriptor = CreateActionDescriptor(
+                        action,
+                        controller,
+                        controllerDescriptor,
+                        model.Filters);
 
-                        parameterDescriptors.Add(new ParameterDescriptor()
-                        {
-                            Name = parameter.ParameterName,
-                            IsOptional = parameter.IsOptional,
+                    AddActionConstraints(actionDescriptor, action, controller);
+                    AddControllerRouteConstraints(actionDescriptor, controller.RouteConstraints, removalConstraints);
 
-                            ParameterBindingInfo = isFromBody
-                                ? null
-                                : new ParameterBindingInfo(
-                                    parameter.ParameterName,
-                                    parameter.ParameterInfo.ParameterType),
-
-                            BodyParameterInfo = isFromBody
-                                ? new BodyParameterInfo(parameter.ParameterInfo.ParameterType)
-                                : null
-                        });
-                    }
-
-                    var combinedRoute = ReflectedAttributeRouteModel.CombineReflectedAttributeRouteModel(
-                            controller.AttributeRouteModel,
-                            action.AttributeRouteModel);
-
-                    var attributeRouteInfo = combinedRoute == null ? null : new AttributeRouteInfo()
-                    {
-                        Template = combinedRoute.Template,
-                        Order = combinedRoute.Order ?? DefaultAttributeRouteOrder,
-                        Name = combinedRoute.Name,
-                    };
-
-                    var actionDescriptor = new ReflectedActionDescriptor()
-                    {
-                        Name = action.ActionName,
-                        ControllerDescriptor = controllerDescriptor,
-                        MethodInfo = action.ActionMethod,
-                        Parameters = parameterDescriptors,
-                        RouteConstraints = new List<RouteDataActionConstraint>(),
-                        AttributeRouteInfo = attributeRouteInfo
-                    };
-
-                    actionDescriptor.DisplayName = string.Format(
-                        "{0}.{1}",
-                        action.ActionMethod.DeclaringType.FullName,
-                        action.ActionMethod.Name);
-
-                    var httpMethods = action.HttpMethods;
-                    if (httpMethods != null && httpMethods.Count > 0)
-                    {
-                        actionDescriptor.MethodConstraints = new List<HttpMethodConstraint>()
-                        {
-                            new HttpMethodConstraint(httpMethods)
-                        };
-                    }
-
-                    actionDescriptor.RouteConstraints.Add(new RouteDataActionConstraint(
-                        "controller",
-                        controller.ControllerName));
-
-                    if (action.IsActionNameMatchRequired)
-                    {
-                        actionDescriptor.RouteConstraints.Add(new RouteDataActionConstraint(
-                            "action",
-                            action.ActionName));
-                    }
-                    else
-                    {
-                        actionDescriptor.RouteConstraints.Add(new RouteDataActionConstraint(
-                            "action",
-                            RouteKeyHandling.DenyKey));
-                    }
-
-                    foreach (var constraintAttribute in controller.RouteConstraints)
-                    {
-                        if (constraintAttribute.BlockNonAttributedActions)
-                        {
-                            removalConstraints.Add(constraintAttribute.RouteKey);
-                        }
-
-                        // Skip duplicates
-                        if (!HasConstraint(actionDescriptor.RouteConstraints, constraintAttribute.RouteKey))
-                        {
-                            if (constraintAttribute.RouteValue == null)
-                            {
-                                actionDescriptor.RouteConstraints.Add(new RouteDataActionConstraint(
-                                    constraintAttribute.RouteKey,
-                                    constraintAttribute.RouteKeyHandling));
-                            }
-                            else
-                            {
-                                actionDescriptor.RouteConstraints.Add(new RouteDataActionConstraint(
-                                    constraintAttribute.RouteKey,
-                                    constraintAttribute.RouteValue));
-                            }
-                        }
-                    }
-
-                    if (actionDescriptor.AttributeRouteInfo != null &&
-                        actionDescriptor.AttributeRouteInfo.Template != null)
+                    if (IsAttributeRoutedAction(actionDescriptor))
                     {
                         hasAttributeRoutes = true;
+
                         // An attribute routed action will ignore conventional routed constraints. We still
-                        // want to provide these values as ambient values.
-                        foreach (var constraint in actionDescriptor.RouteConstraints)
-                        {
-                            // We don't need to do anything with attribute routing for 'catch all' behavior. Order
-                            // and predecedence of attribute routes allow this kind of behavior.
-                            if (constraint.KeyHandling == RouteKeyHandling.RequireKey ||
-                                constraint.KeyHandling == RouteKeyHandling.DenyKey)
-                            {
-                                actionDescriptor.RouteValueDefaults.Add(constraint.RouteKey, constraint.RouteValue);
-                            }
-                        }
+                        // want to provide these values as ambient values for link generation.
+                        AddConstraintsAsDefaultRouteValues(actionDescriptor);
 
                         // Replaces tokens like [controller]/[action] in the route template with the actual values
                         // for this action.
-                        var templateText = actionDescriptor.AttributeRouteInfo.Template;
-                        try
-                        {
-                            templateText = ReflectedAttributeRouteModel.ReplaceTokens(
-                                templateText,
-                                actionDescriptor.RouteValueDefaults);
-                        }
-                        catch (InvalidOperationException ex)
-                        {
-                            var message = Resources.FormatAttributeRoute_IndividualErrorMessage(
-                                actionDescriptor.DisplayName,
-                                Environment.NewLine,
-                                ex.Message);
+                        ReplaceAttributeRouteTokens(actionDescriptor, routeTemplateErrors);
 
-                            routeTemplateErrors.Add(message);
-                        }
-
-                        actionDescriptor.AttributeRouteInfo.Template = templateText;
-
-                        var routeGroupValue = GetRouteGroupValue(
-                            actionDescriptor.AttributeRouteInfo.Order,
-                            templateText);
-
-                        var routeConstraints = new List<RouteDataActionConstraint>();
-                        routeConstraints.Add(new RouteDataActionConstraint(
-                            AttributeRouting.RouteGroupKey,
-                            routeGroupValue));
-
-                        actionDescriptor.RouteConstraints = routeConstraints;
+                        // Attribute routed actions will ignore conventional routed constraints. Instead they have
+                        // a single route constraint "RouteGroup" associated with it.
+                        ReplaceRouteConstraints(actionDescriptor);
                     }
-
-                    actionDescriptor.FilterDescriptors =
-                        action.Filters.Select(f => new FilterDescriptor(f, FilterScope.Action))
-                        .Concat(controller.Filters.Select(f => new FilterDescriptor(f, FilterScope.Controller)))
-                        .Concat(model.Filters.Select(f => new FilterDescriptor(f, FilterScope.Global)))
-                        .OrderBy(d => d, FilterDescriptorOrderComparer.Comparer)
-                        .ToList();
 
                     actions.Add(actionDescriptor);
                 }
@@ -297,11 +161,10 @@ namespace Microsoft.AspNet.Mvc
 
             foreach (var actionDescriptor in actions)
             {
-                if (actionDescriptor.AttributeRouteInfo == null ||
-                    actionDescriptor.AttributeRouteInfo.Template == null)
+                if (!IsAttributeRoutedAction(actionDescriptor))
                 {
-                    // Any any attribute routes are in use, then non-attribute-routed ADs can't be selected
-                    // when a route group returned by the route.
+                    // Any attribute routes are in use, then non-attribute-routed action descriptors can't be
+                    // selected when a route group returned by the route.
                     if (hasAttributeRoutes)
                     {
                         actionDescriptor.RouteConstraints.Add(new RouteDataActionConstraint(
@@ -309,15 +172,11 @@ namespace Microsoft.AspNet.Mvc
                             RouteKeyHandling.DenyKey));
                     }
 
-                    foreach (var key in removalConstraints)
-                    {
-                        if (!HasConstraint(actionDescriptor.RouteConstraints, key))
-                        {
-                            actionDescriptor.RouteConstraints.Add(new RouteDataActionConstraint(
-                                key,
-                                RouteKeyHandling.DenyKey));
-                        }
-                    }
+                    // Add a route constraint with DenyKey for each constraint in the set to all the
+                    // actions that don't have that constraint. For example, if a controller defines
+                    // an area constraint, all actions that don't belong to an area must have a route
+                    // constraint that prevents them from matching an incomming request.
+                    AddRemovalConstraints(actionDescriptor, removalConstraints);
                 }
                 else
                 {
@@ -326,18 +185,7 @@ namespace Microsoft.AspNet.Mvc
                     {
                         // Build a map of attribute route name to action descriptors to ensure that all
                         // attribute routes with a given name have the same template.
-                        IList<ActionDescriptor> namedActionGroup;
-
-                        if (actionsByRouteName.TryGetValue(attributeRouteInfo.Name, out namedActionGroup))
-                        {
-                            namedActionGroup.Add(actionDescriptor);
-                        }
-                        else
-                        {
-                            namedActionGroup = new List<ActionDescriptor>();
-                            namedActionGroup.Add(actionDescriptor);
-                            actionsByRouteName.Add(attributeRouteInfo.Name, namedActionGroup);
-                        }
+                        AddActionToNamedGroup(actionsByRouteName, attributeRouteInfo.Name, actionDescriptor);
                     }
 
                     // We still want to add a 'null' for any constraint with DenyKey so that link generation
@@ -379,7 +227,251 @@ namespace Microsoft.AspNet.Mvc
             return actions;
         }
 
-        private static IList<string> AddErrorNumbers(IList<string> namedRoutedErrors)
+        private static ReflectedActionDescriptor CreateActionDescriptor(ReflectedActionModel action,
+            ReflectedControllerModel controller,
+            ControllerDescriptor controllerDescriptor,
+            IEnumerable<IFilter> globalFilters)
+        {
+            var parameterDescriptors = new List<ParameterDescriptor>();
+            foreach (var parameter in action.Parameters)
+            {
+                var isFromBody = parameter.Attributes.OfType<FromBodyAttribute>().Any();
+                var paramDescriptor = new ParameterDescriptor()
+                {
+                    Name = parameter.ParameterName,
+                    IsOptional = parameter.IsOptional
+                };
+
+                if (isFromBody)
+                {
+                    paramDescriptor.BodyParameterInfo = new BodyParameterInfo(
+                        parameter.ParameterInfo.ParameterType);
+                }
+                else
+                {
+                    paramDescriptor.ParameterBindingInfo = new ParameterBindingInfo(
+                            parameter.ParameterName,
+                            parameter.ParameterInfo.ParameterType);
+                }
+
+                parameterDescriptors.Add(paramDescriptor);
+            }
+
+            var attributeRouteInfo = CreateAttributeRouteInfo(action, controller);
+
+            var actionDescriptor = new ReflectedActionDescriptor()
+            {
+                Name = action.ActionName,
+                ControllerDescriptor = controllerDescriptor,
+                MethodInfo = action.ActionMethod,
+                Parameters = parameterDescriptors,
+                RouteConstraints = new List<RouteDataActionConstraint>(),
+                AttributeRouteInfo = attributeRouteInfo
+            };
+
+            actionDescriptor.DisplayName = string.Format(
+                "{0}.{1}",
+                action.ActionMethod.DeclaringType.FullName,
+                action.ActionMethod.Name);
+
+            actionDescriptor.FilterDescriptors =
+                action.Filters.Select(f => new FilterDescriptor(f, FilterScope.Action))
+                .Concat(controller.Filters.Select(f => new FilterDescriptor(f, FilterScope.Controller)))
+                .Concat(globalFilters.Select(f => new FilterDescriptor(f, FilterScope.Global)))
+                .OrderBy(d => d, FilterDescriptorOrderComparer.Comparer)
+                .ToList();
+
+            return actionDescriptor;
+        }
+
+        private static AttributeRouteInfo CreateAttributeRouteInfo(
+            ReflectedActionModel action,
+            ReflectedControllerModel controller)
+        {
+            var combinedRoute = ReflectedAttributeRouteModel.CombineReflectedAttributeRouteModel(
+                                controller.AttributeRouteModel,
+                                action.AttributeRouteModel);
+
+            if (combinedRoute == null)
+            {
+                return null;
+            }
+            else
+            {
+                return new AttributeRouteInfo()
+                {
+                    Template = combinedRoute.Template,
+                    Order = combinedRoute.Order ?? DefaultAttributeRouteOrder,
+                    Name = combinedRoute.Name,
+                };
+            }
+        }
+
+        private static void AddActionConstraints(
+            ReflectedActionDescriptor actionDescriptor,
+            ReflectedActionModel action,
+            ReflectedControllerModel controller)
+        {
+            var httpMethods = action.HttpMethods;
+            if (httpMethods != null && httpMethods.Count > 0)
+            {
+                actionDescriptor.MethodConstraints = new List<HttpMethodConstraint>()
+                {
+                    new HttpMethodConstraint(httpMethods)
+                };
+            }
+
+            actionDescriptor.RouteConstraints.Add(new RouteDataActionConstraint(
+                "controller",
+                controller.ControllerName));
+
+            if (action.IsActionNameMatchRequired)
+            {
+                actionDescriptor.RouteConstraints.Add(new RouteDataActionConstraint(
+                    "action",
+                    action.ActionName));
+            }
+            else
+            {
+                actionDescriptor.RouteConstraints.Add(new RouteDataActionConstraint(
+                    "action",
+                    RouteKeyHandling.DenyKey));
+            }
+        }
+
+        private static void AddControllerRouteConstraints(
+            ReflectedActionDescriptor actionDescriptor,
+            IList<RouteConstraintAttribute> routeconstraints,
+            ISet<string> removalConstraints)
+        {
+            // Apply all the constraints defined on the controller (for example, [Area]) to the actions
+            // in that controller. Also keep track of all the constraints that require preventing actions
+            // without the constraint to match. For example, actions without an [Area] attribute on their
+            // controller should not match when a value has been given for area when matching a url or
+            // generating a link.
+            foreach (var constraintAttribute in routeconstraints)
+            {
+                if (constraintAttribute.BlockNonAttributedActions)
+                {
+                    removalConstraints.Add(constraintAttribute.RouteKey);
+                }
+
+                // Skip duplicates
+                if (!HasConstraint(actionDescriptor.RouteConstraints, constraintAttribute.RouteKey))
+                {
+                    if (constraintAttribute.RouteValue == null)
+                    {
+                        actionDescriptor.RouteConstraints.Add(new RouteDataActionConstraint(
+                            constraintAttribute.RouteKey,
+                            constraintAttribute.RouteKeyHandling));
+                    }
+                    else
+                    {
+                        actionDescriptor.RouteConstraints.Add(new RouteDataActionConstraint(
+                            constraintAttribute.RouteKey,
+                            constraintAttribute.RouteValue));
+                    }
+                }
+            }
+        }
+
+        private static bool HasConstraint(List<RouteDataActionConstraint> constraints, string routeKey)
+        {
+            return constraints.Any(
+                rc => string.Equals(rc.RouteKey, routeKey, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static void ReplaceRouteConstraints(ReflectedActionDescriptor actionDescriptor)
+        {
+            var routeGroupValue = GetRouteGroupValue(
+                actionDescriptor.AttributeRouteInfo.Order,
+                actionDescriptor.AttributeRouteInfo.Template);
+
+            var routeConstraints = new List<RouteDataActionConstraint>();
+            routeConstraints.Add(new RouteDataActionConstraint(
+                AttributeRouting.RouteGroupKey,
+                routeGroupValue));
+
+            actionDescriptor.RouteConstraints = routeConstraints;
+        }
+
+        private static void ReplaceAttributeRouteTokens(
+            ReflectedActionDescriptor actionDescriptor,
+            IList<string> routeTemplateErrors)
+        {
+            try
+            {
+                actionDescriptor.AttributeRouteInfo.Template = ReflectedAttributeRouteModel.ReplaceTokens(
+                    actionDescriptor.AttributeRouteInfo.Template,
+                    actionDescriptor.RouteValueDefaults);
+            }
+            catch (InvalidOperationException ex)
+            {
+                var message = Resources.FormatAttributeRoute_IndividualErrorMessage(
+                    actionDescriptor.DisplayName,
+                    Environment.NewLine,
+                    ex.Message);
+
+                routeTemplateErrors.Add(message);
+            }
+        }
+
+        private static void AddConstraintsAsDefaultRouteValues(ReflectedActionDescriptor actionDescriptor)
+        {
+            foreach (var constraint in actionDescriptor.RouteConstraints)
+            {
+                // We don't need to do anything with attribute routing for 'catch all' behavior. Order
+                // and predecedence of attribute routes allow this kind of behavior.
+                if (constraint.KeyHandling == RouteKeyHandling.RequireKey ||
+                    constraint.KeyHandling == RouteKeyHandling.DenyKey)
+                {
+                    actionDescriptor.RouteValueDefaults.Add(constraint.RouteKey, constraint.RouteValue);
+                }
+            }
+        }
+
+        private static void AddRemovalConstraints(
+            ReflectedActionDescriptor actionDescriptor,
+            ISet<string> removalConstraints)
+        {
+            foreach (var key in removalConstraints)
+            {
+                if (!HasConstraint(actionDescriptor.RouteConstraints, key))
+                {
+                    actionDescriptor.RouteConstraints.Add(new RouteDataActionConstraint(
+                        key,
+                        RouteKeyHandling.DenyKey));
+                }
+            }
+        }
+
+        private static void AddActionToNamedGroup(
+            IDictionary<string, IList<ActionDescriptor>> actionsByRouteName,
+            string routeName,
+            ReflectedActionDescriptor actionDescriptor)
+        {
+            IList<ActionDescriptor> namedActionGroup;
+
+            if (actionsByRouteName.TryGetValue(routeName, out namedActionGroup))
+            {
+                namedActionGroup.Add(actionDescriptor);
+            }
+            else
+            {
+                namedActionGroup = new List<ActionDescriptor>();
+                namedActionGroup.Add(actionDescriptor);
+                actionsByRouteName.Add(routeName, namedActionGroup);
+            }
+        }
+
+        private static bool IsAttributeRoutedAction(ReflectedActionDescriptor actionDescriptor)
+        {
+            return actionDescriptor.AttributeRouteInfo != null &&
+                actionDescriptor.AttributeRouteInfo.Template != null;
+        }
+
+        private static IList<string> AddErrorNumbers(
+            IList<string> namedRoutedErrors)
         {
             return namedRoutedErrors
                 .Select((nre, i) =>


### PR DESCRIPTION
1. Added tests that cover parameters in actions.
2. Added tests that cover building the reflected application model.
3. Added tests that cover attribute routed action constraints and default values.
4. Added tests that cover conventionally routed action constraints and default values.
5. Refactored and cleaned up ReflectedActionDescriptorProvider. All the refactors consist
   of extracting blocks of code to separate methods to better display the flow when building
   the action descriptors.
