### PR TITLE
Use DefaultOrder in MvcOptionsSetup

### DIFF
--- a/src/Microsoft.AspNet.Mvc/MvcOptionsSetup.cs
+++ b/src/Microsoft.AspNet.Mvc/MvcOptionsSetup.cs
@@ -12,10 +12,9 @@ namespace Microsoft.AspNet.Mvc
     /// </summary>
     public class MvcOptionsSetup : ConfigureOptions<MvcOptions>
     {
-        /// <remarks>Sets the Order to -1 to allow MvcOptionsSetup to run before a user call to ConfigureOptions.</remarks>
         public MvcOptionsSetup() : base(ConfigureMvc)
         {
-            Order = -1;
+            Order = DefaultOrder.DefaultFrameworkSortOrder;
         }
 
         /// <inheritdoc />

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/BasicTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/BasicTests.cs
@@ -27,11 +27,10 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         // use it on all the rest of the tests.
         private readonly Assembly _resourcesAssembly = typeof(BasicTests).GetTypeInfo().Assembly;
 
+        [Theory]
         [InlineData("http://localhost/")]
         [InlineData("http://localhost/Home")]
         [InlineData("http://localhost/Home/Index")]
-        [InlineData("http://localhost/Users")]
-        [InlineData("http://localhost/Monitor/CountActionDescriptorInvocations")]
         public async Task CanRender_ViewsWithLayout(string url)
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/DefaultOrderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/DefaultOrderTest.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Builder;
+using Microsoft.AspNet.Mvc.Description;
+using Microsoft.AspNet.Mvc.Razor;
+using Microsoft.AspNet.TestHost;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.OptionsModel;
+using Xunit;
+
+namespace Microsoft.AspNet.Mvc.FunctionalTests
+{
+    // Tests that various MVC services have the correct order.
+    public class DefaultOrderTest
+    {
+        private readonly IServiceProvider _provider = TestHelper.CreateServices(nameof(BasicWebSite));
+        private readonly Action<IApplicationBuilder> _app = new BasicWebSite.Startup().Configure;
+
+        [Theory]
+        [InlineData(typeof(INestedProvider<ActionDescriptorProviderContext>), typeof(ControllerActionDescriptorProvider), -1000)]
+        [InlineData(typeof(INestedProvider<ActionInvokerProviderContext>), (Type)null, -1000)]
+        [InlineData(typeof(INestedProvider<ApiDescriptionProviderContext>), (Type)null, -1000)]
+        [InlineData(typeof(INestedProvider<FilterProviderContext>), (Type)null, -1000)]
+        [InlineData(typeof(INestedProvider<ViewComponentInvokerProviderContext>), (Type)null, -1000)]
+        [InlineData(typeof(IConfigureOptions<RazorViewEngineOptions>), (Type)null, -1000)]
+        [InlineData(typeof(IConfigureOptions<MvcOptions>), (Type)null, -1000)]
+        public async Task ServiceOrder_GetOrder(Type serviceType, Type actualType, int order)
+        {
+            // Arrange
+            var server = TestServer.Create(_provider, _app);
+            var client = server.CreateClient();
+
+            var url = "http://localhost/Order/GetServiceOrder?serviceType=" + serviceType.AssemblyQualifiedName;
+
+            if (actualType != null)
+            {
+                url += "&actualType=" + actualType.AssemblyQualifiedName;
+            }
+
+            // Act
+            var response = await client.GetAsync(url);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(order, int.Parse(content));
+        }
+    }
+}

--- a/test/WebSites/BasicWebSite/Controllers/OrderController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/OrderController.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNet.Mvc;
+
+namespace BasicWebSite
+{
+    public class OrderController : Controller
+    {
+        public int GetServiceOrder(string serviceType, string actualType)
+        {
+            var elementType = Type.GetType(serviceType);
+
+            var queryType = typeof(IEnumerable<>).MakeGenericType(elementType);
+
+            var services = (IEnumerable<object>)Resolver.GetService(queryType);
+            foreach (var service in services)
+            {
+                if (actualType != null && service.GetType().AssemblyQualifiedName == actualType)
+                {
+                    var orderProperty = elementType.GetProperty("Order");
+                    return (int)orderProperty.GetValue(service);
+                }
+                else if (actualType == null)
+                {
+                    var orderProperty = elementType.GetProperty("Order");
+                    return (int)orderProperty.GetValue(service);
+                }
+            }
+
+            throw new InvalidOperationException();
+        }
+    }
+}

--- a/test/WebSites/BasicWebSite/project.json
+++ b/test/WebSites/BasicWebSite/project.json
@@ -2,8 +2,10 @@
     "dependencies": {
         "Microsoft.AspNet.Mvc": "6.0.0-*",
         "Microsoft.AspNet.Server.IIS": "1.0.0-*",
+        "Microsoft.AspNet.Server.WebListener": "1.0.0-*",
         "Microsoft.AspNet.Mvc.TestConfiguration": "1.0.0"
     },
+     "commands": { "web": "Microsoft.AspNet.Hosting server=Microsoft.AspNet.Server.WebListener server.urls=http://localhost:5001" },
     "frameworks": {
         "aspnet50": { },
         "aspnetcore50": { }


### PR DESCRIPTION
Part of the change to use a standard constant Order value got stomped on by the options changes. This brings it back and adds an integration test.
