### PR TITLE
Fix for issue #1281 - Add ModelBinder for HttpRequestMessage

### DIFF
--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/HttpRequestMessage/HttpRequestMessageModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/HttpRequestMessage/HttpRequestMessageModelBinder.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.AspNet.Mvc.ModelBinding;
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNet.Mvc.WebApiCompatShim
+{
+    public class HttpRequestMessageModelBinder : IModelBinder
+    {
+        public Task<bool> BindModelAsync(ModelBindingContext bindingContext)
+        {
+            if (bindingContext.ModelType == typeof(HttpRequestMessage))
+            {
+                bindingContext.Model = bindingContext.HttpContext.GetHttpRequestMessage();
+                return Task.FromResult(true);
+            }
+
+            return Task.FromResult(false);
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/WebApiCompatShimOptionsSetup.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/WebApiCompatShimOptionsSetup.cs
@@ -21,6 +21,9 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShim
             // Add webapi behaviors to controllers with the appropriate attributes
             options.ApplicationModelConventions.Add(new WebApiActionConventionsGlobalModelConvention());
             options.ApplicationModelConventions.Add(new WebApiOverloadingGlobalModelConvention());
+
+            // Add a model binder to be able to bind HttpRequestMessage
+            options.ModelBinders.Insert(0, new HttpRequestMessageModelBinder());
         }
 
         public void Invoke(WebApiCompatShimOptions options)

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/WebApiCompatShimBasicTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/WebApiCompatShimBasicTest.cs
@@ -101,6 +101,28 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal(expected, content);
         }
+
+        [Fact]
+        public async Task ApiController_RequestParameter()
+        { 
+            // Arrange
+            var server = TestServer.Create(_provider, _app);
+            var client = server.CreateClient();
+
+            var expected =
+                "POST http://localhost/api/Blog/HttpRequestMessage/EchoParameter localhost " +
+                "17 Hello, the world!";
+
+            // Act
+            var response = await client.PostAsync(
+                "http://localhost/api/Blog/HttpRequestMessage/EchoParameter",
+                new StringContent("Hello, the world!"));
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(expected, content);
+        }
     }
 }
 #endif

--- a/test/WebSites/WebApiCompatShimWebSite/Controllers/HttpRequestMessage/HttpRequestMessageController.cs
+++ b/test/WebSites/WebApiCompatShimWebSite/Controllers/HttpRequestMessage/HttpRequestMessageController.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 using System.Web.Http;
 using Microsoft.AspNet.Http;
@@ -12,18 +14,32 @@ namespace WebApiCompatShimWebSite
     {
         public async Task<IActionResult> EchoProperty()
         {
-            var request = Request;
+            await Echo(Request);
+            return new EmptyResult(); 
+        }
 
+        public async Task<IActionResult> EchoParameter(HttpRequestMessage request)
+        {
+            if (!object.ReferenceEquals(request, Request))
+            {
+                throw new InvalidOperationException();
+            }
+
+            await Echo(request);
+            return new EmptyResult();
+        }
+
+        private async Task Echo(HttpRequestMessage request)
+        {
             var message = string.Format(
                 "{0} {1} {2} {3} {4}",
-                request.Method, 
+                request.Method,
                 request.RequestUri.AbsoluteUri,
                 request.Headers.Host,
                 request.Content.Headers.ContentLength,
                 await request.Content.ReadAsStringAsync());
 
             await Context.Response.WriteAsync(message);
-            return new EmptyResult();
         }
     }
 }


### PR DESCRIPTION
This change adds a ModelBinder that can bind an HttpRequestMessage to an
action parameter.

This builds on an earlier change to construct and store the request
message in the HttpContext via an http feature.
