### PR TITLE
Change the IRazorCompilationService's DI lifetime.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/Razor/RazorCompilationService.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Razor/RazorCompilationService.cs
@@ -9,9 +9,6 @@ namespace Microsoft.AspNet.Mvc.Razor
     /// <summary>
     /// Default implementation of <see cref="IRazorCompilationService"/>.
     /// </summary>
-    /// <remarks>
-    /// This class must be registered as a singleton service for the caching to work.
-    /// </remarks>
     public class RazorCompilationService : IRazorCompilationService
     {
         private readonly ICompilationService _compilationService;

--- a/src/Microsoft.AspNet.Mvc/MvcServices.cs
+++ b/src/Microsoft.AspNet.Mvc/MvcServices.cs
@@ -125,9 +125,9 @@ namespace Microsoft.AspNet.Mvc
             yield return describe.Singleton<ICompilationService, RoslynCompilationService>();
 
             // Both the compiler cache and roslyn compilation service hold on the compilation related
-            // caches. RazorCompilation service is just an adapter service, and it is scoped
-            // since it will typically be resolved multiple times per request.
-            yield return describe.Scoped<IRazorCompilationService, RazorCompilationService>();
+            // caches. RazorCompilation service is just an adapter service, and it is transient to ensure
+            // the IMvcRazorHost dependency does not maintain state.
+            yield return describe.Transient<IRazorCompilationService, RazorCompilationService>();
 
             // The ViewStartProvider needs to be able to consume scoped instances of IRazorPageFactory
             yield return describe.Scoped<IViewStartProvider, ViewStartProvider>();


### PR DESCRIPTION
- Modified the MvcServices registration of IRazorCompilationService to be transient to ensure the IMvcRazorHost does not maintain state.

/cc @yishaigalatzer 
