### PR TITLE
[Fixes #885] API Explorer: Link Generation

### DIFF
--- a/samples/MvcSample.Web/Controllers/ApiExplorerSamples/ProductsController.cs
+++ b/samples/MvcSample.Web/Controllers/ApiExplorerSamples/ProductsController.cs
@@ -9,7 +9,7 @@ namespace MvcSample.Web.ApiExplorerSamples
     [Route("api/Products")]
     public class ProductsController : Controller
     {
-        [HttpGet("{id}")]
+        [HttpGet("{id:int}")]
         public Product GetById(int id)
         {
             return null;
@@ -22,7 +22,7 @@ namespace MvcSample.Web.ApiExplorerSamples
         }
 
         [Produces("application/json", Type = typeof(ProductOrderConfirmation))]
-        [HttpPut("{id}/Buy")]
+        [HttpPut("{id:int}/Buy")]
         public IActionResult Buy(int projectId, int quantity = 1)
         {
             return null;

--- a/samples/MvcSample.Web/Views/ApiExplorer/_ApiDescription.cshtml
+++ b/samples/MvcSample.Web/Views/ApiExplorer/_ApiDescription.cshtml
@@ -13,7 +13,11 @@
         <ul>
             @foreach (var parameter in Model.ParameterDescriptions)
             {
-                <li>@parameter.Name - @parameter.Type.FullName - @parameter.Source.ToString()</li>
+                <li>
+                    @parameter.Name - @(parameter?.Type?.FullName ?? "Unknown") - @parameter.Source.ToString()
+                    - Constraint: @(parameter?.Constraint?.GetType()?.Name?.Replace("RouteConstraint", "") ?? " none")
+                    - Default value: @(parameter?.DefaultValue ?? " none")
+                </li>
             }
         </ul>
     }
@@ -22,7 +26,7 @@
     {
         <p>Response Formats:</p>
         <ul>
-            @foreach(var response in Model.SupportedResponseFormats)
+            @foreach (var response in Model.SupportedResponseFormats)
             {
                 <li>@response.MediaType.RawValue - @response.Formatter.GetType().Name</li>
             }

--- a/src/Microsoft.AspNet.Mvc.Core/Description/ApiParameterDescription.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Description/ApiParameterDescription.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.AspNet.Mvc.ModelBinding;
+using Microsoft.AspNet.Routing;
 
 namespace Microsoft.AspNet.Mvc.Description
 {
@@ -17,6 +18,10 @@ namespace Microsoft.AspNet.Mvc.Description
         public ParameterDescriptor ParameterDescriptor { get; set; }
 
         public ApiParameterSource Source { get; set; }
+
+        public IRouteConstraint Constraint { get; set; }
+
+        public object DefaultValue { get; set; }
 
         public Type Type { get; set; }
     }

--- a/src/Microsoft.AspNet.Mvc.Core/Description/ApiParameterSource.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Description/ApiParameterSource.cs
@@ -8,5 +8,6 @@ namespace Microsoft.AspNet.Mvc.Description
     {
         Body,
         Query,
+        Path
     }
 }

--- a/test/WebSites/ApiExplorerWebSite/ApiExplorerDataFilter.cs
+++ b/test/WebSites/ApiExplorerWebSite/ApiExplorerDataFilter.cs
@@ -55,7 +55,8 @@ namespace ApiExplorer
                     IsOptional = parameter.IsOptional,
                     Name = parameter.Name,
                     Source = parameter.Source.ToString(),
-                    Type = parameter.Type.FullName,
+                    Type = parameter?.Type?.FullName,
+                    ConstraintType = parameter?.Constraint?.GetType()?.Name,
                 };
 
                 data.ParameterDescriptions.Add(parameterData);
@@ -101,6 +102,8 @@ namespace ApiExplorer
             public string Source { get; set; }
 
             public string Type { get; set; }
+
+            public string ConstraintType { get; set; }
         }
 
         // Used to serialize data between client and server

--- a/test/WebSites/ApiExplorerWebSite/Controllers/ApiExplorerRouteAndPathParametersInformationController.cs
+++ b/test/WebSites/ApiExplorerWebSite/Controllers/ApiExplorerRouteAndPathParametersInformationController.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Mvc;
+
+namespace ApiExplorer
+{
+    [Route("ApiExplorerRouteAndPathParametersInformation")]
+    public class ApiExplorerRouteAndPathParametersInformationController
+    {
+        [HttpGet]
+        public void Get() { }
+
+        [HttpGet("{id}")]
+        public void Get(int id) { }
+
+        [HttpGet("Optional/{id?}")]
+        public void GetOptional(int id = 0) { }
+
+        [HttpGet("Constraint/{integer:int}")]
+        public void GetInteger(int integer) { }
+
+        [HttpGet("CatchAll/{*parameter}")]
+        public void GetCatchAll(string parameter) { }
+
+        [HttpGet("MultipleParametersInSegment/{month:range(1,12)}-{day:int}-{year:int}")]
+        public void GetMultipleParametersInSegment(string month, string day, string year) { }
+
+        [HttpGet("MultipleParametersInMultipleSegments/{month:range(1,12)}/{day:int?}/{year:int?}")]
+        public void GetMultipleParametersInMultipleSegments(string month, string day, string year = "") { }
+
+        [HttpGet("MultipleTypesOfParameters/{path}/{pathAndQuery}/{pathAndFromBody}")]
+        public void MultipleTypesOfParameters(string query, string pathAndQuery, [FromBody] string pathAndFromBody) { }
+
+        [HttpGet("CatchAllAndConstraint/{*integer:int}")]
+        public void GetIntegers(string integer) { }
+    }
+}


### PR DESCRIPTION
1) Expose the simplified relative path template by cleaning up constraints, optional and catch all tokens from the template.
2) Expose the parameters on the route template as API parameters.
3) Combine parameters from the route and the action descriptor when the parameter doesn't come from the body. #886 will refine this.
4) Expose optionality and constraints for path parameters. Open question: Should we explicitly expose IsCatchAll?
