### PR TITLE
Fix tests and changed TagHelper activates property accessors.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.TagHelpers/AnchorTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/AnchorTagHelper.cs
@@ -18,8 +18,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         private const string RouteAttributePrefix = "route-";
         private const string Href = "href";
 
+        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
         [Activate]
-        private IHtmlGenerator Generator { get; set; }
+        protected internal IHtmlGenerator Generator { get; set; }
 
         /// <summary>
         /// The name of the action method.

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/FormTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/FormTagHelper.cs
@@ -18,11 +18,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     {
         private const string RouteAttributePrefix = "route-";
 
+        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
         [Activate]
-        private ViewContext ViewContext { get; set; }
+        protected internal ViewContext ViewContext { get; set; }
 
+        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
         [Activate]
-        private IHtmlGenerator Generator { get; set; }
+        protected internal IHtmlGenerator Generator { get; set; }
 
         /// <summary>
         /// The name of the action method.

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/TextAreaTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/TextAreaTagHelper.cs
@@ -13,11 +13,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     [ContentBehavior(ContentBehavior.Replace)]
     public class TextAreaTagHelper : TagHelper
     {
+        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
         [Activate]
-        private IHtmlGenerator Generator { get; set; }
+        protected internal IHtmlGenerator Generator { get; set; }
 
+        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
         [Activate]
-        private ViewContext ViewContext { get; set; }
+        protected internal ViewContext ViewContext { get; set; }
 
         /// <summary>
         /// An expression to be evaluated against the current model.

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationMessageTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationMessageTagHelper.cs
@@ -14,11 +14,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     [ContentBehavior(ContentBehavior.Modify)]
     public class ValidationMessageTagHelper : TagHelper
     {
+        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
         [Activate]
-        private ViewContext ViewContext { get; set; }
+        protected internal ViewContext ViewContext { get; set; }
 
+        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
         [Activate]
-        private IHtmlGenerator Generator { get; set; }
+        protected internal IHtmlGenerator Generator { get; set; }
 
         /// <summary>
         /// Name to be validated on the current model.

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/AnchorTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/AnchorTagHelperTest.cs
@@ -3,10 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc.ModelBinding;
-using Microsoft.AspNet.Mvc.Razor;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 using Moq;
@@ -65,9 +63,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var viewContext = TestableHtmlGenerator.GetViewContext(model: null,
                                                                    htmlGenerator: htmlGenerator,
                                                                    metadataProvider: metadataProvider);
-
-            var activator = new DefaultTagHelperActivator();
-            activator.Activate(anchorTagHelper, viewContext);
+            anchorTagHelper.Generator = htmlGenerator;
 
             // Act
             await anchorTagHelper.ProcessAsync(tagHelperContext, output);
@@ -106,8 +102,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     string.Empty, "Default", "http", "contoso.com", "hello=world", null, null))
                 .Returns(new TagBuilder("a"))
                 .Verifiable();
-
-            SetGenerator(anchorTagHelper, generator.Object);
+            anchorTagHelper.Generator = generator.Object;
 
             // Act & Assert
             await anchorTagHelper.ProcessAsync(context, output);
@@ -142,8 +137,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     string.Empty, "Index", "Home", "http", "contoso.com", "hello=world", null, null))
                 .Returns(new TagBuilder("a"))
                 .Verifiable();
-
-            SetGenerator(anchorTagHelper, generator.Object);
+            anchorTagHelper.Generator = generator.Object;
 
             // Act & Assert
             await anchorTagHelper.ProcessAsync(context, output);
@@ -188,10 +182,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             // Act & Assert
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-                async () =>
-                {
-                    await anchorTagHelper.ProcessAsync(context: null, output: output);
-                });
+                () => anchorTagHelper.ProcessAsync(context: null, output: output));
 
             Assert.Equal(expectedErrorMessage, ex.Message);
         }
@@ -216,20 +207,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             // Act & Assert
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-                async () =>
-                {
-                    await anchorTagHelper.ProcessAsync(context: null, output: output);
-                });
+                () => anchorTagHelper.ProcessAsync(context: null, output: output));
 
             Assert.Equal(expectedErrorMessage, ex.Message);
-        }
-
-        private void SetGenerator(ITagHelper tagHelper, IHtmlGenerator generator)
-        {
-            var tagHelperType = tagHelper.GetType();
-
-            tagHelperType.GetProperty("Generator", BindingFlags.NonPublic | BindingFlags.Instance)
-                         .SetValue(tagHelper, generator);
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LabelTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LabelTagHelperTest.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc.ModelBinding;
-using Microsoft.AspNet.Mvc.Razor;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 using Xunit;
@@ -160,8 +159,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
             Model model = null;
             var viewContext = TestableHtmlGenerator.GetViewContext(model, htmlGenerator, metadataProvider);
-            var activator = new DefaultTagHelperActivator();
-            activator.Activate(tagHelper, viewContext);
+            tagHelper.ViewContext = viewContext;
+            tagHelper.Generator = htmlGenerator;
 
             // Act
             await tagHelper.ProcessAsync(tagHelperContext, output);

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TestableHtmlGenerator.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TestableHtmlGenerator.cs
@@ -4,9 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Mvc.ModelBinding;
 using Microsoft.AspNet.Mvc.Rendering;
+using Microsoft.AspNet.PipelineCore;
 using Microsoft.AspNet.Routing;
 using Microsoft.AspNet.Security.DataProtection;
 using Microsoft.Framework.OptionsModel;
@@ -50,22 +50,12 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             IHtmlGenerator htmlGenerator,
             IModelMetadataProvider metadataProvider)
         {
-            var serviceProvider = new Mock<IServiceProvider>();
-            serviceProvider
-                .Setup(provider => provider.GetService(typeof(IHtmlGenerator)))
-                .Returns(htmlGenerator);
-
-            var httpContext = new Mock<HttpContext>();
-            httpContext
-                .Setup(context => context.RequestServices)
-                .Returns(serviceProvider.Object);
-
-            var actionContext = new ActionContext(httpContext.Object, new RouteData(), new ActionDescriptor());
+            var actionContext = new ActionContext(new DefaultHttpContext(), new RouteData(), new ActionDescriptor());
             var viewData = new ViewDataDictionary(metadataProvider)
             {
                 Model = model,
             };
-            var viewContext = new ViewContext(actionContext, Mock.Of<IView>(), viewData, new StringWriter());
+            var viewContext = new ViewContext(actionContext, Mock.Of<IView>(), viewData, TextWriter.Null);
 
             return viewContext;
         }

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TextAreaTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TextAreaTagHelperTest.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc.ModelBinding;
-using Microsoft.AspNet.Mvc.Razor;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 using Xunit;
@@ -57,8 +56,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     { modelWithText, typeof(NestedModel), () => modelWithText.NestedModel.Text, "NestedModel.Text",
                         Environment.NewLine + "inner text" },
 
-                        // Top-level indexing does not work end-to-end due to code generation issue #1345.
-                        // TODO: Remove above comment when #1345 is fixed.
+                    // Top-level indexing does not work end-to-end due to code generation issue #1345.
+                    // TODO: Remove above comment when #1345 is fixed.
                     { models, typeof(Model), () => models[0].Text, "[0].Text",
                         Environment.NewLine },
                     { models, typeof(Model), () => models[1].Text, "[1].Text",
@@ -119,8 +118,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 }
             };
             var viewContext = TestableHtmlGenerator.GetViewContext(model, htmlGenerator, metadataProvider);
-            var activator = new DefaultTagHelperActivator();
-            activator.Activate(tagHelper, viewContext);
+            tagHelper.ViewContext = viewContext;
+            tagHelper.Generator = htmlGenerator;
 
             // Act
             await tagHelper.ProcessAsync(tagHelperContext, output);
@@ -166,8 +165,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             };
             Model model = null;
             var viewContext = TestableHtmlGenerator.GetViewContext(model, htmlGenerator, metadataProvider);
-            var activator = new DefaultTagHelperActivator();
-            activator.Activate(tagHelper, viewContext);
+            tagHelper.ViewContext = viewContext;
+            tagHelper.Generator = htmlGenerator;
 
             // Act
             await tagHelper.ProcessAsync(tagHelperContext, output);

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ValidationSummaryTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ValidationSummaryTagHelperTest.cs
@@ -4,11 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Mvc.ModelBinding;
-using Microsoft.AspNet.Mvc.Razor;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.PipelineCore;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
@@ -259,8 +256,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                                   "are 'All', 'ModelOnly' and 'None'.";
 
             // Act
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => 
-                validationSummaryTagHelper.ProcessAsync(context: null, output: output));
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => validationSummaryTagHelper.ProcessAsync(context: null, output: output));
 
             // Assert
             Assert.Equal(expectedMessage, ex.Message);


### PR DESCRIPTION
- Changed TagHelper property accessors from private to protected internal.
- Changed throw tests to be shorter.
- Changed reflection setting to now use the internal accessibility of the TagHelpers
- Removed activator to just use internal accessibility of TagHelpers.
