### PR TITLE
Move caching of compilation results to its own layer.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/Compilation/CompilerCache.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Compilation/CompilerCache.cs
@@ -9,13 +9,13 @@ using System.Reflection;
 
 namespace Microsoft.AspNet.Mvc.Razor
 {
-    public class CompilerCache
+    public class CompilerCache : ICompilerCache
     {
         private readonly ConcurrentDictionary<string, CompilerCacheEntry> _cache;
         private static readonly Type[] EmptyType = new Type[0];
 
-        public CompilerCache([NotNull] IEnumerable<Assembly> assemblies)
-            : this(GetFileInfos(assemblies))
+        public CompilerCache([NotNull] IAssemblyProvider provider)
+            : this(GetFileInfos(provider.CandidateAssemblies))
         {
         }
 

--- a/src/Microsoft.AspNet.Mvc.Razor/Compilation/CompilerCacheEntry.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Compilation/CompilerCacheEntry.cs
@@ -6,7 +6,7 @@ using System;
 namespace Microsoft.AspNet.Mvc.Razor
 {
     /// <summary>
-    /// An entry in <see cref="CompilerCache"/> that contain metadata about precompiled and dynamically compiled file.
+    /// An entry in <see cref="ICompilerCache"/> that contain metadata about precompiled and dynamically compiled file.
     /// </summary>
     public class CompilerCacheEntry
     {

--- a/src/Microsoft.AspNet.Mvc.Razor/Compilation/ICompilerCache.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Compilation/ICompilerCache.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNet.FileSystems;
+
+namespace Microsoft.AspNet.Mvc.Razor
+{
+	public interface ICompilerCache
+	{
+        CompilationResult GetOrAdd([NotNull] RelativeFileInfo fileInfo,
+                                   bool enableInstrumentation,
+                                   [NotNull] Func<CompilationResult> compile);
+	}
+}

--- a/src/Microsoft.AspNet.Mvc.Razor/Compilation/UncachedCompilationResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Compilation/UncachedCompilationResult.cs
@@ -6,7 +6,7 @@ using System;
 namespace Microsoft.AspNet.Mvc.Razor
 {
     /// <summary>
-    /// Represents the result of compilation that does not come from the <see cref="CompilerCache" />.
+    /// Represents the result of compilation that does not come from the <see cref="ICompilerCache" />.
     /// </summary>
     public class UncachedCompilationResult : CompilationResult
     {

--- a/src/Microsoft.AspNet.Mvc.Razor/Razor/RazorCompilationService.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Razor/RazorCompilationService.cs
@@ -16,42 +16,18 @@ namespace Microsoft.AspNet.Mvc.Razor
     /// </remarks>
     public class RazorCompilationService : IRazorCompilationService
     {
-        private readonly IServiceProvider _serviceProvider;
-
-        private readonly CompilerCache _cache;
-        private ICompilationService _compilationService;
-
-        private ICompilationService CompilationService
-        {
-            get
-            {
-                if (_compilationService == null)
-                {
-                    _compilationService = _serviceProvider.GetService<ICompilationService>();
-                }
-
-                return _compilationService;
-            }
-        }
-
+        private readonly ICompilationService _compilationService;
         private readonly IMvcRazorHost _razorHost;
 
-        public RazorCompilationService(IServiceProvider serviceProvider,
-                                       IAssemblyProvider _assemblyProvider,
+        public RazorCompilationService(ICompilationService compilationService,
                                        IMvcRazorHost razorHost)
         {
-            _serviceProvider = serviceProvider;
+            _compilationService = compilationService;
             _razorHost = razorHost;
-            _cache = new CompilerCache(_assemblyProvider.CandidateAssemblies);
         }
 
         /// <inheritdoc />
         public CompilationResult Compile([NotNull] RelativeFileInfo file, bool isInstrumented)
-        {
-            return _cache.GetOrAdd(file, isInstrumented, () => CompileCore(file, isInstrumented));
-        }
-
-        internal CompilationResult CompileCore(RelativeFileInfo file, bool isInstrumented)
         {
             _razorHost.EnableInstrumentation = isInstrumented;
 
@@ -68,7 +44,7 @@ namespace Microsoft.AspNet.Mvc.Razor
                 return CompilationResult.Failed(file.FileInfo, results.GeneratedCode, messages);
             }
 
-            return CompilationService.Compile(file.FileInfo, results.GeneratedCode);
+            return _compilationService.Compile(file.FileInfo, results.GeneratedCode);
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc/MvcServices.cs
+++ b/src/Microsoft.AspNet.Mvc/MvcServices.cs
@@ -51,6 +51,7 @@ namespace Microsoft.AspNet.Mvc
             // The host is designed to be discarded after consumption and is very inexpensive to initialize.
             yield return describe.Transient<IMvcRazorHost, MvcRazorHost>();
 
+            yield return describe.Singleton<ICompilerCache, CompilerCache>();
             yield return describe.Singleton<ICompilationService, RoslynCompilationService>();
             yield return describe.Singleton<IRazorCompilationService, RazorCompilationService>();
 


### PR DESCRIPTION
This will allow only creating the razor compilation when really needed, with the right lifetime.

Without this change, the ICompilerService might be resolved with a disposed scoped service provider.
