### PR TITLE
Remove framework assembly versions.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/project.json
+++ b/src/Microsoft.AspNet.Mvc.Core/project.json
@@ -21,7 +21,7 @@
   "frameworks": {
     "aspnet50": {
       "frameworkAssemblies": {
-        "System.Xml": "4.0.0.0"
+        "System.Xml": ""
       }
     },
     "aspnetcore50": {

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/project.json
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/project.json
@@ -14,9 +14,9 @@
   "frameworks": {
     "aspnet50": {
       "frameworkAssemblies": {
-        "System.Xml": "4.0.0.0",
-        "System.ComponentModel.DataAnnotations": "4.0.0.0",
-        "System.Runtime.Serialization": "4.0.0.0"
+        "System.Xml": "",
+        "System.ComponentModel.DataAnnotations": "",
+        "System.Runtime.Serialization": ""
       }
     },
     "aspnetcore50": {

--- a/src/Microsoft.AspNet.Mvc.Razor.Host/project.json
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/project.json
@@ -11,18 +11,18 @@
     "frameworks": {
         "net45": {
             "frameworkAssemblies": {
-                "System.Collections": "4.0.0.0",
-                "System.Runtime": "4.0.0.0",
-                "System.Xml": "4.0.0.0",
-                "System.Xml.Linq": "4.0.0.0"
+                "System.Collections": "",
+                "System.Runtime": "",
+                "System.Xml": "",
+                "System.Xml.Linq": ""
             }
         },
         "aspnet50": {
             "frameworkAssemblies": {
-                "System.Collections": "4.0.0.0",
-                "System.Runtime": "4.0.10.0",
-                "System.Xml": "4.0.0.0",
-                "System.Xml.Linq": "4.0.0.0"
+                "System.Collections": "",
+                "System.Runtime": "",
+                "System.Xml": "",
+                "System.Xml.Linq": ""
             },
             "dependencies": {
                 "Microsoft.Framework.Runtime.Interfaces": { "version": "1.0.0-*", "type": "build" }

--- a/src/Microsoft.AspNet.Mvc.Razor/project.json
+++ b/src/Microsoft.AspNet.Mvc.Razor/project.json
@@ -18,13 +18,13 @@
     "frameworks": {
         "aspnet50": {
             "frameworkAssemblies": {
-                "System.Collections": "4.0.0.0",
-                "System.IO": "4.0.0.0",
-                "System.Runtime": "4.0.0.0",
-                "System.Text.Encoding": "4.0.0.0",
-                "System.Threading.Tasks": "4.0.0.0",
-                "System.Xml": "4.0.0.0",
-                "System.Xml.Linq": "4.0.0.0"
+                "System.Collections": "",
+                "System.IO": "",
+                "System.Runtime": "",
+                "System.Text.Encoding": "",
+                "System.Threading.Tasks": "",
+                "System.Xml": "",
+                "System.Xml.Linq": ""
             }
         },
         "aspnetcore50": {


### PR DESCRIPTION
- This unblocked running the sample in the Mvc.sln.
- Essentially specifying specific assembly versions was incorrect because they can vary on a per-machine basis for the time being.  Once we ship we'll be able to replace the versions with a specific version because we can ensure that it will be on the machine.
