### PR TITLE
[Fixes #737] Attribute Routing: Come up with a good scheme for generatin...

### DIFF
--- a/test/Microsoft.AspNet.Mvc.Core.Test/ReflectedActionDescriptorProviderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ReflectedActionDescriptorProviderTests.cs
@@ -1001,6 +1001,43 @@ namespace Microsoft.AspNet.Mvc.Test
             Assert.Equal(groupIds[0], groupIds[1]);
         }
 
+        [Fact]
+        public void AttributeRouting_GroupIdsAreAssigned_Correctly()
+        {
+            // Arrange
+            var provider = GetProvider(typeof(GroupIdController).GetTypeInfo());
+
+            // Act
+            var actions = provider.GetDescriptors();
+
+            // Assert
+            Assert.Equal(6, actions.Count());
+
+            var groupIds = actions.Select(a => GetRouteConstraintValue(a));
+
+            Assert.Equal(5, groupIds.Distinct().Count());
+
+            var index = Assert.Single(actions, a => a.Name == nameof(GroupIdController.Index));
+            var indexGroupId = GetRouteConstraintValue(index);
+            Assert.Single(groupIds, indexGroupId);
+
+            var edit = Assert.Single(actions, a => a.Name == nameof(GroupIdController.Edit));
+            var editGroupId = GetRouteConstraintValue(edit);
+            Assert.Single(groupIds, editGroupId);
+
+            var patch = actions.Where(a => a.Name == nameof(GroupIdController.Patch));
+            var patchGroupIds = patch.Select(p => GetRouteConstraintValue(p));
+            Assert.Equal(2, patchGroupIds.Distinct().Count());
+
+            var delete = Assert.Single(actions, a => a.Name == nameof(GroupIdController.Delete));
+            var deleteGroupId = GetRouteConstraintValue(delete);
+
+            var put = Assert.Single(actions, a => a.Name == nameof(GroupIdController.Put));
+            var putGroupId = GetRouteConstraintValue(put);
+
+            Assert.Equal(deleteGroupId, putGroupId);
+        }
+
         // Parameters are validated later. This action uses the forbidden {action} and {controller}
         [Fact]
         public void AttributeRouting_DoesNotValidateParameters()
@@ -1074,6 +1111,11 @@ namespace Microsoft.AspNet.Mvc.Test
                 null);
 
             return provider.GetDescriptors();
+        }
+
+        private static string GetRouteConstraintValue(ReflectedActionDescriptor index)
+        {
+            return index.RouteConstraints.Single(r => r.RouteKey == AttributeRouting.RouteGroupKey).RouteValue;
         }
 
         private class HttpMethodController
@@ -1387,6 +1429,25 @@ namespace Microsoft.AspNet.Mvc.Test
                     return _methods;
                 }
             }
+        }
+
+        public class GroupIdController
+        {
+            [HttpGet("Customers/Index")] // Action descriptor 1
+            public void Index() { }
+
+            [HttpGet("Customers/Edit")] // Action descriptor 2
+            public void Edit() { }
+
+            [HttpPut("Customers/{id}")] // Action descriptor 3
+            public void Put() { }
+
+            [HttpPatch("Customers/{id}", Order = 1)] // Action descriptor 4
+            [HttpPatch("Customers/UpdateCustomer/{id}")] // Action descriptor 5
+            public void Patch() { }
+
+            [HttpPut("Customers/{id}")] // Action descriptor 6
+            public void Delete() { }
         }
 
         private class PutOrPatchAttribute : HttpMethodAttribute


### PR DESCRIPTION
...g route group tokens (optimization)

Assigns route group values to each attribute routed action descriptors
by giving each descriptor a secuential number as their route group and
keeping track of the action descriptors for which it has provided a
route group value.

The value of the group id for an action descriptor will be their position
on the list the first time we see that action descriptor. Other actions
with the same route group will get the same route group value because we
will scan the list for equivalent action descriptors before giving them
a value.

For example:
Given the following controller

``` C#
public class CustomersController
{
    [HttpGet("Customers/Index")] // Action descriptor 1
    public ActionResult Index() { }

    [HttpGet("Customers/Edit")] // Action descriptor 2
    public ActionResult Edit() { }

    [HttpPut("Customers/{id}")] // Action descriptor 3
    public ActionResult Put() { }

    [HttpPatch("Customers/{id}", Order = 1)] // Action descriptor 4
    [HttpPatch("Customers/UpdateCustomer/{id}")] // Action descriptor 5
    public ActionResult Patch() { }

    [HttpPut("Customers/{id}")] // Action descriptor 6
    public ActionResult Delete() { }
}
```

Action descriptor 1 with template /Customers/Index and order 0 will have route group id 0.
Action descriptor 2 with template /Customers/Edit and order 0 will have route group id 1
Action descriptor 3 with template /Customers/{id} and order 0 will have route group id 2
Action descriptor 4 with template /Customers/{id} and order 1 will have route group id 3
Action descriptor 5 with template /Customers/UpdateCustomer/{id} and order 0 will have route group id 4
Action descriptor 6 with template /Customers/{id} and order 0 will have route group id 5
