### PR TITLE
[Fixes #1183] Response uses chunked encoding when returning a string

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/Formatters/TextPlainFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Formatters/TextPlainFormatter.cs
@@ -51,7 +51,9 @@ namespace Microsoft.AspNet.Mvc
             }
 
             var response = context.ActionContext.HttpContext.Response;
-            using (var writer = new StreamWriter(response.Body, context.SelectedEncoding, 1024, leaveOpen: true))
+
+            using (var delegatingStream = new DelegatingStream(response.Body))
+            using (var writer = new StreamWriter(delegatingStream, context.SelectedEncoding, 1024, leaveOpen: true))
             {
                 await writer.WriteAsync(valueAsString);
             }


### PR DESCRIPTION
/cc: @harshgMSFT @Tratcher @yishaigalatzer 

Just FYI...before my current changes following was the behavior when a string data was returned:
- Helios : chunked response
- WebListener : non-chunked response
