### PR TITLE
Porting razorpage perf improvements from codeplex-2119

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
@@ -153,7 +153,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         /// <param name="value">The <see cref="string"/> to write.</param>
         public virtual void WriteTo(TextWriter writer, string value)
         {
-            if (value != null)
+            if (!string.IsNullOrEmpty(value))
             {
                 writer.Write(WebUtility.HtmlEncode(value));
             }
@@ -187,7 +187,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         /// <param name="value">The <see cref="string"/> to write.</param>
         public virtual void WriteLiteralTo(TextWriter writer, string value)
         {
-            if (value != null)
+            if (!string.IsNullOrEmpty(value))
             {
                 writer.Write(value);
             }


### PR DESCRIPTION
These changes were worth 2-3% of execution time on a page that makes heavy
use of attribute writing.

Making the overloads for writing a string public should show a small
throughput increase for a typical razor page.
