### PR TITLE
Add `DefaultEditorTemplates.MultilineTemplate`

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/DefaultEditorTemplates.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/DefaultEditorTemplates.cs
@@ -212,6 +212,17 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return htmlAttributes;
         }
 
+        public static string MultilineTemplate(IHtmlHelper html)
+        {
+            var htmlString = html.TextArea(
+                string.Empty,
+                html.ViewContext.ViewData.TemplateInfo.FormattedModelValue.ToString(),
+                rows: 0,
+                columns: 0,
+                htmlAttributes: CreateHtmlAttributes(html, "text-box multi-line"));
+            return htmlString.ToString();
+        }
+
         public static string ObjectTemplate(IHtmlHelper html)
         {
             var viewData = html.ViewData;

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/TemplateRenderer.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/TemplateRenderer.cs
@@ -8,7 +8,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using Microsoft.AspNet.Mvc.Core;
-using Microsoft.AspNet.Mvc.Internal;
 using Microsoft.Framework.DependencyInjection;
 
 namespace Microsoft.AspNet.Mvc.Rendering
@@ -21,32 +20,32 @@ namespace Microsoft.AspNet.Mvc.Rendering
         private static readonly Dictionary<string, Func<IHtmlHelper, string>> _defaultDisplayActions =
             new Dictionary<string, Func<IHtmlHelper, string>>(StringComparer.OrdinalIgnoreCase)
             {
+                { "Collection", DefaultDisplayTemplates.CollectionTemplate },
                 { "EmailAddress", DefaultDisplayTemplates.EmailAddressTemplate },
                 { "HiddenInput", DefaultDisplayTemplates.HiddenInputTemplate },
                 { "Html", DefaultDisplayTemplates.HtmlTemplate },
                 { "Text", DefaultDisplayTemplates.StringTemplate },
                 { "Url", DefaultDisplayTemplates.UrlTemplate },
-                { "Collection", DefaultDisplayTemplates.CollectionTemplate },
                 { typeof(bool).Name, DefaultDisplayTemplates.BooleanTemplate },
                 { typeof(decimal).Name, DefaultDisplayTemplates.DecimalTemplate },
                 { typeof(string).Name, DefaultDisplayTemplates.StringTemplate },
                 { typeof(object).Name, DefaultDisplayTemplates.ObjectTemplate },
             };
 
-        // TODO: Add DefaultEditorTemplates.MultilineTextTemplate and place in this dictionary.
         private static readonly Dictionary<string, Func<IHtmlHelper, string>> _defaultEditorActions =
             new Dictionary<string, Func<IHtmlHelper, string>>(StringComparer.OrdinalIgnoreCase)
             {
-                { "HiddenInput", DefaultEditorTemplates.HiddenInputTemplate },
-                { "Password", DefaultEditorTemplates.PasswordTemplate },
-                { "Text", DefaultEditorTemplates.StringTemplate },
                 { "Collection", DefaultEditorTemplates.CollectionTemplate },
-                { "PhoneNumber", DefaultEditorTemplates.PhoneNumberInputTemplate },
-                { "Url", DefaultEditorTemplates.UrlInputTemplate },
                 { "EmailAddress", DefaultEditorTemplates.EmailAddressInputTemplate },
+                { "HiddenInput", DefaultEditorTemplates.HiddenInputTemplate },
+                { "MultilineText", DefaultEditorTemplates.MultilineTemplate },
+                { "Password", DefaultEditorTemplates.PasswordTemplate },
+                { "PhoneNumber", DefaultEditorTemplates.PhoneNumberInputTemplate },
+                { "Text", DefaultEditorTemplates.StringTemplate },
+                { "Url", DefaultEditorTemplates.UrlInputTemplate },
+                { "Date", DefaultEditorTemplates.DateInputTemplate },
                 { "DateTime", DefaultEditorTemplates.DateTimeInputTemplate },
                 { "DateTime-local", DefaultEditorTemplates.DateTimeLocalInputTemplate },
-                { "Date", DefaultEditorTemplates.DateInputTemplate },
                 { "Time", DefaultEditorTemplates.TimeInputTemplate },
                 { typeof(byte).Name, DefaultEditorTemplates.NumberInputTemplate },
                 { typeof(sbyte).Name, DefaultEditorTemplates.NumberInputTemplate },


### PR DESCRIPTION
- #965
- test call-throughs from `Html.Editor[For]()` to inner `IHtmlHelper`
  - add another parameter to `DefaultTemplatesUtilities.GetHtmlHelper()`

nit: reorder dictionaries at the top of `TemplateRenderer` slightly

/cc @pranavkm  or @NTaylorMullen 
