### PR TITLE
Fix tests and changed TagHelper activates property accessors.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.TagHelpers/AnchorTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/AnchorTagHelper.cs
@@ -18,8 +18,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         private const string RouteAttributePrefix = "route-";
         private const string Href = "href";
 
+        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
         [Activate]
-        private IHtmlGenerator Generator { get; set; }
+        protected internal IHtmlGenerator Generator { get; set; }
 
         /// <summary>
         /// The name of the action method.

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/FormTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/FormTagHelper.cs
@@ -18,11 +18,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     {
         private const string RouteAttributePrefix = "route-";
 
+        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
         [Activate]
-        private ViewContext ViewContext { get; set; }
+        protected internal ViewContext ViewContext { get; set; }
 
+        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
         [Activate]
-        private IHtmlGenerator Generator { get; set; }
+        protected internal IHtmlGenerator Generator { get; set; }
 
         /// <summary>
         /// The name of the action method.

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/TextAreaTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/TextAreaTagHelper.cs
@@ -13,11 +13,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     [ContentBehavior(ContentBehavior.Replace)]
     public class TextAreaTagHelper : TagHelper
     {
+        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
         [Activate]
-        private IHtmlGenerator Generator { get; set; }
+        protected internal IHtmlGenerator Generator { get; set; }
 
+        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
         [Activate]
-        private ViewContext ViewContext { get; set; }
+        protected internal ViewContext ViewContext { get; set; }
 
         /// <summary>
         /// An expression to be evaluated against the current model.

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationMessageTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationMessageTagHelper.cs
@@ -14,11 +14,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     [ContentBehavior(ContentBehavior.Modify)]
     public class ValidationMessageTagHelper : TagHelper
     {
+        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
         [Activate]
-        private ViewContext ViewContext { get; set; }
+        protected internal ViewContext ViewContext { get; set; }
 
+        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
         [Activate]
-        private IHtmlGenerator Generator { get; set; }
+        protected internal IHtmlGenerator Generator { get; set; }
 
         /// <summary>
         /// Name to be validated on the current model.

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/AnchorTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/AnchorTagHelperTest.cs
@@ -3,10 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc.ModelBinding;
-using Microsoft.AspNet.Mvc.Razor;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 using Moq;
@@ -65,9 +63,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var viewContext = TestableHtmlGenerator.GetViewContext(model: null,
                                                                    htmlGenerator: htmlGenerator,
                                                                    metadataProvider: metadataProvider);
-
-            var activator = new DefaultTagHelperActivator();
-            activator.Activate(anchorTagHelper, viewContext);
+            anchorTagHelper.Generator = htmlGenerator;
 
             // Act
             await anchorTagHelper.ProcessAsync(tagHelperContext, output);
@@ -106,8 +102,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     string.Empty, "Default", "http", "contoso.com", "hello=world", null, null))
                 .Returns(new TagBuilder("a"))
                 .Verifiable();
-
-            SetGenerator(anchorTagHelper, generator.Object);
+            anchorTagHelper.Generator = generator.Object;
 
             // Act & Assert
             await anchorTagHelper.ProcessAsync(context, output);
@@ -142,8 +137,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     string.Empty, "Index", "Home", "http", "contoso.com", "hello=world", null, null))
                 .Returns(new TagBuilder("a"))
                 .Verifiable();
-
-            SetGenerator(anchorTagHelper, generator.Object);
+            anchorTagHelper.Generator = generator.Object;
 
             // Act & Assert
             await anchorTagHelper.ProcessAsync(context, output);
@@ -187,11 +181,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                                        "protocol, host or fragment attribute.";
 
             // Act & Assert
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-                async () =>
-                {
-                    await anchorTagHelper.ProcessAsync(context: null, output: output);
-                });
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => 
+                anchorTagHelper.ProcessAsync(context: null, output: output));
 
             Assert.Equal(expectedErrorMessage, ex.Message);
         }
@@ -215,21 +206,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                                        "specified route must not have an action or controller attribute.";
 
             // Act & Assert
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-                async () =>
-                {
-                    await anchorTagHelper.ProcessAsync(context: null, output: output);
-                });
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                anchorTagHelper.ProcessAsync(context: null, output: output));
 
             Assert.Equal(expectedErrorMessage, ex.Message);
-        }
-
-        private void SetGenerator(ITagHelper tagHelper, IHtmlGenerator generator)
-        {
-            var tagHelperType = tagHelper.GetType();
-
-            tagHelperType.GetProperty("Generator", BindingFlags.NonPublic | BindingFlags.Instance)
-                         .SetValue(tagHelper, generator);
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/FormTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/FormTagHelperTest.cs
@@ -4,12 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Mvc.ModelBinding;
-using Microsoft.AspNet.Mvc.Razor;
 using Microsoft.AspNet.Mvc.Rendering;
+using Microsoft.AspNet.PipelineCore;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 using Microsoft.AspNet.Routing;
 using Moq;
@@ -65,8 +63,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                                                                    metadataProvider: metadataProvider);
             var expectedContent = "Something" + htmlGenerator.GenerateAntiForgery(viewContext)
                                                              .ToString(TagRenderMode.SelfClosing);
-            var activator = new DefaultTagHelperActivator();
-            activator.Activate(formTagHelper, viewContext);
+            formTagHelper.ViewContext = viewContext;
+            formTagHelper.Generator = htmlGenerator;
 
             // Act
             await formTagHelper.ProcessAsync(tagHelperContext, output);
@@ -115,8 +113,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             generator.Setup(mock => mock.GenerateAntiForgery(viewContext))
                      .Returns(new TagBuilder("input"));
-
-            SetViewContextAndGenerator(formTagHelper, viewContext, generator.Object);
+            formTagHelper.ViewContext = viewContext;
+            formTagHelper.Generator = generator.Object;
 
             // Act
             await formTagHelper.ProcessAsync(context, output);
@@ -175,8 +173,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     })
                 .Returns(new TagBuilder("form"))
                 .Verifiable();
-
-            SetViewContextAndGenerator(formTagHelper, testViewContext, generator.Object);
+            formTagHelper.ViewContext = testViewContext;
+            formTagHelper.Generator = generator.Object;
 
             // Act & Assert
             await formTagHelper.ProcessAsync(context, output);
@@ -211,10 +209,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 .Setup(mock => mock.GenerateForm(viewContext, "Index", "Home", null, "POST", null))
                 .Returns(new TagBuilder("form"))
                 .Verifiable();
-
-            SetViewContextAndGenerator(formTagHelper,
-                                       viewContext,
-                                       generator.Object);
+            formTagHelper.ViewContext = viewContext;
+            formTagHelper.Generator = generator.Object;
 
             // Act & Assert
             await formTagHelper.ProcessAsync(context, output);
@@ -273,9 +269,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 Action = "http://www.contoso.com",
                 AntiForgery = antiForgery,
             };
-            SetViewContextAndGenerator(formTagHelper,
-                                       viewContext,
-                                       generator.Object);
+            formTagHelper.ViewContext = viewContext;
+            formTagHelper.Generator = generator.Object;
+
             var output = new TagHelperOutput("form",
                                              attributes: new Dictionary<string, string>(),
                                              content: string.Empty);
@@ -313,10 +309,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 content: string.Empty);
 
             // Act & Assert
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-            {
-                await formTagHelper.ProcessAsync(context: null, output: tagHelperOutput);
-            });
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                formTagHelper.ProcessAsync(context: null, output: tagHelperOutput));
 
             Assert.Equal(expectedErrorMessage, ex.Message);
         }
@@ -341,10 +335,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 content: string.Empty);
 
             // Act & Assert
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-            {
-                await formTagHelper.ProcessAsync(context: null, output: tagHelperOutput);
-            });
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                formTagHelper.ProcessAsync(context: null, output: tagHelperOutput));
 
             Assert.Equal(expectedErrorMessage, ex.Message);
         }
@@ -352,7 +344,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         private static ViewContext CreateViewContext()
         {
             var actionContext = new ActionContext(
-                new Mock<HttpContext>().Object,
+                new DefaultHttpContext(),
                 new RouteData(),
                 new ActionDescriptor());
 
@@ -362,18 +354,6 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 new ViewDataDictionary(
                     new DataAnnotationsModelMetadataProvider()),
                 new StringWriter());
-        }
-
-        private static void SetViewContextAndGenerator(ITagHelper tagHelper,
-                                                ViewContext viewContext,
-                                                IHtmlGenerator generator)
-        {
-            var tagHelperType = tagHelper.GetType();
-
-            tagHelperType.GetProperty("ViewContext", BindingFlags.NonPublic | BindingFlags.Instance)
-                         .SetValue(tagHelper, viewContext);
-            tagHelperType.GetProperty("Generator", BindingFlags.NonPublic | BindingFlags.Instance)
-                         .SetValue(tagHelper, generator);
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TextAreaTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TextAreaTagHelperTest.cs
@@ -57,8 +57,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     { modelWithText, typeof(NestedModel), () => modelWithText.NestedModel.Text, "NestedModel.Text",
                         Environment.NewLine + "inner text" },
 
-                        // Top-level indexing does not work end-to-end due to code generation issue #1345.
-                        // TODO: Remove above comment when #1345 is fixed.
+                    // Top-level indexing does not work end-to-end due to code generation issue #1345.
+                    // TODO: Remove above comment when #1345 is fixed.
                     { models, typeof(Model), () => models[0].Text, "[0].Text",
                         Environment.NewLine },
                     { models, typeof(Model), () => models[1].Text, "[1].Text",
@@ -119,8 +119,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 }
             };
             var viewContext = TestableHtmlGenerator.GetViewContext(model, htmlGenerator, metadataProvider);
-            var activator = new DefaultTagHelperActivator();
-            activator.Activate(tagHelper, viewContext);
+            tagHelper.ViewContext = viewContext;
+            tagHelper.Generator = htmlGenerator;
 
             // Act
             await tagHelper.ProcessAsync(tagHelperContext, output);

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ValidationMessageTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ValidationMessageTagHelperTest.cs
@@ -3,12 +3,10 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Mvc.ModelBinding;
-using Microsoft.AspNet.Mvc.Razor;
 using Microsoft.AspNet.Mvc.Rendering;
+using Microsoft.AspNet.PipelineCore;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 using Microsoft.AspNet.Routing;
 using Moq;
@@ -46,9 +44,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var viewContext = TestableHtmlGenerator.GetViewContext(model: null,
                                                                    htmlGenerator: htmlGenerator,
                                                                    metadataProvider: metadataProvider);
-
-            var activator = new DefaultTagHelperActivator();
-            activator.Activate(validationMessageTagHelper, viewContext);
+            validationMessageTagHelper.ViewContext = viewContext;
+            validationMessageTagHelper.Generator = htmlGenerator;
 
             // Act
             await validationMessageTagHelper.ProcessAsync(tagHelperContext, output);
@@ -82,12 +79,12 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var expectedViewContext = CreateViewContext();
             var generator = new Mock<IHtmlGenerator>();
             generator
-                .Setup(mock => 
+                .Setup(mock =>
                     mock.GenerateValidationMessage(expectedViewContext, "Hello", null, null, null))
                 .Returns(new TagBuilder("span"))
                 .Verifiable();
-
-            SetViewContextAndGenerator(validationMessageTagHelper, expectedViewContext, generator.Object);
+            validationMessageTagHelper.Generator = generator.Object;
+            validationMessageTagHelper.ViewContext = expectedViewContext;
 
             // Act & Assert
             await validationMessageTagHelper.ProcessAsync(context: null, output: output);
@@ -120,7 +117,6 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             tagBuilder.Attributes.Add("data-foo", "bar");
             tagBuilder.Attributes.Add("data-hello", "world");
 
-            var expectedViewContext = CreateViewContext();
             var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
             var setup = generator
                 .Setup(mock => mock.GenerateValidationMessage(
@@ -130,8 +126,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     It.IsAny<string>(),
                     It.IsAny<object>()))
                 .Returns(tagBuilder);
-
-            SetViewContextAndGenerator(validationMessageTagHelper, expectedViewContext, generator.Object);
+            var viewContext = CreateViewContext();
+            validationMessageTagHelper.ViewContext = viewContext;
+            validationMessageTagHelper.Generator = generator.Object;
 
             // Act
             await validationMessageTagHelper.ProcessAsync(context: null, output: output);
@@ -155,10 +152,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 "span",
                 attributes: new Dictionary<string, string>(),
                 content: "Content of validation message");
-            var expectedViewContext = CreateViewContext();
+            var viewContext = CreateViewContext();
             var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
-
-            SetViewContextAndGenerator(validationMessageTagHelper, expectedViewContext, generator.Object);
+            validationMessageTagHelper.ViewContext = viewContext;
+            validationMessageTagHelper.Generator = generator.Object;
 
             // Act
             await validationMessageTagHelper.ProcessAsync(context: null, output: output);
@@ -184,7 +181,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         private static ViewContext CreateViewContext()
         {
             var actionContext = new ActionContext(
-                new Mock<HttpContext>().Object,
+                new DefaultHttpContext(),
                 new RouteData(),
                 new ActionDescriptor());
 
@@ -194,18 +191,6 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 new ViewDataDictionary(
                     new DataAnnotationsModelMetadataProvider()),
                 new StringWriter());
-        }
-
-        private static void SetViewContextAndGenerator(ITagHelper tagHelper,
-                                                       ViewContext viewContext,
-                                                       IHtmlGenerator generator)
-        {
-            var tagHelperType = tagHelper.GetType();
-
-            tagHelperType.GetProperty("ViewContext", BindingFlags.NonPublic | BindingFlags.Instance)
-                         .SetValue(tagHelper, viewContext);
-            tagHelperType.GetProperty("Generator", BindingFlags.NonPublic | BindingFlags.Instance)
-                         .SetValue(tagHelper, generator);
         }
     }
 }


### PR DESCRIPTION
- Changed TagHelper property accessors from private to protected internal.
- Changed throw tests to be shorter.
- Changed reflection setting to now use the internal accessibility of the TagHelpers
- Removed activator to just use internal accessibility of TagHelpers.
