### PR TITLE
Removing Overloading

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/AmbiguousActionException.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/AmbiguousActionException.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Microsoft.AspNet.Mvc
+{
+    /// <summary>
+    /// An exception which indicates multiple matches in action selection.
+    /// </summary>
+    #if ASPNET50
+    [Serializable]
+    #endif
+    public class AmbiguousActionException : InvalidOperationException
+    {
+        public AmbiguousActionException(string message)
+            : base(message)
+        {
+        }
+
+        #if ASPNET50
+        protected AmbiguousActionException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+        #endif
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Logging/DefaultActionSelectorSelectAsyncValues.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Logging/DefaultActionSelectorSelectAsyncValues.cs
@@ -38,12 +38,12 @@ namespace Microsoft.AspNet.Mvc.Logging
         public IReadOnlyList<ActionDescriptor> ActionsMatchingRouteAndMethodAndDynamicConstraints { get; set; }
 
         /// <summary>
-        /// The actions that matched with at least one constraint.
+        /// The list of actions that are the best matches. These match all constraints.
         /// </summary>
-        public IReadOnlyList<ActionDescriptor> ActionsMatchingWithConstraints { get; set; }
+        public IReadOnlyList<ActionDescriptor> FinalMatches { get; set; }
 
         /// <summary>
-        /// The selected action.
+        /// The selected action. Will be null if no matches are found or more than one match is found.
         /// </summary>
         public ActionDescriptor SelectedAction { get; set; }
 
@@ -65,8 +65,8 @@ namespace Microsoft.AspNet.Mvc.Logging
                 builder.Append("\tActions matching route, method, and dynamic constraints: ");
                 StringBuilderHelpers.Append(builder, ActionsMatchingRouteAndMethodAndDynamicConstraints, Formatter);
                 builder.AppendLine();
-                builder.Append("\tActions matching with at least one constraint: ");
-                StringBuilderHelpers.Append(builder, ActionsMatchingWithConstraints, Formatter);
+                builder.Append("\tBest Matches: ");
+                StringBuilderHelpers.Append(builder, FinalMatches, Formatter);
                 builder.AppendLine();
                 builder.Append("\tSelected action: ");
                 builder.Append(Formatter(SelectedAction));

--- a/src/Microsoft.AspNet.Mvc.Core/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Properties/Resources.Designer.cs
@@ -1434,6 +1434,22 @@ namespace Microsoft.AspNet.Mvc.Core
             return GetString("AttributeRoute_NullTemplateRepresentation");
         }
 
+        /// <summary>
+        /// Multiple actions matched. The following actions matched route data and had all constraints satisfied:{0}{0}{1}
+        /// </summary>
+        internal static string DefaultActionSelector_AmbiguousActions
+        {
+            get { return GetString("DefaultActionSelector_AmbiguousActions"); }
+        }
+
+        /// <summary>
+        /// Multiple actions matched. The following actions matched route data and had all constraints satisfied:{0}{0}{1}
+        /// </summary>
+        internal static string FormatDefaultActionSelector_AmbiguousActions(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("DefaultActionSelector_AmbiguousActions"), p0, p1);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNet.Mvc.Core/Resources.resx
+++ b/src/Microsoft.AspNet.Mvc.Core/Resources.resx
@@ -393,4 +393,8 @@
   <data name="AttributeRoute_NullTemplateRepresentation" xml:space="preserve">
     <value>(none)</value>
   </data>
+  <data name="DefaultActionSelector_AmbiguousActions" xml:space="preserve">
+    <value>Multiple actions matched. The following actions matched route data and had all constraints satisfied:{0}{0}{1}</value>
+    <comment>0 is the newline - 1 is a newline separate list of action display names</comment>
+  </data>
 </root>

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ActionAttributeTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ActionAttributeTests.cs
@@ -88,26 +88,6 @@ namespace Microsoft.AspNet.Mvc
         }
 
         [Theory]
-        [InlineData("GET")]
-        [InlineData("POST")]
-        public async Task HttpMethodAttribute_DefaultMethod_IgnoresMethodsWithCustomAttributesAndInvalidMethods(string verb)
-        {
-            // Arrange
-            // Note no action name is passed, hence should return a null action descriptor.
-            var routeContext = new RouteContext(GetHttpContext(verb));
-            routeContext.RouteData.Values = new Dictionary<string, object>
-            {
-                { "controller", "HttpMethodAttributeTests_DefaultMethodValidation" },
-            };
-
-            // Act
-            var result = await InvokeActionSelector(routeContext);
-
-            // Assert
-            Assert.Equal("Index", result.Name);
-        }
-
-        [Theory]
         [InlineData("Put")]
         [InlineData("RPCMethod")]
         [InlineData("RPCMethodWithHttpGet")]
@@ -198,12 +178,9 @@ namespace Microsoft.AspNet.Mvc
             var actionCollectionDescriptorProvider = new DefaultActionDescriptorsCollectionProvider(serviceContainer);
             var decisionTreeProvider = new ActionSelectorDecisionTreeProvider(actionCollectionDescriptorProvider);
 
-            var bindingProvider = new Mock<IActionBindingContextProvider>();
-
             var defaultActionSelector = new DefaultActionSelector(
                 actionCollectionDescriptorProvider, 
                 decisionTreeProvider,
-                bindingProvider.Object,
                 NullLoggerFactory.Instance);
 
             return await defaultActionSelector.SelectAsync(context);
@@ -244,14 +221,15 @@ namespace Microsoft.AspNet.Mvc
 
         private class CustomActionConvention : DefaultActionDiscoveryConventions
         {
-            public override IEnumerable<string> GetSupportedHttpMethods(MethodInfo methodInfo)
+            public override IEnumerable<ActionInfo> GetActions([NotNull]MethodInfo methodInfo, [NotNull]TypeInfo controllerTypeInfo)
             {
-                if (methodInfo.Name.Equals("PostSomething", StringComparison.OrdinalIgnoreCase))
+                var actions = new List<ActionInfo>(base.GetActions(methodInfo, controllerTypeInfo));
+                if (methodInfo.Name == "PostSomething")
                 {
-                    return new[] { "POST" };
+                    actions[0].HttpMethods = new string[] { "POST" };
                 }
 
-                return null;
+                return actions;
             }
         }
 

--- a/test/Microsoft.AspNet.Mvc.Core.Test/DefaultActionDiscoveryConventionsActionSelectionTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/DefaultActionDiscoveryConventionsActionSelectionTests.cs
@@ -21,16 +21,15 @@ namespace Microsoft.AspNet.Mvc
 {
     public class DefaultActionDiscoveryConventionsActionSelectionTests
     {
-        [Theory]
-        [InlineData("GET")]
-        [InlineData("POST")]
-        public async Task ActionSelection_IndexSelectedByDefaultInAbsenceOfVerbOnlyMethod(string verb)
+        [Fact]
+        public async Task ActionSelection_ActionSelectedByName()
         {
             // Arrange
-            var routeContext = new RouteContext(GetHttpContext(verb));
+            var routeContext = new RouteContext(GetHttpContext("GET"));
             routeContext.RouteData.Values = new Dictionary<string, object>
             {
-                { "controller", "RpcOnly" }
+                { "controller", "RpcOnly" },
+                { "action", "Index" }
             };
 
             // Act
@@ -40,101 +39,7 @@ namespace Microsoft.AspNet.Mvc
             Assert.Equal("Index", result.Name);
         }
 
-        [Theory]
-        [InlineData("GET")]
-        [InlineData("POST")]
-        public async Task ActionSelection_PrefersVerbOnlyMethodOverIndex(string verb)
-        {
-            // Arrange
-            var routeContext = new RouteContext(GetHttpContext(verb));
-            routeContext.RouteData.Values = new Dictionary<string, object>
-            {
-                { "controller", "MixedRpcAndRest" }
-            };
-
-            // Act
-            var result = await InvokeActionSelector(routeContext);
-
-            // Assert
-            Assert.Equal(verb, result.Name, StringComparer.OrdinalIgnoreCase);
-        }
-
-        [Theory]
-        [InlineData("PUT")]
-        [InlineData("DELETE")]
-        [InlineData("PATCH")]
-        public async Task ActionSelection_IndexNotSelectedByDefaultExceptGetAndPostVerbs(string verb)
-        {
-            // Arrange
-            var routeContext = new RouteContext(GetHttpContext(verb));
-            routeContext.RouteData.Values = new Dictionary<string, object>
-            {
-                { "controller", "RpcOnly" }
-            };
-
-            // Act
-            var result = await InvokeActionSelector(routeContext);
-
-            // Assert
-            Assert.Equal(null, result);
-        }
-
-        [Theory]
-        [InlineData("HEAD")]
-        [InlineData("OPTIONS")]
-        public async Task ActionSelection_NoConventionBasedRoutingForHeadAndOptions(string verb)
-        {
-            // Arrange
-            var routeContext = new RouteContext(GetHttpContext(verb));
-            routeContext.RouteData.Values = new Dictionary<string, object>
-            {
-                { "controller", "MixedRpcAndRest" },
-            };
-
-            // Act
-            var result = await InvokeActionSelector(routeContext);
-
-            // Assert
-            Assert.Equal(null, result);
-        }
-
-        [Theory]
-        [InlineData("HEAD")]
-        [InlineData("OPTIONS")]
-        public async Task ActionSelection_ActionNameBasedRoutingForHeadAndOptions(string verb)
-        {
-            // Arrange
-            var routeContext = new RouteContext(GetHttpContext(verb));
-            routeContext.RouteData.Values = new Dictionary<string, object>
-            {
-                { "controller", "MixedRpcAndRest" },
-                { "action", verb },
-            };
-
-            // Act
-            var result = await InvokeActionSelector(routeContext);
-
-            // Assert
-            Assert.Equal(verb, result.Name, StringComparer.OrdinalIgnoreCase);
-        }
-
-        [Fact]
-        public async Task ActionSelection_ChangeDefaultConventionPicksCustomMethodForPost_DefaultMethodIsSelectedForGet()
-        {
-            // Arrange
-            var routeContext = new RouteContext(GetHttpContext("GET"));
-            routeContext.RouteData.Values = new Dictionary<string, object>
-            {
-                { "controller", "RpcOnly" }
-            };
-
-            // Act
-            var result = await InvokeActionSelector(routeContext, new CustomActionConvention());
-
-            // Assert
-            Assert.Equal("INDEX", result.Name, StringComparer.OrdinalIgnoreCase);
-        }
-
+        // Uses custom conventions to map a web-api-style action
         [Fact]
         public async Task ActionSelection_ChangeDefaultConventionPicksCustomMethodForPost_CutomMethodIsSelected()
         {
@@ -177,12 +82,9 @@ namespace Microsoft.AspNet.Mvc
             var actionCollectionDescriptorProvider = new DefaultActionDescriptorsCollectionProvider(serviceContainer);
             var decisionTreeProvider = new ActionSelectorDecisionTreeProvider(actionCollectionDescriptorProvider);
 
-            var bindingProvider = new Mock<IActionBindingContextProvider>();
-
             var defaultActionSelector = new DefaultActionSelector(
                 actionCollectionDescriptorProvider,
                 decisionTreeProvider,
-                bindingProvider.Object,
                 NullLoggerFactory.Instance);
 
             return await defaultActionSelector.SelectAsync(context);
@@ -223,64 +125,19 @@ namespace Microsoft.AspNet.Mvc
                     .Contains(typeInfo);
             }
 
-            public override IEnumerable<string> GetSupportedHttpMethods(MethodInfo methodInfo)
+            public override IEnumerable<ActionInfo> GetActions([NotNull]MethodInfo methodInfo, [NotNull]TypeInfo controllerTypeInfo)
             {
-                if (methodInfo.Name.Equals("PostSomething", StringComparison.OrdinalIgnoreCase))
+                var actions = new List<ActionInfo>(
+                    base.GetActions(methodInfo, controllerTypeInfo) ?? 
+                    new List<ActionInfo>());
+
+                if (methodInfo.Name == "PostSomething")
                 {
-                    return new[] { "POST" };
+                    actions[0].HttpMethods = new string[] { "POST" };
+                    actions[0].RequireActionNameMatch = false;
                 }
 
-                return null;
-            }
-        }
-
-        private class MixedRpcAndRestController
-        {
-            public void Index()
-            {
-            }
-
-            public void Get()
-            {
-            }
-
-            public void Post()
-            { }
-
-            public void GetSomething()
-            { }
-
-            // This will be treated as an RPC method.
-            public void Head()
-            {
-            }
-
-            // This will be treated as an RPC method.
-            public void Options()
-            {
-            }
-        }
-
-        private class RestOnlyController
-        {
-            public void Get()
-            {
-            }
-
-            public void Put()
-            {
-            }
-
-            public void Post()
-            {
-            }
-
-            public void Delete()
-            {
-            }
-
-            public void Patch()
-            {
+                return actions;
             }
         }
 


### PR DESCRIPTION
This change removes action overloading based on method parameters (WebAPI style) from the core framework

This feature will be implemented in accordance with the legacy behavior for compat, but outside of the `IActionSelector`. For the core framework, we'll have have the ability to opt-in to specific overloading behaviors explicitly.
