### PR TITLE
[Fixes #739] Attribute Routing: Multiple routes per-action

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ActionConvention.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionConvention.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using Microsoft.AspNet.Mvc.Routing;
 
 namespace Microsoft.AspNet.Mvc
 {
@@ -9,6 +10,7 @@ namespace Microsoft.AspNet.Mvc
     {
         public string ActionName { get; set; }
         public string[] HttpMethods { get; set; }
+        public IRouteTemplateProvider AttributeRoute { get; set; }
         public bool RequireActionNameMatch { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/DefaultActionDiscoveryConventions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/DefaultActionDiscoveryConventions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Reflection;
+using Microsoft.AspNet.Mvc.Routing;
 
 namespace Microsoft.AspNet.Mvc
 {
@@ -55,7 +56,7 @@ namespace Microsoft.AspNet.Mvc
 
         // If the convention is All methods starting with Get do not have an action name,
         // for a input GetXYZ methodInfo, the return value will be
-        // { { HttpMethods = "GET", ActionName = "GetXYZ", RequireActionNameMatch = false }}
+        // { { HttpMethods = "GET", ActionName = "GetXYZ", RequireActionNameMatch = false, AttributeRoute = null }}
         public virtual IEnumerable<ActionInfo> GetActions(
             [NotNull] MethodInfo methodInfo,
             [NotNull] TypeInfo controllerTypeInfo)
@@ -65,7 +66,7 @@ namespace Microsoft.AspNet.Mvc
                 return null;
             }
 
-            var actionInfos = GetActionsForMethodsWithCustomAttributes(methodInfo);
+            var actionInfos = GetActionsForMethodsWithCustomAttributes(methodInfo, controllerTypeInfo);
             if (actionInfos.Any())
             {
                 return actionInfos;
@@ -129,26 +130,79 @@ namespace Microsoft.AspNet.Mvc
             var attributes = methodInfo.GetCustomAttributes();
             var actionNameAttribute = attributes.OfType<ActionNameAttribute>().FirstOrDefault();
             var httpMethodConstraints = attributes.OfType<IActionHttpMethodProvider>();
+            var routeTemplates = attributes.OfType<IRouteTemplateProvider>();
+
             return new ActionAttributes()
             {
+                ActionNameAttribute = actionNameAttribute,
                 HttpMethodProviderAttributes = httpMethodConstraints,
-                ActionNameAttribute = actionNameAttribute
+                RouteTemplateProviderAttributes = routeTemplates,
             };
         }
 
-        private IEnumerable<ActionInfo> GetActionsForMethodsWithCustomAttributes(MethodInfo methodInfo)
+        private IEnumerable<ActionInfo> GetActionsForMethodsWithCustomAttributes(
+            MethodInfo methodInfo,
+            TypeInfo controller)
         {
+            var hasControllerAttributeRoutes = HasValidControllerRouteTemplates(controller);
             var actionAttributes = GetActionCustomAttributes(methodInfo);
-            if (!actionAttributes.Any())
+
+            // We need to check controllerRouteTemplates to take into account the
+            // case where the controller has [Route] on it and the action does not have any
+            // attributes applied to it.
+            if (actionAttributes.Any() || hasControllerAttributeRoutes)
+            {
+                var actionNameAttribute = actionAttributes.ActionNameAttribute;
+                var actionName = actionNameAttribute != null ? actionNameAttribute.Name : methodInfo.Name;
+
+                // The moment we see a non null attribute route template in the method or
+                // in the controller we consider the whole group to be attribute routed actions.
+                // If a combination ends up producing a non attribute routed action we consider
+                // that an error and throw at a later point in the pipeline.
+                if (hasControllerAttributeRoutes || ActionHasAttributeRoutes(actionAttributes))
+                {
+                    return GetAttributeRoutedActions(actionAttributes, actionName);
+                }
+                else
+                {
+                    return GetHttpConstrainedActions(actionAttributes, actionName);
+                }
+            }
+            else
             {
                 // If the action is not decorated with any of the attributes,
                 // it would be handled by convention.
-                yield break;
+                return Enumerable.Empty<ActionInfo>();
             }
+        }
 
-            var actionNameAttribute = actionAttributes.ActionNameAttribute;
-            var actionName = actionNameAttribute != null ? actionNameAttribute.Name : methodInfo.Name;
+        private static bool ActionHasAttributeRoutes(
+            ActionAttributes actionAttributes)
+        {
+            // We neet to check for null as some attributes implement IActionHttpMethodProvider
+            // and IRouteTemplateProvider and allow the user to provide a null template. An example
+            // of this is HttpGetAttribute. If the user provides a template, the attribute marks the
+            // action as attribute routed, but in other case, the attribute only adds a constraint
+            // that allows the action to be called with the GET HTTP method.
+            return actionAttributes.RouteTemplateProviderAttributes
+                .Any(rtp => rtp.Template != null);
+        }
 
+        private static bool HasValidControllerRouteTemplates(TypeInfo controller)
+        {
+            // A method inside a controller is considered to create attribute routed actions if the controller
+            // has one or more attributes that implement IRouteTemplateProvider with a non null template applied
+            // to it.
+            return controller.GetCustomAttributes()
+                            .OfType<IRouteTemplateProvider>()
+                            .Where(cr => cr.Template != null)
+                            .Any();
+        }
+
+        private static IEnumerable<ActionInfo> GetHttpConstrainedActions(
+            ActionAttributes actionAttributes,
+            string actionName)
+        {
             var httpMethodProviders = actionAttributes.HttpMethodProviderAttributes;
             var httpMethods = httpMethodProviders.SelectMany(x => x.HttpMethods).Distinct().ToArray();
 
@@ -156,8 +210,52 @@ namespace Microsoft.AspNet.Mvc
             {
                 HttpMethods = httpMethods,
                 ActionName = actionName,
-                RequireActionNameMatch = true
+                RequireActionNameMatch = true,
             };
+        }
+
+        private static IEnumerable<ActionInfo> GetAttributeRoutedActions(
+            ActionAttributes actionAttributes,
+            string actionName)
+        {
+            var actions = new List<ActionInfo>();
+
+            // This is the case where the controller has [Route] applied to it and
+            // the action doesn't have any [Route] or [Http*] attribute applied.
+            if (!actionAttributes.RouteTemplateProviderAttributes.Any())
+            {
+                actions.Add(new ActionInfo
+                {
+                    ActionName = actionName,
+                    HttpMethods = null,
+                    RequireActionNameMatch = true,
+                    AttributeRoute = null
+                });
+            }
+
+            foreach (var routeTemplateProvider in actionAttributes.RouteTemplateProviderAttributes)
+            {
+                actions.Add(new ActionInfo()
+                {
+                    ActionName = actionName,
+                    HttpMethods = GetRouteTemplateHttpMethods(routeTemplateProvider),
+                    RequireActionNameMatch = true,
+                    AttributeRoute = routeTemplateProvider
+                });
+            }
+
+            return actions;
+        }
+
+        private static string[] GetRouteTemplateHttpMethods(IRouteTemplateProvider routeTemplateProvider)
+        {
+            var provider = routeTemplateProvider as IActionHttpMethodProvider;
+            if (provider != null && provider.HttpMethods != null)
+            {
+                return provider.HttpMethods.ToArray();
+            }
+
+            return null;
         }
 
         private IEnumerable<ActionInfo> GetActionsForMethodsWithoutCustomAttributes(
@@ -226,12 +324,15 @@ namespace Microsoft.AspNet.Mvc
 
         private class ActionAttributes
         {
-            public IEnumerable<IActionHttpMethodProvider> HttpMethodProviderAttributes { get; set; }
             public ActionNameAttribute ActionNameAttribute { get; set; }
+            public IEnumerable<IActionHttpMethodProvider> HttpMethodProviderAttributes { get; set; }
+            public IEnumerable<IRouteTemplateProvider> RouteTemplateProviderAttributes { get; set; }
 
             public bool Any()
             {
-                return ActionNameAttribute != null || HttpMethodProviderAttributes.Any();
+                return ActionNameAttribute != null ||
+                    HttpMethodProviderAttributes.Any() ||
+                    RouteTemplateProviderAttributes.Any();
             }
         }
     }

--- a/src/Microsoft.AspNet.Mvc.Core/HttpMethodAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/HttpMethodAttribute.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNet.Mvc
     /// <summary>
     /// Identifies an action that only supports a given set of HTTP methods.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
     public abstract class HttpMethodAttribute : Attribute, IActionHttpMethodProvider, IRouteTemplateProvider
     {
         private int? _order;

--- a/src/Microsoft.AspNet.Mvc.Core/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Properties/Resources.Designer.cs
@@ -1354,6 +1354,70 @@ namespace Microsoft.AspNet.Mvc.Core
             return string.Format(CultureInfo.CurrentCulture, GetString("AttributeRoute_AggregateErrorMessage_ErrorNumber"), p0, p1, p2);
         }
 
+        /// <summary>
+        /// A method '{0}' that defines attribute routed actions must not contain attributes that implement '{1}' and do not implement '{2}':{3}{4}
+        /// </summary>
+        internal static string AttributeRoute_InvalidHttpConstraints
+        {
+            get { return GetString("AttributeRoute_InvalidHttpConstraints"); }
+        }
+
+        /// <summary>
+        /// A method '{0}' that defines attribute routed actions must not contain attributes that implement '{1}' and do not implement '{2}':{3}{4}
+        /// </summary>
+        internal static string FormatAttributeRoute_InvalidHttpConstraints(object p0, object p1, object p2, object p3, object p4)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("AttributeRoute_InvalidHttpConstraints"), p0, p1, p2, p3, p4);
+        }
+
+        /// <summary>
+        /// Action '{0}' has '{1}' invalid '{2}' attributes.
+        /// </summary>
+        internal static string AttributeRoute_InvalidHttpConstraints_Item
+        {
+            get { return GetString("AttributeRoute_InvalidHttpConstraints_Item"); }
+        }
+
+        /// <summary>
+        /// Action '{0}' has '{1}' invalid '{2}' attributes.
+        /// </summary>
+        internal static string FormatAttributeRoute_InvalidHttpConstraints_Item(object p0, object p1, object p2)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("AttributeRoute_InvalidHttpConstraints_Item"), p0, p1, p2);
+        }
+
+        /// <summary>
+        /// A method '{0}' must not define attribute routed actions and non attribute routed actions at the same time:{1}{2}
+        /// </summary>
+        internal static string AttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod
+        {
+            get { return GetString("AttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod"); }
+        }
+
+        /// <summary>
+        /// A method '{0}' must not define attribute routed actions and non attribute routed actions at the same time:{1}{2}
+        /// </summary>
+        internal static string FormatAttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod(object p0, object p1, object p2)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("AttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod"), p0, p1, p2);
+        }
+
+        /// <summary>
+        /// Action: '{0}' - Template: '{1}'
+        /// </summary>
+        internal static string AttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod_Item
+        {
+            get { return GetString("AttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod_Item"); }
+        }
+
+        /// <summary>
+        /// Action: '{0}' - Template: '{1}'
+        /// </summary>
+        internal static string FormatAttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod_Item(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("AttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod_Item"), p0, p1);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNet.Mvc.Core/ReflectedActionDescriptorProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ReflectedActionDescriptorProvider.cs
@@ -4,9 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-#if ASPNETCORE50
 using System.Reflection;
-#endif
 using Microsoft.AspNet.Mvc.Core;
 using Microsoft.AspNet.Mvc.ReflectedModelBuilder;
 using Microsoft.AspNet.Mvc.Routing;
@@ -99,6 +97,12 @@ namespace Microsoft.AspNet.Mvc
                         actionModel.IsActionNameMatchRequired = actionInfo.RequireActionNameMatch;
                         actionModel.HttpMethods.AddRange(actionInfo.HttpMethods ?? Enumerable.Empty<string>());
 
+                        if (actionInfo.AttributeRoute != null)
+                        {
+                            actionModel.AttributeRouteModel = new ReflectedAttributeRouteModel(
+                                actionInfo.AttributeRoute);
+                        }
+
                         foreach (var parameter in methodInfo.GetParameters())
                         {
                             actionModel.Parameters.Add(new ReflectedParameterModel(parameter));
@@ -119,48 +123,89 @@ namespace Microsoft.AspNet.Mvc
             var hasAttributeRoutes = false;
             var removalConstraints = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+            // We need to build a map of methods to reflected actions and reflected actions to
+            // action descriptors so that we can validate later that no method produced attribute
+            // and non attributed actions at the same time, and that no method that produced attribute
+            // routed actions has no attributes that implement IActionHttpMethodProvider and do not
+            // implement IRouteTemplateProvider. For example [HttpGet("Customers")] can't be used with
+            // [AcceptVerbs("POST, PUT")] on the same method.
+            var methodInfoMap =
+                new Dictionary<MethodInfo,
+                               IDictionary<ReflectedActionModel, IList<ReflectedActionDescriptor>>>();
+
             var routeTemplateErrors = new List<string>();
+            var attributeRoutingConfigurationErrors = new Dictionary<MethodInfo, string>();
 
             foreach (var controller in model.Controllers)
             {
                 var controllerDescriptor = new ControllerDescriptor(controller.ControllerType);
                 foreach (var action in controller.Actions)
                 {
-                    var actionDescriptor = CreateActionDescriptor(
-                        action,
-                        controller,
-                        controllerDescriptor,
-                        model.Filters);
+                    // Controllers with multiple [Route] attributes (or user defined implementation of
+                    // IRouteTemplateProvider) will generate one action descriptor per IRouteTemplateProvider
+                    // instance.
+                    // Actions with multiple [Http*] attributes or other (IRouteTemplateProvider implementations
+                    // have already been identified as different actions during action discovery.
+                    var actionDescriptors = CreateActionDescriptors(action, controller, controllerDescriptor);
 
-                    AddActionConstraints(actionDescriptor, action, controller);
-                    AddControllerRouteConstraints(actionDescriptor, controller.RouteConstraints, removalConstraints);
-
-                    if (IsAttributeRoutedAction(actionDescriptor))
+                    foreach (var actionDescriptor in actionDescriptors)
                     {
-                        hasAttributeRoutes = true;
+                        AddActionFilters(actionDescriptor, action.Filters, controller.Filters, model.Filters);
+                        AddActionConstraints(actionDescriptor, action, controller);
+                        AddControllerRouteConstraints(
+                            actionDescriptor,
+                            controller.RouteConstraints,
+                            removalConstraints);
 
-                        // An attribute routed action will ignore conventional routed constraints. We still
-                        // want to provide these values as ambient values for link generation.
-                        AddConstraintsAsDefaultRouteValues(actionDescriptor);
+                        if (IsAttributeRoutedAction(actionDescriptor))
+                        {
+                            hasAttributeRoutes = true;
 
-                        // Replaces tokens like [controller]/[action] in the route template with the actual values
-                        // for this action.
-                        ReplaceAttributeRouteTokens(actionDescriptor, routeTemplateErrors);
+                            // An attribute routed action will ignore conventional routed constraints. We still
+                            // want to provide these values as ambient values for link generation.
+                            AddConstraintsAsDefaultRouteValues(actionDescriptor);
 
-                        // Attribute routed actions will ignore conventional routed constraints. Instead they have
-                        // a single route constraint "RouteGroup" associated with it.
-                        ReplaceRouteConstraints(actionDescriptor);
+                            // Replaces tokens like [controller]/[action] in the route template with the actual values
+                            // for this action.
+                            ReplaceAttributeRouteTokens(actionDescriptor, routeTemplateErrors);
+
+                            // Attribute routed actions will ignore conventional routed constraints. Instead they have
+                            // a single route constraint "RouteGroup" associated with it.
+                            ReplaceRouteConstraints(actionDescriptor);
+                        }
                     }
 
-                    actions.Add(actionDescriptor);
+                    // Filter duplicate action descriptors, that is, those action descriptors that have the same
+                    // attribute route template and the same method info. This means that for example, the
+                    // combination of [Route]+[HttpGet] produced the same attribute route template for two action
+                    // descriptors on the same C# method. For example, [Route("Products")]+"[HttpGet("{id}")] and
+                    // [HttpGet("/Products/{id}")].
+                    // We also update the methodInfoMap by adding the given action and action descriptors to the map.
+                    actionDescriptors = FilterDuplicates(methodInfoMap, action, actionDescriptors);
+
+                    actions.AddRange(actionDescriptors);
                 }
             }
 
             var actionsByRouteName = new Dictionary<string, IList<ActionDescriptor>>(
                 StringComparer.OrdinalIgnoreCase);
 
+            // Keeps track of all the C# methods that we've validated to avoid visiting each action group
+            // more than once.
+            var validatedMethods = new HashSet<MethodInfo>();
+
             foreach (var actionDescriptor in actions)
             {
+                if (!validatedMethods.Contains(actionDescriptor.MethodInfo))
+                {
+                    ValidateActionGroupConfiguration(
+                        methodInfoMap,
+                        actionDescriptor,
+                        attributeRoutingConfigurationErrors);
+
+                    validatedMethods.Add(actionDescriptor.MethodInfo);
+                }
+
                 if (!IsAttributeRoutedAction(actionDescriptor))
                 {
                     // Any attribute routes are in use, then non-attribute-routed action descriptors can't be
@@ -203,36 +248,118 @@ namespace Microsoft.AspNet.Mvc
                 }
             }
 
+            if (attributeRoutingConfigurationErrors.Any())
+            {
+                var message = CreateAttributeRoutingAggregateErrorMessage(
+                    attributeRoutingConfigurationErrors.Values);
+
+                throw new InvalidOperationException(message);
+            }
+
             var namedRoutedErrors = ValidateNamedAttributeRoutedActions(actionsByRouteName);
             if (namedRoutedErrors.Any())
             {
-                namedRoutedErrors = AddErrorNumbers(namedRoutedErrors);
-
-                var message = Resources.FormatAttributeRoute_AggregateErrorMessage(
-                    Environment.NewLine,
-                    string.Join(Environment.NewLine + Environment.NewLine, namedRoutedErrors));
-
+                var message = CreateAttributeRoutingAggregateErrorMessage(namedRoutedErrors);
                 throw new InvalidOperationException(message);
             }
 
             if (routeTemplateErrors.Any())
             {
-                var message = Resources.FormatAttributeRoute_AggregateErrorMessage(
-                    Environment.NewLine,
-                    string.Join(Environment.NewLine + Environment.NewLine, routeTemplateErrors));
-
+                var message = CreateAttributeRoutingAggregateErrorMessage(routeTemplateErrors);
                 throw new InvalidOperationException(message);
             }
 
             return actions;
         }
 
-        private static ReflectedActionDescriptor CreateActionDescriptor(ReflectedActionModel action,
-            ReflectedControllerModel controller,
-            ControllerDescriptor controllerDescriptor,
-            IEnumerable<IFilter> globalFilters)
+        private List<ReflectedActionDescriptor> FilterDuplicates(
+            IDictionary<MethodInfo, IDictionary<ReflectedActionModel, IList<ReflectedActionDescriptor>>> methodMap,
+            ReflectedActionModel action,
+            IList<ReflectedActionDescriptor> actionDescriptors)
         {
+            var filteredList = new List<ReflectedActionDescriptor>();
 
+            IDictionary<ReflectedActionModel, IList<ReflectedActionDescriptor>> actionsForMethod = null;
+            if (methodMap.TryGetValue(action.ActionMethod, out actionsForMethod))
+            {
+                var actions = actionsForMethod.SelectMany(a => a.Value).ToArray();
+
+                foreach (var descriptor in actionDescriptors)
+                {
+                    if (!IsDuplicateActionDescriptor(actions, descriptor))
+                    {
+                        filteredList.Add(descriptor);
+                    }
+                }
+
+                actionsForMethod.Add(action, actionDescriptors);
+            }
+            else
+            {
+                var reflectedActionMap = new Dictionary<ReflectedActionModel, IList<ReflectedActionDescriptor>>();
+                reflectedActionMap.Add(action, actionDescriptors);
+                methodMap.Add(action.ActionMethod, reflectedActionMap);
+
+                foreach (var actionDescriptor in actionDescriptors)
+                {
+                    if (!IsDuplicateActionDescriptor(filteredList, actionDescriptor))
+                    {
+                        filteredList.Add(actionDescriptor);
+                    }
+                }
+            }
+
+            return filteredList;
+        }
+
+        private static bool IsDuplicateActionDescriptor(
+            IEnumerable<ReflectedActionDescriptor> actions,
+            ReflectedActionDescriptor descriptor)
+        {
+            return actions.Any(a => a.AttributeRouteInfo != null &&
+                                    a.AttributeRouteInfo.Template != null &&
+                                    descriptor.AttributeRouteInfo != null &&
+                                    a.AttributeRouteInfo.Template.Equals(
+                                        descriptor.AttributeRouteInfo.Template,
+                                        StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static IList<ReflectedActionDescriptor> CreateActionDescriptors(
+            ReflectedActionModel action,
+            ReflectedControllerModel controller,
+            ControllerDescriptor controllerDescriptor)
+        {
+            var actionDescriptors = new List<ReflectedActionDescriptor>();
+
+            if (controller.AttributeRoutes != null &&
+                controller.AttributeRoutes.Count > 0)
+            {
+                foreach (var controllerAttributeRoute in controller.AttributeRoutes)
+                {
+                    var actionDescriptor = CreateActionDescriptor(
+                        action,
+                        controllerAttributeRoute,
+                        controllerDescriptor);
+
+                    actionDescriptors.Add(actionDescriptor);
+                }
+            }
+            else
+            {
+                actionDescriptors.Add(CreateActionDescriptor(
+                    action,
+                    controllerAttributeRoute: null,
+                    controllerDescriptor: controllerDescriptor));
+            }
+
+            return actionDescriptors;
+        }
+
+        private static ReflectedActionDescriptor CreateActionDescriptor(
+            ReflectedActionModel action,
+            ReflectedAttributeRouteModel controllerAttributeRoute,
+            ControllerDescriptor controllerDescriptor)
+        {
             var parameterDescriptors = new List<ParameterDescriptor>();
             foreach (var parameter in action.Parameters)
             {
@@ -252,13 +379,15 @@ namespace Microsoft.AspNet.Mvc
                 {
                     paramDescriptor.ParameterBindingInfo = new ParameterBindingInfo(
                             parameter.ParameterName,
-                            parameter.ParameterInfo.ParameterType);
+                        parameter.ParameterInfo.ParameterType);
                 }
 
                 parameterDescriptors.Add(paramDescriptor);
             }
 
-            var attributeRouteInfo = CreateAttributeRouteInfo(action, controller);
+            AttributeRouteInfo attributeRouteInfo = CreateAttributeRouteInfo(
+                action.AttributeRouteModel,
+                controllerAttributeRoute);
 
             var actionDescriptor = new ReflectedActionDescriptor()
             {
@@ -275,23 +404,30 @@ namespace Microsoft.AspNet.Mvc
                 action.ActionMethod.DeclaringType.FullName,
                 action.ActionMethod.Name);
 
-            actionDescriptor.FilterDescriptors =
-                action.Filters.Select(f => new FilterDescriptor(f, FilterScope.Action))
-                .Concat(controller.Filters.Select(f => new FilterDescriptor(f, FilterScope.Controller)))
-                .Concat(globalFilters.Select(f => new FilterDescriptor(f, FilterScope.Global)))
-                .OrderBy(d => d, FilterDescriptorOrderComparer.Comparer)
-                .ToList();
-
             return actionDescriptor;
         }
 
+        private static void AddActionFilters(
+            ReflectedActionDescriptor actionDescriptor,
+            IEnumerable<IFilter> actionFilters,
+            IEnumerable<IFilter> controllerFilters,
+            IEnumerable<IFilter> globalFilters)
+        {
+            actionDescriptor.FilterDescriptors =
+                            actionFilters.Select(f => new FilterDescriptor(f, FilterScope.Action))
+                            .Concat(controllerFilters.Select(f => new FilterDescriptor(f, FilterScope.Controller)))
+                            .Concat(globalFilters.Select(f => new FilterDescriptor(f, FilterScope.Global)))
+                            .OrderBy(d => d, FilterDescriptorOrderComparer.Comparer)
+                            .ToList();
+        }
+
         private static AttributeRouteInfo CreateAttributeRouteInfo(
-            ReflectedActionModel action,
-            ReflectedControllerModel controller)
+            ReflectedAttributeRouteModel action,
+            ReflectedAttributeRouteModel controller)
         {
             var combinedRoute = ReflectedAttributeRouteModel.CombineReflectedAttributeRouteModel(
-                                controller.AttributeRouteModel,
-                                action.AttributeRouteModel);
+                                controller,
+                                action);
 
             if (combinedRoute == null)
             {
@@ -317,9 +453,9 @@ namespace Microsoft.AspNet.Mvc
             if (httpMethods != null && httpMethods.Count > 0)
             {
                 actionDescriptor.MethodConstraints = new List<HttpMethodConstraint>()
-                {
-                    new HttpMethodConstraint(httpMethods)
-                };
+                        {
+                            new HttpMethodConstraint(httpMethods)
+                        };
             }
 
             actionDescriptor.RouteConstraints.Add(new RouteDataActionConstraint(
@@ -467,11 +603,12 @@ namespace Microsoft.AspNet.Mvc
 
         private static bool IsAttributeRoutedAction(ReflectedActionDescriptor actionDescriptor)
         {
-            return actionDescriptor.AttributeRouteInfo?.Template != null;
+            return actionDescriptor.AttributeRouteInfo != null &&
+                actionDescriptor.AttributeRouteInfo.Template != null;
         }
 
         private static IList<string> AddErrorNumbers(
-            IList<string> namedRoutedErrors)
+            IEnumerable<string> namedRoutedErrors)
         {
             return namedRoutedErrors
                 .Select((nre, i) =>
@@ -525,6 +662,166 @@ namespace Microsoft.AspNet.Mvc
             }
 
             return namedRouteErrors;
+        }
+
+        private void ValidateActionGroupConfiguration(
+            IDictionary<MethodInfo, IDictionary<ReflectedActionModel, IList<ReflectedActionDescriptor>>> methodMap,
+            ReflectedActionDescriptor actionDescriptor,
+            IDictionary<MethodInfo, string> routingConfigurationErrors)
+        {
+            // Text to show as the attribute route template for conventionally routed actions.
+            const string NullTemplate = "(null)";
+
+            string mixedRoutingTypesErrorMessage = null;
+            string invalidHttpErrorMessage = null;
+
+            var hasAttributeRoutedActions = false;
+            var hasConventionallyRoutedActions = false;
+
+            // Validate that no C# method result in attribute and non attribute actions at the same time.
+            // This is for example the case when someone uses [HttpGet("Products")] and [HttpPost]
+            // on the same C# method. We consider this an invalid configuration.
+            // By design all the actions in a C# method are either attribute routed or conventionally
+            // routed, but mixing attribute and non attributed actions in the same method is not allowed.
+            var actionsForMethod = methodMap[actionDescriptor.MethodInfo];
+            foreach (var action in actionsForMethod.SelectMany(a => a.Value))
+            {
+                if (IsAttributeRoutedAction(action))
+                {
+                    hasAttributeRoutedActions = true;
+                }
+                else
+                {
+                    hasConventionallyRoutedActions = true;
+                }
+
+                // If we have valid and invalid attribute routed actions we found an invalid configuration.
+                if (hasAttributeRoutedActions && hasConventionallyRoutedActions)
+                {
+                    break;
+                }
+            }
+
+            if (hasAttributeRoutedActions && hasConventionallyRoutedActions)
+            {
+                var actionDescriptions = actionsForMethod
+                    .SelectMany(a => a.Value)
+                    .Select(ad =>
+                    Resources.FormatAttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod_Item(
+                        ad.DisplayName,
+                        ad.AttributeRouteInfo != null ? ad.AttributeRouteInfo.Template : NullTemplate));
+
+                var methodFullName = string.Format("{0}.{1}",
+                        actionDescriptor.MethodInfo.DeclaringType.FullName,
+                        actionDescriptor.MethodInfo.Name);
+
+                // Sample error message:
+                // A method 'MyApplication.CustomerController.Index' must not define attributed actions and
+                // non attributed actions at the same time:
+                // Action: 'MyApplication.CustomerController.Index' - Template: 'Products'
+                // Action: 'MyApplication.CustomerController.Index' - Template: '(null)'
+                mixedRoutingTypesErrorMessage =
+                    Resources.FormatAttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod(
+                        methodFullName,
+                        Environment.NewLine,
+                        string.Join(Environment.NewLine, actionDescriptions));
+            }
+
+            if (hasAttributeRoutedActions)
+            {
+                invalidHttpErrorMessage = ValidateHttpMethodProviderAttributes(actionDescriptor, actionsForMethod);
+            }
+
+            if (invalidHttpErrorMessage != null &&
+                mixedRoutingTypesErrorMessage != null)
+            {
+                var errorMessage = string.Join(
+                    Environment.NewLine,
+                    mixedRoutingTypesErrorMessage,
+                    invalidHttpErrorMessage);
+
+                routingConfigurationErrors.Add(actionDescriptor.MethodInfo, errorMessage);
+            }
+            else if (invalidHttpErrorMessage != null || mixedRoutingTypesErrorMessage != null)
+            {
+                routingConfigurationErrors.Add(
+                    actionDescriptor.MethodInfo,
+                    mixedRoutingTypesErrorMessage ?? invalidHttpErrorMessage);
+            }
+        }
+
+        private static string ValidateHttpMethodProviderAttributes(
+            ReflectedActionDescriptor actionDescriptor,
+            IDictionary<ReflectedActionModel, IList<ReflectedActionDescriptor>> actionsForMethod)
+        {
+            // Validates that no C# method that creates attribute routed actions and
+            // also uses attributes that only constraint the set of HTTP methods, for example [AcceptVerbs].
+            // This situation is considered to be an invalid configuration. By design only attribute routes
+            // can define which HTTP methods their resulted action allows by implementing
+            // IActionHttpMethodProvider. An example of such attributes is [HttpGet].
+            var invalidActions = new Dictionary<ReflectedActionModel, IEnumerable<string>>();
+
+            foreach (var action in actionsForMethod)
+            {
+                var invalidConstraintAttributes = action.Key.Attributes
+                    .Where(attr => attr is IActionHttpMethodProvider &&
+                                   !(attr is IRouteTemplateProvider))
+                    .Select(attr => attr.GetType().FullName);
+
+                if (invalidConstraintAttributes.Any())
+                {
+                    invalidActions.Add(action.Key, invalidConstraintAttributes);
+                }
+            }
+
+            var messagesForMethodInfo = new List<string>();
+            if (invalidActions.Any())
+            {
+                foreach (var invalidAction in invalidActions)
+                {
+                    var invalidAttributesList = string.Join(", ", invalidAction.Value);
+                    foreach (var descriptor in actionsForMethod[invalidAction.Key])
+                    {
+                        var messageItem = Resources.FormatAttributeRoute_InvalidHttpConstraints_Item(
+                            descriptor.DisplayName,
+                            invalidAttributesList,
+                            typeof(IActionHttpMethodProvider).FullName);
+
+                        messagesForMethodInfo.Add(messageItem);
+                    }
+                }
+
+                var methodFullName = string.Format("{0}.{1}",
+                    actionDescriptor.MethodInfo.DeclaringType.FullName,
+                    actionDescriptor.MethodInfo.Name);
+
+                // Sample message:
+                // A method 'MyApplication.CustomerController.Index' that defines attribute routed actions must
+                // not contain attributes that implement 'Microsoft.AspNet.Mvc.IActionHttpMethodProvider'
+                // and do not implement 'Microsoft.AspNet.Mvc.Routing.IRouteTemplateProvider':
+                // Action 'MyApplication.CustomerController.Index' has 'Microsoft.AspNet.Mvc.AcceptVerbsAttribute'
+                // invalid 'Microsoft.AspNet.Mvc.IActionHttpMethodProvider' attributes.
+                return
+                    Resources.FormatAttributeRoute_InvalidHttpConstraints(
+                        methodFullName,
+                        typeof(IActionHttpMethodProvider).FullName,
+                        typeof(IRouteTemplateProvider).FullName,
+                        Environment.NewLine,
+                        string.Join(Environment.NewLine, messagesForMethodInfo));
+            }
+
+            return null;
+        }
+
+        private static string CreateAttributeRoutingAggregateErrorMessage(
+            IEnumerable<string> individualErrors)
+        {
+            var errorMessages = AddErrorNumbers(individualErrors);
+
+            var message = Resources.FormatAttributeRoute_AggregateErrorMessage(
+                Environment.NewLine,
+                string.Join(Environment.NewLine + Environment.NewLine, errorMessages));
+            return message;
         }
 
         private static string GetRouteGroupValue(int order, string template)

--- a/src/Microsoft.AspNet.Mvc.Core/ReflectedModelBuilder/ReflectedActionModel.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ReflectedModelBuilder/ReflectedActionModel.cs
@@ -19,13 +19,6 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder
             Attributes = actionMethod.GetCustomAttributes(inherit: true).OfType<object>().ToList();
 
             Filters = Attributes.OfType<IFilter>().ToList();
-
-            var routeTemplateAttribute = Attributes.OfType<IRouteTemplateProvider>().FirstOrDefault();
-            if (routeTemplateAttribute != null)
-            {
-                AttributeRouteModel = new ReflectedAttributeRouteModel(routeTemplateAttribute);
-            }
-
             HttpMethods = new List<string>();
             Parameters = new List<ReflectedParameterModel>();
         }

--- a/src/Microsoft.AspNet.Mvc.Core/ReflectedModelBuilder/ReflectedControllerModel.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ReflectedModelBuilder/ReflectedControllerModel.cs
@@ -24,11 +24,9 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder
             Filters = Attributes.OfType<IFilter>().ToList();
             RouteConstraints = Attributes.OfType<RouteConstraintAttribute>().ToList();
 
-            var routeTemplateAttribute = Attributes.OfType<IRouteTemplateProvider>().FirstOrDefault();
-            if (routeTemplateAttribute != null)
-            {
-                AttributeRouteModel = new ReflectedAttributeRouteModel(routeTemplateAttribute);
-            }
+            AttributeRoutes = Attributes.OfType<IRouteTemplateProvider>()
+                .Select(rtp => new ReflectedAttributeRouteModel(rtp))
+                .ToList();
 
             ControllerName = controllerType.Name.EndsWith("Controller", StringComparison.Ordinal)
                         ? controllerType.Name.Substring(0, controllerType.Name.Length - "Controller".Length)
@@ -47,6 +45,6 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder
 
         public List<RouteConstraintAttribute> RouteConstraints { get; private set; }
 
-        public ReflectedAttributeRouteModel AttributeRouteModel { get; set; }
+        public List<ReflectedAttributeRouteModel> AttributeRoutes { get; private set; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/Resources.resx
+++ b/src/Microsoft.AspNet.Mvc.Core/Resources.resx
@@ -375,4 +375,19 @@
     <value>Error {0}:{1}{2}</value>
     <comment>{0} is the error number, {1} is Environment.NewLine {2} is the  error message</comment>
   </data>
+  <data name="AttributeRoute_InvalidHttpConstraints" xml:space="preserve">
+    <value>A method '{0}' that defines attribute routed actions must not contain attributes that implement '{1}' and do not implement '{2}':{3}{4}</value>
+    <comment>{0} is the MethodInfo.FullName, {1} is typeof(IActionHttpMethodProvider).FullName, {2} is typeof(IRouteTemplateProvider).FullName, {3} is Environment.NewLine, {4} is the list of actions and their respective invalid IActionHttpMethodProvider attributes formatted using AttributeRoute_InvalidHttpMethodConstraints_Item</comment>
+  </data>
+  <data name="AttributeRoute_InvalidHttpConstraints_Item" xml:space="preserve">
+    <value>Action '{0}' has '{1}' invalid '{2}' attributes.</value>
+    <comment>{0} The display name of the action, {1} the formatted list of invalid attributes using string.Join(", ", attributes), {2} is typeof(IActionHttpMethodProvider).FullName.</comment>
+  </data>
+  <data name="AttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod" xml:space="preserve">
+    <value>A method '{0}' must not define attribute routed actions and non attribute routed actions at the same time:{1}{2}</value>
+    <comment>{0} is the MethodInfo.FullName, {1} is Environment.NewLine, {2} is the formatted list of actions defined by that method info.</comment>
+  </data>
+  <data name="AttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod_Item" xml:space="preserve">
+    <value>Action: '{0}' - Template: '{1}'</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNet.Mvc.Core/RouteAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/RouteAttribute.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNet.Mvc
     /// <summary>
     /// Specifies an attribute route on a controller. 
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
     public class RouteAttribute : Attribute, IRouteTemplateProvider
     {
         private int? _order;

--- a/test/Microsoft.AspNet.Mvc.Core.Test/DefaultActionDiscoveryConventionsTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/DefaultActionDiscoveryConventionsTests.cs
@@ -4,6 +4,8 @@
 using System.Reflection;
 using Microsoft.AspNet.Mvc.DefaultActionDiscoveryConventionsControllers;
 using Xunit;
+using System.Linq;
+using System;
 
 namespace Microsoft.AspNet.Mvc
 {
@@ -144,6 +146,234 @@ namespace Microsoft.AspNet.Mvc
 
             // Assert
             Assert.False(isValid);
+        }
+
+        [Fact]
+        public void GetActions_ConventionallyRoutedAction_WithoutHttpConstraints()
+        {
+            // Arrange
+            var conventions = new DefaultActionDiscoveryConventions();
+            var typeInfo = typeof(ConventionallyRoutedController).GetTypeInfo();
+            var actionName = nameof(ConventionallyRoutedController.Edit);
+
+            // Act
+            var actionInfos = conventions.GetActions(typeInfo.GetMethod(actionName), typeInfo);
+
+            // Assert
+            var action = Assert.Single(actionInfos);
+            Assert.Equal("Edit", action.ActionName);
+            Assert.True(action.RequireActionNameMatch);
+            Assert.Null(action.HttpMethods);
+            Assert.Null(action.AttributeRoute);
+        }
+
+        [Fact]
+        public void GetActions_ConventionallyRoutedAction_WithHttpConstraints()
+        {
+            // Arrange
+            var conventions = new DefaultActionDiscoveryConventions();
+            var typeInfo = typeof(ConventionallyRoutedController).GetTypeInfo();
+            var actionName = nameof(ConventionallyRoutedController.Update);
+
+            // Act
+            var actionInfos = conventions.GetActions(typeInfo.GetMethod(actionName), typeInfo);
+
+            // Assert
+            var action = Assert.Single(actionInfos);
+            Assert.Equal("Update", action.ActionName);
+            Assert.True(action.RequireActionNameMatch);
+            Assert.Equal(new[] { "PUT", "PATCH" }, action.HttpMethods);
+            Assert.Null(action.AttributeRoute);
+        }
+
+        [Fact]
+        public void GetActions_ConventionallyRoutedActionWithHttpConstraints_AndInvalidRouteTemplateProvider()
+        {
+            // Arrange
+            var conventions = new DefaultActionDiscoveryConventions();
+            var typeInfo = typeof(ConventionallyRoutedController).GetTypeInfo();
+            var actionName = nameof(ConventionallyRoutedController.Delete);
+
+            // Act
+            var actionInfos = conventions.GetActions(typeInfo.GetMethod(actionName), typeInfo);
+
+            // Assert
+            var action = Assert.Single(actionInfos);
+            Assert.Equal("Delete", action.ActionName);
+            Assert.True(action.RequireActionNameMatch);
+
+            var httpMethod = Assert.Single(action.HttpMethods);
+            Assert.Equal("DELETE", httpMethod);
+            Assert.Null(action.AttributeRoute);
+        }
+
+        [Fact]
+        public void GetActions_ConventionallyRoutedAction_WithMultipleHttpConstraints()
+        {
+            // Arrange
+            var conventions = new DefaultActionDiscoveryConventions();
+            var typeInfo = typeof(ConventionallyRoutedController).GetTypeInfo();
+            var actionName = nameof(ConventionallyRoutedController.Details);
+
+            // Act
+            var actionInfos = conventions.GetActions(typeInfo.GetMethod(actionName), typeInfo);
+
+            // Assert
+            var action = Assert.Single(actionInfos);
+            Assert.Equal("Details", action.ActionName);
+            Assert.True(action.RequireActionNameMatch);
+            Assert.Equal(new[] { "POST", "GET" }, action.HttpMethods);
+            Assert.Null(action.AttributeRoute);
+        }
+
+        [Fact]
+        public void GetActions_ConventionallyRoutedAction_WithMultipleOverlappingHttpConstraints()
+        {
+            // Arrange
+            var conventions = new DefaultActionDiscoveryConventions();
+            var typeInfo = typeof(ConventionallyRoutedController).GetTypeInfo();
+            var actionName = nameof(ConventionallyRoutedController.List);
+
+            // Act
+            var actionInfos = conventions.GetActions(typeInfo.GetMethod(actionName), typeInfo);
+
+            // Assert
+            var action = Assert.Single(actionInfos);
+            Assert.Equal("List", action.ActionName);
+            Assert.True(action.RequireActionNameMatch);
+            Assert.Equal(new[] { "GET", "PUT", "POST" }, action.HttpMethods);
+            Assert.Null(action.AttributeRoute);
+        }
+
+        [Fact]
+        public void GetActions_AttributeRouteOnAction()
+        {
+            // Arrange
+            var conventions = new DefaultActionDiscoveryConventions();
+            var typeInfo = typeof(NoRouteAttributeController).GetTypeInfo();
+            var actionName = nameof(NoRouteAttributeController.Edit);
+
+            // Act
+            var actionInfos = conventions.GetActions(typeInfo.GetMethod(actionName), typeInfo);
+
+            // Assert
+            var action = Assert.Single(actionInfos);
+
+            Assert.Equal("Edit", action.ActionName);
+            Assert.True(action.RequireActionNameMatch);
+
+            var httpMethod = Assert.Single(action.HttpMethods);
+            Assert.Equal("POST", httpMethod);
+
+            Assert.NotNull(action.AttributeRoute);
+            Assert.Equal("Change", action.AttributeRoute.Template);
+        }
+
+
+        [Fact]
+        public void GetActions_AttributeRouteOnAction_CreatesOneActionInforPerRouteTemplate()
+        {
+            // Arrange
+            var conventions = new DefaultActionDiscoveryConventions();
+            var typeInfo = typeof(NoRouteAttributeController).GetTypeInfo();
+            var actionName = nameof(NoRouteAttributeController.Index);
+
+            // Act
+            var actionInfos = conventions.GetActions(typeInfo.GetMethod(actionName), typeInfo);
+
+            // Assert
+            Assert.Equal(2, actionInfos.Count());
+
+            foreach (var action in actionInfos)
+            {
+                Assert.Equal("Index", action.ActionName);
+                Assert.True(action.RequireActionNameMatch);
+
+                Assert.NotNull(action.AttributeRoute);
+            }
+
+            var list = Assert.Single(actionInfos, ai => ai.AttributeRoute.Template.Equals("List"));
+            var listMethod = Assert.Single(list.HttpMethods);
+            Assert.Equal("POST", listMethod);
+
+            var all = Assert.Single(actionInfos, ai => ai.AttributeRoute.Template.Equals("All"));
+            var allMethod = Assert.Single(all.HttpMethods);
+            Assert.Equal("GET", allMethod);
+        }
+
+        [Fact]
+        public void GetActions_NoRouteOnController_AllowsConventionallyRoutedActions_OnTheSameController()
+        {
+            // Arrange
+            var conventions = new DefaultActionDiscoveryConventions();
+            var typeInfo = typeof(NoRouteAttributeController).GetTypeInfo();
+            var actionName = nameof(NoRouteAttributeController.Remove);
+
+            // Act
+            var actionInfos = conventions.GetActions(typeInfo.GetMethod(actionName), typeInfo);
+
+            // Assert
+            var action = Assert.Single(actionInfos);
+
+            Assert.Equal("Remove", action.ActionName);
+            Assert.True(action.RequireActionNameMatch);
+
+            Assert.Null(action.HttpMethods);
+
+            Assert.Null(action.AttributeRoute);
+        }
+
+        [Theory]
+        [InlineData(typeof(SingleRouteAttributeController))]
+        [InlineData(typeof(MultipleRouteAttributeController))]
+        public void GetActions_RouteAttributeOnController_CreatesAttributeRoute_ForNonAttributedActions(Type controller)
+        {
+            // Arrange
+            var conventions = new DefaultActionDiscoveryConventions();
+            var typeInfo = controller.GetTypeInfo();
+
+            // Act
+            var actionInfos = conventions.GetActions(typeInfo.GetMethod("Delete"), typeInfo);
+
+            // Assert
+            var action = Assert.Single(actionInfos);
+
+            Assert.Equal("Delete", action.ActionName);
+            Assert.True(action.RequireActionNameMatch);
+
+            Assert.Null(action.HttpMethods);
+
+            Assert.Null(action.AttributeRoute);
+        }
+
+        [Theory]
+        [InlineData(typeof(SingleRouteAttributeController))]
+        [InlineData(typeof(MultipleRouteAttributeController))]
+        public void GetActions_RouteOnController_CreatesOneActionInforPerRouteTemplateOnAction(Type controller)
+        {
+            // Arrange
+            var conventions = new DefaultActionDiscoveryConventions();
+            var typeInfo = controller.GetTypeInfo();
+
+            // Act
+            var actionInfos = conventions.GetActions(typeInfo.GetMethod("Index"), typeInfo);
+
+            // Assert
+            Assert.Equal(2, actionInfos.Count());
+
+            foreach (var action in actionInfos)
+            {
+                Assert.Equal("Index", action.ActionName);
+                Assert.True(action.RequireActionNameMatch);
+
+                var httpMethod = Assert.Single(action.HttpMethods);
+                Assert.Equal("GET", httpMethod);
+
+                Assert.NotNull(action.AttributeRoute);
+            }
+
+            Assert.Single(actionInfos, ai => ai.AttributeRoute.Template.Equals("List"));
+            Assert.Single(actionInfos, ai => ai.AttributeRoute.Template.Equals("All"));
         }
 
         [Fact]
@@ -407,5 +637,62 @@ namespace Microsoft.AspNet.Mvc.DefaultActionDiscoveryConventionsControllers
         {
             return new OperatorOverloadingController();
         }
+    }
+
+    public class NoRouteAttributeController : Controller
+    {
+        [HttpGet("All")]
+        [HttpPost("List")]
+        public void Index() { }
+
+        [HttpPost("Change")]
+        public void Edit() { }
+
+        public void Remove() { }
+    }
+
+
+    [Route("Products")]
+    public class SingleRouteAttributeController : Controller
+    {
+        [HttpGet("All")]
+        [HttpGet("List")]
+        public void Index() { }
+
+        public void Delete() { }
+    }
+
+    [Route("Products")]
+    [Route("Items")]
+    public class MultipleRouteAttributeController : Controller
+    {
+        [HttpGet("All")]
+        [HttpGet("List")]
+        public void Index() { }
+
+        public void Delete() { }
+    }
+
+    public class ConventionallyRoutedController : Controller
+    {
+        public void Edit() { }
+
+        [AcceptVerbs("PUT", "PATCH")]
+        public void Update() { }
+
+        // Here the constraint is acting as an IActionHttpMethodProvider and
+        // not as an IRouteTemplateProvider given that there is no RouteAttribute
+        // on the controller and the template for [HttpDelete] is null.
+        [HttpDelete]
+        public void Delete() { }
+
+        [HttpPost]
+        [HttpGet]
+        public void Details() { }
+
+        [HttpGet]
+        [HttpPut]
+        [AcceptVerbs("GET", "POST")]
+        public void List() { }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ReflectedModelBuilder/ReflectedActionModelTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ReflectedModelBuilder/ReflectedActionModelTests.cs
@@ -38,20 +38,6 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder.Test
             Assert.IsType<MyFilterAttribute>(model.Filters[0]);
         }
 
-        [Fact]
-        public void ReflectedActionModel_PopulatesAttributeRouteInfo()
-        {
-            // Arrange
-            var actionMethod = typeof(BlogController).GetMethod("Edit");
-
-            // Act
-            var model = new ReflectedActionModel(actionMethod);
-
-            // Assert
-            Assert.NotNull(model.AttributeRouteModel);
-            Assert.Equal("Edit", model.AttributeRouteModel.Template);
-        }
-
         private class BlogController
         {
             [MyOther]

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ReflectedModelBuilder/ReflectedControllerModelTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ReflectedModelBuilder/ReflectedControllerModelTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Reflection;
 using Xunit;
 
@@ -19,12 +20,16 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder.Test
             var model = new ReflectedControllerModel(controllerType.GetTypeInfo());
 
             // Assert
-            Assert.Equal(4, model.Attributes.Count);
+            Assert.Equal(5, model.Attributes.Count);
 
             Assert.Single(model.Attributes, a => a is MyOtherAttribute);
             Assert.Single(model.Attributes, a => a is MyFilterAttribute);
             Assert.Single(model.Attributes, a => a is MyRouteConstraintAttribute);
-            Assert.Single(model.Attributes, a => a is RouteAttribute);
+
+            var routes = model.Attributes.OfType<RouteAttribute>().ToList();
+            Assert.Equal(2, routes.Count());
+            Assert.Single(routes, r => r.Template.Equals("Blog"));
+            Assert.Single(routes, r => r.Template.Equals("Microblog"));
         }
 
         [Fact]
@@ -91,14 +96,17 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder.Test
             var model = new ReflectedControllerModel(controllerType.GetTypeInfo());
 
             // Assert
-            Assert.NotNull(model.AttributeRouteModel);
-            Assert.Equal("Blog", model.AttributeRouteModel.Template);
+            Assert.NotNull(model.AttributeRoutes);
+            Assert.Equal(2, model.AttributeRoutes.Count); ;
+            Assert.Single(model.AttributeRoutes, r => r.Template.Equals("Blog"));
+            Assert.Single(model.AttributeRoutes, r => r.Template.Equals("Microblog"));
         }
 
         [MyOther]
         [MyFilter]
         [MyRouteConstraint]
         [Route("Blog")]
+        [Route("Microblog")]
         private class BlogController
         {
         }

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/RoutingTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/RoutingTests.cs
@@ -162,6 +162,163 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
                 result.RouteValues);
         }
 
+        [Theory]
+        [InlineData("http://localhost/api/v1/Maps")]
+        [InlineData("http://localhost/api/v2/Maps")]
+        public async Task AttributeRoutedAction_MultipleRouteAttributes_WorksWithNameAndOrder(string url)
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // Act
+            var response = await client.GetAsync(url);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var body = await response.Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<RoutingResult>(body);
+
+            Assert.Equal("Maps", result.Controller);
+            Assert.Equal("Get", result.Action);
+
+            Assert.Equal(new string[]
+            {
+                    "/api/v2/Maps",
+                    "/api/v1/Maps",
+                    "/api/v2/Maps"
+            },
+            result.ExpectedUrls);
+        }
+
+        [Fact]
+        public async Task AttributeRoutedAction_MultipleRouteAttributes_WorksWithOverrideRoutes()
+        {
+            // Arrange
+            var url = "http://localhost/api/v2/Maps";
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // Act
+            var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Post, url));
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var body = await response.Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<RoutingResult>(body);
+
+            Assert.Equal("Maps", result.Controller);
+            Assert.Equal("Post", result.Action);
+
+            Assert.Equal(new string[]
+            {
+                    "/api/v2/Maps",
+                    "/api/v2/Maps"
+            },
+            result.ExpectedUrls);
+        }
+
+        [Fact]
+        public async Task AttributeRoutedAction_MultipleRouteAttributes_RouteAttributeTemplatesIgnoredForOverrideActions()
+        {
+            // Arrange
+            var url = "http://localhost/api/v1/Maps";
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // Act
+            var response = await client.SendAsync(new HttpRequestMessage(new HttpMethod("POST"), url));
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData("http://localhost/api/v1/Maps/5", "PUT")]
+        [InlineData("http://localhost/api/v2/Maps/5", "PUT")]
+        [InlineData("http://localhost/api/v1/Maps/PartialUpdate/5", "PATCH")]
+        [InlineData("http://localhost/api/v2/Maps/PartialUpdate/5", "PATCH")]
+        public async Task AttributeRoutedAction_MultipleRouteAttributes_CombinesWithMultipleHttpAttributes(
+            string url,
+            string method)
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // Act
+            var response = await client.SendAsync(new HttpRequestMessage(new HttpMethod(method), url));
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var body = await response.Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<RoutingResult>(body);
+
+            Assert.Equal("Maps", result.Controller);
+            Assert.Equal("Update", result.Action);
+
+            Assert.Equal(new string[]
+            {
+                    "/api/v2/Maps/PartialUpdate/5",
+                    "/api/v2/Maps/PartialUpdate/5"
+            },
+            result.ExpectedUrls);
+        }
+
+        [Theory]
+        [InlineData("http://localhost/Banks/Get/5")]
+        [InlineData("http://localhost/Bank/Get/5")]
+        public async Task AttributeRoutedAction_MultipleHttpAttributesAndTokenReplacement(string url)
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+            var expectedUrl = new Uri(url).AbsolutePath;
+
+            // Act
+            var response = await client.GetAsync(url);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var body = await response.Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<RoutingResult>(body);
+
+            Assert.Equal("Banks", result.Controller);
+            Assert.Equal("Get", result.Action);
+
+            Assert.Equal(new string[]
+            {
+                    "/Bank/Get/5",
+                    "/Bank/Get/5"
+            },
+            result.ExpectedUrls);
+        }
+
+        [Theory]
+        [InlineData("http://localhost/api/v1/Maps/5", "PATCH")]
+        [InlineData("http://localhost/api/v2/Maps/5", "PATCH")]
+        [InlineData("http://localhost/api/v1/Maps/PartialUpdate/5", "PUT")]
+        [InlineData("http://localhost/api/v2/Maps/PartialUpdate/5", "PUT")]
+        public async Task AttributeRoutedAction_MultipleRouteAttributes_WithMultipleHttpAttributes_RespectsConstraints(
+            string url,
+            string method)
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+            var expectedUrl = new Uri(url).AbsolutePath;
+
+            // Act
+            var response = await client.SendAsync(new HttpRequestMessage(new HttpMethod(method), url));
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
         // The url would be /Store/ListProducts with conventional routes
         [Fact]
         public async Task AttributeRoutedAction_IsNotReachableWithTraditionalRoute()
@@ -421,7 +578,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         }
 
         [Fact]
-        public async Task AttributeRoutedAction__LinkGeneration_OrderOnActionOverridesOrderOnController()
+        public async Task AttributeRoutedAction_LinkGeneration_OrderOnActionOverridesOrderOnController()
         {
             // Arrange
             var server = TestServer.Create(_services, _app);

--- a/test/WebSites/RoutingWebSite/Controllers/BanksController.cs
+++ b/test/WebSites/RoutingWebSite/Controllers/BanksController.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNet.Mvc;
+using System;
+
+namespace RoutingWebSite
+{
+    public class BanksController : Controller
+    {
+        private readonly TestResponseGenerator _generator;
+
+        public BanksController(TestResponseGenerator generator)
+	    {
+            _generator = generator;
+	    }
+
+        [HttpGet("Banks/[action]/{id}")]
+        [HttpGet("Bank/[action]/{id}")]
+        public ActionResult Get(int id)
+        {
+            return _generator.Generate(
+                Url.Action(),
+                Url.RouteUrl(new { }));
+        }
+    }
+}

--- a/test/WebSites/RoutingWebSite/Controllers/EmployeeController.cs
+++ b/test/WebSites/RoutingWebSite/Controllers/EmployeeController.cs
@@ -20,7 +20,7 @@ namespace RoutingWebSite
             return _generator.Generate("/api/Employee");
         }
 
-        [AcceptVerbs("PUT", "PATCH")]
+        [MultipleHttpMethods(null, "PUT", "PATCH")]
         public IActionResult UpdateEmployee()
         {
             return _generator.Generate("/api/Employee");

--- a/test/WebSites/RoutingWebSite/Controllers/MapsController.cs
+++ b/test/WebSites/RoutingWebSite/Controllers/MapsController.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.AspNet.Mvc;
+using System;
+
+namespace RoutingWebSite
+{
+    [Route("api/v1/Maps", Name = "v1", Order = 1)]
+    [Route("api/v2/Maps")]
+    public class MapsController : Controller
+    {
+        private readonly TestResponseGenerator _generator;
+
+        public MapsController(TestResponseGenerator generator)
+	    {
+            _generator = generator;
+	    }
+
+        [HttpGet]
+        public ActionResult Get()
+        {
+            // Multiple attribute routes with name and order.
+            // We will always generate v2 routes except when
+            // we explicitly use "v1" to generate a v1 route.
+            return _generator.Generate(
+                Url.Action(),
+                Url.RouteUrl("v1"),
+                Url.RouteUrl(new { }));
+        }
+
+        [HttpPost("/api/v2/Maps")]
+        public ActionResult Post()
+        {
+            return _generator.Generate(
+                Url.Action(),
+                Url.RouteUrl(new { }));
+        }
+
+        [HttpPut("{id}")]
+        [HttpPatch("PartialUpdate/{id}")]
+        public ActionResult Update(int id)
+        {
+            // We will generate "/api/v2/Maps/PartialUpdate/{id}"
+            // in both cases, v1 routes will be discarded due to their
+            // Order and for v2 routes PartialUpdate has higher precedence.
+            // api/v1/Maps/{id} and api/v2/Maps/{id} will only match on PUT.
+            // api/v1/Maps/PartialUpdate/{id} and api/v2/Maps/PartialUpdate/{id} will only match on PATCH.
+            return _generator.Generate(
+                Url.Action(),
+                Url.RouteUrl(new { }));
+        }
+    }
+}

--- a/test/WebSites/RoutingWebSite/MultipleHttpMethodsAttribute.cs
+++ b/test/WebSites/RoutingWebSite/MultipleHttpMethodsAttribute.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNet.Mvc;
+using Microsoft.AspNet.Mvc.Routing;
+using Microsoft.AspNet.Routing;
+
+namespace RoutingWebSite
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public class MultipleHttpMethodsAttribute : Attribute, IActionHttpMethodProvider, IRouteTemplateProvider
+    {
+        private readonly IEnumerable<string> _supportedMethods;
+
+        public MultipleHttpMethodsAttribute(params string[] methods)
+            : this(null, methods)
+        {
+        }
+
+        public MultipleHttpMethodsAttribute(string template, params string[] methods)
+        {
+            _supportedMethods = methods ?? new string[0];
+            Template = template;
+        }
+
+        public IEnumerable<string> HttpMethods
+        {
+            get { return _supportedMethods; }
+        }
+
+        /// <inheritdoc />
+        public string Template { get; private set; }
+
+        /// <inheritdoc />
+        int? IRouteTemplateProvider.Order { get { return _order; } }
+
+        private int? _order;
+
+        public int Order
+        {
+            get { return _order.GetValueOrDefault(); }
+            set { _order = value; }
+        }
+
+        /// <inheritdoc />
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
1. Support multiple [Http*] attributes on an action.
2. Support multiple [Route] attributes on a controller.
3. Detect attribute routed actions during action discovery
   and return one action per [Http*] found on the method.
4. Build one action descriptor per [Route]+[Http*] combination
   in an action.
5. Disallow the use of [AcceptVerbs] and other IActionHttpMethodProvider
   attributes in attribute routed actions.
6. Disallow mixing attribute routed and non attribute routed actions on
   the same method.
