### PR TITLE
Changes to address IFileSystem.Watch method addition

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/Compilation/DefaultRazorFileSystemCache.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Compilation/DefaultRazorFileSystemCache.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using Microsoft.AspNet.FileSystems;
 using Microsoft.Framework.OptionsModel;
+using Microsoft.Framework.Expiration.Interfaces;
 
 namespace Microsoft.AspNet.Mvc.Razor
 {
@@ -69,6 +70,12 @@ namespace Microsoft.AspNet.Mvc.Razor
 
                 return fileInfo;
             }
+        }
+
+        /// <inheritdoc />
+        public IExpirationTrigger Watch(string filter)
+        {
+            return _fileSystem.Watch(filter);
         }
 
         private class ExpiringFileInfo

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFileInfo.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFileInfo.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using System.Text;
 using Microsoft.AspNet.FileSystems;
-using Microsoft.Framework.Expiration.Interfaces;
 
 namespace Microsoft.AspNet.Mvc.Razor
 {
@@ -58,11 +57,6 @@ namespace Microsoft.AspNet.Mvc.Razor
         }
 
         public void Delete()
-        {
-            throw new NotSupportedException();
-        }
-
-        public IExpirationTrigger CreateFileChangeTrigger()
         {
             throw new NotSupportedException();
         }

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFileSystem.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFileSystem.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.AspNet.FileSystems;
+using Microsoft.Framework.Expiration.Interfaces;
 
 namespace Microsoft.AspNet.Mvc.Razor
 {
@@ -53,5 +54,9 @@ namespace Microsoft.AspNet.Mvc.Razor
             }
         }
 
+        public IExpirationTrigger Watch(string filter)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/Compilation/DefaultRazorFileSystemCacheTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/Compilation/DefaultRazorFileSystemCacheTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.AspNet.FileSystems;
 using Microsoft.Framework.OptionsModel;
+using Microsoft.Framework.Expiration.Interfaces;
 using Moq;
 using Xunit;
 
@@ -404,7 +405,7 @@ namespace Microsoft.AspNet.Mvc.Razor
                 }
             }
 
-            public bool TryGetParentPath(string subpath, out string parentPath)
+            public IExpirationTrigger Watch(string filter)
             {
                 throw new NotImplementedException();
             }


### PR DESCRIPTION
Absorbs the new IFileSystem interface. This change is to just address the breaking change introduced in IFileSystem.
Razor has to do the necessary changes to subscribe to the Watch event for expiring the modified files.

Related IFileSystem PR : https://github.com/aspnet/FileSystem/pull/24

@pranavkm 
