### PR TITLE
Address aspnet/razor#236, recreate XML files when xml-docs-test target is run directly

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -6,5 +6,5 @@ var AUTHORS='Microsoft Open Technologies, Inc.'
 use-standard-lifecycle
 k-standard-goals
 
-#xml-docs-test target='test'
+#xml-docs-test .clean .build-compile description='Check generated XML documentation files for errors' target='test'
   k-xml-docs-test


### PR DESCRIPTION
- must still `build initialize` between `git clean` and `build xml-docs-test`

nit: add description of xml-docs-test target
