### PR TITLE
Fix for EF issue 1109 - removing Microsoft.DataAnnotations nuget package

### DIFF
--- a/src/Microsoft.AspNet.Mvc.ModelBinding/project.json
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/project.json
@@ -8,13 +8,13 @@
     "Microsoft.AspNet.Http": "1.0.0-*",
     "Microsoft.AspNet.Mvc.Common": { "version": "6.0.0-*", "type": "build" },
     "Microsoft.AspNet.Mvc.HeaderValueAbstractions": "1.0.0-*",
-    "Microsoft.DataAnnotations": "1.0.0-*",
     "Microsoft.Framework.DependencyInjection": "1.0.0-*",
     "Newtonsoft.Json": "6.0.6"
   },
   "frameworks": {
     "aspnet50": {
       "frameworkAssemblies": {
+        "System.ComponentModel.DataAnnotations": "4.0.0.0",
         "System.Xml": "",
         "System.Runtime.Serialization": ""
       }
@@ -22,6 +22,7 @@
     "aspnetcore50": {
       "dependencies": {
         "System.Collections.Concurrent": "4.0.10-beta-*",
+        "System.ComponentModel.Annotations": "4.0.10-beta-*",
         "System.ComponentModel.TypeConverter": "4.0.0-beta-*",
         "System.Reflection.TypeExtensions": "4.0.0-beta-*",
         "System.Runtime.Serialization.Primitives": "4.0.0-beta-*",


### PR DESCRIPTION
@bricelam @yishaigalatzer 

Replacing dependencies with direct dependencies on the underlying packages/assemblies.

See https://github.com/aspnet/EntityFramework/issues/1160.
