### PR TITLE
Create a new copy of routedata for each 'router' for MVC

### DIFF
--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/RouteDataTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/RouteDataTest.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Builder;
+using Microsoft.AspNet.Mvc.Routing;
+using Microsoft.AspNet.Routing;
+using Microsoft.AspNet.Routing.Template;
+using Microsoft.AspNet.TestHost;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.AspNet.Mvc.FunctionalTests
+{
+    public class RouteDataTest
+    {
+        private readonly IServiceProvider _services = TestHelper.CreateServices(nameof(BasicWebSite));
+        private readonly Action<IApplicationBuilder> _app = new BasicWebSite.Startup().Configure;
+
+        [Fact]
+        public async Task RouteData_Routers_ConventionalRoute()
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // Act
+            var response = await client.GetAsync("http://localhost/Routing/Conventional");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var body = await response.Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<ResultData>(body);
+
+            Assert.Equal(new string[]
+                {
+                    typeof(RouteCollection).FullName,
+                    typeof(TemplateRoute).FullName,
+                    typeof(MvcRouteHandler).FullName,
+                },
+                result.Routers);
+        }
+
+        [Fact]
+        public async Task RouteData_Routers_AttributeRoute()
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // Act
+            var response = await client.GetAsync("http://localhost/Routing/Attribute");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var body = await response.Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<ResultData>(body);
+
+            Assert.Equal(new string[]
+                {
+                    typeof(RouteCollection).FullName,
+                    typeof(AttributeRoute).FullName,
+                    typeof(TemplateRoute).FullName,
+                    typeof(MvcRouteHandler).FullName,
+                },
+                result.Routers);
+        }
+
+
+        private class ResultData
+        {
+            public string[] Routers { get; set; }
+        }
+    }
+}

--- a/test/WebSites/BasicWebSite/Controllers/RoutingController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/RoutingController.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.AspNet.Mvc;
+
+namespace BasicWebSite
+{
+    public class RoutingController : Controller
+    {
+        public object Conventional()
+        {
+            return GetData();
+        }
+
+        [Route("Routing/Attribute")]
+        public object Attribute()
+        {
+            return GetData();
+        }
+
+        private object GetData()
+        {
+            var routers = ActionContext.RouteData.Routers.Select(r => r.GetType().FullName).ToArray();
+            return new { Routers = routers };
+        }
+    }
+}


### PR DESCRIPTION
This is the MVC companion to https://github.com/aspnet/Routing/pull/122

As routing flows, routes replace the route data and mutate a copy. This
allows users to make changes that dirty the data without affecting
undesired state changes.
