### PR TITLE
[Fixes #739] Attribute Routing: Multiple routes per-action

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/AcceptVerbsAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/AcceptVerbsAttribute.cs
@@ -4,16 +4,18 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.AspNet.Mvc.Routing;
 
 namespace Microsoft.AspNet.Mvc
 {
     /// <summary>
     /// Specifies what HTTP methods an action supports.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
-    public sealed class AcceptVerbsAttribute : Attribute, IActionHttpMethodProvider
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+    public sealed class AcceptVerbsAttribute : Attribute, IActionHttpMethodProvider, IRouteTemplateProvider
     {
         private readonly IEnumerable<string> _httpMethods;
+        private int? _order;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AcceptVerbsAttribute" /> class.
@@ -45,5 +47,40 @@ namespace Microsoft.AspNet.Mvc
                 return _httpMethods;
             }
         }
+
+        /// <summary>
+        /// The route template. May be null.
+        /// </summary>
+        public string Route { get; set; }
+
+        /// <inheritdoc />
+        string IRouteTemplateProvider.Template
+        {
+            get { return Route; }
+        }
+
+        /// <summary>
+        /// Gets the route order. The order determines the order of route execution. Routes with a lower
+        /// order value are tried first. When a route doesn't specify a value, it gets the value of the
+        /// <see cref="RouteAttribute.Order"/> or a default value of 0 if the <see cref="RouteAttribute"/>
+        /// doesn't define a value on the controller.
+        /// </summary>
+        public int Order
+        {
+            get { return _order ?? 0; }
+            set { _order = value; }
+        }
+
+        /// <inheritdoc />
+        int? IRouteTemplateProvider.Order
+        {
+            get
+            {
+                return _order;
+            }
+        }
+
+        /// <inheritdoc />
+        public string Name { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ActionConvention.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionConvention.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using Microsoft.AspNet.Mvc.Routing;
 
 namespace Microsoft.AspNet.Mvc
 {
@@ -9,6 +10,7 @@ namespace Microsoft.AspNet.Mvc
     {
         public string ActionName { get; set; }
         public string[] HttpMethods { get; set; }
+        public IRouteTemplateProvider AttributeRoute { get; set; }
         public bool RequireActionNameMatch { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/HttpMethodAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/HttpMethodAttribute.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNet.Mvc
     /// <summary>
     /// Identifies an action that only supports a given set of HTTP methods.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
     public abstract class HttpMethodAttribute : Attribute, IActionHttpMethodProvider, IRouteTemplateProvider
     {
         private int? _order;

--- a/src/Microsoft.AspNet.Mvc.Core/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Properties/Resources.Designer.cs
@@ -1354,6 +1354,86 @@ namespace Microsoft.AspNet.Mvc.Core
             return string.Format(CultureInfo.CurrentCulture, GetString("AttributeRoute_AggregateErrorMessage_ErrorNumber"), p0, p1, p2);
         }
 
+        /// <summary>
+        /// A method '{0}' that defines attribute routed actions must not have attributes that implement '{1}' and do not implement '{2}':{3}{4}
+        /// </summary>
+        internal static string AttributeRoute_InvalidHttpConstraints
+        {
+            get { return GetString("AttributeRoute_InvalidHttpConstraints"); }
+        }
+
+        /// <summary>
+        /// A method '{0}' that defines attribute routed actions must not have attributes that implement '{1}' and do not implement '{2}':{3}{4}
+        /// </summary>
+        internal static string FormatAttributeRoute_InvalidHttpConstraints(object p0, object p1, object p2, object p3, object p4)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("AttributeRoute_InvalidHttpConstraints"), p0, p1, p2, p3, p4);
+        }
+
+        /// <summary>
+        /// Action '{0}' with route template '{1}' has '{2}' invalid '{3}' attributes.
+        /// </summary>
+        internal static string AttributeRoute_InvalidHttpConstraints_Item
+        {
+            get { return GetString("AttributeRoute_InvalidHttpConstraints_Item"); }
+        }
+
+        /// <summary>
+        /// Action '{0}' with route template '{1}' has '{2}' invalid '{3}' attributes.
+        /// </summary>
+        internal static string FormatAttributeRoute_InvalidHttpConstraints_Item(object p0, object p1, object p2, object p3)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("AttributeRoute_InvalidHttpConstraints_Item"), p0, p1, p2, p3);
+        }
+
+        /// <summary>
+        /// A method '{0}' must not define attribute routed actions and non attribute routed actions at the same time:{1}{2}
+        /// </summary>
+        internal static string AttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod
+        {
+            get { return GetString("AttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod"); }
+        }
+
+        /// <summary>
+        /// A method '{0}' must not define attribute routed actions and non attribute routed actions at the same time:{1}{2}
+        /// </summary>
+        internal static string FormatAttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod(object p0, object p1, object p2)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("AttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod"), p0, p1, p2);
+        }
+
+        /// <summary>
+        /// Action: '{0}' - Template: '{1}'
+        /// </summary>
+        internal static string AttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod_Item
+        {
+            get { return GetString("AttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod_Item"); }
+        }
+
+        /// <summary>
+        /// Action: '{0}' - Template: '{1}'
+        /// </summary>
+        internal static string FormatAttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod_Item(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("AttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod_Item"), p0, p1);
+        }
+
+        /// <summary>
+        /// (none)
+        /// </summary>
+        internal static string AttributeRoute_NullTemplateRepresentation
+        {
+            get { return GetString("AttributeRoute_NullTemplateRepresentation"); }
+        }
+
+        /// <summary>
+        /// (none)
+        /// </summary>
+        internal static string FormatAttributeRoute_NullTemplateRepresentation()
+        {
+            return GetString("AttributeRoute_NullTemplateRepresentation");
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNet.Mvc.Core/ReflectedModelBuilder/ReflectedActionModel.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ReflectedModelBuilder/ReflectedActionModel.cs
@@ -19,13 +19,6 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder
             Attributes = actionMethod.GetCustomAttributes(inherit: true).OfType<object>().ToList();
 
             Filters = Attributes.OfType<IFilter>().ToList();
-
-            var routeTemplateAttribute = Attributes.OfType<IRouteTemplateProvider>().FirstOrDefault();
-            if (routeTemplateAttribute != null)
-            {
-                AttributeRouteModel = new ReflectedAttributeRouteModel(routeTemplateAttribute);
-            }
-
             HttpMethods = new List<string>();
             Parameters = new List<ReflectedParameterModel>();
         }

--- a/src/Microsoft.AspNet.Mvc.Core/ReflectedModelBuilder/ReflectedAttributeRouteModel.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ReflectedModelBuilder/ReflectedAttributeRouteModel.cs
@@ -30,6 +30,15 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder
 
         public string Name { get; set; }
 
+        public bool IsAbsoluteTemplate
+        {
+            get
+            {
+                return Template != null &&
+                    IsOverridePattern(Template);
+            }
+        }
+
         /// <summary>
         /// Combines two <see cref="ReflectedAttributeRouteModel"/> instances and returns
         /// a new <see cref="ReflectedAttributeRouteModel"/> instance with the result.

--- a/src/Microsoft.AspNet.Mvc.Core/ReflectedModelBuilder/ReflectedControllerModel.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ReflectedModelBuilder/ReflectedControllerModel.cs
@@ -24,11 +24,9 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder
             Filters = Attributes.OfType<IFilter>().ToList();
             RouteConstraints = Attributes.OfType<RouteConstraintAttribute>().ToList();
 
-            var routeTemplateAttribute = Attributes.OfType<IRouteTemplateProvider>().FirstOrDefault();
-            if (routeTemplateAttribute != null)
-            {
-                AttributeRouteModel = new ReflectedAttributeRouteModel(routeTemplateAttribute);
-            }
+            AttributeRoutes = Attributes.OfType<IRouteTemplateProvider>()
+                .Select(rtp => new ReflectedAttributeRouteModel(rtp))
+                .ToList();
 
             ControllerName = controllerType.Name.EndsWith("Controller", StringComparison.Ordinal)
                         ? controllerType.Name.Substring(0, controllerType.Name.Length - "Controller".Length)
@@ -47,6 +45,6 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder
 
         public List<RouteConstraintAttribute> RouteConstraints { get; private set; }
 
-        public ReflectedAttributeRouteModel AttributeRouteModel { get; set; }
+        public List<ReflectedAttributeRouteModel> AttributeRoutes { get; private set; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/Resources.resx
+++ b/src/Microsoft.AspNet.Mvc.Core/Resources.resx
@@ -375,4 +375,22 @@
     <value>Error {0}:{1}{2}</value>
     <comment>{0} is the error number, {1} is Environment.NewLine {2} is the  error message</comment>
   </data>
+  <data name="AttributeRoute_InvalidHttpConstraints" xml:space="preserve">
+    <value>A method '{0}' that defines attribute routed actions must not have attributes that implement '{1}' and do not implement '{2}':{3}{4}</value>
+    <comment>{0} is the MethodInfo.FullName, {1} is typeof(IActionHttpMethodProvider).FullName, {2} is typeof(IRouteTemplateProvider).FullName, {3} is Environment.NewLine, {4} is the list of actions and their respective invalid IActionHttpMethodProvider attributes formatted using AttributeRoute_InvalidHttpMethodConstraints_Item</comment>
+  </data>
+  <data name="AttributeRoute_InvalidHttpConstraints_Item" xml:space="preserve">
+    <value>Action '{0}' with route template '{1}' has '{2}' invalid '{3}' attributes.</value>
+    <comment>{0} The display name of the action, {1} the route template, {2} the formatted list of invalid attributes using string.Join(", ", attributes), {3} is typeof(IActionHttpMethodProvider).FullName.</comment>
+  </data>
+  <data name="AttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod" xml:space="preserve">
+    <value>A method '{0}' must not define attribute routed actions and non attribute routed actions at the same time:{1}{2}</value>
+    <comment>{0} is the MethodInfo.FullName, {1} is Environment.NewLine, {2} is the formatted list of actions defined by that method info.</comment>
+  </data>
+  <data name="AttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod_Item" xml:space="preserve">
+    <value>Action: '{0}' - Template: '{1}'</value>
+  </data>
+  <data name="AttributeRoute_NullTemplateRepresentation" xml:space="preserve">
+    <value>(none)</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNet.Mvc.Core/RouteAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/RouteAttribute.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNet.Mvc
     /// <summary>
     /// Specifies an attribute route on a controller. 
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
     public class RouteAttribute : Attribute, IRouteTemplateProvider
     {
         private int? _order;

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ReflectedModelBuilder/ReflectedActionModelTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ReflectedModelBuilder/ReflectedActionModelTests.cs
@@ -38,20 +38,6 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder.Test
             Assert.IsType<MyFilterAttribute>(model.Filters[0]);
         }
 
-        [Fact]
-        public void ReflectedActionModel_PopulatesAttributeRouteInfo()
-        {
-            // Arrange
-            var actionMethod = typeof(BlogController).GetMethod("Edit");
-
-            // Act
-            var model = new ReflectedActionModel(actionMethod);
-
-            // Assert
-            Assert.NotNull(model.AttributeRouteModel);
-            Assert.Equal("Edit", model.AttributeRouteModel.Template);
-        }
-
         private class BlogController
         {
             [MyOther]

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ReflectedModelBuilder/ReflectedControllerModelTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ReflectedModelBuilder/ReflectedControllerModelTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Reflection;
 using Xunit;
 
@@ -19,12 +20,16 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder.Test
             var model = new ReflectedControllerModel(controllerType.GetTypeInfo());
 
             // Assert
-            Assert.Equal(4, model.Attributes.Count);
+            Assert.Equal(5, model.Attributes.Count);
 
             Assert.Single(model.Attributes, a => a is MyOtherAttribute);
             Assert.Single(model.Attributes, a => a is MyFilterAttribute);
             Assert.Single(model.Attributes, a => a is MyRouteConstraintAttribute);
-            Assert.Single(model.Attributes, a => a is RouteAttribute);
+
+            var routes = model.Attributes.OfType<RouteAttribute>().ToList();
+            Assert.Equal(2, routes.Count());
+            Assert.Single(routes, r => r.Template.Equals("Blog"));
+            Assert.Single(routes, r => r.Template.Equals("Microblog"));
         }
 
         [Fact]
@@ -91,14 +96,17 @@ namespace Microsoft.AspNet.Mvc.ReflectedModelBuilder.Test
             var model = new ReflectedControllerModel(controllerType.GetTypeInfo());
 
             // Assert
-            Assert.NotNull(model.AttributeRouteModel);
-            Assert.Equal("Blog", model.AttributeRouteModel.Template);
+            Assert.NotNull(model.AttributeRoutes);
+            Assert.Equal(2, model.AttributeRoutes.Count); ;
+            Assert.Single(model.AttributeRoutes, r => r.Template.Equals("Blog"));
+            Assert.Single(model.AttributeRoutes, r => r.Template.Equals("Microblog"));
         }
 
         [MyOther]
         [MyFilter]
         [MyRouteConstraint]
         [Route("Blog")]
+        [Route("Microblog")]
         private class BlogController
         {
         }

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/RoutingTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/RoutingTests.cs
@@ -162,6 +162,163 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
                 result.RouteValues);
         }
 
+        [Theory]
+        [InlineData("http://localhost/api/v1/Maps")]
+        [InlineData("http://localhost/api/v2/Maps")]
+        public async Task AttributeRoutedAction_MultipleRouteAttributes_WorksWithNameAndOrder(string url)
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // Act
+            var response = await client.GetAsync(url);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var body = await response.Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<RoutingResult>(body);
+
+            Assert.Equal("Maps", result.Controller);
+            Assert.Equal("Get", result.Action);
+
+            Assert.Equal(new string[]
+            {
+                    "/api/v2/Maps",
+                    "/api/v1/Maps",
+                    "/api/v2/Maps"
+            },
+            result.ExpectedUrls);
+        }
+
+        [Fact]
+        public async Task AttributeRoutedAction_MultipleRouteAttributes_WorksWithOverrideRoutes()
+        {
+            // Arrange
+            var url = "http://localhost/api/v2/Maps";
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // Act
+            var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Post, url));
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var body = await response.Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<RoutingResult>(body);
+
+            Assert.Equal("Maps", result.Controller);
+            Assert.Equal("Post", result.Action);
+
+            Assert.Equal(new string[]
+            {
+                    "/api/v2/Maps",
+                    "/api/v2/Maps"
+            },
+            result.ExpectedUrls);
+        }
+
+        [Fact]
+        public async Task AttributeRoutedAction_MultipleRouteAttributes_RouteAttributeTemplatesIgnoredForOverrideActions()
+        {
+            // Arrange
+            var url = "http://localhost/api/v1/Maps";
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // Act
+            var response = await client.SendAsync(new HttpRequestMessage(new HttpMethod("POST"), url));
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData("http://localhost/api/v1/Maps/5", "PUT")]
+        [InlineData("http://localhost/api/v2/Maps/5", "PUT")]
+        [InlineData("http://localhost/api/v1/Maps/PartialUpdate/5", "PATCH")]
+        [InlineData("http://localhost/api/v2/Maps/PartialUpdate/5", "PATCH")]
+        public async Task AttributeRoutedAction_MultipleRouteAttributes_CombinesWithMultipleHttpAttributes(
+            string url,
+            string method)
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // Act
+            var response = await client.SendAsync(new HttpRequestMessage(new HttpMethod(method), url));
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var body = await response.Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<RoutingResult>(body);
+
+            Assert.Equal("Maps", result.Controller);
+            Assert.Equal("Update", result.Action);
+
+            Assert.Equal(new string[]
+            {
+                    "/api/v2/Maps/PartialUpdate/5",
+                    "/api/v2/Maps/PartialUpdate/5"
+            },
+            result.ExpectedUrls);
+        }
+
+        [Theory]
+        [InlineData("http://localhost/Banks/Get/5")]
+        [InlineData("http://localhost/Bank/Get/5")]
+        public async Task AttributeRoutedAction_MultipleHttpAttributesAndTokenReplacement(string url)
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+            var expectedUrl = new Uri(url).AbsolutePath;
+
+            // Act
+            var response = await client.GetAsync(url);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var body = await response.Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<RoutingResult>(body);
+
+            Assert.Equal("Banks", result.Controller);
+            Assert.Equal("Get", result.Action);
+
+            Assert.Equal(new string[]
+            {
+                    "/Bank/Get/5",
+                    "/Bank/Get/5"
+            },
+            result.ExpectedUrls);
+        }
+
+        [Theory]
+        [InlineData("http://localhost/api/v1/Maps/5", "PATCH")]
+        [InlineData("http://localhost/api/v2/Maps/5", "PATCH")]
+        [InlineData("http://localhost/api/v1/Maps/PartialUpdate/5", "PUT")]
+        [InlineData("http://localhost/api/v2/Maps/PartialUpdate/5", "PUT")]
+        public async Task AttributeRoutedAction_MultipleRouteAttributes_WithMultipleHttpAttributes_RespectsConstraints(
+            string url,
+            string method)
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+            var expectedUrl = new Uri(url).AbsolutePath;
+
+            // Act
+            var response = await client.SendAsync(new HttpRequestMessage(new HttpMethod(method), url));
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
         // The url would be /Store/ListProducts with conventional routes
         [Fact]
         public async Task AttributeRoutedAction_IsNotReachableWithTraditionalRoute()
@@ -357,6 +514,57 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Contains("/api/Employee", result.ExpectedUrls);
             Assert.Equal("Employee", result.Controller);
             Assert.Equal("UpdateEmployee", result.Action);
+        }
+
+        [Theory]
+        [InlineData("PUT")]
+        [InlineData("PATCH")]
+        public async Task AttributeRoutedAction_ControllerLevelRoute_WithAcceptVerbsAndRouteTemplate_IsReachable(string verb)
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // Act
+            var message = new HttpRequestMessage(new HttpMethod(verb), "http://localhost/api/Employee/Manager");
+            var response = await client.SendAsync(message);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var body = await response.Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<RoutingResult>(body);
+
+            Assert.Contains("/api/Employee/Manager", result.ExpectedUrls);
+            Assert.Equal("Employee", result.Controller);
+            Assert.Equal("UpdateManager", result.Action);
+        }
+
+        [Theory]
+        [InlineData("PUT", "Bank")]
+        [InlineData("PATCH", "Bank")]
+        [InlineData("PUT", "Bank/Update")]
+        [InlineData("PATCH", "Bank/Update")]
+        public async Task AttributeRoutedAction_AcceptVerbsAndRouteTemplate_IsReachable(string verb, string path)
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+            var expectedUrl = "/Bank";
+
+            // Act
+            var message = new HttpRequestMessage(new HttpMethod(verb), "http://localhost/" + path);
+            var response = await client.SendAsync(message);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var body = await response.Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<RoutingResult>(body);
+
+            Assert.Equal(new string[] { expectedUrl, expectedUrl }, result.ExpectedUrls);
+            Assert.Equal("Banks", result.Controller);
+            Assert.Equal("UpdateBank", result.Action);
         }
 
         [Fact]

--- a/test/WebSites/RoutingWebSite/Controllers/BanksController.cs
+++ b/test/WebSites/RoutingWebSite/Controllers/BanksController.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.AspNet.Mvc;
+using System;
+
+namespace RoutingWebSite
+{
+    public class BanksController : Controller
+    {
+        private readonly TestResponseGenerator _generator;
+
+        public BanksController(TestResponseGenerator generator)
+	    {
+            _generator = generator;
+	    }
+
+        [HttpGet("Banks/[action]/{id}")]
+        [HttpGet("Bank/[action]/{id}")]
+        public ActionResult Get(int id)
+        {
+            return _generator.Generate(
+                Url.Action(),
+                Url.RouteUrl(new { }));
+        }
+
+        [AcceptVerbs("PUT", Route ="Bank")]
+        [HttpPatch("Bank")]
+        [AcceptVerbs("PUT", Route ="Bank/Update")]
+        [HttpPatch("Bank/Update")]
+        public ActionResult UpdateBank()
+        {
+            return _generator.Generate(
+                Url.Action(),
+                Url.RouteUrl(new { }));
+        }
+    }
+}

--- a/test/WebSites/RoutingWebSite/Controllers/EmployeeController.cs
+++ b/test/WebSites/RoutingWebSite/Controllers/EmployeeController.cs
@@ -26,6 +26,12 @@ namespace RoutingWebSite
             return _generator.Generate("/api/Employee");
         }
 
+        [AcceptVerbs("PUT", "PATCH", Route = "Manager")]
+        public IActionResult UpdateManager()
+        {
+            return _generator.Generate("/api/Employee/Manager");
+        }
+
         [HttpMerge("{id}")]
         public IActionResult MergeEmployee(int id)
         {

--- a/test/WebSites/RoutingWebSite/Controllers/MapsController.cs
+++ b/test/WebSites/RoutingWebSite/Controllers/MapsController.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.AspNet.Mvc;
+using System;
+
+namespace RoutingWebSite
+{
+    [Route("api/v1/Maps", Name = "v1", Order = 1)]
+    [Route("api/v2/Maps")]
+    public class MapsController : Controller
+    {
+        private readonly TestResponseGenerator _generator;
+
+        public MapsController(TestResponseGenerator generator)
+	    {
+            _generator = generator;
+	    }
+
+        [HttpGet]
+        public ActionResult Get()
+        {
+            // Multiple attribute routes with name and order.
+            // We will always generate v2 routes except when
+            // we explicitly use "v1" to generate a v1 route.
+            return _generator.Generate(
+                Url.Action(),
+                Url.RouteUrl("v1"),
+                Url.RouteUrl(new { }));
+        }
+
+        [HttpPost("/api/v2/Maps")]
+        public ActionResult Post()
+        {
+            return _generator.Generate(
+                Url.Action(),
+                Url.RouteUrl(new { }));
+        }
+
+        [HttpPut("{id}")]
+        [HttpPatch("PartialUpdate/{id}")]
+        public ActionResult Update(int id)
+        {
+            // We will generate "/api/v2/Maps/PartialUpdate/{id}"
+            // in both cases, v1 routes will be discarded due to their
+            // Order and for v2 routes PartialUpdate has higher precedence.
+            // api/v1/Maps/{id} and api/v2/Maps/{id} will only match on PUT.
+            // api/v1/Maps/PartialUpdate/{id} and api/v2/Maps/PartialUpdate/{id} will only match on PATCH.
+            return _generator.Generate(
+                Url.Action(),
+                Url.RouteUrl(new { }));
+        }
+    }
+}


### PR DESCRIPTION
1. Support multiple [Http*] attributes on an action.
2. Support multiple [Route] attributes on a controller and on an action.
3. Support creating multiple attribute routes using [AcceptVerbs("...", Template ="...")]
4. Detect attribute routed actions during action discovery
   and return one action per [Http*], [Route] or [AcceptVerbs] attribute found on the method when there is
   at least one valid attribute route.
5. Merge all the HTTP methods of [Http*] and [AcceptVerbs] attributes in a method during action discovery 
   when there are no valid attribute routes defined on the action.
6. Build one action descriptor per controller [Route] + action [Http*], [AcceptVerbs] or [Route] combination
   in an action.
7. Disallow the use of attributes that do not implement IActionHttpMethodProvider and
   IRouteTemplateProvider simultaneously in methods that define attribute routed actions and throw an
   exception during startup.
8. Disallow mixing attribute routed and non attribute routed actions on the same method and throw an
   exception during startup.
9. Disallow creating attribute routed actions that have same template and have an HTTP method in common
   on the same action and throw an exception during startup.
