### PR TITLE
React to aspnet/Razor#214 changes.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor.Host/MvcTagHelperAttributeValueCodeRenderer.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/MvcTagHelperAttributeValueCodeRenderer.cs
@@ -34,9 +34,7 @@ namespace Microsoft.AspNet.Mvc.Razor
                                                   [NotNull] CodeBuilderContext codeBuilderContext,
                                                   [NotNull] Action<CSharpCodeWriter> renderAttributeValue)
         {
-            var propertyType = attributeDescriptor.PropertyInfo.PropertyType;
-
-            if (propertyType.FullName.Equals(_context.ModelExpressionTypeName, StringComparison.Ordinal))
+            if (attributeDescriptor.TypeName.Equals(_context.ModelExpressionTypeName, StringComparison.Ordinal))
             {
                 writer.WriteStartMethodInvocation(_context.CreateModelExpressionMethodName)
                       .Write(ModelLambdaVariableName)

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/MvcTagHelperAttributeValueCodeRendererTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/MvcTagHelperAttributeValueCodeRendererTest.cs
@@ -26,9 +26,7 @@ namespace Microsoft.AspNet.Mvc.Razor
                     ModelExpressionTypeName = modelExpressionType,
                     CreateModelExpressionMethodName = "SomeMethod"
                 });
-            var propertyInfo = new Mock<PropertyInfo>();
-            propertyInfo.Setup(mock => mock.PropertyType.FullName).Returns(propertyType);
-            var attributeDescriptor = new TagHelperAttributeDescriptor("MyAttribute", propertyInfo.Object);
+            var attributeDescriptor = new TagHelperAttributeDescriptor("MyAttribute", "SomeProperty", propertyType);
             var writer = new CSharpCodeWriter();
             var generatorContext = new CodeGeneratorContext(host: null,
                                                             className: string.Empty,


### PR DESCRIPTION
- TagHelperAttributeDescriptors changed to be lighterweight and not depend on PropertyInfo, had to modify our use of them to work with the new contract.
