### PR TITLE
Rename GlobalModel -> ApplicationModel

### DIFF
--- a/samples/MvcSample.Web/AutoGenerateRouteNamesAttribute.cs
+++ b/samples/MvcSample.Web/AutoGenerateRouteNamesAttribute.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNet.Mvc.ApplicationModel;
+using Microsoft.AspNet.Mvc.ApplicationModels;
 
 namespace MvcSample.Web
 {

--- a/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/ActionModel.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/ActionModel.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-namespace Microsoft.AspNet.Mvc.ApplicationModel
+namespace Microsoft.AspNet.Mvc.ApplicationModels
 {
     public class ActionModel
     {

--- a/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/ApplicationModel.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/ApplicationModel.cs
@@ -3,11 +3,11 @@
 
 using System.Collections.Generic;
 
-namespace Microsoft.AspNet.Mvc.ApplicationModel
+namespace Microsoft.AspNet.Mvc.ApplicationModels
 {
-    public class GlobalModel
+    public class ApplicationModel
     {
-        public GlobalModel()
+        public ApplicationModel()
         {
             Controllers = new List<ControllerModel>();
             Filters = new List<IFilter>();

--- a/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/ApplicationModelConventions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/ApplicationModelConventions.cs
@@ -4,21 +4,21 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Microsoft.AspNet.Mvc.ApplicationModel
+namespace Microsoft.AspNet.Mvc.ApplicationModels
 {
     /// <summary>
-    /// Applies conventions to a <see cref="GlobalModel"/>.
+    /// Applies conventions to a <see cref="ApplicationModel"/>.
     /// </summary>
     public static class ApplicationModelConventions
     {
         /// <summary>
-        /// Applies conventions to a <see cref="GlobalModel"/>.
+        /// Applies conventions to a <see cref="ApplicationModel"/>.
         /// </summary>
-        /// <param name="applicationModel">The <see cref="GlobalModel"/>.</param>
+        /// <param name="applicationModel">The <see cref="ApplicationModel"/>.</param>
         /// <param name="conventions">The set of conventions.</param>
         public static void ApplyConventions(
-            [NotNull] GlobalModel applicationModel, 
-            [NotNull] IEnumerable<IGlobalModelConvention> conventions)
+            [NotNull] ApplicationModel applicationModel, 
+            [NotNull] IEnumerable<IApplicationModelConvention> conventions)
         {
             // Conventions are applied from the outside-in to allow for scenarios where an action overrides
             // a controller, etc.

--- a/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/AttributeRouteModel.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/AttributeRouteModel.cs
@@ -7,7 +7,7 @@ using System.Text;
 using Microsoft.AspNet.Mvc.Core;
 using Microsoft.AspNet.Mvc.Routing;
 
-namespace Microsoft.AspNet.Mvc.ApplicationModel
+namespace Microsoft.AspNet.Mvc.ApplicationModels
 {
     public class AttributeRouteModel
     {

--- a/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/ControllerModel.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/ControllerModel.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-namespace Microsoft.AspNet.Mvc.ApplicationModel
+namespace Microsoft.AspNet.Mvc.ApplicationModels
 {
     public class ControllerModel
     {
@@ -47,7 +47,7 @@ namespace Microsoft.AspNet.Mvc.ApplicationModel
 
         public List<ActionModel> Actions { get; private set; }
 
-        public GlobalModel Application { get; set; }
+        public ApplicationModel Application { get; set; }
 
         public List<object> Attributes { get; private set; }
 

--- a/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/DefaultActionModelBuilder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/DefaultActionModelBuilder.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNet.Mvc.Description;
 using Microsoft.AspNet.Mvc.ModelBinding;
 using Microsoft.AspNet.Mvc.Routing;
 
-namespace Microsoft.AspNet.Mvc.ApplicationModel
+namespace Microsoft.AspNet.Mvc.ApplicationModels
 {
     /// <summary>
     /// A default implementation of <see cref="IActionModelBuilder"/>.

--- a/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/DefaultControllerModelBuilder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/DefaultControllerModelBuilder.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 using Microsoft.AspNet.Mvc.Description;
 using Microsoft.AspNet.Mvc.Routing;
 
-namespace Microsoft.AspNet.Mvc.ApplicationModel
+namespace Microsoft.AspNet.Mvc.ApplicationModels
 {
     /// <summary>
     /// A default implementation of <see cref="IControllerModelBuilder"/>.

--- a/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/IActionModelBuilder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/IActionModelBuilder.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using System.Reflection;
 
-namespace Microsoft.AspNet.Mvc.ApplicationModel
+namespace Microsoft.AspNet.Mvc.ApplicationModels
 {
     /// <summary>
     /// Creates a set of <see cref="ActionModel"/> for a method. 

--- a/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/IActionModelConvention.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/IActionModelConvention.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.AspNet.Mvc.ApplicationModel
+namespace Microsoft.AspNet.Mvc.ApplicationModels
 {
     /// <summary>
     /// Allows customization of the of the <see cref="ActionModel"/>.
@@ -19,7 +19,7 @@ namespace Microsoft.AspNet.Mvc.ApplicationModel
         /// <summary>
         /// Called to apply the convention to the <see cref="ActionModel"/>.
         /// </summary>
-        /// <param name="model">The <see cref="ActionModel"/>.</param>
-        void Apply([NotNull] ActionModel model);
+        /// <param name="action">The <see cref="ActionModel"/>.</param>
+        void Apply([NotNull] ActionModel action);
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/IApplicationModelConvention.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/IApplicationModelConvention.cs
@@ -1,24 +1,24 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.AspNet.Mvc.ApplicationModel
+namespace Microsoft.AspNet.Mvc.ApplicationModels
 {
     /// <summary>
-    /// Allows customization of the of the <see cref="GlobalModel"/>.
+    /// Allows customization of the of the <see cref="ApplicationModel"/>.
     /// </summary>
     /// <remarks>
     /// Implementaions of this interface can be registered in <see cref="MvcOptions.ApplicationModelConventions"/>
     /// to customize metadata about the application.
     /// 
-    /// <see cref="IGlobalModelConvention"/> run before other types of customizations to the
+    /// <see cref="IApplicationModelConvention"/> run before other types of customizations to the
     /// reflected model.
     /// </remarks>
-    public interface IGlobalModelConvention
+    public interface IApplicationModelConvention
     {
         /// <summary>
-        /// Called to apply the convention to the <see cref="GlobalModel"/>.
+        /// Called to apply the convention to the <see cref="ApplicationModel"/>.
         /// </summary>
-        /// <param name="model">The <see cref="GlobalModel"/>.</param>
-        void Apply([NotNull] GlobalModel model);
+        /// <param name="application">The <see cref="ApplicationModel"/>.</param>
+        void Apply([NotNull] ApplicationModel application);
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/IControllerModelBuilder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/IControllerModelBuilder.cs
@@ -3,7 +3,7 @@
 
 using System.Reflection;
 
-namespace Microsoft.AspNet.Mvc.ApplicationModel
+namespace Microsoft.AspNet.Mvc.ApplicationModels
 {
     /// <summary>
     /// Creates a set of <see cref="ControllerModel"/> for a type. 

--- a/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/IControllerModelConvention.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/IControllerModelConvention.cs
@@ -1,24 +1,25 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.AspNet.Mvc.ApplicationModel
+namespace Microsoft.AspNet.Mvc.ApplicationModels
 {
     /// <summary>
     /// Allows customization of the of the <see cref="ControllerModel"/>.
     /// </summary>
     /// <remarks>
     /// To use this interface, create an <see cref="System.Attribute"/> class which implements the interface and
-    /// place it on an action method parameter.
+    /// place it on a controller class.
     /// 
-    /// <see cref="IParameterModelConvention"/> customizations run after 
+    /// <see cref="IControllerModelConvention"/> customizations run after 
+    /// <see cref="IApplicationModelConvention"/> customizations and before 
     /// <see cref="IActionModelConvention"/> customizations.
     /// </remarks>
-    public interface IParameterModelConvention
+    public interface IControllerModelConvention
     {
         /// <summary>
-        /// Called to apply the convention to the <see cref="ParameterModel"/>.
+        /// Called to apply the convention to the <see cref="ControllerModel"/>.
         /// </summary>
-        /// <param name="model">The <see cref="ParameterModel"/>.</param>
-        void Apply([NotNull] ParameterModel model);
+        /// <param name="controller">The <see cref="ControllerModel"/>.</param>
+        void Apply([NotNull] ControllerModel controller);
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/IParameterModelConvention.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/IParameterModelConvention.cs
@@ -1,25 +1,24 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.AspNet.Mvc.ApplicationModel
+namespace Microsoft.AspNet.Mvc.ApplicationModels
 {
     /// <summary>
     /// Allows customization of the of the <see cref="ControllerModel"/>.
     /// </summary>
     /// <remarks>
     /// To use this interface, create an <see cref="System.Attribute"/> class which implements the interface and
-    /// place it on a controller class.
+    /// place it on an action method parameter.
     /// 
-    /// <see cref="IControllerModelConvention"/> customizations run after 
-    /// <see cref="IGlobalModelConvention"/> customizations and before 
+    /// <see cref="IParameterModelConvention"/> customizations run after 
     /// <see cref="IActionModelConvention"/> customizations.
     /// </remarks>
-    public interface IControllerModelConvention
+    public interface IParameterModelConvention
     {
         /// <summary>
-        /// Called to apply the convention to the <see cref="ControllerModel"/>.
+        /// Called to apply the convention to the <see cref="ParameterModel"/>.
         /// </summary>
-        /// <param name="model">The <see cref="ControllerModel"/>.</param>
-        void Apply([NotNull] ControllerModel model);
+        /// <param name="parameter">The <see cref="ParameterModel"/>.</param>
+        void Apply([NotNull] ParameterModel parameter);
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/ParameterModel.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/ParameterModel.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.AspNet.Mvc.ModelBinding;
 
-namespace Microsoft.AspNet.Mvc.ApplicationModel
+namespace Microsoft.AspNet.Mvc.ApplicationModels
 {
     public class ParameterModel
     {

--- a/src/Microsoft.AspNet.Mvc.Core/ControllerActionDescriptorBuilder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ControllerActionDescriptorBuilder.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
-using Microsoft.AspNet.Mvc.ApplicationModel;
+using Microsoft.AspNet.Mvc.ApplicationModels;
 using Microsoft.AspNet.Mvc.Core;
 using Microsoft.AspNet.Mvc.Description;
 using Microsoft.AspNet.Mvc.Routing;
@@ -14,7 +14,7 @@ using Microsoft.AspNet.Mvc.Routing;
 namespace Microsoft.AspNet.Mvc
 {
     /// <summary>
-    /// Creates instances of <see cref="ControllerActionDescriptor"/> from <see cref="GlobalModel"/>.
+    /// Creates instances of <see cref="ControllerActionDescriptor"/> from <see cref="ApplicationModel"/>.
     /// </summary>
     public static class ControllerActionDescriptorBuilder
     {
@@ -23,11 +23,11 @@ namespace Microsoft.AspNet.Mvc
         private const int DefaultAttributeRouteOrder = 0;
 
         /// <summary>
-        /// Creates instances of <see cref="ControllerActionDescriptor"/> from <see cref="GlobalModel"/>.
+        /// Creates instances of <see cref="ControllerActionDescriptor"/> from <see cref="ApplicationModel"/>.
         /// </summary>
-        /// <param name="application">The <see cref="GlobalModel"/>.</param>
+        /// <param name="application">The <see cref="ApplicationModel"/>.</param>
         /// <returns>The list of <see cref="ControllerActionDescriptor"/>.</returns>
-        public static IList<ControllerActionDescriptor> Build(GlobalModel application)
+        public static IList<ControllerActionDescriptor> Build(ApplicationModel application)
         {
             var actions = new List<ControllerActionDescriptor>();
 
@@ -176,7 +176,7 @@ namespace Microsoft.AspNet.Mvc
         }
 
         private static IList<ControllerActionDescriptor> CreateActionDescriptors(
-            GlobalModel application,
+            ApplicationModel application,
             ControllerModel controller,
             ActionModel action)
         {

--- a/src/Microsoft.AspNet.Mvc.Core/ControllerActionDescriptorProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ControllerActionDescriptorProvider.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNet.Mvc.Filters;
-using Microsoft.AspNet.Mvc.ApplicationModel;
+using Microsoft.AspNet.Mvc.ApplicationModels;
 using Microsoft.Framework.OptionsModel;
 
 namespace Microsoft.AspNet.Mvc
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.Mvc
         private readonly IControllerModelBuilder _applicationModelBuilder;
         private readonly IAssemblyProvider _assemblyProvider;
         private readonly IReadOnlyList<IFilter> _globalFilters;
-        private readonly IEnumerable<IGlobalModelConvention> _modelConventions;
+        private readonly IEnumerable<IApplicationModelConvention> _modelConventions;
 
         public ControllerActionDescriptorProvider(IAssemblyProvider assemblyProvider,
                                                  IControllerModelBuilder applicationModelBuilder,
@@ -47,9 +47,9 @@ namespace Microsoft.AspNet.Mvc
             return ControllerActionDescriptorBuilder.Build(applicationModel);
         }
 
-        public GlobalModel BuildModel()
+        public ApplicationModel BuildModel()
         {
-            var applicationModel = new GlobalModel();
+            var applicationModel = new ApplicationModel();
             applicationModel.Filters.AddRange(_globalFilters);
 
             var assemblies = _assemblyProvider.CandidateAssemblies;

--- a/src/Microsoft.AspNet.Mvc.Core/MvcOptions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/MvcOptions.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.AspNet.Mvc.ApplicationModel;
+using Microsoft.AspNet.Mvc.ApplicationModels;
 using Microsoft.AspNet.Mvc.Core;
 using Microsoft.AspNet.Mvc.ModelBinding;
 using Microsoft.AspNet.Mvc.OptionDescriptors;
@@ -20,7 +20,7 @@ namespace Microsoft.AspNet.Mvc
 
         public MvcOptions()
         {
-            ApplicationModelConventions = new List<IGlobalModelConvention>();
+            ApplicationModelConventions = new List<IApplicationModelConvention>();
             ModelBinders = new List<ModelBinderDescriptor>();
             ViewEngines = new List<ViewEngineDescriptor>();
             ValueProviderFactories = new List<ValueProviderFactoryDescriptor>();
@@ -121,6 +121,10 @@ namespace Microsoft.AspNet.Mvc
         /// </summary>
         public List<ValueProviderFactoryDescriptor> ValueProviderFactories { get; private set; }
 
-        public List<IGlobalModelConvention> ApplicationModelConventions { get; private set; }
+        /// <summary>
+        /// Gets a list of <see cref="IApplicationModelConvention"/> instances that will be applied to
+        /// the <see cref="ApplicationModel"/> when discovering actions.
+        /// </summary>
+        public List<IApplicationModelConvention> ApplicationModelConventions { get; private set; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/Conventions/WebApiActionConventionsApplicationModelConvention.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/Conventions/WebApiActionConventionsApplicationModelConvention.cs
@@ -4,11 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.AspNet.Mvc.ApplicationModel;
+using Microsoft.AspNet.Mvc.ApplicationModels;
 
 namespace Microsoft.AspNet.Mvc.WebApiCompatShim
 {
-    public class WebApiActionConventionsGlobalModelConvention : IGlobalModelConvention
+    public class WebApiActionConventionsApplicationModelConvention : IApplicationModelConvention
     {
         private static readonly string[] SupportedHttpMethodConventions = new string[]
         {
@@ -21,9 +21,9 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShim
             "OPTIONS",
         };
 
-        public void Apply(GlobalModel model)
+        public void Apply(ApplicationModel application)
         {
-            foreach (var controller in model.Controllers)
+            foreach (var controller in application.Controllers)
             {
                 if (IsConventionApplicable(controller))
                 {
@@ -37,11 +37,11 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShim
             return controller.Attributes.OfType<IUseWebApiActionConventions>().Any();
         }
 
-        private void Apply(ControllerModel model)
+        private void Apply(ControllerModel controller)
         {
             var newActions = new List<ActionModel>();
 
-            foreach (var action in model.Actions)
+            foreach (var action in controller.Actions)
             {
                 SetHttpMethodFromConvention(action);
 
@@ -57,7 +57,7 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShim
                 }
             }
 
-            model.Actions.AddRange(newActions);
+            controller.Actions.AddRange(newActions);
         }
 
         private bool IsActionAttributeRouted(ActionModel action)

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/Conventions/WebApiOverloadingApplicationModelConvention.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/Conventions/WebApiOverloadingApplicationModelConvention.cs
@@ -2,15 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
-using Microsoft.AspNet.Mvc.ApplicationModel;
+using Microsoft.AspNet.Mvc.ApplicationModels;
 
 namespace Microsoft.AspNet.Mvc.WebApiCompatShim
 {
-    public class WebApiOverloadingGlobalModelConvention : IGlobalModelConvention
+    public class WebApiOverloadingApplicationModelConvention : IApplicationModelConvention
     {
-        public void Apply(GlobalModel model)
+        public void Apply(ApplicationModel application)
         {
-            foreach (var controller in model.Controllers)
+            foreach (var controller in application.Controllers)
             {
                 if (IsConventionApplicable(controller))
                 {
@@ -24,9 +24,9 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShim
             return controller.Attributes.OfType<IUseWebApiOverloading>().Any();
         }
 
-        private void Apply(ControllerModel model)
+        private void Apply(ControllerModel controller)
         {
-            foreach (var action in model.Actions)
+            foreach (var action in controller.Actions)
             {
                 action.ActionConstraints.Add(new OverloadActionConstraint());
             }

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/Conventions/WebApiParameterConventionsApplicationModelConvention.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/Conventions/WebApiParameterConventionsApplicationModelConvention.cs
@@ -3,16 +3,16 @@
 
 using System.Linq;
 using System.Web.Http;
-using Microsoft.AspNet.Mvc.ApplicationModel;
+using Microsoft.AspNet.Mvc.ApplicationModels;
 using Microsoft.AspNet.Mvc.ModelBinding;
 
 namespace Microsoft.AspNet.Mvc.WebApiCompatShim
 {
-    public class WebApiParameterConventionsGlobalModelConvention : IGlobalModelConvention
+    public class WebApiParameterConventionsApplicationModelConvention : IApplicationModelConvention
     {
-        public void Apply(GlobalModel model)
+        public void Apply(ApplicationModel application)
         {
-            foreach (var controller in model.Controllers)
+            foreach (var controller in application.Controllers)
             {
                 if (IsConventionApplicable(controller))
                 {
@@ -26,9 +26,9 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShim
             return controller.Attributes.OfType<IUseWebApiParameterConventions>().Any();
         }
 
-        private void Apply(ControllerModel model)
+        private void Apply(ControllerModel controller)
         {
-            foreach (var action in model.Actions)
+            foreach (var action in controller.Actions)
             {
                 foreach (var parameter in action.Parameters)
                 {

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/Conventions/WebApiRoutesApplicationModelConvention.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/Conventions/WebApiRoutesApplicationModelConvention.cs
@@ -2,22 +2,22 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
-using Microsoft.AspNet.Mvc.ApplicationModel;
+using Microsoft.AspNet.Mvc.ApplicationModels;
 
 namespace Microsoft.AspNet.Mvc.WebApiCompatShim
 {
-    public class WebApiRoutesGlobalModelConvention : IGlobalModelConvention
+    public class WebApiRoutesApplicationModelConvention : IApplicationModelConvention
     {
         private readonly string _area;
 
-        public WebApiRoutesGlobalModelConvention(string area)
+        public WebApiRoutesApplicationModelConvention(string area)
         {
             _area = area;
         }
 
-        public void Apply(GlobalModel model)
+        public void Apply(ApplicationModel application)
         {
-            foreach (var controller in model.Controllers)
+            foreach (var controller in application.Controllers)
             {
                 if (IsConventionApplicable(controller))
                 {
@@ -31,9 +31,9 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShim
             return controller.Attributes.OfType<IUseWebApiRoutes>().Any();
         }
 
-        private void Apply(ControllerModel model)
+        private void Apply(ControllerModel controller)
         {
-            model.RouteConstraints.Add(new AreaAttribute(_area));
+            controller.RouteConstraints.Add(new AreaAttribute(_area));
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/WebApiCompatShimOptionsSetup.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/WebApiCompatShimOptionsSetup.cs
@@ -21,10 +21,10 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShim
         public void Configure(MvcOptions options, string name = "")
         {
             // Add webapi behaviors to controllers with the appropriate attributes
-            options.ApplicationModelConventions.Add(new WebApiActionConventionsGlobalModelConvention());
-            options.ApplicationModelConventions.Add(new WebApiParameterConventionsGlobalModelConvention());
-            options.ApplicationModelConventions.Add(new WebApiOverloadingGlobalModelConvention());
-            options.ApplicationModelConventions.Add(new WebApiRoutesGlobalModelConvention(area: DefaultAreaName));
+            options.ApplicationModelConventions.Add(new WebApiActionConventionsApplicationModelConvention());
+            options.ApplicationModelConventions.Add(new WebApiParameterConventionsApplicationModelConvention());
+            options.ApplicationModelConventions.Add(new WebApiOverloadingApplicationModelConvention());
+            options.ApplicationModelConventions.Add(new WebApiRoutesApplicationModelConvention(area: DefaultAreaName));
 
             // Add an action filter for handling the HttpResponseException.
             options.Filters.Add(new HttpResponseExceptionActionFilter());

--- a/src/Microsoft.AspNet.Mvc/MvcServices.cs
+++ b/src/Microsoft.AspNet.Mvc/MvcServices.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using Microsoft.AspNet.Mvc.ApplicationModel;
+using Microsoft.AspNet.Mvc.ApplicationModels;
 using Microsoft.AspNet.Mvc.Description;
 using Microsoft.AspNet.Mvc.Filters;
 using Microsoft.AspNet.Mvc.Internal;

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ApplicationModel/ActionModelTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ApplicationModel/ActionModelTest.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using Xunit;
 
-namespace Microsoft.AspNet.Mvc.ApplicationModel
+namespace Microsoft.AspNet.Mvc.ApplicationModels
 {
     public class ActionModelTest
     {

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ApplicationModel/AttributeRouteModelTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ApplicationModel/AttributeRouteModelTests.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using Xunit;
 
-namespace Microsoft.AspNet.Mvc.ApplicationModel
+namespace Microsoft.AspNet.Mvc.ApplicationModels
 {
     public class AttributeRouteModelTests
     {

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ApplicationModel/ControllerModelTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ApplicationModel/ControllerModelTest.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using Xunit;
 
-namespace Microsoft.AspNet.Mvc.ApplicationModel
+namespace Microsoft.AspNet.Mvc.ApplicationModels
 {
     public class ControllerModelTest
     {
@@ -46,7 +46,7 @@ namespace Microsoft.AspNet.Mvc.ApplicationModel
             controller.ActionConstraints.Add(new HttpMethodConstraint(new string[] { "GET" }));
             controller.ApiExplorerGroupName = "group";
             controller.ApiExplorerIsVisible = true;
-            controller.Application = new GlobalModel();
+            controller.Application = new ApplicationModel();
             controller.Attributes.Add(new HttpGetAttribute());
             controller.ControllerName = "cool";
             controller.Filters.Add(new AuthorizeAttribute());

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ApplicationModel/DefaultActionModelBuilderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ApplicationModel/DefaultActionModelBuilderTest.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Reflection;
 using Xunit;
 
-namespace Microsoft.AspNet.Mvc.ApplicationModel
+namespace Microsoft.AspNet.Mvc.ApplicationModels
 {
     public class DefaultActionModelBuilderTest
     {

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ApplicationModel/DefaultControllerModelBuilderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ApplicationModel/DefaultControllerModelBuilderTest.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Reflection;
-using Microsoft.AspNet.Mvc.ApplicationModel.DefaultControllerModelBuilderTestControllers;
+using Microsoft.AspNet.Mvc.ApplicationModels.DefaultControllerModelBuilderTestControllers;
 using Xunit;
 
-namespace Microsoft.AspNet.Mvc.ApplicationModel
+namespace Microsoft.AspNet.Mvc.ApplicationModels
 {
     public class DefaultControllerModelBuilderTest
     {
@@ -183,7 +183,7 @@ namespace Microsoft.AspNet.Mvc.ApplicationModel
 // implementation of this class to test it, they are just top level classes. Don't reuse
 // these outside this test - find a better way or use nested classes to keep the tests
 // independent.
-namespace Microsoft.AspNet.Mvc.ApplicationModel.DefaultControllerModelBuilderTestControllers
+namespace Microsoft.AspNet.Mvc.ApplicationModels.DefaultControllerModelBuilderTestControllers
 {
     public abstract class AbstractController : Mvc.Controller
     {

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ApplicationModel/ParameterModelTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ApplicationModel/ParameterModelTest.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using Microsoft.AspNet.Mvc.ModelBinding;
 using Xunit;
 
-namespace Microsoft.AspNet.Mvc.ApplicationModel
+namespace Microsoft.AspNet.Mvc.ApplicationModels
 {
     public class ParameterModelTest
     {

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ControllerActionDescriptorProviderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ControllerActionDescriptorProviderTests.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.AspNet.Mvc.Description;
 using Microsoft.AspNet.Mvc.Routing;
-using Microsoft.AspNet.Mvc.ApplicationModel;
+using Microsoft.AspNet.Mvc.ApplicationModels;
 using Microsoft.Framework.OptionsModel;
 using Moq;
 using Xunit;
@@ -1114,9 +1114,9 @@ namespace Microsoft.AspNet.Mvc.Test
             // Arrange
             var sequence = 0;
 
-            var applicationConvention = new Mock<IGlobalModelConvention>();
+            var applicationConvention = new Mock<IApplicationModelConvention>();
             applicationConvention
-                .Setup(c => c.Apply(It.IsAny<GlobalModel>()))
+                .Setup(c => c.Apply(It.IsAny<ApplicationModel>()))
                 .Callback(() => { Assert.Equal(0, sequence++); });
 
             var controllerConvention = new Mock<IControllerModelConvention>();

--- a/test/Microsoft.AspNet.Mvc.Core.Test/DefaultActionSelectorTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/DefaultActionSelectorTests.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Reflection;
 using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Mvc.ApplicationModel;
+using Microsoft.AspNet.Mvc.ApplicationModels;
 using Microsoft.AspNet.Mvc.Logging;
 using Microsoft.AspNet.Mvc.Routing;
 using Microsoft.AspNet.PipelineCore;

--- a/test/Microsoft.AspNet.Mvc.Core.Test/StaticControllerModelBuilder.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/StaticControllerModelBuilder.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-namespace Microsoft.AspNet.Mvc.ApplicationModel
+namespace Microsoft.AspNet.Mvc.ApplicationModels
 {
     /// <summary>
     /// An implementation of StaticControllerModelBuilder that only allows controllers

--- a/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/ApiControllerActionDiscoveryTest.cs
+++ b/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/ApiControllerActionDiscoveryTest.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNet.Mvc;
-using Microsoft.AspNet.Mvc.ApplicationModel;
+using Microsoft.AspNet.Mvc.ApplicationModels;
 using Microsoft.AspNet.Mvc.Filters;
 using Microsoft.AspNet.Mvc.WebApiCompatShim;
 using Microsoft.Framework.DependencyInjection;

--- a/test/WebSites/ApiExplorerWebSite/ApiExplorerVisibilityDisabledConvention.cs
+++ b/test/WebSites/ApiExplorerWebSite/ApiExplorerVisibilityDisabledConvention.cs
@@ -3,14 +3,14 @@
 
 using System;
 using System.Reflection;
-using Microsoft.AspNet.Mvc.ApplicationModel;
+using Microsoft.AspNet.Mvc.ApplicationModels;
 
 namespace ApiExplorer
 {
     // Disables ApiExplorer for a specific controller type.
     // This is part of the test that validates that ApiExplorer can be configured via
     // convention
-    public class ApiExplorerVisibilityDisabledConvention : IGlobalModelConvention
+    public class ApiExplorerVisibilityDisabledConvention : IApplicationModelConvention
     {
         private readonly TypeInfo _type;
 
@@ -19,9 +19,9 @@ namespace ApiExplorer
             _type = type.GetTypeInfo();
         }
 
-        public void Apply(GlobalModel model)
+        public void Apply(ApplicationModel application)
         {
-            foreach (var controller in model.Controllers)
+            foreach (var controller in application.Controllers)
             {
                 if (controller.ControllerType == _type)
                 {

--- a/test/WebSites/ApiExplorerWebSite/ApiExplorerVisibilityEnabledConvention.cs
+++ b/test/WebSites/ApiExplorerWebSite/ApiExplorerVisibilityEnabledConvention.cs
@@ -1,18 +1,18 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNet.Mvc.ApplicationModel;
+using Microsoft.AspNet.Mvc.ApplicationModels;
 
 namespace ApiExplorer
 {
     // Enables ApiExplorer for controllers that haven't explicitly configured it.
     // This is part of the test that validates that ApiExplorer can be configured via
     // convention
-    public class ApiExplorerVisibilityEnabledConvention : IGlobalModelConvention
+    public class ApiExplorerVisibilityEnabledConvention : IApplicationModelConvention
     {
-        public void Apply(GlobalModel model)
+        public void Apply(ApplicationModel application)
         {
-            foreach (var controller in model.Controllers)
+            foreach (var controller in application.Controllers)
             {
                 if (controller.ApiExplorerIsVisible == null)
                 {

--- a/test/WebSites/ApplicationModelWebSite/Controllers/ActionModelController.cs
+++ b/test/WebSites/ApplicationModelWebSite/Controllers/ActionModelController.cs
@@ -3,7 +3,7 @@
 
 using System;
 using Microsoft.AspNet.Mvc;
-using Microsoft.AspNet.Mvc.ApplicationModel;
+using Microsoft.AspNet.Mvc.ApplicationModels;
 
 namespace ApplicationModelWebSite
 {

--- a/test/WebSites/ApplicationModelWebSite/Controllers/ControllerModelController.cs
+++ b/test/WebSites/ApplicationModelWebSite/Controllers/ControllerModelController.cs
@@ -3,7 +3,7 @@
 
 using System;
 using Microsoft.AspNet.Mvc;
-using Microsoft.AspNet.Mvc.ApplicationModel;
+using Microsoft.AspNet.Mvc.ApplicationModels;
 
 namespace ApplicationModelWebSite
 {

--- a/test/WebSites/ApplicationModelWebSite/Controllers/ParameterModelController.cs
+++ b/test/WebSites/ApplicationModelWebSite/Controllers/ParameterModelController.cs
@@ -3,7 +3,7 @@
 
 using System;
 using Microsoft.AspNet.Mvc;
-using Microsoft.AspNet.Mvc.ApplicationModel;
+using Microsoft.AspNet.Mvc.ApplicationModels;
 
 namespace ApplicationModelWebSite
 {


### PR DESCRIPTION
This also comes with a rename of the namespace
Microsoft.AspNet.Mvc.ApplicationModel to
Microsoft.AspNet.Mvc.ApplicationModels.

Also tuned up some parameter and variable names for increased
understandability.
