### PR TITLE
Added support for parametrized DI-friendly action filters.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/Filters/IParametrizedFilter.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Filters/IParametrizedFilter.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNet.Mvc
+{
+    public interface IParametrizedFilter<in TParameters> : IFilter
+    {
+        void OnException(ExceptionContext context, TParameters parameters);
+
+        Task OnExceptionAsync(ExceptionContext context, TParameters parameters);
+
+        void OnAuthorization(AuthorizationContext context, TParameters parameters);
+
+        Task OnAuthorizationAsync(AuthorizationContext context, TParameters parameters);
+
+        void OnActionExecuting(ActionExecutingContext context, TParameters parameters);
+
+        void OnActionExecuted(ActionExecutedContext context, TParameters parameters);
+
+        Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next, TParameters parameters);
+
+        void OnResultExecuting(ResultExecutingContext context, TParameters parameters);
+
+        void OnResultExecuted(ResultExecutedContext context, TParameters parameters);
+
+        Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next, TParameters parameters);
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Filters/ParametrizedFilterAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Filters/ParametrizedFilterAttribute.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNet.Mvc.Core;
+
+namespace Microsoft.AspNet.Mvc
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
+    public abstract class ParametrizedFilterAttribute : Attribute, IFilterFactory, IOrderedFilter
+    {
+        private readonly Type _serviceType;
+
+        protected ParametrizedFilterAttribute()
+        {
+            _serviceType = typeof (IParametrizedFilter<>).MakeGenericType(GetType());
+        }
+
+        public int Order { get; set; }
+
+        public IFilter CreateInstance(IServiceProvider serviceProvider)
+        {
+            var handler = serviceProvider.GetService(_serviceType);
+
+            if (handler == null || !_serviceType.IsAssignableFrom(handler.GetType()))
+            {
+                throw new InvalidOperationException(
+                    Resources.FormatFilterFactoryAttribute_TypeMustImplementIFilter(
+                        GetType(),
+                        _serviceType.Name
+                    )
+                );
+            }
+
+            return Wrap((dynamic) handler, (dynamic)this);
+        }
+
+        private IFilter Wrap<T>(IParametrizedFilter<T> handler, T data)
+        {
+            return new ParametrizedFilterWrapper<T>(handler, data);
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Filters/ParametrizedFilterBase.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Filters/ParametrizedFilterBase.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNet.Mvc
+{
+    public abstract class ParametrizedFilterBase<TParameters> : IParametrizedFilter<TParameters>
+    {
+        public virtual void OnException(ExceptionContext context, TParameters parameters)
+        {
+        }
+
+        public virtual Task OnExceptionAsync(ExceptionContext context, TParameters parameters)
+        {
+            return Task.CompletedTask;
+        }
+
+        public virtual void OnAuthorization(AuthorizationContext context, TParameters parameters)
+        {
+        }
+
+        public virtual Task OnAuthorizationAsync(AuthorizationContext context, TParameters parameters)
+        {
+            return Task.CompletedTask;
+        }
+
+        public virtual void OnActionExecuting(ActionExecutingContext context, TParameters parameters)
+        {
+        }
+
+        public virtual void OnActionExecuted(ActionExecutedContext context, TParameters parameters)
+        {
+        }
+
+        public virtual Task OnActionExecutionAsync(
+            ActionExecutingContext context,
+            ActionExecutionDelegate next,
+            TParameters parameters)
+        {
+            return next();
+        }
+
+        public virtual void OnResultExecuting(ResultExecutingContext context, TParameters parameters)
+        {
+        }
+
+        public virtual void OnResultExecuted(ResultExecutedContext context, TParameters parameters)
+        {
+        }
+
+        public virtual Task OnResultExecutionAsync(
+            ResultExecutingContext context,
+            ResultExecutionDelegate next,
+            TParameters parameters)
+        {
+            return next();
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Filters/ParametrizedFilterWrapper.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Filters/ParametrizedFilterWrapper.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNet.Mvc
+{
+    internal sealed class ParametrizedFilterWrapper<T> :
+        IAuthorizationFilter,
+        IAsyncAuthorizationFilter,
+        IExceptionFilter,
+        IAsyncExceptionFilter,
+        IActionFilter,
+        IAsyncActionFilter,
+        IResultFilter,
+        IAsyncResultFilter
+    {
+        private readonly T _data;
+        private readonly IParametrizedFilter<T> _handler;
+
+        public ParametrizedFilterWrapper([NotNull] IParametrizedFilter<T> handler, [NotNull] T data)
+        {
+            _handler = handler;
+            _data = data;
+        }
+
+        public void OnActionExecuting(ActionExecutingContext context)
+        {
+            _handler.OnActionExecuting(context, _data);
+        }
+
+        public void OnActionExecuted(ActionExecutedContext context)
+        {
+            _handler.OnActionExecuted(context, _data);
+        }
+
+        public Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+        {
+            return _handler.OnActionExecutionAsync(context, next, _data);
+        }
+
+        public Task OnAuthorizationAsync(AuthorizationContext context)
+        {
+            return _handler.OnAuthorizationAsync(context, _data);
+        }
+
+        public Task OnExceptionAsync(ExceptionContext context)
+        {
+            return _handler.OnExceptionAsync(context, _data);
+        }
+
+        public Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)
+        {
+            return _handler.OnResultExecutionAsync(context, next, _data);
+        }
+
+        public void OnAuthorization(AuthorizationContext context)
+        {
+            _handler.OnAuthorization(context, _data);
+        }
+
+        public void OnException(ExceptionContext context)
+        {
+            _handler.OnException(context, _data);
+        }
+
+        public void OnResultExecuting(ResultExecutingContext context)
+        {
+            _handler.OnResultExecuting(context, _data);
+        }
+
+        public void OnResultExecuted(ResultExecutedContext context)
+        {
+            _handler.OnResultExecuted(context, _data);
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Filters/ActionFilterAttributeTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Filters/ActionFilterAttributeTests.cs
@@ -222,7 +222,7 @@ namespace Microsoft.AspNet.Mvc.Test
                 .Verify(f => f.OnResultExecuted(It.IsAny<ResultExecutedContext>()), Times.Never());
         }
 
-        private static ActionExecutingContext CreateActionExecutingContext(IFilter filter)
+        public static ActionExecutingContext CreateActionExecutingContext(IFilter filter)
         {
             return new ActionExecutingContext(
                 CreateActionContext(),
@@ -230,7 +230,7 @@ namespace Microsoft.AspNet.Mvc.Test
                 new Dictionary<string, object>());
         }
 
-        private static ActionExecutedContext CreateActionExecutedContext(ActionExecutingContext context)
+        public static ActionExecutedContext CreateActionExecutedContext(ActionExecutingContext context)
         {
             return new ActionExecutedContext(context, context.Filters)
             {
@@ -238,7 +238,7 @@ namespace Microsoft.AspNet.Mvc.Test
             };
         }
 
-        private static ResultExecutingContext CreateResultExecutingContext(IFilter filter)
+        public static ResultExecutingContext CreateResultExecutingContext(IFilter filter)
         {
             return new ResultExecutingContext(
                 CreateActionContext(),
@@ -246,12 +246,12 @@ namespace Microsoft.AspNet.Mvc.Test
                 new NoOpResult());
         }
 
-        private static ResultExecutedContext CreateResultExecutedContext(ResultExecutingContext context)
+        public static ResultExecutedContext CreateResultExecutedContext(ResultExecutingContext context)
         {
             return new ResultExecutedContext(context, context.Filters, context.Result);
         }
 
-        private static ActionContext CreateActionContext()
+        public static ActionContext CreateActionContext()
         {
             return new ActionContext(Mock.Of<HttpContext>(), new RouteData(), new ActionDescriptor());
         }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Filters/ParametrizedFilterAttributeTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Filters/ParametrizedFilterAttributeTests.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+
+using System;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNet.Mvc.Test
+{
+    public class ParametrizedFilterAttributeTests {
+        public class StubAttribute : ParametrizedFilterAttribute {
+        }
+
+        [Fact]
+        public void ParametrizedFilterAttribute_CreateInstance_WithValidService_ReturnsWrappedService()
+        {
+            // Arrange
+            var attribute = new StubAttribute();
+            var context = ActionFilterAttributeTests.CreateActionExecutingContext(Mock.Of<IFilter>());
+            var filter = new Mock<IParametrizedFilter<StubAttribute>>();            
+
+            var serviceProvider = new Mock<IServiceProvider>();
+            serviceProvider
+                .Setup(p => p.GetService(typeof(IParametrizedFilter<StubAttribute>)))
+                .Returns(filter.Object);
+
+            // Act
+            var instance = attribute.CreateInstance(serviceProvider.Object) as ParametrizedFilterWrapper<StubAttribute>;
+          
+            // Assert
+            Assert.NotNull(instance);
+            instance.OnActionExecuting(context);
+            filter.Verify(_ => _.OnActionExecuting(context, attribute));
+        }
+
+        [Fact]
+        public void ParametrizedFilterAttribute_CreateInstance_WithInvalidService_Throws() {
+            // Arrange
+            var attribute = new StubAttribute();
+            var serviceProvider = new Mock<IServiceProvider>();
+            serviceProvider
+                .Setup(p => p.GetService(It.IsAny<Type>()))
+                .Returns("I am a bad service");
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() => 
+                attribute.CreateInstance(serviceProvider.Object)
+            );
+        }
+    }
+}
+

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Filters/ParametrizedFilterWrapperTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Filters/ParametrizedFilterWrapperTests.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNet.Mvc.Test
+{
+    public class ParametrizedFilterWrapperTests
+    {
+        [Fact]
+        public async Task ParametrizedFilterWrapper_AllMethods_DelegatedProperly()
+        {
+            // Arrange
+            var filter = new Mock<IParametrizedFilter<object>>();
+            var parameters = new object();
+            var wrapper = new ParametrizedFilterWrapper<object>(filter.Object, parameters);
+            
+            var actionContext = ActionFilterAttributeTests.CreateActionContext();
+            var exceptionContext = new ExceptionContext(actionContext, new IFilter[0]);
+            var authorizationContext = new AuthorizationContext(actionContext, new IFilter[0]);
+
+            var actionExecutingContext = 
+                ActionFilterAttributeTests.CreateActionExecutingContext(filter.Object);
+            var actionExecutedContext = 
+                ActionFilterAttributeTests.CreateActionExecutedContext(actionExecutingContext);
+            ActionExecutionDelegate actionExecutionDelegate = () => null;
+
+            var resultExecutingContext =
+                ActionFilterAttributeTests.CreateResultExecutingContext(filter.Object);
+            var resultExecutedContext =
+                ActionFilterAttributeTests.CreateResultExecutedContext(resultExecutingContext);
+            ResultExecutionDelegate resultExecutionDelegate = () => null;
+
+            // Act
+            wrapper.OnException(exceptionContext);
+            await wrapper.OnExceptionAsync(exceptionContext);
+
+            wrapper.OnAuthorization(authorizationContext);
+            await wrapper.OnAuthorizationAsync(authorizationContext);
+
+            wrapper.OnActionExecuting(actionExecutingContext);
+            wrapper.OnActionExecuted(actionExecutedContext);
+            await wrapper.OnActionExecutionAsync(actionExecutingContext, actionExecutionDelegate);
+
+            wrapper.OnResultExecuting(resultExecutingContext);
+            wrapper.OnResultExecuted(resultExecutedContext);
+            await wrapper.OnResultExecutionAsync(resultExecutingContext, resultExecutionDelegate);
+
+            // Assert
+            filter.Verify(_ => _.OnException(exceptionContext, parameters));
+            filter.Verify(_ => _.OnExceptionAsync(exceptionContext, parameters));
+
+            filter.Verify(_ => _.OnAuthorization(authorizationContext, parameters));
+            filter.Verify(_ => _.OnAuthorizationAsync(authorizationContext, parameters));
+
+            filter.Verify(_ => _.OnActionExecuting(actionExecutingContext, parameters));
+            filter.Verify(_ => _.OnActionExecuted(actionExecutedContext, parameters));
+            filter.Verify(_ => _.OnActionExecutionAsync(actionExecutingContext, actionExecutionDelegate, parameters));
+
+            filter.Verify(_ => _.OnResultExecuting(resultExecutingContext, parameters));
+            filter.Verify(_ => _.OnResultExecuted(resultExecutedContext, parameters));
+            filter.Verify(_ => _.OnResultExecutionAsync(resultExecutingContext, resultExecutionDelegate, parameters));
+        }
+    }
+}
+

--- a/test/WebSites/FiltersWebSite/Controllers/RandomNumberController.cs
+++ b/test/WebSites/FiltersWebSite/Controllers/RandomNumberController.cs
@@ -41,6 +41,11 @@ namespace FiltersWebSite
             return randomNumber;
         }
 
+        [ParametrizedRandomNumber( MinValue = 100, MaxValue = 500)]
+        public int GetMultipliedRandomNumber(int randomNumber) {
+            return randomNumber;
+        }
+
         public string ThrowException()
         {
             throw new InvalidOperationException();

--- a/test/WebSites/FiltersWebSite/Filters/ParametrizedRandomNumberAttribute.cs
+++ b/test/WebSites/FiltersWebSite/Filters/ParametrizedRandomNumberAttribute.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNet.Mvc;
+
+namespace FiltersWebSite
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+    public class ParametrizedRandomNumberAttribute : ParametrizedFilterAttribute
+    {
+        public int MinValue { get; set; }
+
+        public int MaxValue { get; set; } = int.MaxValue;
+    }
+}

--- a/test/WebSites/FiltersWebSite/Filters/ParametrizedRandomNumberFilter.cs
+++ b/test/WebSites/FiltersWebSite/Filters/ParametrizedRandomNumberFilter.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Mvc;
+
+namespace FiltersWebSite
+{
+    public class ParametrizedRandomNumberFilter : ParametrizedFilterBase<ParametrizedRandomNumberAttribute> {
+        private RandomNumberService _random;
+
+        public ParametrizedRandomNumberFilter(RandomNumberService random) {
+            _random = random;
+        }
+
+        public override void OnActionExecuting(ActionExecutingContext context, ParametrizedRandomNumberAttribute data) {
+            context.ActionArguments["randomNumber"] = _random.GetRandomNumber(data.MinValue, data.MaxValue);
+        }
+    }
+}

--- a/test/WebSites/FiltersWebSite/Filters/RandomNumberModifier.cs
+++ b/test/WebSites/FiltersWebSite/Filters/RandomNumberModifier.cs
@@ -21,7 +21,7 @@ namespace FiltersWebSite
         public void OnActionExecuting(ActionExecutingContext context)
         {
             var paramterValue = (int)context.ActionArguments["randomNumber"];
-            context.ActionArguments["randomNumber"] = paramterValue + _random.GetRandamNumber();
+            context.ActionArguments["randomNumber"] = paramterValue + _random.GetRandomNumber();
         }
     }
 }

--- a/test/WebSites/FiltersWebSite/Filters/RandomNumberProvider.cs
+++ b/test/WebSites/FiltersWebSite/Filters/RandomNumberProvider.cs
@@ -20,7 +20,7 @@ namespace FiltersWebSite
 
         public void OnActionExecuting(ActionExecutingContext context)
         {
-            context.ActionArguments["randomNumber"] = _random.GetRandamNumber();
+            context.ActionArguments["randomNumber"] = _random.GetRandomNumber();
         }
     }
 }

--- a/test/WebSites/FiltersWebSite/Services/RandomNumberService.cs
+++ b/test/WebSites/FiltersWebSite/Services/RandomNumberService.cs
@@ -1,13 +1,19 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace FiltersWebSite
 {
     public class RandomNumberService
     {
-        public int GetRandamNumber()
+        public int GetRandomNumber()
         {
             return 44;
+        }
+
+        public int GetRandomNumber(int minValue, int maxValue) {
+            return new Random().Next(minValue, maxValue);
         }
     }
 }

--- a/test/WebSites/FiltersWebSite/Startup.cs
+++ b/test/WebSites/FiltersWebSite/Startup.cs
@@ -18,6 +18,7 @@ namespace FiltersWebSite
                 services.AddMvc(configuration);
                 services.AddSingleton<RandomNumberFilter>();
                 services.AddSingleton<RandomNumberService>();
+                services.AddSingleton<IParametrizedFilter<ParametrizedRandomNumberAttribute>, ParametrizedRandomNumberFilter>();
 
                 services.Configure<MvcOptions>(options =>
                 {


### PR DESCRIPTION
How to use:
1. Create data-only attribute class inherited from `ParametrizedFilterAttribute`. Add parameters as non-private properties:

```
public class MyParametrizedFilterAttribute : ParametrizedFilterAttribute
{
    public int MyParameter { get; set; }
    public int MySecondParameter { get; set; }
}
```
1. Create filter class inherited from `ParametrizedFilterBase<>`. Inject required services to constructor. Override required methods. Attribute instance will be passed as parameter to each method:

```
public class MyParametrizedFilter : ParametrizedFilterBase<MyParametrizedFilterAttribute>
{
    private readonly IMyService _service;

    public MyParametrizedFilter(IMyService service)
    {
        _service = service;
    }

    // all mvc filter methods are supported the same way
    public override void OnActionExecuting(
        ActionExecutingContext context,
        MyParametrizedFilterAttribute data) 
    {
        var myValue = _service.CalculateSomething(
            data.MyParameter,
            data.MySecondParameter,
            GetSomethingFromContext(context));

        context.Result = new ContentResult {
            Content = myValue.ToString()
        };
    }
}
```
1. Register filter in IoC container with `IParametrizedFilter<>` service:

```
services.AddSingleton<IParametrizedFilter<MyParametrizedFilterAttribute >, MyParametrizedFilter>();
```
1. Use new attribute as a regular filter with parameters:

```
[MyParametrizedFilterAttribute(MyParameter = 10, MySecondParameter = 435, Order = 1)]
public IActionResult TheAction()
{
}
```
