### PR TITLE
Update precompilation to use the library manager instead of relative

### DIFF
--- a/test/WebSites/PrecompilationWebSite/Compiler/PreProcess/RazorPreCompilation.cs
+++ b/test/WebSites/PrecompilationWebSite/Compiler/PreProcess/RazorPreCompilation.cs
@@ -25,16 +25,14 @@ namespace PrecompilationWebSite
         public static IServiceProvider ReplaceProvider(IServiceProvider provider)
         {
             var originalEnvironment = provider.GetService<IApplicationEnvironment>();
-            var newPath = Path.GetFullPath(
-                Path.Combine(
-                    originalEnvironment.ApplicationBasePath,
-                    "..",
-                    "WebSites",
-                    "PrecompilationWebSite"));
+
+            var libraryManager = provider.GetService<ILibraryManager>();
+            var info = libraryManager.GetLibraryInformation("PrecompilationWebSite");
+            var directory = Path.GetDirectoryName(info.Path);
 
             var precompilationApplicationEnvironment = new PrecompilationApplicationEnvironment(
                 originalEnvironment,
-                newPath);
+                directory);
 
             var collection = HostingServices.Create(provider);
             collection.AddInstance<IApplicationEnvironment>(precompilationApplicationEnvironment);


### PR DESCRIPTION
paths.

This website is written to assume that $pwd is always in the functional
tests directory when it's launched. This works fine for the functional
tests, but causes issues in many other contexts, including VS.
