### PR TITLE
Fix for #1277 - Add Options/Startup API for WebAPI shim

### DIFF
--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/WebApiCompatShimOptions.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/WebApiCompatShimOptions.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Net.Http.Formatting;
+
+namespace Microsoft.AspNet.Mvc.WebApiCompatShim
+{
+    public class WebApiCompatShimOptions
+    {
+        public WebApiCompatShimOptions()
+        {
+            // Start with an empty collection, our options setup will add the default formatters.
+            Formatters = new MediaTypeFormatterCollection(Enumerable.Empty<MediaTypeFormatter>());
+        }
+
+        public MediaTypeFormatterCollection Formatters { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/WebApiCompatShimOptionsSetup.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/WebApiCompatShimOptionsSetup.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Net.Http.Formatting;
+using Microsoft.Framework.OptionsModel;
+
+namespace Microsoft.AspNet.Mvc.WebApiCompatShim
+{
+    public class WebApiCompatShimOptionsSetup : IOptionsAction<MvcOptions>, IOptionsAction<WebApiCompatShimOptions>
+    {
+        public int Order
+        {
+            // We want to run after the default MvcOptionsSetup.
+            get { return DefaultOrder.DefaultFrameworkSortOrder + 10; }
+        }
+
+        public string Name { get; set; }
+
+        public void Invoke(MvcOptions options)
+        {
+            // Placeholder
+        }
+
+        public void Invoke(WebApiCompatShimOptions options)
+        {
+            // Add the default formatters
+            options.Formatters.AddRange(new MediaTypeFormatterCollection());
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/WebApiCompatShimServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/WebApiCompatShimServiceCollectionExtensions.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Mvc.WebApiCompatShim;
+
+namespace Microsoft.Framework.DependencyInjection
+{
+    public static class WebApiCompatShimServiceCollectionExtensions
+    {
+        public static IServiceCollection AddWebApiConventions(this IServiceCollection services)
+        {
+            services.AddOptionsAction<WebApiCompatShimOptionsSetup>();
+            return services;
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/WebApiCompatShimBasicTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/WebApiCompatShimBasicTest.cs
@@ -3,11 +3,13 @@
 
 #if ASPNET50
 using System;
+using System.Net;
+using System.Net.Http.Formatting;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.TestHost;
+using Newtonsoft.Json;
 using Xunit;
-using System.Net;
 
 namespace Microsoft.AspNet.Mvc.FunctionalTests
 {
@@ -50,6 +52,31 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal(
                 "Visited: /BasicApi/GenerateUrl",
                 content);
+        }
+
+        [Fact]
+        public async Task Options_SetsDefaultFormatters()
+        {
+            // Arrange
+            var server = TestServer.Create(_provider, _app);
+            var client = server.CreateClient();
+
+            var expected = new string[]
+            {
+                typeof(JsonMediaTypeFormatter).FullName,
+                typeof(XmlMediaTypeFormatter).FullName,
+                typeof(FormUrlEncodedMediaTypeFormatter).FullName,
+            };
+
+            // Act
+            var response = await client.GetAsync("http://localhost/BasicApi/GetFormatters");
+            var content = await response.Content.ReadAsStringAsync();
+
+            var formatters = JsonConvert.DeserializeObject<string[]>(content);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(expected, formatters);
         }
     }
 }

--- a/test/WebSites/WebApiCompatShimWebSite/Controllers/BasicApiController.cs
+++ b/test/WebSites/WebApiCompatShimWebSite/Controllers/BasicApiController.cs
@@ -1,15 +1,21 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using System.Threading.Tasks;
 using System.Web.Http;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Mvc;
+using Microsoft.AspNet.Mvc.WebApiCompatShim;
+using Microsoft.Framework.OptionsModel;
 
 namespace WebApiCompatShimWebSite
 {
     public class BasicApiController : ApiController
     {
+        [Activate]
+        public IOptionsAccessor<WebApiCompatShimOptions> OptionsAccessor { get; set; }
+
         // Verifies property activation
         [HttpGet]
         public async Task<IActionResult> WriteToHttpContext()
@@ -31,6 +37,13 @@ namespace WebApiCompatShimWebSite
 
             await Context.Response.WriteAsync(message);
             return new EmptyResult();
+        }
+
+        // Verifies the default options configure formatters correctly.
+        [HttpGet]
+        public string[] GetFormatters()
+        {
+            return OptionsAccessor.Options.Formatters.Select(f => f.GetType().FullName).ToArray();
         }
     }
 }

--- a/test/WebSites/WebApiCompatShimWebSite/Startup.cs
+++ b/test/WebSites/WebApiCompatShimWebSite/Startup.cs
@@ -15,8 +15,10 @@ namespace WebApiCompatShimWebSite
             app.UseServices(services =>
             {
                 services.AddMvc(configuration);
-            });
 
+                services.AddWebApiConventions();
+            });
+            
             app.UseMvc();
         }
     }


### PR DESCRIPTION
Adds an options class, as well as a default options setup that will
configure the default set of formatters.

Currently most of what options needs to do is a placeholder, but it later
do things like add ApplicationModelConventions, filters, formatters, model
binders, etc. Those will be added in follow up items.
