### PR TITLE
Adding Api Explorer

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ActionDescriptor.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionDescriptor.cs
@@ -11,6 +11,7 @@ namespace Microsoft.AspNet.Mvc
     {
         public ActionDescriptor()
         {
+            Properties = new Dictionary<object, object>();
             RouteValueDefaults = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
         }
 
@@ -34,5 +35,10 @@ namespace Microsoft.AspNet.Mvc
         /// A friendly name for this action.
         /// </summary>
         public virtual string DisplayName { get; set; }
+
+        /// <summary>
+        /// Stores arbitrary metadata properties associated with the <see cref="ActionDescriptor"/>.
+        /// </summary>
+        public IDictionary<object, object> Properties { get; private set; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ActionDescriptorExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionDescriptorExtensions.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNet.Mvc
+{
+    /// <summary>
+    /// Extension methods for <see cref="ActionDescriptor"/>.
+    /// </summary>
+    public static class ActionDescriptorExtensions
+    {
+        /// <summary>
+        /// Gets the value of a property from the <see cref="ActionDescriptor.Properties"/> collection 
+        /// using the provided value of <typeparamref name="T"/> as the key.
+        /// </summary>
+        /// <typeparam name="T">The type of the property.</typeparam>
+        /// <param name="actionDescriptor">The action descriptor.</param>
+        /// <returns>The property or the default value of <typeparamref name="T"/>.</returns>
+        public static T GetProperty<T>([NotNull] this ActionDescriptor actionDescriptor)
+        {
+            object value;
+            if (actionDescriptor.Properties.TryGetValue(typeof(T), out value))
+            {
+                return (T)value;
+            }
+            else
+            {
+                return default(T);
+            }
+        }
+
+        /// <summary>
+        /// Sets the value of an property in the <see cref="ActionDescriptor.Properties"/> collection using
+        /// the provided value of <typeparamref name="T"/> as the key.
+        /// </summary>
+        /// <typeparam name="T">The type of the property.</typeparam>
+        /// <param name="actionDescriptor">The action descriptor.</param>
+        /// <param name="value">The value of the property.</param>
+        public static void SetProperty<T>([NotNull] this ActionDescriptor actionDescriptor, [NotNull] T value)
+        {
+            actionDescriptor.Properties[typeof(T)] = value;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Description/ApiDescription.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Description/ApiDescription.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNet.Mvc.ModelBinding;
+
+namespace Microsoft.AspNet.Mvc.Description
+{
+    /// <summary>
+    /// Represents an API exposed by this application.
+    /// </summary>
+    public class ApiDescription
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="ApiDescription"/>.
+        /// </summary>
+        public ApiDescription()
+        {
+            Properties = new Dictionary<object, object>();
+            ParameterDescriptions = new List<ApiParameterDescription>();
+            SupportedResponseFormats = new List<ApiResponseFormat>();
+        }
+
+        /// <summary>
+        /// The <see cref="ActionDescriptor"/> for this api.
+        /// </summary>
+        public ActionDescriptor ActionDescriptor { get; set; }
+
+        /// <summary>
+        /// The group name for this api.
+        /// </summary>
+        public string GroupName { get; set; }
+
+        /// <summary>
+        /// The supported HTTP method for this api, or null if all HTTP methods are supported.
+        /// </summary>
+        public string HttpMethod { get; set; }
+
+        /// <summary>
+        /// The list of <see cref="ApiParameterDescription"/> for this api.
+        /// </summary>
+        public List<ApiParameterDescription> ParameterDescriptions { get; private set; }
+
+        /// <summary>
+        /// Stores arbitrary metadata properties associated with the <see cref="ApiDescription"/>.
+        /// </summary>
+        public IDictionary<object, object> Properties { get; private set; }
+
+        /// <summary>
+        /// The relative url path template (relative to application root) for this api.
+        /// </summary>
+        public string RelativePath { get; set; }
+
+        /// <summary>
+        /// The <see cref="ModelMetadata"/> for the <see cref="ResponseType"/> or null.
+        /// </summary>
+        /// <remarks>
+        /// Will be null if <see cref="ResponseType"/> is null.
+        /// </remarks>
+        public ModelMetadata ResponseModelMetadata { get; set; }
+
+        /// <summary>
+        /// The CLR data type of the response or null.
+        /// </summary>
+        /// <remarks>
+        /// Will be null if the action returns no response, or if the response type is unclear. Use 
+        /// <see cref="ProducesAttribute"/> on an action method to specify a response type.
+        /// </remarks>
+        public Type ResponseType { get; set; }
+
+        /// <summary>
+        /// A list of possible formats for a response.
+        /// </summary>
+        /// <remarks>
+        /// Will be empty if the action returns no response, or if the response type is unclear. Use
+        /// <see cref="ProducesAttribute"/> on an action method to specify a response type.
+        /// </remarks>
+        public IList<ApiResponseFormat> SupportedResponseFormats { get; private set; }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Description/ApiDescriptionActionData.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Description/ApiDescriptionActionData.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNet.Mvc.Description
+{
+    /// <summary>
+    /// Represents data used to build an <see cref="ApiDescription"/>, stored as part of the 
+    /// <see cref="ActionDescriptor.Properties"/>.
+    /// </summary>
+    public class ApiDescriptionActionData
+    {
+        /// <summary>
+        /// The <see cref="ApiDescription.GroupName"/> of <see cref="ApiDescription"/> objects for the associated 
+        /// action.
+        /// </summary>
+        public string GroupName { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Description/ApiDescriptionCollectionGroupProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Description/ApiDescriptionCollectionGroupProvider.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.Framework.DependencyInjection;
+
+namespace Microsoft.AspNet.Mvc.Description
+{
+    /// <inheritdoc />
+    public class ApiDescriptionGroupCollectionProvider : IApiDescriptionGroupCollectionProvider
+    {
+        private readonly IActionDescriptorsCollectionProvider _actionDescriptorCollectionProvider;
+        private readonly INestedProviderManager<ApiDescriptionProviderContext> _apiDescriptionProvider;
+
+        private ApiDescriptionGroupCollection _apiDescriptionGroups;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="ApiDescriptionGroupCollectionProvider"/>.
+        /// </summary>
+        /// <param name="actionDescriptorCollectionProvider">
+        /// The <see cref="IActionDescriptorsCollectionProvider"/>.
+        /// </param>
+        /// <param name="apiDescriptionProvider">
+        /// The <see cref="INestedProviderManager{ApiDescriptionProviderContext}"/>.
+        /// </param>
+        public ApiDescriptionGroupCollectionProvider(
+            IActionDescriptorsCollectionProvider actionDescriptorCollectionProvider,
+            INestedProviderManager<ApiDescriptionProviderContext> apiDescriptionProvider)
+        {
+            _actionDescriptorCollectionProvider = actionDescriptorCollectionProvider;
+            _apiDescriptionProvider = apiDescriptionProvider;
+        }
+
+        /// <inheritdoc />
+        public ApiDescriptionGroupCollection ApiDescriptionGroups
+        {
+            get
+            {
+                var actionDescriptors = _actionDescriptorCollectionProvider.ActionDescriptors;
+                if (_apiDescriptionGroups == null || _apiDescriptionGroups.Version != actionDescriptors.Version)
+                {
+                    _apiDescriptionGroups = GetCollection(actionDescriptors);
+                }
+
+                return _apiDescriptionGroups;
+            }
+        }
+
+        private ApiDescriptionGroupCollection GetCollection(ActionDescriptorsCollection actionDescriptors)
+        {
+            var context = new ApiDescriptionProviderContext(actionDescriptors.Items);
+            _apiDescriptionProvider.Invoke(context);
+
+            var groups = context.Results
+                .GroupBy(d => d.GroupName)
+                .Select(g => new ApiDescriptionGroup(g.Key, g.ToArray()))
+                .ToArray();
+
+            return new ApiDescriptionGroupCollection(groups, actionDescriptors.Version);
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Description/ApiDescriptionExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Description/ApiDescriptionExtensions.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNet.Mvc.Description
+{
+    /// <summary>
+    /// Extension methods for <see cref="ApiDescription"/>.
+    /// </summary>
+    public static class ApiDescriptionExtensions
+    {
+        /// <summary>
+        /// Gets the value of a property from the <see cref="ApiDescription.Properties"/> collection 
+        /// using the provided value of <typeparamref name="T"/> as the key.
+        /// </summary>
+        /// <typeparam name="T">The type of the property.</typeparam>
+        /// <param name="apiDescription">The <see cref="ApiDescription"/>.</param>
+        /// <returns>The property or the default value of <typeparamref name="T"/>.</returns>
+        public static T GetProperty<T>([NotNull] this ApiDescription apiDescription)
+        {
+            object value;
+            if (apiDescription.Properties.TryGetValue(typeof(T), out value))
+            {
+                return (T)value;
+            }
+            else
+            {
+                return default(T);
+            }
+        }
+
+        /// <summary>
+        /// Sets the value of an property in the <see cref="ApiDescription.Properties"/> collection using
+        /// the provided value of <typeparamref name="T"/> as the key.
+        /// </summary>
+        /// <typeparam name="T">The type of the property.</typeparam>
+        /// <param name="apiDescription">The <see cref="ApiDescription"/>.</param>
+        /// <param name="value">The value of the property.</param>
+        public static void SetProperty<T>([NotNull] this ApiDescription apiDescription, [NotNull] T value)
+        {
+            apiDescription.Properties[typeof(T)] = value;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Description/ApiDescriptionGroup.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Description/ApiDescriptionGroup.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNet.Mvc.Description
+{
+    /// <summary>
+    /// Represents a group of related apis.
+    /// </summary>
+    public class ApiDescriptionGroup
+    {
+        /// <summary>
+        /// Creates a new <see cref="ApiDescriptionGroup"/>.
+        /// </summary>
+        /// <param name="groupName">The group name.</param>
+        /// <param name="items">A collection of <see cref="ApiDescription"/> items for this group.</param>
+        public ApiDescriptionGroup(string groupName, IReadOnlyList<ApiDescription> items)
+        {
+            GroupName = groupName;
+            Items = items;
+        }
+
+        /// <summary>
+        /// The group name.
+        /// </summary>
+        public string GroupName { get; private set; }
+
+        /// <summary>
+        /// A collection of <see cref="ApiDescription"/> items for this group.
+        /// </summary>
+        public IReadOnlyList<ApiDescription> Items { get; private set; }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Description/ApiDescriptionGroupCollection.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Description/ApiDescriptionGroupCollection.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNet.Mvc.Description
+{
+    /// <summary>
+    /// A cached collection of <see cref="ApiDescriptionGroup" />.
+    /// </summary>
+    public class ApiDescriptionGroupCollection
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiDescriptionGroupCollection"/>.
+        /// </summary>
+        /// <param name="items">The list of <see cref="ApiDescriptionGroup"/>.</param>
+        /// <param name="version">The unique version of discovered groups.</param>
+        public ApiDescriptionGroupCollection([NotNull] IReadOnlyList<ApiDescriptionGroup> items, int version)
+        {
+            Items = items;
+            Version = version;
+        }
+
+        /// <summary>
+        /// Returns the list of <see cref="IReadOnlyList{ApiDescriptionGroup}"/>.
+        /// </summary>
+        public IReadOnlyList<ApiDescriptionGroup> Items { get; private set; }
+
+        /// <summary>
+        /// Returns the unique version of the current items.
+        /// </summary>
+        public int Version { get; private set; }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Description/ApiDescriptionProviderContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Description/ApiDescriptionProviderContext.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNet.Mvc.Description
+{
+    /// <summary>
+    /// A context object for <see cref="ApiDescription"/> providers.
+    /// </summary>
+    public class ApiDescriptionProviderContext
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="ApiDescriptionProviderContext"/>.
+        /// </summary>
+        /// <param name="actions">The list of actions.</param>
+        public ApiDescriptionProviderContext([NotNull] IReadOnlyList<ActionDescriptor> actions)
+        {
+            Actions = actions;
+
+            Results = new List<ApiDescription>();
+        }
+
+        /// <summary>
+        /// The list of actions.
+        /// </summary>
+        public IReadOnlyList<ActionDescriptor> Actions { get; private set; }
+
+        /// <summary>
+        /// The list of resulting <see cref="ApiDescription"/>.
+        /// </summary>
+        public List<ApiDescription> Results { get; private set; }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Description/ApiExplorerSettingsAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Description/ApiExplorerSettingsAttribute.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNet.Mvc.Description;
+
+namespace Microsoft.AspNet.Mvc
+{
+    /// <summary>
+    /// Controls the visibility and group name for an <see cref="ApiDescription"/> of the associated
+    /// controller class or action method.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public class ApiExplorerSettingsAttribute : 
+        Attribute, 
+        IApiDescriptionGroupNameProvider, 
+        IApiDescriptionVisibilityProvider
+    {
+        /// <inheritdoc />
+        public string GroupName { get; set; }
+
+        /// <inheritdoc />
+        public bool IgnoreApi { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Description/ApiParameterDescription.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Description/ApiParameterDescription.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNet.Mvc.ModelBinding;
+
+namespace Microsoft.AspNet.Mvc.Description
+{
+    public class ApiParameterDescription
+    {
+        public bool IsOptional { get; set; }
+
+        public ModelMetadata ModelMetadata { get; set; }
+
+        public string Name { get; set; }
+
+        public ParameterDescriptor ParameterDescriptor { get; set; }
+
+        public ApiParameterSource Source { get; set; }
+
+        public Type Type { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Description/ApiParameterSource.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Description/ApiParameterSource.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNet.Mvc.Description
+{
+    // This is a placeholder - see #886
+    public enum ApiParameterSource
+    {
+        Body,
+        Query,
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Description/ApiResponseFormat.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Description/ApiResponseFormat.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Mvc.HeaderValueAbstractions;
+
+namespace Microsoft.AspNet.Mvc.Description
+{
+    /// <summary>
+    /// Represents a possible format for the body of a response.
+    /// </summary>
+    public class ApiResponseFormat
+    {
+        /// <summary>
+        /// The formatter used to output this response.
+        /// </summary>
+        public IOutputFormatter Formatter { get; set; }
+
+        /// <summary>
+        /// The media type of the response.
+        /// </summary>
+        public MediaTypeHeaderValue MediaType { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Description/DefaultApiDescriptionProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Description/DefaultApiDescriptionProvider.cs
@@ -1,0 +1,301 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Mvc.HeaderValueAbstractions;
+using Microsoft.AspNet.Mvc.ModelBinding;
+using Microsoft.Framework.DependencyInjection;
+
+namespace Microsoft.AspNet.Mvc.Description
+{
+    /// <summary>
+    /// Implements a provider of <see cref="ApiDescription"/> for actions represented
+    /// by <see cref="ReflectedActionDescriptor"/>.
+    /// </summary>
+    public class DefaultApiDescriptionProvider : INestedProvider<ApiDescriptionProviderContext>
+    {
+        private readonly IOutputFormattersProvider _formattersProvider;
+        private readonly IModelMetadataProvider _modelMetadataProvider;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="DefaultApiDescriptionProvider"/>.
+        /// </summary>
+        /// <param name="formattersProvider">The <see cref="IOutputFormattersProvider"/>.</param>
+        /// <param name="modelMetadataProvider">The <see cref="IModelMetadataProvider"/>.</param>
+        public DefaultApiDescriptionProvider(
+            IOutputFormattersProvider formattersProvider,
+            IModelMetadataProvider modelMetadataProvider)
+        {
+            _formattersProvider = formattersProvider;
+            _modelMetadataProvider = modelMetadataProvider;
+        }
+
+        /// <inheritdoc />
+        public int Order { get; private set; }
+
+        /// <inheritdoc />
+        public void Invoke(ApiDescriptionProviderContext context, Action callNext)
+        {
+            foreach (var action in context.Actions.OfType<ReflectedActionDescriptor>())
+            {
+                var extensionData = action.GetProperty<ApiDescriptionActionData>();
+                if (extensionData != null)
+                {
+                    var httpMethods = GetHttpMethods(action);
+                    foreach (var httpMethod in httpMethods)
+                    {
+                        context.Results.Add(CreateApiDescription(action, httpMethod, extensionData.GroupName));
+                    }
+                }
+            }
+
+            callNext();
+        }
+
+        private ApiDescription CreateApiDescription(
+            ReflectedActionDescriptor action, 
+            string httpMethod, 
+            string groupName)
+        {
+            var apiDescription = new ApiDescription()
+            {
+                ActionDescriptor = action,
+                GroupName = groupName,
+                HttpMethod = httpMethod,
+                RelativePath = GetRelativePath(action),
+            };
+
+            if (action.Parameters != null)
+            {
+                foreach (var parameter in action.Parameters)
+                {
+                    apiDescription.ParameterDescriptions.Add(GetParameter(parameter));
+                }
+            }
+
+            var responseMetadataAttributes = GetResponseMetadataAttributes(action);
+
+            // We only provide response info if we can figure out a type that is a user-data type.
+            // Void /Task object/IActionResult will result in no data.
+            var declaredReturnType = GetDeclaredReturnType(action);
+
+            // Now 'simulate' an action execution. This attempts to figure out to the best of our knowledge
+            // what the logical data type is using filters.
+            var runtimeReturnType = GetRuntimeReturnType(declaredReturnType, responseMetadataAttributes);
+
+            // We might not be able to figure out a good runtime return type. If that's the case we don't
+            // provide any information about outputs. The workaround is to attribute the action.
+            if (runtimeReturnType == typeof(void))
+            {
+                // As a special case, if the return type is void - we want to surface that information
+                // specifically, but nothing else. This can be overridden with a filter/attribute.
+                apiDescription.ResponseType = runtimeReturnType;
+            }
+            else if (runtimeReturnType != null)
+            {
+                apiDescription.ResponseType = runtimeReturnType;
+
+                apiDescription.ResponseModelMetadata = _modelMetadataProvider.GetMetadataForType(
+                    modelAccessor: null, 
+                    modelType: runtimeReturnType);
+
+                var formats = GetResponseFormats(
+                    action, 
+                    responseMetadataAttributes, 
+                    declaredReturnType, 
+                    runtimeReturnType);
+
+                foreach (var format in formats)
+                {
+                    apiDescription.SupportedResponseFormats.Add(format);
+                }
+            }
+
+            return apiDescription;
+        }
+
+        private IEnumerable<string> GetHttpMethods(ReflectedActionDescriptor action)
+        {
+            if (action.MethodConstraints != null && action.MethodConstraints.Count > 0)
+            {
+                return action.MethodConstraints.SelectMany(c => c.HttpMethods);
+            }
+            else
+            {
+                return new string[] { null };
+            }
+        }
+
+        private string GetRelativePath(ReflectedActionDescriptor action)
+        {
+            // This is a placeholder for functionality which will correctly generate the relative path
+            // stub of an action. See: #885
+            if (action.AttributeRouteInfo != null &&
+                action.AttributeRouteInfo.Template != null)
+            {
+                return action.AttributeRouteInfo.Template;
+            }
+
+            return null;
+        }
+
+        private ApiParameterDescription GetParameter(ParameterDescriptor parameter)
+        {
+            // This is a placeholder based on currently available functionality for parameters. See #886.
+            var resourceParameter = new ApiParameterDescription()
+            {
+                IsOptional = parameter.IsOptional,
+                Name = parameter.Name,
+                ParameterDescriptor = parameter,
+            };
+
+            if (parameter.ParameterBindingInfo != null)
+            {
+                resourceParameter.Type = parameter.ParameterBindingInfo.ParameterType;
+                resourceParameter.Source = ApiParameterSource.Query;
+            }
+
+            if (parameter.BodyParameterInfo != null)
+            {
+                resourceParameter.Type = parameter.BodyParameterInfo.ParameterType;
+                resourceParameter.Source = ApiParameterSource.Body;
+            }
+
+            if (resourceParameter.Type != null)
+            {
+                resourceParameter.ModelMetadata = _modelMetadataProvider.GetMetadataForType(
+                    modelAccessor: null, 
+                    modelType: resourceParameter.Type);
+            }
+
+            return resourceParameter;
+        }
+
+        private IReadOnlyList<ApiResponseFormat> GetResponseFormats(
+            ReflectedActionDescriptor action,
+            IApiResponseMetadataProvider[] responseMetadataAttributes,
+            Type declaredType,
+            Type runtimeType)
+        {
+            var results = new List<ApiResponseFormat>();
+
+            // Walk through all 'filter' attributes in order, and allow each one to see or override
+            // the results of the previous ones. This is similar to the execution path for content-negotiation.
+            var contentTypes = new List<MediaTypeHeaderValue>();
+            if (responseMetadataAttributes != null)
+            {
+                foreach (var metadataAttribute in responseMetadataAttributes)
+                {
+                    metadataAttribute.SetContentTypes(contentTypes);
+                }
+            }
+
+            if (contentTypes.Count == 0)
+            {
+                contentTypes.Add(null);
+            }
+
+            var formatters = _formattersProvider.OutputFormatters;
+            foreach (var contentType in contentTypes)
+            {
+                foreach (var formatter in formatters)
+                {
+                    var supportedTypes = formatter.GetSupportedContentTypes(declaredType, runtimeType, contentType);
+                    if (supportedTypes != null)
+                    {
+                        foreach (var supportedType in supportedTypes)
+                        {
+                            results.Add(new ApiResponseFormat()
+                            {
+                                Formatter = formatter,
+                                MediaType = supportedType,
+                            });
+                        }
+                    }
+                }
+            }            
+
+            return results;
+        }
+
+        private Type GetDeclaredReturnType(ReflectedActionDescriptor action)
+        {
+            var declaredReturnType = action.MethodInfo.ReturnType;
+            if (declaredReturnType == typeof(void) ||
+                declaredReturnType == typeof(Task))
+            {
+                return typeof(void);
+            }
+
+            // Unwrap the type if it's a Task<T>. The Task (non-generic) case was already handled.
+            var unwrappedType = TypeHelper.GetTaskInnerTypeOrNull(declaredReturnType) ?? declaredReturnType;
+
+            // If the method is declared to return IActionResult or a derived class, that information
+            // isn't valuable to the formatter.
+            if (typeof(IActionResult).IsAssignableFrom(unwrappedType))
+            {
+                return null;
+            }
+            else
+            {
+                return unwrappedType;
+            }
+        }
+
+        private Type GetRuntimeReturnType(Type declaredReturnType, IApiResponseMetadataProvider[] metadataAttributes)
+        {
+            // Walk through all of the filter attributes and allow them to set the type. This will execute them
+            // in filter-order allowing the desired behavior for overriding.
+            if (metadataAttributes != null)
+            {
+                Type typeSetByAttribute = null;
+                foreach (var metadataAttribute in metadataAttributes)
+                {
+                    if (metadataAttribute.Type != null)
+                    {
+                        typeSetByAttribute = metadataAttribute.Type;
+                    }
+                }
+
+                // If one of the filters set a type, then trust it.
+                if (typeSetByAttribute != null)
+                {
+                    return typeSetByAttribute;
+                }
+            }
+
+            // If we get here, then a filter didn't give us an answer, so we need to figure out if we
+            // want to use the declared return type.
+            //
+            // We've already excluded Task, void, and IActionResult at this point.
+            //
+            // If the action might return any object, then assume we don't know anything about it.
+            if (declaredReturnType == typeof(object))
+            {
+                return null;
+            }
+
+            return declaredReturnType;
+        }
+
+        private IApiResponseMetadataProvider[] GetResponseMetadataAttributes(ReflectedActionDescriptor action)
+        {
+            if (action.FilterDescriptors == null)
+            {
+                return null;
+            }
+
+            // This technique for enumerating filters will intentionally ignore any filter that is an IFilterFactory
+            // for a filter that implements IApiResponseMetadataProvider.
+            //
+            // The workaround for that is to implement the metadata interface on the IFilterFactory.
+            return action.FilterDescriptors
+                .Select(fd => fd.Filter)
+                .OfType<IApiResponseMetadataProvider>()
+                .ToArray();
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Description/IApiDescriptionGroupCollectionProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Description/IApiDescriptionGroupCollectionProvider.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNet.Mvc.Description
+{
+    /// <summary>
+    /// Provides access to a collection of <see cref="ApiDescriptionGroup"/>.
+    /// </summary>
+    public interface IApiDescriptionGroupCollectionProvider
+    {
+        /// <summary>
+        /// Gets a collection of <see cref="ApiDescriptionGroup"/>.
+        /// </summary>
+        ApiDescriptionGroupCollection ApiDescriptionGroups { get; }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Description/IApiDescriptionGroupNameProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Description/IApiDescriptionGroupNameProvider.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNet.Mvc.Description
+{
+    /// <summary>
+    /// Represents group name metadata for an <see cref="ApiDescription"/>.
+    /// </summary>
+    public interface IApiDescriptionGroupNameProvider
+    {
+        /// <summary>
+        /// The group name for the <see cref="ApiDescription"/> of the associated action or controller.
+        /// </summary>
+        string GroupName { get; }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Description/IApiDescriptionVisibilityProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Description/IApiDescriptionVisibilityProvider.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNet.Mvc.Description
+{
+    /// <summary>
+    /// Represents visibility metadata for an <see cref="ApiDescription"/>.
+    /// </summary>
+    public interface IApiDescriptionVisibilityProvider
+    {
+        /// <summary>
+        /// If <c>false</c> then no <see cref="ApiDescription"/> objects will be created for the associated controller
+        /// or action.
+        /// </summary>
+        bool IgnoreApi { get; }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Description/IApiResponseMetadataProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Description/IApiResponseMetadataProvider.cs
@@ -5,21 +5,21 @@ using System;
 using System.Collections.Generic;
 using Microsoft.AspNet.Mvc.HeaderValueAbstractions;
 
-namespace Microsoft.AspNet.Mvc
+namespace Microsoft.AspNet.Mvc.Description
 {
     /// <summary>
     /// Provides a return type and a set of possible content types returned by a successful execution of the action.
     /// </summary>
-    public interface IProducesMetadataProvider
+    public interface IApiResponseMetadataProvider
     {
         /// <summary>
         /// Optimistic return type of the action.
         /// </summary>
-        Type Type { get; set; }
+        Type Type { get; }
 
         /// <summary>
-        /// A collection of allowed content types which can be produced by the action.
+        /// Configures a collection of allowed content types which can be produced by the action.
         /// </summary>
-        IList<MediaTypeHeaderValue> ContentTypes { get; set; }
+        void SetContentTypes(IList<MediaTypeHeaderValue> contentTypes);
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/Filters/ProducesAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Filters/ProducesAttribute.cs
@@ -3,8 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using Microsoft.AspNet.Mvc.Core;
+using Microsoft.AspNet.Mvc.Description;
 using Microsoft.AspNet.Mvc.HeaderValueAbstractions;
 
 namespace Microsoft.AspNet.Mvc
@@ -14,7 +13,7 @@ namespace Microsoft.AspNet.Mvc
     /// which can be used to select a formatter while executing <see cref="ObjectResult"/>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
-    public class ProducesAttribute : ResultFilterAttribute, IProducesMetadataProvider
+    public class ProducesAttribute : ResultFilterAttribute, IApiResponseMetadataProvider
     {
         public ProducesAttribute(string contentType, params string[] additionalContentTypes)
         {
@@ -32,7 +31,7 @@ namespace Microsoft.AspNet.Mvc
 
             if (objectResult != null)
             {
-                objectResult.ContentTypes = ContentTypes;
+                SetContentTypes(objectResult.ContentTypes);
             }
         }
 
@@ -47,6 +46,15 @@ namespace Microsoft.AspNet.Mvc
             }
 
             return contentTypes;
+        }
+
+        public void SetContentTypes(IList<MediaTypeHeaderValue> contentTypes)
+        {
+            contentTypes.Clear();
+            foreach (var contentType in ContentTypes)
+            {
+                contentTypes.Add(contentType);
+            }
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ReflectedActionDescriptorProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ReflectedActionDescriptorProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNet.Mvc.Core;
+using Microsoft.AspNet.Mvc.Description;
 using Microsoft.AspNet.Mvc.Filters;
 using Microsoft.AspNet.Mvc.ReflectedModelBuilder;
 using Microsoft.AspNet.Mvc.Routing;
@@ -143,6 +144,7 @@ namespace Microsoft.AspNet.Mvc
 
                     foreach (var actionDescriptor in actionDescriptors)
                     {
+                        AddApiExplorerInfo(actionDescriptor, action, controller);
                         AddActionFilters(actionDescriptor, action.Filters, controller.Filters, model.Filters);
                         AddActionConstraints(actionDescriptor, action, controller);
                         AddControllerRouteConstraints(
@@ -345,6 +347,23 @@ namespace Microsoft.AspNet.Mvc
                 action.ActionMethod.Name);
 
             return actionDescriptor;
+        }
+
+        private static void AddApiExplorerInfo(
+            ReflectedActionDescriptor actionDescriptor,
+            ReflectedActionModel action, 
+            ReflectedControllerModel controller)
+        {
+            var apiExplorerIsVisible = action.ApiExplorerIsVisible ?? controller.ApiExplorerIsVisible ?? false;
+            if (apiExplorerIsVisible)
+            {
+                var apiExplorerActionData = new ApiDescriptionActionData()
+                {
+                    GroupName = action.ApiExplorerGroupName ?? controller.ApiExplorerGroupName,
+                };  
+
+                actionDescriptor.SetProperty(apiExplorerActionData);
+            }
         }
 
         private static void AddActionFilters(

--- a/src/Microsoft.AspNet.Mvc.Core/ReflectedModelBuilder/ReflectedActionModel.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ReflectedModelBuilder/ReflectedActionModel.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Microsoft.AspNet.Mvc.Description;
 using Microsoft.AspNet.Mvc.Routing;
 
 namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder
@@ -28,6 +29,18 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder
                 AttributeRouteModel = new ReflectedAttributeRouteModel(routeTemplateAttribute);
             }
 
+            var apiExplorerNameAttribute = Attributes.OfType<IApiDescriptionGroupNameProvider>().FirstOrDefault();
+            if (apiExplorerNameAttribute != null)
+            {
+                ApiExplorerGroupName = apiExplorerNameAttribute.GroupName;
+            }
+
+            var apiExplorerVisibilityAttribute = Attributes.OfType<IApiDescriptionVisibilityProvider>().FirstOrDefault();
+            if (apiExplorerVisibilityAttribute != null)
+            {
+                ApiExplorerIsVisible = !apiExplorerVisibilityAttribute.IgnoreApi;
+            }
+
             HttpMethods = new List<string>();
             Parameters = new List<ReflectedParameterModel>();
         }
@@ -47,5 +60,18 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder
         public List<ReflectedParameterModel> Parameters { get; private set; }
 
         public ReflectedAttributeRouteModel AttributeRouteModel { get; set; }
+
+        /// <summary>
+        /// If <c>true</c>, <see cref="ApiDescription"/> objects will be created for this action. If <c>null</c>
+        /// then the value of <see cref="ReflectedControllerModel.ApiExplorerIsVisible"/> will be used.
+        /// </summary>
+        public bool? ApiExplorerIsVisible { get; set; }
+
+        /// <summary>
+        /// The value for <see cref="ApiDescription.GroupName"/> of <see cref="ApiDescription"/> objects created
+        /// for actions defined by this controller. If <c>null</c> then the value of 
+        /// <see cref="ReflectedControllerModel.ApiExplorerGroupName"/> will be used.
+        /// </summary>
+        public string ApiExplorerGroupName { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ReflectedModelBuilder/ReflectedControllerModel.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ReflectedModelBuilder/ReflectedControllerModel.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Microsoft.AspNet.Mvc.Description;
 using Microsoft.AspNet.Mvc.Routing;
 
 namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder
@@ -31,6 +32,18 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder
                 .Select(rtp => new ReflectedAttributeRouteModel(rtp))
                 .ToList();
 
+            var apiExplorerNameAttribute = Attributes.OfType<IApiDescriptionGroupNameProvider>().FirstOrDefault();
+            if (apiExplorerNameAttribute != null)
+            {
+                ApiExplorerGroupName = apiExplorerNameAttribute.GroupName;
+            }
+
+            var apiExplorerVisibilityAttribute = Attributes.OfType<IApiDescriptionVisibilityProvider>().FirstOrDefault();
+            if (apiExplorerVisibilityAttribute != null)
+            {
+                ApiExplorerIsVisible = !apiExplorerVisibilityAttribute.IgnoreApi;
+            }
+
             ControllerName = controllerType.Name.EndsWith("Controller", StringComparison.Ordinal)
                         ? controllerType.Name.Substring(0, controllerType.Name.Length - "Controller".Length)
                         : controllerType.Name;
@@ -49,5 +62,17 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder
         public List<RouteConstraintAttribute> RouteConstraints { get; private set; }
 
         public List<ReflectedAttributeRouteModel> AttributeRoutes { get; private set; }
+
+        /// <summary>
+        /// If <c>true</c>, <see cref="ApiDescription"/> objects will be created for actions defined by this 
+        /// controller. 
+        /// </summary>
+        public bool? ApiExplorerIsVisible { get; set; }
+
+        /// <summary>
+        /// The value for <see cref="ApiDescription.GroupName"/> of <see cref="ApiDescription"/> objects created
+        /// for actions defined by this controller.
+        /// </summary>
+        public string ApiExplorerGroupName { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc/MvcServices.cs
+++ b/src/Microsoft.AspNet.Mvc/MvcServices.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using Microsoft.AspNet.Mvc.Core;
+using Microsoft.AspNet.Mvc.Description;
 using Microsoft.AspNet.Mvc.Filters;
 using Microsoft.AspNet.Mvc.Internal;
 using Microsoft.AspNet.Mvc.ModelBinding;
@@ -102,6 +103,11 @@ namespace Microsoft.AspNet.Mvc
             yield return describe.Singleton<AntiForgery, AntiForgery>();
             yield return describe.Singleton<IAntiForgeryAdditionalDataProvider,
                 DefaultAntiForgeryAdditionalDataProvider>();
+
+            yield return describe.Singleton<IApiDescriptionGroupCollectionProvider,
+                ApiDescriptionGroupCollectionProvider>();
+            yield return describe.Transient<INestedProvider<ApiDescriptionProviderContext>, 
+                DefaultApiDescriptionProvider>();
 
             yield return
                describe.Describe(

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Description/DefaultApiDescriptionProviderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Description/DefaultApiDescriptionProviderTest.cs
@@ -1,0 +1,508 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Mvc.HeaderValueAbstractions;
+using Microsoft.AspNet.Mvc.ModelBinding;
+using Microsoft.AspNet.Mvc.Routing;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNet.Mvc.Description
+{
+    public class DefaultApiDescriptionProviderTest
+    {
+        [Fact]
+        public void GetApiDescription_IgnoresNonReflectedActionDescriptor()
+        {
+            // Arrange
+            var action = new ActionDescriptor();
+            action.SetProperty(new ApiDescriptionActionData());
+
+            // Act
+            var descriptions = GetApiDescriptions(action);
+
+            // Assert
+            Assert.Empty(descriptions);
+        }
+
+        [Fact]
+        public void GetApiDescription_IgnoresActionWithoutApiExplorerData()
+        {
+            // Arrange
+            var action = new ReflectedActionDescriptor();
+
+            // Act
+            var descriptions = GetApiDescriptions(action);
+
+            // Assert
+            Assert.Empty(descriptions);
+        }
+
+        [Fact]
+        public void GetApiDescription_PopulatesActionDescriptor()
+        {
+            // Arrange
+            var action = CreateActionDescriptor();
+
+            // Act
+            var descriptions = GetApiDescriptions(action);
+
+            // Assert
+            var description = Assert.Single(descriptions);
+            Assert.Same(action, description.ActionDescriptor);
+        }
+
+        [Fact]
+        public void GetApiDescription_PopulatesGroupName()
+        {
+            // Arrange
+            var action = CreateActionDescriptor();
+            action.GetProperty<ApiDescriptionActionData>().GroupName = "Customers";
+
+            // Act
+            var descriptions = GetApiDescriptions(action);
+
+            // Assert
+            var description = Assert.Single(descriptions);
+            Assert.Equal("Customers", description.GroupName);
+        }
+
+        [Fact]
+        public void GetApiDescription_HttpMethodIsNullWithoutConstraint()
+        {
+            // Arrange
+            var action = CreateActionDescriptor();
+
+            // Act
+            var descriptions = GetApiDescriptions(action);
+
+            // Assert
+            var description = Assert.Single(descriptions);
+            Assert.Null(description.HttpMethod);
+        }
+
+
+        [Fact]
+        public void GetApiDescription_CreatesMultipleDescriptionsForMultipleHttpMethods()
+        {
+            // Arrange
+            var action = CreateActionDescriptor();
+            action.MethodConstraints = new List<HttpMethodConstraint>()
+            {
+                new HttpMethodConstraint(new string[] { "PUT", "POST" }),
+                new HttpMethodConstraint(new string[] { "GET" }),
+            };
+
+            // Act
+            var descriptions = GetApiDescriptions(action);
+
+            // Assert
+            Assert.Equal(3, descriptions.Count);
+
+            Assert.Single(descriptions, d => d.HttpMethod == "PUT");
+            Assert.Single(descriptions, d => d.HttpMethod == "POST");
+            Assert.Single(descriptions, d => d.HttpMethod == "GET");
+        }
+
+        // This is a test for the placeholder behavior - see #886
+        [Fact]
+        public void GetApiDescription_PopulatesParameters()
+        {
+            // Arrange
+            var action = CreateActionDescriptor();
+            action.Parameters = new List<ParameterDescriptor>()
+            {
+                new ParameterDescriptor()
+                {
+                    Name = "id",
+                    IsOptional = true,
+                    ParameterBindingInfo = new ParameterBindingInfo("id", typeof(int)),
+                },
+                new ParameterDescriptor()
+                {
+                    Name = "username",
+                    BodyParameterInfo = new BodyParameterInfo(typeof(string)),
+                }
+            };
+
+            // Act
+            var descriptions = GetApiDescriptions(action);
+
+            // Assert
+            var description = Assert.Single(descriptions);
+            Assert.Equal(2, description.ParameterDescriptions.Count);
+
+            var id = Assert.Single(description.ParameterDescriptions, p => p.Name == "id");
+            Assert.NotNull(id.ModelMetadata);
+            Assert.True(id.IsOptional);
+            Assert.Same(action.Parameters[0], id.ParameterDescriptor);
+            Assert.Equal(ApiParameterSource.Query, id.Source);
+            Assert.Equal(typeof(int), id.Type);
+
+            var username = Assert.Single(description.ParameterDescriptions, p => p.Name == "username");
+            Assert.NotNull(username.ModelMetadata);
+            Assert.False(username.IsOptional);
+            Assert.Same(action.Parameters[1], username.ParameterDescriptor);
+            Assert.Equal(ApiParameterSource.Body, username.Source);
+            Assert.Equal(typeof(string), username.Type);
+        }
+
+        // This is a placeholder based on current functionality - see #885
+        [Fact]
+        public void GetApiDescription_PopluatesRelativePath()
+        {
+            // Arrange
+            var action = CreateActionDescriptor();
+            action.AttributeRouteInfo = new AttributeRouteInfo();
+            action.AttributeRouteInfo.Template = "api/Products/{id}";
+
+            // Act
+            var descriptions = GetApiDescriptions(action);
+
+            // Assert
+            var description = Assert.Single(descriptions);
+            Assert.Equal("api/Products/{id}", description.RelativePath);
+        }
+
+        [Fact]
+        public void GetApiDescription_PopluatesResponseType_WithProduct()
+        {
+            // Arrange
+            var action = CreateActionDescriptor(nameof(ReturnsProduct));
+
+            // Act
+            var descriptions = GetApiDescriptions(action);
+
+            // Assert
+            var description = Assert.Single(descriptions);
+            Assert.Equal(typeof(Product), description.ResponseType);
+            Assert.NotNull(description.ResponseModelMetadata);
+        }
+
+        [Fact]
+        public void GetApiDescription_PopluatesResponseType_WithTaskOfProduct()
+        {
+            // Arrange
+            var action = CreateActionDescriptor(nameof(ReturnsTaskOfProduct));
+
+            // Act
+            var descriptions = GetApiDescriptions(action);
+
+            // Assert
+            var description = Assert.Single(descriptions);
+            Assert.Equal(typeof(Product), description.ResponseType);
+            Assert.NotNull(description.ResponseModelMetadata);
+        }
+
+        [Theory]
+        [InlineData(nameof(ReturnsObject))]
+        [InlineData(nameof(ReturnsActionResult))]
+        [InlineData(nameof(ReturnsJsonResult))]
+        [InlineData(nameof(ReturnsTaskOfObject))]
+        [InlineData(nameof(ReturnsTaskOfActionResult))]
+        [InlineData(nameof(ReturnsTaskOfJsonResult))]
+        public void GetApiDescription_DoesNotPopluatesResponseInformation_WhenUnknown(string methodName)
+        {
+            // Arrange
+            var action = CreateActionDescriptor(methodName);
+
+            // Act
+            var descriptions = GetApiDescriptions(action);
+
+            // Assert
+            var description = Assert.Single(descriptions);
+            Assert.Null(description.ResponseType);
+            Assert.Null(description.ResponseModelMetadata);
+            Assert.Empty(description.SupportedResponseFormats);
+        }
+
+        [Theory]
+        [InlineData(nameof(ReturnsVoid))]
+        [InlineData(nameof(ReturnsTask))]
+        public void GetApiDescription_DoesNotPopluatesResponseInformation_WhenVoid(string methodName)
+        {
+            // Arrange
+            var action = CreateActionDescriptor(methodName);
+
+            // Act
+            var descriptions = GetApiDescriptions(action);
+
+            // Assert
+            var description = Assert.Single(descriptions);
+            Assert.Equal(typeof(void), description.ResponseType);
+            Assert.Null(description.ResponseModelMetadata);
+            Assert.Empty(description.SupportedResponseFormats);
+        }
+
+        [Theory]
+        [InlineData(nameof(ReturnsObject))]
+        [InlineData(nameof(ReturnsVoid))]
+        [InlineData(nameof(ReturnsActionResult))]
+        [InlineData(nameof(ReturnsJsonResult))]
+        [InlineData(nameof(ReturnsTaskOfObject))]
+        [InlineData(nameof(ReturnsTask))]
+        [InlineData(nameof(ReturnsTaskOfActionResult))]
+        [InlineData(nameof(ReturnsTaskOfJsonResult))]
+        public void GetApiDescription_PopluatesResponseInformation_WhenSetByFilter(string methodName)
+        {
+            // Arrange
+            var action = CreateActionDescriptor(methodName);
+            var filter = new ContentTypeAttribute("text/*")
+            {
+                Type = typeof(Order)
+            };
+
+            action.FilterDescriptors = new List<FilterDescriptor>();
+            action.FilterDescriptors.Add(new FilterDescriptor(filter, FilterScope.Action));
+
+            // Act
+            var descriptions = GetApiDescriptions(action);
+
+            // Assert
+            var description = Assert.Single(descriptions);
+            Assert.Equal(typeof(Order), description.ResponseType);
+            Assert.NotNull(description.ResponseModelMetadata);
+        }
+
+        [Fact]
+        public void GetApiDescription_IncludesResponseFormats()
+        {
+            // Arrange
+            var action = CreateActionDescriptor(nameof(ReturnsProduct));
+
+            // Act
+            var descriptions = GetApiDescriptions(action);
+
+            // Assert
+            var description = Assert.Single(descriptions);
+            Assert.Equal(4, description.SupportedResponseFormats.Count);
+
+            var formats = description.SupportedResponseFormats;
+            Assert.Single(formats, f => f.MediaType.RawValue == "text/json");
+            Assert.Single(formats, f => f.MediaType.RawValue == "application/json");
+            Assert.Single(formats, f => f.MediaType.RawValue == "text/xml");
+            Assert.Single(formats, f => f.MediaType.RawValue == "application/xml");
+        }
+
+        [Fact]
+        public void GetApiDescription_IncludesResponseFormats_FilteredByAttribute()
+        {
+            // Arrange
+            var action = CreateActionDescriptor(nameof(ReturnsProduct));
+
+            action.FilterDescriptors = new List<FilterDescriptor>();
+            action.FilterDescriptors.Add(new FilterDescriptor(new ContentTypeAttribute("text/*"), FilterScope.Action));
+
+            // Act
+            var descriptions = GetApiDescriptions(action);
+
+            // Assert
+            var description = Assert.Single(descriptions);
+            Assert.Equal(2, description.SupportedResponseFormats.Count);
+
+            var formats = description.SupportedResponseFormats;
+            Assert.Single(formats, f => f.MediaType.RawValue == "text/json");
+            Assert.Single(formats, f => f.MediaType.RawValue == "text/xml");
+        }
+
+        [Fact]
+        public void GetApiDescription_IncludesResponseFormats_FilteredByType()
+        {
+            // Arrange
+            var action = CreateActionDescriptor(nameof(ReturnsObject));
+            var filter = new ContentTypeAttribute("text/*")
+            {
+                Type = typeof(Order)
+            };
+
+            action.FilterDescriptors = new List<FilterDescriptor>();
+            action.FilterDescriptors.Add(new FilterDescriptor(filter, FilterScope.Action));
+
+            var formatters = CreateFormatters();
+            
+            // This will just format Order
+            formatters[0].SupportedTypes.Add(typeof(Order));
+
+            // This will just format Product
+            formatters[1].SupportedTypes.Add(typeof(Product));
+
+            // Act
+            var descriptions = GetApiDescriptions(action, formatters);
+
+            // Assert
+            var description = Assert.Single(descriptions);
+            Assert.Equal(1, description.SupportedResponseFormats.Count);
+            Assert.Equal(typeof(Order), description.ResponseType);
+            Assert.NotNull(description.ResponseModelMetadata);
+
+            var formats = description.SupportedResponseFormats;
+            Assert.Single(formats, f => f.MediaType.RawValue == "text/json");
+            Assert.Same(formatters[0], formats[0].Formatter);
+        }
+
+        private IReadOnlyList<ApiDescription> GetApiDescriptions(ActionDescriptor action)
+        {
+            return GetApiDescriptions(action, CreateFormatters());
+        }
+
+        private IReadOnlyList<ApiDescription> GetApiDescriptions(ActionDescriptor action, List<MockFormatter> formatters)
+        {
+            var context = new ApiDescriptionProviderContext(new ActionDescriptor[] { action });
+
+            var formattersProvider = new Mock<IOutputFormattersProvider>(MockBehavior.Strict);
+            formattersProvider.Setup(fp => fp.OutputFormatters).Returns(formatters);
+
+            var modelMetadataProvider = new Mock<IModelMetadataProvider>(MockBehavior.Strict);
+            modelMetadataProvider
+                .Setup(mmp => mmp.GetMetadataForType(null, It.IsAny<Type>()))
+                .Returns((Func<object> accessor, Type type) =>
+                {
+                    return new ModelMetadata(modelMetadataProvider.Object, null, accessor, type, null);
+                });
+
+            var provider = new DefaultApiDescriptionProvider(formattersProvider.Object, modelMetadataProvider.Object);
+            provider.Invoke(context, () => { });
+            return context.Results;
+        }
+
+        private List<MockFormatter> CreateFormatters()
+        {
+            // Include some default formatters that look reasonable, some tests will override this.
+            var formatters = new List<MockFormatter>()
+            {
+                new MockFormatter(),
+                new MockFormatter(),
+            };
+
+            formatters[0].SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/json"));
+            formatters[0].SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("text/json"));
+
+            formatters[1].SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/xml"));
+            formatters[1].SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("text/xml"));
+
+            return formatters;
+        }
+
+        private ReflectedActionDescriptor CreateActionDescriptor(string methodName = null)
+        {
+            var action = new ReflectedActionDescriptor();
+            action.SetProperty(new ApiDescriptionActionData());
+
+            action.MethodInfo = GetType().GetMethod(
+                methodName ?? "ReturnsObject",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+
+
+            return action;
+        }
+
+        private object ReturnsObject()
+        {
+            return null;
+        }
+
+        private void ReturnsVoid()
+        {
+
+        }
+
+        private IActionResult ReturnsActionResult()
+        {
+            return null;
+        }
+
+        private JsonResult ReturnsJsonResult()
+        {
+            return null;
+        }
+
+        private Task<Product> ReturnsTaskOfProduct()
+        {
+            return null;
+        }
+
+        private Task<object> ReturnsTaskOfObject()
+        {
+            return null;
+        }
+
+        private Task ReturnsTask()
+        {
+            return null;
+        }
+
+        private Task<IActionResult> ReturnsTaskOfActionResult()
+        {
+            return null;
+        }
+
+        private Task<JsonResult> ReturnsTaskOfJsonResult()
+        {
+            return null;
+        }
+
+        private Product ReturnsProduct()
+        {
+            return null;
+        }
+
+        private class Product
+        {
+        }
+
+        private class Order
+        {
+        }
+
+        private class MockFormatter : OutputFormatter
+        {
+            public List<Type> SupportedTypes { get; } = new List<Type>();
+
+            public override Task WriteResponseBodyAsync(OutputFormatterContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            protected override bool CanWriteType(Type declaredType, Type actualType)
+            {
+                if (SupportedTypes.Count == 0)
+                {
+                    return true;
+                }
+                else if ((actualType ?? declaredType) == null)
+                {
+                    return false;
+                }
+                else
+                {
+                    return SupportedTypes.Contains(actualType ?? declaredType);
+                }
+            }
+        }
+
+        private class ContentTypeAttribute : Attribute, IFilter, IApiResponseMetadataProvider
+        {
+            public ContentTypeAttribute(string mediaType)
+            {
+                ContentTypes.Add(MediaTypeHeaderValue.Parse(mediaType));
+            }
+
+            public List<MediaTypeHeaderValue> ContentTypes { get; } = new List<MediaTypeHeaderValue>();
+
+            public Type Type { get; set; }
+
+            public void SetContentTypes(IList<MediaTypeHeaderValue> contentTypes)
+            {
+                contentTypes.Clear();
+                foreach (var contentType in ContentTypes)
+                {
+                    contentTypes.Add(contentType);
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ReflectedModelBuilder/ReflectedActionModelTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ReflectedModelBuilder/ReflectedActionModelTests.cs
@@ -38,6 +38,34 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder.Test
             Assert.IsType<MyFilterAttribute>(model.Filters[0]);
         }
 
+        [Fact]
+        public void ReflectedActionModel_PopulatesApiExplorerInfo()
+        {
+            // Arrange
+            var actionMethod = typeof(BlogController).GetMethod("Create");
+
+            // Act
+            var model = new ReflectedActionModel(actionMethod);
+
+            // Assert
+            Assert.Equal(false, model.ApiExplorerIsVisible);
+            Assert.Equal("Blog", model.ApiExplorerGroupName);
+        }
+
+        [Fact]
+        public void ReflectedActionModel_PopulatesApiExplorerInfo_NoAttribute()
+        {
+            // Arrange
+            var actionMethod = typeof(BlogController).GetMethod("Edit");
+
+            // Act
+            var model = new ReflectedActionModel(actionMethod);
+
+            // Assert
+            Assert.Null(model.ApiExplorerIsVisible);
+            Assert.Null(model.ApiExplorerGroupName);
+        }
+
         private class BlogController
         {
             [MyOther]
@@ -45,6 +73,12 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder.Test
             [HttpGet("Edit")]
             public void Edit()
             {
+            }
+
+            [ApiExplorerSettings(IgnoreApi = true, GroupName = "Blog")]
+            public void Create()
+            {
+
             }
         }
 

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ReflectedModelBuilder/ReflectedControllerModelTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ReflectedModelBuilder/ReflectedControllerModelTests.cs
@@ -20,11 +20,12 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder.Test
             var model = new ReflectedControllerModel(controllerType.GetTypeInfo());
 
             // Assert
-            Assert.Equal(5, model.Attributes.Count);
+            Assert.Equal(6, model.Attributes.Count);
 
             Assert.Single(model.Attributes, a => a is MyOtherAttribute);
             Assert.Single(model.Attributes, a => a is MyFilterAttribute);
             Assert.Single(model.Attributes, a => a is MyRouteConstraintAttribute);
+            Assert.Single(model.Attributes, a => a is ApiExplorerSettingsAttribute);
 
             var routes = model.Attributes.OfType<RouteAttribute>().ToList();
             Assert.Equal(2, routes.Count());
@@ -102,17 +103,70 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder.Test
             Assert.Single(model.AttributeRoutes, r => r.Template.Equals("Microblog"));
         }
 
+        [Fact]
+        public void ReflectedControllerModel_PopulatesApiExplorerInfo()
+        {
+            // Arrange
+            var controllerType = typeof(BlogController);
+
+            // Act
+            var model = new ReflectedControllerModel(controllerType.GetTypeInfo());
+
+            // Assert
+            Assert.Equal(true, model.ApiExplorerIsVisible);
+            Assert.Equal("Blog", model.ApiExplorerGroupName);
+        }
+
+        [Fact]
+        public void ReflectedControllerModel_PopulatesApiExplorerInfo_Inherited()
+        {
+            // Arrange
+            var controllerType = typeof(DerivedController);
+
+            // Act
+            var model = new ReflectedControllerModel(controllerType.GetTypeInfo());
+
+            // Assert
+            Assert.Equal(true, model.ApiExplorerIsVisible);
+            Assert.Equal("API", model.ApiExplorerGroupName);
+        }
+
+        [Fact]
+        public void ReflectedControllerModel_PopulatesApiExplorerInfo_NoAttribute()
+        {
+            // Arrange
+            var controllerType = typeof(Store);
+
+            // Act
+            var model = new ReflectedControllerModel(controllerType.GetTypeInfo());
+
+            // Assert
+            Assert.Null(model.ApiExplorerIsVisible);
+            Assert.Null(model.ApiExplorerGroupName);
+        }
+
         [MyOther]
         [MyFilter]
         [MyRouteConstraint]
         [Route("Blog")]
         [Route("Microblog")]
+        [ApiExplorerSettings(GroupName = "Blog")]
         private class BlogController
         {
         }
 
         private class Store
         {
+        }
+
+        private class DerivedController : BaseController
+        {
+        }
+
+        [ApiExplorerSettings(GroupName = "API")]
+        private class BaseController
+        {
+
         }
 
         private class MyRouteConstraintAttribute : RouteConstraintAttribute


### PR DESCRIPTION
Adds ApiExplorer to MVC and some new plumbing through action descriptors to share arbitrary data.

ApiExplorer produces a set of `ApiDescription` objects for each action that is _visible_. 
- `ApiDescription` maps to a specific HTTP verb - or all verbs if there is no restriction
- There can be multiple per action based on routes and verbs
- Includes data about formatters, content-types, parameters

Visibility and Group Name for an `ApiDescription` can be configured right now using an attribute, and using reflected model. The default is _not visible_. Working on a fluent API for simplifying this process in startup, but it will come as a separate workitem.

There's a number of things are **are not** included in this work item
- Providing access to user-written doc comments
- Full implementation of the URL part
- Full implementation of the parameter part

ApiExplorer shares a number of implementation characteristics with the `ActionDescriptor` provider pipeline
- The collection of `ApiDescription` is cached, lazy and versioning
- `ApiDescription` objects are produced by an `INestedProvider<>` pipeline
- We only produce them for our _default_ `ReflectedActionDescriptor` objects.

The other new thing that's here is an arbitrary metadata mechanism for data that's associated with an AD, but not used for any execution details. I did the same on the `ApiDescription` which has serious need for a _add your framework-specific data here_ concept.
