### PR TITLE
React to case insensitive TagHelperOutput.Attributes.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.TagHelpers/InputTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/InputTagHelper.cs
@@ -154,9 +154,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 if (!string.IsNullOrEmpty(inputType))
                 {
                     // inputType may be more specific than default the generator chooses below.
-                    // TODO: Use Attributes.ContainsKey once aspnet/Razor#186 is fixed.
-                    if (!output.Attributes.Any(
-                        item => string.Equals("type", item.Key, StringComparison.OrdinalIgnoreCase)))
+                    if (!output.Attributes.ContainsKey("type"))
                     {
                         output.Attributes["type"] = inputType;
                     }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/TagHelperOutputExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/TagHelperOutputExtensions.cs
@@ -89,13 +89,11 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             foreach (var attribute in tagBuilder.Attributes)
             {
-                // TODO: Use Attributes.ContainsKey once aspnet/Razor#186 is fixed.
-                if (!tagHelperOutput.Attributes.Any(
-                    item => string.Equals(attribute.Key, item.Key, StringComparison.OrdinalIgnoreCase)))
+                if (!tagHelperOutput.Attributes.ContainsKey(attribute.Key))
                 {
                     tagHelperOutput.Attributes.Add(attribute.Key, attribute.Value);
                 }
-                else if (attribute.Key.Equals("class", StringComparison.Ordinal))
+                else if (attribute.Key.Equals("class", StringComparison.OrdinalIgnoreCase))
                 {
                     tagHelperOutput.Attributes["class"] += " " + attribute.Value;
                 }

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TagHelperOutputExtensionsTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TagHelperOutputExtensionsTest.cs
@@ -157,6 +157,31 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal(expectedAttribute, attribute);
         }
 
+        [Theory]
+        [InlineData("class", "CLAss")]
+        [InlineData("ClaSS", "class")]
+        [InlineData("ClaSS", "cLaSs")]
+        public void MergeAttributes_AppendsClass_TagHelperOutputAttributeValues_IgnoresCase(
+            string originalName, string updateName)
+        {
+            // Arrange
+            var tagHelperOutput = new TagHelperOutput(
+                "p",
+                attributes: new Dictionary<string, string>(),
+                content: string.Empty);
+            tagHelperOutput.Attributes.Add(originalName, "Hello");
+
+            var tagBuilder = new TagBuilder("p");
+            tagBuilder.Attributes.Add(updateName, "btn");
+
+            // Act
+            tagHelperOutput.MergeAttributes(tagBuilder);
+
+            // Assert
+            var attribute = Assert.Single(tagHelperOutput.Attributes);
+            Assert.Equal(new KeyValuePair<string, string>(originalName, "Hello btn"), attribute);
+        }
+
         [Fact]
         public void MergeAttributes_DoesNotEncode_TagHelperOutputAttributeValues()
         {


### PR DESCRIPTION
- Cleaned up some existing bad code that worked around case sensitive TagHelperOutput.Attributes.
- Modified MergeAttributes to be case insensitive when it comes to merging class attributes.
- Added a test to verify the new MergeAttribute case insensitive class merging.

https://github.com/aspnet/Mvc/issues/1449

**NOTE:** This PR depends on https://github.com/aspnet/Razor/pull/198 being merged.
