### PR TITLE
Fixing NRE with logging

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/Logging/DefaultActionSelectorSelectAsyncValues.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Logging/DefaultActionSelectorSelectAsyncValues.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNet.Mvc.Logging
 
         private string Formatter(ActionDescriptor descriptor)
         {
-            return descriptor.DisplayName;
+            return descriptor != null ? descriptor.DisplayName : "";
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/DefaultActionSelectorTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/DefaultActionSelectorTests.cs
@@ -57,7 +57,8 @@ namespace Microsoft.AspNet.Mvc
             Assert.Empty(values.ActionsMatchingRouteConstraints);
             Assert.Empty(values.ActionsMatchingActionConstraints);
             Assert.Empty(values.FinalMatches);
-            Assert.Null(values.SelectedAction);
+            Assert.Null(values.SelectedAction);            
+            Assert.DoesNotThrow(() => values.Summary);
         }
 
         [Fact]
@@ -160,6 +161,7 @@ namespace Microsoft.AspNet.Mvc
             Assert.Equal<ActionDescriptor>(actions, values.ActionsMatchingActionConstraints);
             Assert.Equal<ActionDescriptor>(actions, values.FinalMatches);
             Assert.Null(values.SelectedAction);
+            Assert.DoesNotThrow(() => values.Summary);
         }
 
         [Fact]


### PR DESCRIPTION
This fixes #1292

`DefaultActionSelectorSelectAsyncValues.SelectedAction` could be null when no action is selected. This can happen when no action is matched, or there's an ambiguity.

Adding a null check to `Formatter` to handle this case.

Also added a couple checks to related tests.
