### PR TITLE
Add missing license headers

### DIFF
--- a/samples/MvcSample.Web/Areas/Travel/Controllers/Flight.cs
+++ b/samples/MvcSample.Web/Areas/Travel/Controllers/Flight.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNet.Mvc;
 
 namespace MvcSample.Web

--- a/samples/MvcSample.Web/Areas/Travel/Controllers/HomeController.cs
+++ b/samples/MvcSample.Web/Areas/Travel/Controllers/HomeController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNet.Mvc;
 
 namespace MvcSample.Web.Areas.Travel.Controllers

--- a/samples/MvcSample.Web/Components/TagCloud.cs
+++ b/samples/MvcSample.Web/Components/TagCloud.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Linq;
 using System.Threading.Tasks;

--- a/samples/MvcSample.Web/Controllers/ApiExplorerSamples/ProductsAdminController.cs
+++ b/samples/MvcSample.Web/Controllers/ApiExplorerSamples/ProductsAdminController.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using Microsoft.AspNet.Mvc;
 

--- a/samples/MvcSample.Web/Controllers/ApiExplorerSamples/ProductsController.cs
+++ b/samples/MvcSample.Web/Controllers/ApiExplorerSamples/ProductsController.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using Microsoft.AspNet.Mvc;
 
 namespace MvcSample.Web.ApiExplorerSamples

--- a/samples/MvcSample.Web/Filters/AgeEnhancerFilterAttribute.cs
+++ b/samples/MvcSample.Web/Filters/AgeEnhancerFilterAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNet.Mvc;
 

--- a/samples/MvcSample.Web/Filters/BlockAnonymous.cs
+++ b/samples/MvcSample.Web/Filters/BlockAnonymous.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNet.Mvc;
 
 namespace MvcSample.Web.Filters

--- a/samples/MvcSample.Web/Filters/DelayAttribute.cs
+++ b/samples/MvcSample.Web/Filters/DelayAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc;

--- a/samples/MvcSample.Web/Filters/ErrorMessagesAttribute.cs
+++ b/samples/MvcSample.Web/Filters/ErrorMessagesAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNet.Mvc;
 
 namespace MvcSample.Web

--- a/samples/MvcSample.Web/Filters/FakeUserAttribute.cs
+++ b/samples/MvcSample.Web/Filters/FakeUserAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Security.Claims;
 using Microsoft.AspNet.Mvc;
 

--- a/samples/MvcSample.Web/Filters/InspectResultPageAttribute.cs
+++ b/samples/MvcSample.Web/Filters/InspectResultPageAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNet.Mvc;
 using MvcSample.Web.Models;

--- a/samples/MvcSample.Web/Filters/PassThroughAttribute.cs
+++ b/samples/MvcSample.Web/Filters/PassThroughAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc;
 

--- a/samples/MvcSample.Web/Filters/UserNameProvider.cs
+++ b/samples/MvcSample.Web/Filters/UserNameProvider.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNet.Mvc;
 
 namespace MvcSample.Web.Filters

--- a/samples/MvcSample.Web/Filters/UserNameService.cs
+++ b/samples/MvcSample.Web/Filters/UserNameService.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace MvcSample.Web.Filters
 {
     public class UserNameService

--- a/samples/MvcSample.Web/FiltersController.cs
+++ b/samples/MvcSample.Web/FiltersController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNet.Mvc;
 using MvcSample.Web.Filters;

--- a/samples/MvcSample.Web/Home2Controller.cs
+++ b/samples/MvcSample.Web/Home2Controller.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Mvc;

--- a/samples/MvcSample.Web/HomeController.cs
+++ b/samples/MvcSample.Web/HomeController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNet.Http;

--- a/samples/MvcSample.Web/LanguageViewLocationExpander.cs
+++ b/samples/MvcSample.Web/LanguageViewLocationExpander.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using Microsoft.AspNet.Mvc;
 using Microsoft.AspNet.Mvc.Razor;

--- a/samples/MvcSample.Web/LinkController.cs
+++ b/samples/MvcSample.Web/LinkController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNet.Mvc;
 
 namespace MvcSample.Web

--- a/samples/MvcSample.Web/Models/ApiExplorerSamples/Product.cs
+++ b/samples/MvcSample.Web/Models/ApiExplorerSamples/Product.cs
@@ -1,4 +1,7 @@
-﻿namespace MvcSample.Web.ApiExplorerSamples
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace MvcSample.Web.ApiExplorerSamples
 {
     public class Product
     {

--- a/samples/MvcSample.Web/Models/ApiExplorerSamples/ProductOrderConfirmation.cs
+++ b/samples/MvcSample.Web/Models/ApiExplorerSamples/ProductOrderConfirmation.cs
@@ -1,4 +1,7 @@
-﻿namespace MvcSample.Web.ApiExplorerSamples
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace MvcSample.Web.ApiExplorerSamples
 {
     public class ProductOrderConfirmation
     {

--- a/samples/MvcSample.Web/Models/User.cs
+++ b/samples/MvcSample.Web/Models/User.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 

--- a/samples/MvcSample.Web/Monitoring/MonitoringMiddlware.cs
+++ b/samples/MvcSample.Web/Monitoring/MonitoringMiddlware.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 #if ASPNET50
 using System;
 using System.Collections.Generic;

--- a/samples/MvcSample.Web/Monitoring/MonitoringModule.cs
+++ b/samples/MvcSample.Web/Monitoring/MonitoringModule.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 #if ASPNET50
 using System;
 using System.Collections.Concurrent;

--- a/samples/MvcSample.Web/OverloadController.cs
+++ b/samples/MvcSample.Web/OverloadController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.AspNet.Mvc;
 using Microsoft.AspNet.Mvc.WebApiCompatShim;

--- a/samples/MvcSample.Web/SimplePocoController.cs
+++ b/samples/MvcSample.Web/SimplePocoController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Diagnostics;
 using System.Globalization;
 using Microsoft.AspNet.Mvc;

--- a/samples/MvcSample.Web/SimpleRest.cs
+++ b/samples/MvcSample.Web/SimpleRest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNet.Mvc;
 
 namespace MvcSample.Web

--- a/samples/MvcSample.Web/Startup.cs
+++ b/samples/MvcSample.Web/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.IO;
 using Microsoft.AspNet.Builder;

--- a/samples/MvcSample.Web/ViewMetadata.cs
+++ b/samples/MvcSample.Web/ViewMetadata.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 #if VIEWMETADATA
 using System;
 using System.Collections.Generic;

--- a/samples/TagHelperSample.Web/Controllers/HomeController.cs
+++ b/samples/TagHelperSample.Web/Controllers/HomeController.cs
@@ -1,4 +1,6 @@
-﻿
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNet.Mvc;

--- a/samples/TagHelperSample.Web/Models/User.cs
+++ b/samples/TagHelperSample.Web/Models/User.cs
@@ -1,4 +1,6 @@
-﻿
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 
 namespace TagHelperSample.Web.Models

--- a/samples/TagHelperSample.Web/Startup.cs
+++ b/samples/TagHelperSample.Web/Startup.cs
@@ -1,4 +1,6 @@
-﻿
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNet.Builder;
 using Microsoft.Framework.DependencyInjection;
 

--- a/src/Microsoft.AspNet.Mvc.Core/DefaultOrder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/DefaultOrder.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNet.Mvc
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNet.Mvc
 {
     public static class DefaultOrder
     {

--- a/src/Microsoft.AspNet.Mvc.Razor/Razor/PreCompileViews/GeneratorResultExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Razor/PreCompileViews/GeneratorResultExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Linq;
 using Microsoft.AspNet.Razor;
 using Microsoft.CodeAnalysis;

--- a/src/Microsoft.AspNet.Mvc.Razor/Razor/PreCompileViews/RazorErrorExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Razor/PreCompileViews/RazorErrorExtensions.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Razor.Parser.SyntaxTree;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/HttpRequestMessage/HttpRequestMessageExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/HttpRequestMessage/HttpRequestMessageExtensions.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Net.Http.Formatting;

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ActionResults/ChallengeResultTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ActionResults/ChallengeResultTest.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Routing;
 using Moq;

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ActionResults/HttpNotFoundResultTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ActionResults/HttpNotFoundResultTests.cs
@@ -1,4 +1,7 @@
-﻿using Xunit;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
 
 namespace Microsoft.AspNet.Mvc
 {

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ActionResults/HttpStatusCodeResultTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ActionResults/HttpStatusCodeResultTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.PipelineCore;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.PipelineCore;
 using Microsoft.AspNet.Routing;
 using Xunit;
 

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/FlushReportingStream.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/FlushReportingStream.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
 using System.Threading;
 using Moq;
 

--- a/test/Microsoft.AspNet.Mvc.Core.Test/RouteDataActionConstraintTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/RouteDataActionConstraintTest.cs
@@ -1,4 +1,7 @@
-﻿using Xunit;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
 
 namespace Microsoft.AspNet.Mvc.Core
 {

--- a/test/Microsoft.AspNet.Mvc.Core.Test/RouteTemplateProviderAttributesTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/RouteTemplateProviderAttributesTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Mvc.Routing;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Mvc.Routing;
 using Xunit;
 
 namespace Microsoft.AspNet.Mvc

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/CustomUrlHelperTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/CustomUrlHelperTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/DependencyResolverTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/DependencyResolverTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 #if ASPNET50
 using System;
 using System.Net.Http;

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/JsonOutputFormatterTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/JsonOutputFormatterTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.TestHost;

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/NullLoggerFactory.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/NullLoggerFactory.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Mvc

--- a/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/FormDataCollectionExtensionsTest.cs
+++ b/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/FormDataCollectionExtensionsTest.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
 using System.Net.Http.Formatting;

--- a/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/HttpErrorTest.cs
+++ b/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/HttpErrorTest.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.IO;

--- a/test/WebSites/ActivatorWebSite/Components/TestComponent.cs
+++ b/test/WebSites/ActivatorWebSite/Components/TestComponent.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Mvc;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Mvc;
 
 namespace ActivatorWebSite
 {

--- a/test/WebSites/AntiForgeryWebSite/Models/AccountViewModels.cs
+++ b/test/WebSites/AntiForgeryWebSite/Models/AccountViewModels.cs
@@ -1,4 +1,7 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel.DataAnnotations;
 
 namespace AntiForgeryWebSite
 {

--- a/test/WebSites/AntiForgeryWebSite/Startup.cs
+++ b/test/WebSites/AntiForgeryWebSite/Startup.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Builder;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Routing;
 using Microsoft.Framework.DependencyInjection;
 

--- a/test/WebSites/ApiExplorerWebSite/Controllers/ApiExplorerHttpMethodController.cs
+++ b/test/WebSites/ApiExplorerWebSite/Controllers/ApiExplorerHttpMethodController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Mvc;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Mvc;
 
 namespace ApiExplorer
 {

--- a/test/WebSites/AutofacWebSite/Controllers/BasicController.cs
+++ b/test/WebSites/AutofacWebSite/Controllers/BasicController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Mvc;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Mvc;
 
 namespace AutofacWebSite.Controllers
 {

--- a/test/WebSites/AutofacWebSite/Controllers/DIController.cs
+++ b/test/WebSites/AutofacWebSite/Controllers/DIController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Mvc;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Mvc;
 
 namespace AutofacWebSite.Controllers
 {

--- a/test/WebSites/AutofacWebSite/HelloWorldBuilder.cs
+++ b/test/WebSites/AutofacWebSite/HelloWorldBuilder.cs
@@ -1,4 +1,7 @@
-﻿namespace AutofacWebSite
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace AutofacWebSite
 {
     public class HelloWorldBuilder
     {

--- a/test/WebSites/AutofacWebSite/Startup.cs
+++ b/test/WebSites/AutofacWebSite/Startup.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using Autofac;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Routing;

--- a/test/WebSites/BasicWebSite/ActionDescriptorCreationCounter.cs
+++ b/test/WebSites/BasicWebSite/ActionDescriptorCreationCounter.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Threading;
 using Microsoft.AspNet.Mvc;
 

--- a/test/WebSites/BasicWebSite/Components/JsonTextInView.cs
+++ b/test/WebSites/BasicWebSite/Components/JsonTextInView.cs
@@ -1,4 +1,7 @@
-﻿using BasicWebSite.Models;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using BasicWebSite.Models;
 using Microsoft.AspNet.Mvc;
 
 namespace BasicWebSite.Components

--- a/test/WebSites/BasicWebSite/Controllers/LinkGeneration/LinksController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/LinkGeneration/LinksController.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using Microsoft.AspNet.Mvc;
 
 namespace BasicWebSite.Controllers.LinkGeneration

--- a/test/WebSites/BasicWebSite/Controllers/LinkGeneration/OrdersController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/LinkGeneration/OrdersController.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using Microsoft.AspNet.Mvc;
 
 namespace BasicWebSite.Controllers.LinkGeneration

--- a/test/WebSites/BasicWebSite/Controllers/LinkGeneration/ProductsController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/LinkGeneration/ProductsController.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using Microsoft.AspNet.Mvc;
 
 namespace BasicWebSite.Controllers.LinkGeneration

--- a/test/WebSites/BasicWebSite/Controllers/MonitorController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/MonitorController.cs
@@ -1,4 +1,7 @@
-﻿using System.Globalization;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Globalization;
 using Microsoft.AspNet.Mvc;
 using Microsoft.Framework.DependencyInjection;
 

--- a/test/WebSites/BasicWebSite/Controllers/UsersController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/UsersController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Mvc;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Mvc;
 
 namespace BasicWebSite.Controllers
 {

--- a/test/WebSites/BasicWebSite/Models/Person.cs
+++ b/test/WebSites/BasicWebSite/Models/Person.cs
@@ -1,4 +1,7 @@
-﻿namespace BasicWebSite.Models
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace BasicWebSite.Models
 {
     public class Person
     {

--- a/test/WebSites/BasicWebSite/Startup.cs
+++ b/test/WebSites/BasicWebSite/Startup.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Builder;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Mvc;
 using Microsoft.AspNet.Routing;
 using Microsoft.Framework.DependencyInjection;

--- a/test/WebSites/FiltersWebSite/Filters/AddHeaderAttribute.cs
+++ b/test/WebSites/FiltersWebSite/Filters/AddHeaderAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright(c) Microsoft Open Technologies, Inc.All rights reserved.
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNet.Mvc;

--- a/test/WebSites/FormatterWebSite/Controllers/JsonFormatterController.cs
+++ b/test/WebSites/FormatterWebSite/Controllers/JsonFormatterController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Mvc;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Mvc;
 using Newtonsoft.Json;
 
 namespace FormatterWebSite.Controllers

--- a/test/WebSites/InlineConstraintsWebSite/Controllers/HomeController.cs
+++ b/test/WebSites/InlineConstraintsWebSite/Controllers/HomeController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Mvc;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Mvc;
 
 namespace InlineConstraints.Controllers
 {

--- a/test/WebSites/InlineConstraintsWebSite/Controllers/UsersController.cs
+++ b/test/WebSites/InlineConstraintsWebSite/Controllers/UsersController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Mvc;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Mvc;
 
 namespace InlineConstraints.Controllers
 {

--- a/test/WebSites/InlineConstraintsWebSite/Startup.cs
+++ b/test/WebSites/InlineConstraintsWebSite/Startup.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/test/WebSites/RazorWebSite/Startup.cs
+++ b/test/WebSites/RazorWebSite/Startup.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Builder;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Mvc;
 using Microsoft.AspNet.Mvc.Razor;
 using Microsoft.Framework.DependencyInjection;

--- a/test/WebSites/RoutingWebSite/Controllers/EmployeeController.cs
+++ b/test/WebSites/RoutingWebSite/Controllers/EmployeeController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Mvc;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Mvc;
 
 namespace RoutingWebSite
 {

--- a/test/WebSites/RoutingWebSite/Controllers/MapsController.cs
+++ b/test/WebSites/RoutingWebSite/Controllers/MapsController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Mvc;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Mvc;
 
 namespace RoutingWebSite
 {

--- a/test/WebSites/RoutingWebSite/Controllers/TeamController.cs
+++ b/test/WebSites/RoutingWebSite/Controllers/TeamController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Mvc;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Mvc;
 
 namespace RoutingWebSite
 {

--- a/test/WebSites/UrlHelperWebSite/AppOptions.cs
+++ b/test/WebSites/UrlHelperWebSite/AppOptions.cs
@@ -1,4 +1,7 @@
-﻿namespace UrlHelperWebSite
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace UrlHelperWebSite
 {
     public class AppOptions
     {

--- a/test/WebSites/UrlHelperWebSite/Controllers/SimplePocoController.cs
+++ b/test/WebSites/UrlHelperWebSite/Controllers/SimplePocoController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Mvc;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Mvc;
 
 namespace UrlHelperWebSite.Controllers
 {

--- a/test/WebSites/UrlHelperWebSite/CustomUrlHelper.cs
+++ b/test/WebSites/UrlHelperWebSite/CustomUrlHelper.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Mvc;
 using Microsoft.Framework.DependencyInjection;

--- a/test/WebSites/UrlHelperWebSite/Startup.cs
+++ b/test/WebSites/UrlHelperWebSite/Startup.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Builder;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Mvc;
 using Microsoft.AspNet.Routing;
 using Microsoft.Framework.DependencyInjection;

--- a/test/WebSites/VersioningWebSite/Controllers/VouchersController.cs
+++ b/test/WebSites/VersioningWebSite/Controllers/VouchersController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Mvc;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Mvc;
 
 namespace VersioningWebSite
 {


### PR DESCRIPTION
- #EngineeringDay
- license present but incorrect in just a few files
- skip generated files such as Resources.Designer.cs and files under
  test\Microsoft.AspNet.Mvc.Razor.Host.Test\TestFiles\Output

FYI only. Will merge immediately.
