### PR TITLE
React to aspnet/Razor#221: Modify TagHelpers to utilize new ContentMode design.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
@@ -154,6 +154,18 @@ namespace Microsoft.AspNet.Mvc.Razor
         /// </remarks>
         public void StartWritingScope()
         {
+            StartWritingScope(new StringWriter());
+        }
+
+        /// <summary>
+        /// Starts a new writing scope with the given <paramref name="writer"/>.
+        /// </summary>
+        /// <remarks>
+        /// All writes to the <see cref="Output"/> or <see cref="ViewContext.Writer"/> after calling this method will
+        /// be buffered until <see cref="EndWritingScope"/> is called.
+        /// </remarks>
+        public void StartWritingScope(TextWriter writer)
+        {
             // If there isn't a base writer take the ViewContext.Writer
             if (_originalWriter == null)
             {
@@ -162,7 +174,7 @@ namespace Microsoft.AspNet.Mvc.Razor
 
             // We need to replace the ViewContext's Writer to ensure that all content (including content written
             // from HTML helpers) is redirected.
-            ViewContext.Writer = new StringWriter();
+            ViewContext.Writer = writer;
 
             _writerScopes.Push(ViewContext.Writer);
         }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/FormTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/FormTagHelper.cs
@@ -6,14 +6,12 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
-using Microsoft.AspNet.Razor.TagHelpers;
 
 namespace Microsoft.AspNet.Mvc.TagHelpers
 {
     /// <summary>
     /// <see cref="ITagHelper"/> implementation targeting &lt;form&gt; elements.
     /// </summary>
-    [ContentBehavior(ContentBehavior.Append)]
     public class FormTagHelper : TagHelper
     {
         private const string ActionAttributeName = "asp-action";
@@ -106,7 +104,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 if (tagBuilder != null)
                 {
                     output.MergeAttributes(tagBuilder);
-                    output.Content += tagBuilder.InnerHtml;
+                    output.PostContent += tagBuilder.InnerHtml;
                     output.SelfClosing = false;
                 }
             }
@@ -116,7 +114,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 var antiForgeryTagBuilder = Generator.GenerateAntiForgery(ViewContext);
                 if (antiForgeryTagBuilder != null)
                 {
-                    output.Content += antiForgeryTagBuilder.ToString(TagRenderMode.SelfClosing);
+                    output.PostContent += antiForgeryTagBuilder.ToString(TagRenderMode.SelfClosing);
                 }
             }
         }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/InputTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/InputTagHelper.cs
@@ -15,7 +15,6 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     /// <summary>
     /// <see cref="ITagHelper"/> implementation targeting &lt;input&gt; elements with an <c>asp-for</c> attribute.
     /// </summary>
-    [ContentBehavior(ContentBehavior.Replace)]
     public class InputTagHelper : TagHelper
     {
         private const string ForAttributeName = "asp-for";

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/LabelTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/LabelTagHelper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 using Microsoft.AspNet.Razor.TagHelpers;
@@ -10,7 +11,6 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     /// <summary>
     /// <see cref="ITagHelper"/> implementation targeting &lt;label&gt; elements with an <c>asp-for</c> attribute.
     /// </summary>
-    [ContentBehavior(ContentBehavior.Modify)]
     public class LabelTagHelper : TagHelper
     {
         private const string ForAttributeName = "asp-for";
@@ -31,7 +31,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
         /// <inheritdoc />
         /// <remarks>Does nothing if <see cref="For"/> is <c>null</c>.</remarks>
-        public override void Process(TagHelperContext context, TagHelperOutput output)
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
             if (For != null)
             {
@@ -45,10 +45,12 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 {
                     output.MergeAttributes(tagBuilder);
 
+                    var childContent = await context.GetChildContentAsync();
+
                     // We check for whitespace to detect scenarios such as:
                     // <label for="Name">
                     // </label>
-                    if (string.IsNullOrWhiteSpace(output.Content))
+                    if (string.IsNullOrWhiteSpace(childContent) && string.IsNullOrEmpty(output.Content))
                     {
                         output.Content = tagBuilder.InnerHtml;
                     }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/OptionTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/OptionTagHelper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 using Microsoft.AspNet.Razor.TagHelpers;
@@ -17,7 +18,6 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     /// <see cref="ContentBehavior.Modify"/> in order to read element's content but does not modify that content. The
     /// only modification it makes is to add a <c>selected</c> attribute in some cases.
     /// </remarks>
-    [ContentBehavior(ContentBehavior.Modify)]
     public class OptionTagHelper : TagHelper
     {
         // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
@@ -51,7 +51,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         /// <see cref="ICollection{string}"/> instance. Also does nothing if the associated &lt;option&gt; is already
         /// selected.
         /// </remarks>
-        public override void Process(TagHelperContext context, TagHelperOutput output)
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
             // Pass through attributes that are also well-known HTML attributes.
             if (Value != null)
@@ -84,9 +84,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     }
 
                     // Select this <option/> element if value attribute or content matches a selected value. Callers
-                    // encode values as-needed before setting TagHelperOutput.Content. But TagHelperOutput itself
+                    // encode values as-needed while executing child content. But TagHelperOutput itself
                     // encodes attribute values later, when GenerateStartTag() is called.
-                    var text = output.Content;
+                    var text = await context.GetChildContentAsync();
                     var selected = (Value != null) ? selectedValues.Contains(Value) : encodedValues.Contains(text);
                     if (selected)
                     {

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/SelectTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/SelectTagHelper.cs
@@ -15,7 +15,6 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     /// <summary>
     /// <see cref="ITagHelper"/> implementation targeting &lt;select&gt; elements with an <c>asp-for</c> attribute.
     /// </summary>
-    [ContentBehavior(ContentBehavior.Append)]
     public class SelectTagHelper : TagHelper
     {
         private const string ForAttributeName = "asp-for";
@@ -146,7 +145,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 if (tagBuilder != null)
                 {
                     output.MergeAttributes(tagBuilder);
-                    output.Content += tagBuilder.InnerHtml;
+                    output.PostContent += tagBuilder.InnerHtml;
                     output.SelfClosing = false;
                 }
 

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/TextAreaTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/TextAreaTagHelper.cs
@@ -10,7 +10,6 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     /// <summary>
     /// <see cref="ITagHelper"/> implementation targeting &lt;textarea&gt; elements with an <c>asp-for</c> attribute.
     /// </summary>
-    [ContentBehavior(ContentBehavior.Replace)]
     public class TextAreaTagHelper : TagHelper
     {
         private const string ForAttributeName = "asp-for";

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationMessageTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationMessageTagHelper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 using Microsoft.AspNet.Razor.TagHelpers;
@@ -12,7 +13,6 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     /// attribute.
     /// </summary>
     [TagName("span")]
-    [ContentBehavior(ContentBehavior.Modify)]
     public class ValidationMessageTagHelper : TagHelper
     {
         private const string ValidationForAttributeName = "asp-validation-for";
@@ -33,7 +33,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
         /// <inheritdoc />
         /// <remarks>Does nothing if <see cref="For"/> is <c>null</c>.</remarks>
-        public override void Process(TagHelperContext context, TagHelperOutput output)
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
             if (For != null)
             {
@@ -47,10 +47,12 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 {
                     output.MergeAttributes(tagBuilder);
 
+                    var childContent = await context.GetChildContentAsync();
+
                     // We check for whitespace to detect scenarios such as:
                     // <span validation-for="Name">
                     // </span>
-                    if (string.IsNullOrWhiteSpace(output.Content))
+                    if (string.IsNullOrWhiteSpace(childContent) && string.IsNullOrEmpty(output.Content))
                     {
                         output.Content = tagBuilder.InnerHtml;
                     }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationSummaryTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationSummaryTagHelper.cs
@@ -13,7 +13,6 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     /// attribute.
     /// </summary>
     [TagName("div")]
-    [ContentBehavior(ContentBehavior.Append)]
     public class ValidationSummaryTagHelper : TagHelper
     {
         private const string ValidationSummaryAttributeName = "asp-validation-summary";
@@ -71,7 +70,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 if (tagBuilder != null)
                 {
                     output.MergeAttributes(tagBuilder);
-                    output.Content += tagBuilder.InnerHtml;
+                    output.PostContent += tagBuilder.InnerHtml;
                 }
             }
         }

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/ModelExpressionTagHelper.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/ModelExpressionTagHelper.cs
@@ -43,13 +43,29 @@ namespace Asp
             BeginContext(120, 2, true);
             WriteLiteral("\r\n");
             EndContext();
-            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("inputTest", "test");
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("inputTest", "test", async() => {
+            }
+            , StartWritingScope, EndWritingScope);
             __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper = CreateTagHelper<Microsoft.AspNet.Mvc.Razor.InputTestTagHelper>();
             __tagHelperExecutionContext.Add(__Microsoft_AspNet_Mvc_Razor_InputTestTagHelper);
             __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For = CreateModelExpression(__model => __model.Now);
             __tagHelperExecutionContext.AddTagHelperAttribute("For", __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For);
             __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
             WriteLiteral(__tagHelperExecutionContext.Output.GenerateStartTag());
+            WriteLiteral(__tagHelperExecutionContext.Output.GeneratePreContent());
+            if (__tagHelperExecutionContext.Output.ContentSet)
+            {
+                WriteLiteral(__tagHelperExecutionContext.Output.GenerateContent());
+            }
+            else if (__tagHelperExecutionContext.ChildContentRetrieved)
+            {
+                WriteLiteral(__tagHelperExecutionContext.GetChildContentAsync().Result);
+            }
+            else
+            {
+                __tagHelperExecutionContext.ExecuteChildContentAsync().Wait();
+            }
+            WriteLiteral(__tagHelperExecutionContext.Output.GeneratePostContent());
             WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
         }

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/AnchorTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/AnchorTagHelperTest.cs
@@ -32,15 +32,18 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     { "asp-host", "contoso.com" },
                     { "asp-protocol", "http" }
                 },
-                uniqueId: "test");
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something Else"));
             var output = new TagHelperOutput(
                 expectedTagName,
                 attributes: new Dictionary<string, string>
                 {
                     { "id", "myanchor" },
                     { "asp-route-foo", "bar" },
-                },
-                content: "Something");
+                })
+            {
+                Content = "Something"
+            };
 
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper
@@ -85,11 +88,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             // Arrange
             var context = new TagHelperContext(
-                allAttributes: new Dictionary<string, object>(), uniqueId: "test");
+                allAttributes: new Dictionary<string, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
             var output = new TagHelperOutput(
                 "a",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>())
+            {
+                Content = string.Empty
+            };
 
             var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
             generator
@@ -119,11 +126,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             // Arrange
             var context = new TagHelperContext(
-                allAttributes: new Dictionary<string, object>(), uniqueId: "test");
+                allAttributes: new Dictionary<string, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
             var output = new TagHelperOutput(
                 "a",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>())
+                {
+                    Content = string.Empty
+                };
 
             var generator = new Mock<IHtmlGenerator>();
             generator
@@ -166,8 +177,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 attributes: new Dictionary<string, string>()
                 {
                     { "href", "http://www.contoso.com" }
-                },
-                content: string.Empty);
+                });
             if (propertyName == "asp-route-")
             {
                 output.Attributes.Add("asp-route-foo", "bar");
@@ -202,8 +212,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             typeof(AnchorTagHelper).GetProperty(propertyName).SetValue(anchorTagHelper, "Home");
             var output = new TagHelperOutput(
                 "a",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>());
             var expectedErrorMessage = "Cannot determine an 'href' attribute for <a>. An <a> with a specified " +
                 "'asp-route' must not have an 'asp-action' or 'asp-controller' attribute.";
 

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/FormTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/FormTagHelperTest.cs
@@ -33,15 +33,18 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     { "method", "post" },
                     { "asp-anti-forgery", true }
                 },
-                uniqueId: "test");
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something Else"));
             var output = new TagHelperOutput(
                 expectedTagName,
                 attributes: new Dictionary<string, string>
                 {
                     { "id", "myform" },
                     { "asp-route-foo", "bar" },
-                },
-                content: "Something");
+                })
+            {
+                PostContent = "Something"
+            };
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper
                 .Setup(mock => mock.Action(It.IsAny<string>(),
@@ -56,8 +59,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var viewContext = TestableHtmlGenerator.GetViewContext(model: null,
                                                                    htmlGenerator: htmlGenerator,
                                                                    metadataProvider: metadataProvider);
-            var expectedContent = "Something" + htmlGenerator.GenerateAntiForgery(viewContext)
-                                                             .ToString(TagRenderMode.SelfClosing);
+            var expectedPostContent = "Something" + htmlGenerator.GenerateAntiForgery(viewContext)
+                                                                 .ToString(TagRenderMode.SelfClosing);
             var formTagHelper = new FormTagHelper
             {
                 Action = "index",
@@ -79,7 +82,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal("post", attribute.Value);
             attribute = Assert.Single(output.Attributes, kvp => kvp.Key.Equals("action"));
             Assert.Equal("home/index", attribute.Value);
-            Assert.Equal(expectedContent, output.Content);
+            Assert.Empty(output.PreContent);
+            Assert.Empty(output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.Equal(expectedTagName, output.TagName);
         }
 
@@ -87,16 +92,17 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         [InlineData(true, "<input />")]
         [InlineData(false, "")]
         [InlineData(null, "<input />")]
-        public async Task ProcessAsync_GeneratesAntiForgeryCorrectly(bool? antiForgery, string expectedContent)
+        public async Task ProcessAsync_GeneratesAntiForgeryCorrectly(bool? antiForgery, string expectedPostContent)
         {
             // Arrange
             var viewContext = CreateViewContext();
             var context = new TagHelperContext(
-                allAttributes: new Dictionary<string, object>(), uniqueId: "test");
+                allAttributes: new Dictionary<string, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
             var output = new TagHelperOutput(
                 "form",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>());
             var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
             generator
                 .Setup(mock => mock.GenerateForm(
@@ -124,7 +130,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Assert
             Assert.Equal("form", output.TagName);
             Assert.Empty(output.Attributes);
-            Assert.Equal(expectedContent, output.Content);
+            Assert.Empty(output.PreContent);
+            Assert.Empty(output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
         }
 
         [Fact]
@@ -133,7 +141,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var testViewContext = CreateViewContext();
             var context = new TagHelperContext(
-                allAttributes: new Dictionary<string, object>(), uniqueId: "test");
+                allAttributes: new Dictionary<string, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
             var expectedAttribute = new KeyValuePair<string, string>("asp-ROUTEE-NotRoute", "something");
             var output = new TagHelperOutput(
                 "form",
@@ -141,8 +151,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 {
                     { "asp-route-val", "hello" },
                     { "asp-roUte--Foo", "bar" }
-                },
-                content: string.Empty);
+                });
             output.Attributes.Add(expectedAttribute);
 
             var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
@@ -184,7 +193,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal("form", output.TagName);
             var attribute = Assert.Single(output.Attributes);
             Assert.Equal(expectedAttribute, attribute);
+            Assert.Empty(output.PreContent);
             Assert.Empty(output.Content);
+            Assert.Empty(output.PostContent);
             generator.Verify();
         }
 
@@ -194,11 +205,12 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var viewContext = CreateViewContext();
             var context = new TagHelperContext(
-                allAttributes: new Dictionary<string, object>(), uniqueId: "test");
+                allAttributes: new Dictionary<string, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
             var output = new TagHelperOutput(
                 "form",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>());
             var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
             generator
                 .Setup(mock => mock.GenerateForm(viewContext, "Index", "Home", null, "POST", null))
@@ -220,7 +232,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             Assert.Equal("form", output.TagName);
             Assert.Empty(output.Attributes);
+            Assert.Empty(output.PreContent);
             Assert.Empty(output.Content);
+            Assert.Empty(output.PostContent);
         }
 
         [Theory]
@@ -238,14 +252,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                                              attributes: new Dictionary<string, string>
                                              {
                                                  { "aCTiON", htmlAction },
-                                             },
-                                             content: string.Empty);
+                                             });
+
             var context = new TagHelperContext(
                 allAttributes: new Dictionary<string, object>()
                 {
                     { "METhod", "POST" }
                 },
-                uniqueId: "test");
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
 
             // Act
             await formTagHelper.ProcessAsync(context, output);
@@ -257,7 +272,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal(htmlAction, attribute.Value);
             attribute = Assert.Single(output.Attributes, kvp => kvp.Key.Equals("METhod"));
             Assert.Equal("POST", attribute.Value);
+            Assert.Empty(output.PreContent);
             Assert.Empty(output.Content);
+            Assert.Empty(output.PostContent);
         }
 
         [Theory]
@@ -266,11 +283,12 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         [InlineData(null, "")]
         public async Task ProcessAsync_SupportsAntiForgeryIfActionIsSpecified(
             bool? antiForgery,
-            string expectedContent)
+            string expectedPostContent)
         {
             // Arrange
             var viewContext = CreateViewContext();
             var generator = new Mock<IHtmlGenerator>();
+
             generator.Setup(mock => mock.GenerateAntiForgery(It.IsAny<ViewContext>()))
                      .Returns(new TagBuilder("input"));
             var formTagHelper = new FormTagHelper
@@ -284,9 +302,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                                              attributes: new Dictionary<string, string>
                                              {
                                                  { "aCTiON", "my-action" },
-                                             },
-                                             content: string.Empty);
-            var context = new TagHelperContext(allAttributes: new Dictionary<string, object>(), uniqueId: "test");
+                                             });
+            var context = new TagHelperContext(
+                allAttributes: new Dictionary<string, object>()
+                {
+                    { "aCTiON", "http://www.contoso.com" }
+                },
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
+
 
             // Act
             await formTagHelper.ProcessAsync(context, output);
@@ -295,7 +319,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal("form", output.TagName);
             var attribute = Assert.Single(output.Attributes);
             Assert.Equal(new KeyValuePair<string, string>("aCTiON", "my-action"), attribute);
-            Assert.Equal(expectedContent, output.Content);
+            Assert.Empty(output.PreContent);
+            Assert.Empty(output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
         }
 
         [Theory]
@@ -314,8 +340,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 attributes: new Dictionary<string, string>
                 {
                     { "action", "my-action" },
-                },
-                content: string.Empty);
+                });
             if (propertyName == "asp-route-")
             {
                 tagHelperOutput.Attributes.Add("asp-route-foo", "bar");

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/InputTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/InputTagHelperTest.cs
@@ -89,16 +89,23 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "valid", "from validation attributes" },
                 { "value", expectedValue },
             };
+            var expectedPreContent = "original pre-content";
             var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var expectedTagName = "not-input";
 
-            var context = new TagHelperContext(new Dictionary<string, object>(), uniqueId: "test");
+            var context = new TagHelperContext(allAttributes: new Dictionary<string, object>(),
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
             var originalAttributes = new Dictionary<string, string>
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, expectedContent)
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
                 SelfClosing = false,
             };
 
@@ -124,7 +131,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             // Assert
             Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.True(output.SelfClosing);
             Assert.Equal(expectedTagName, output.TagName);
         }
@@ -133,17 +142,24 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         public async Task ProcessAsync_CallsGenerateCheckBox_WithExpectedParameters()
         {
             // Arrange
-            var originalContent = "something";
+            var originalContent = "original content";
             var originalTagName = "not-input";
+            var expectedPreContent = "original pre-content";
             var expectedContent = originalContent + "<input class=\"form-control\" /><hidden />";
+            var expectedPostContent = "original post-content";
 
-            var context = new TagHelperContext(allAttributes: new Dictionary<string, object>(), uniqueId: "test");
+            var context = new TagHelperContext(allAttributes: new Dictionary<string, object>(),
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
             var originalAttributes = new Dictionary<string, string>
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(originalTagName, originalAttributes, content: originalContent)
+            var output = new TagHelperOutput(originalTagName, originalAttributes)
             {
+                PreContent = expectedPreContent,
+                Content = originalContent,
+                PostContent = expectedPostContent,
                 SelfClosing = true,
             };
 
@@ -180,9 +196,11 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             htmlGenerator.Verify();
 
             Assert.Empty(output.Attributes);    // Moved to Content and cleared
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.False(output.SelfClosing);
-            Assert.Empty(output.TagName);       // Cleared
+            Assert.Null(output.TagName);       // Cleared
         }
 
         [Theory]
@@ -214,16 +232,23 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "class", "form-control hidden-control" },
                 { "type", inputTypeName ?? "hidden" },      // Generator restores type attribute; adds "hidden" if none.
             };
-            var expectedContent = "something";
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var expectedTagName = "not-input";
 
-            var context = new TagHelperContext(allAttributes: contextAttributes, uniqueId: "test");
+            var context = new TagHelperContext(allAttributes: contextAttributes,
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
             var originalAttributes = new Dictionary<string, string>
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, content: expectedContent)
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
                 SelfClosing = false,
             };
 
@@ -257,7 +282,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             htmlGenerator.Verify();
 
             Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.True(output.SelfClosing);
             Assert.Equal(expectedTagName, output.TagName);
         }
@@ -291,16 +318,23 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "class", "form-control password-control" },
                 { "type", inputTypeName ?? "password" },    // Generator restores type attribute; adds "password" if none.
             };
-            var expectedContent = "something";
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var expectedTagName = "not-input";
 
-            var context = new TagHelperContext(allAttributes: contextAttributes, uniqueId: "test");
+            var context = new TagHelperContext(allAttributes: contextAttributes,
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
             var originalAttributes = new Dictionary<string, string>
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, content: expectedContent)
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
                 SelfClosing = false,
             };
 
@@ -333,7 +367,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             htmlGenerator.Verify();
 
             Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.True(output.SelfClosing);
             Assert.Equal(expectedTagName, output.TagName);
         }
@@ -365,16 +401,23 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "type", inputTypeName ?? "radio" },       // Generator restores type attribute; adds "radio" if none.
                 { "value", value },
             };
-            var expectedContent = "something";
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var expectedTagName = "not-input";
 
-            var context = new TagHelperContext(allAttributes: contextAttributes, uniqueId: "test");
+            var context = new TagHelperContext(allAttributes: contextAttributes,
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
             var originalAttributes = new Dictionary<string, string>
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, content: expectedContent)
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
                 SelfClosing = false,
             };
 
@@ -408,7 +451,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             htmlGenerator.Verify();
 
             Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.True(output.SelfClosing);
             Assert.Equal(expectedTagName, output.TagName);
         }
@@ -454,16 +499,23 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "class", "form-control text-control" },
                 { "type", inputTypeName ?? "text" },        // Generator restores type attribute; adds "text" if none.
             };
-            var expectedContent = "something";
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var expectedTagName = "not-input";
 
-            var context = new TagHelperContext(allAttributes: contextAttributes, uniqueId: "test");
+            var context = new TagHelperContext(allAttributes: contextAttributes,
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
             var originalAttributes = new Dictionary<string, string>
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, content: expectedContent)
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
                 SelfClosing = false,
             };
 
@@ -497,7 +549,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             htmlGenerator.Verify();
 
             Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.True(output.SelfClosing);
             Assert.Equal(expectedTagName, output.TagName);
         }
@@ -512,12 +566,19 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "type", "datetime" },
                 { "value", "2014-10-15T23:24:19.000-7:00" },
             };
+            var expectedPreContent = "original pre-content";
             var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var expectedTagName = "input";
 
-            var tagHelperContext = new TagHelperContext(new Dictionary<string, object>(), uniqueId: "test");
-            var output = new TagHelperOutput(expectedTagName, expectedAttributes, expectedContent)
+            var context = new TagHelperContext(allAttributes: new Dictionary<string, object>(),
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
+            var output = new TagHelperOutput(expectedTagName, expectedAttributes)
             {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
                 SelfClosing = false,
             };
 
@@ -532,11 +593,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             tagHelper.For = null;
 
             // Act
-            await tagHelper.ProcessAsync(tagHelperContext, output);
+            await tagHelper.ProcessAsync(context, output);
 
             // Assert
             Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.False(output.SelfClosing);
             Assert.Equal(expectedTagName, output.TagName);
         }
@@ -558,13 +621,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var contextAttributes = new Dictionary<string, object>();
             var originalAttributes = new Dictionary<string, string>();
-            var content = "original content";
             var expectedTagName = "select";
             var expectedMessage = "Unable to format without a 'asp-for' expression for <input>. 'asp-format' must " +
                 "be null if 'asp-for' is null.";
 
-            var tagHelperContext = new TagHelperContext(contextAttributes, uniqueId: "test");
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, content);
+            var context = new TagHelperContext(
+                allAttributes: new Dictionary<string, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
+            var output = new TagHelperOutput(expectedTagName, originalAttributes);
             var tagHelper = new InputTagHelper
             {
                 Format = "{0}",
@@ -572,7 +637,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             // Act & Assert
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                () => tagHelper.ProcessAsync(tagHelperContext, output));
+                () => tagHelper.ProcessAsync(context, output));
             Assert.Equal(expectedMessage, exception.Message);
         }
 

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LabelTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LabelTagHelperTest.cs
@@ -44,45 +44,95 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 return new TheoryData<object, Type, Func<object>, string, TagHelperOutputContent>
                 {
                     { null, typeof(Model), () => null, "Text",
-                        new TagHelperOutputContent(Environment.NewLine, "Text", "Text") },
+                        new TagHelperOutputContent(string.Empty, Environment.NewLine, Environment.NewLine, "Text") },
+                    { null, typeof(Model), () => null, "Text",
+                        new TagHelperOutputContent(Environment.NewLine, string.Empty, "Text", "Text") },
 
                     { modelWithNull, typeof(Model), () => modelWithNull.Text, "Text",
-                        new TagHelperOutputContent(Environment.NewLine, "Text", "Text") },
+                        new TagHelperOutputContent(string.Empty, Environment.NewLine, Environment.NewLine, "Text") },
+                    { modelWithNull, typeof(Model), () => modelWithNull.Text, "Text",
+                        new TagHelperOutputContent(Environment.NewLine, string.Empty, "Text", "Text") },
                     { modelWithText, typeof(Model), () => modelWithText.Text, "Text",
-                        new TagHelperOutputContent(Environment.NewLine, "Text", "Text") },
+                        new TagHelperOutputContent(string.Empty, Environment.NewLine, Environment.NewLine, "Text") },
+                    { modelWithText, typeof(Model), () => modelWithText.Text, "Text",
+                        new TagHelperOutputContent(Environment.NewLine, string.Empty, "Text", "Text") },
                     { modelWithText, typeof(Model), () => modelWithNull.Text, "Text",
-                        new TagHelperOutputContent("Hello World", "Hello World", "Text") },
+                        new TagHelperOutputContent(string.Empty, "Hello World", "Hello World", "Text") },
                     { modelWithText, typeof(Model), () => modelWithText.Text, "Text",
-                        new TagHelperOutputContent("Hello World", "Hello World", "Text") },
+                        new TagHelperOutputContent(string.Empty, "Hello World", "Hello World", "Text") },
+                    { modelWithText, typeof(Model), () => modelWithNull.Text, "Text",
+                        new TagHelperOutputContent("Hello World", null, null, "Text") },
+                    { modelWithText, typeof(Model), () => modelWithText.Text, "Text",
+                        new TagHelperOutputContent("Hello World", null, null, "Text") },
+                    { modelWithText, typeof(Model), () => modelWithNull.Text, "Text",
+                        new TagHelperOutputContent("Hello World1", "Hello World2", "Hello World2", "Text") },
+                    { modelWithText, typeof(Model), () => modelWithText.Text, "Text",
+                        new TagHelperOutputContent("Hello World1", "Hello World2", "Hello World2", "Text") },
 
                     { modelWithNull, typeof(NestedModel), () => modelWithNull.NestedModel.Text, "NestedModel.Text",
-                        new TagHelperOutputContent(Environment.NewLine, "Text", "NestedModel_Text") },
-                    { modelWithText, typeof(NestedModel), () => modelWithText.NestedModel.Text, "NestedModel.Text",
-                        new TagHelperOutputContent(Environment.NewLine, "Text", "NestedModel_Text") },
+                        new TagHelperOutputContent(Environment.NewLine, string.Empty, "Text", "NestedModel_Text") },
                     { modelWithNull, typeof(NestedModel), () => modelWithNull.NestedModel.Text, "NestedModel.Text",
-                        new TagHelperOutputContent("Hello World", "Hello World", "NestedModel_Text") },
+                        new TagHelperOutputContent(string.Empty, Environment.NewLine, Environment.NewLine, "NestedModel_Text") },
                     { modelWithText, typeof(NestedModel), () => modelWithText.NestedModel.Text, "NestedModel.Text",
-                        new TagHelperOutputContent("Hello World", "Hello World", "NestedModel_Text") },
+                        new TagHelperOutputContent(Environment.NewLine, string.Empty, "Text", "NestedModel_Text") },
+                    { modelWithText, typeof(NestedModel), () => modelWithText.NestedModel.Text, "NestedModel.Text",
+                        new TagHelperOutputContent(string.Empty, Environment.NewLine, Environment.NewLine, "NestedModel_Text") },
+                    { modelWithNull, typeof(NestedModel), () => modelWithNull.NestedModel.Text, "NestedModel.Text",
+                        new TagHelperOutputContent(string.Empty, "Hello World", "Hello World", "NestedModel_Text") },
+                    { modelWithText, typeof(NestedModel), () => modelWithText.NestedModel.Text, "NestedModel.Text",
+                        new TagHelperOutputContent(string.Empty, "Hello World", "Hello World", "NestedModel_Text") },
+                    { modelWithNull, typeof(NestedModel), () => modelWithNull.NestedModel.Text, "NestedModel.Text",
+                        new TagHelperOutputContent("Hello World", null, null, "NestedModel_Text") },
+                    { modelWithText, typeof(NestedModel), () => modelWithText.NestedModel.Text, "NestedModel.Text",
+                        new TagHelperOutputContent("Hello World", null, null, "NestedModel_Text") },
+                    { modelWithNull, typeof(NestedModel), () => modelWithNull.NestedModel.Text, "NestedModel.Text",
+                        new TagHelperOutputContent("Hello World1", "Hello World2", "Hello World2", "NestedModel_Text") },
+                    { modelWithText, typeof(NestedModel), () => modelWithText.NestedModel.Text, "NestedModel.Text",
+                        new TagHelperOutputContent("Hello World1", "Hello World2", "Hello World2", "NestedModel_Text") },
 
                     // Note: Tests cases below here will not work in practice due to current limitations on indexing
                     // into ModelExpressions. Will be fixed in https://github.com/aspnet/Mvc/issues/1345.
                     { models, typeof(Model), () => models[0].Text, "[0].Text",
-                        new TagHelperOutputContent(Environment.NewLine, "Text", "z0__Text") },
-                    { models, typeof(Model), () => models[1].Text, "[1].Text",
-                        new TagHelperOutputContent(Environment.NewLine, "Text", "z1__Text") },
+                        new TagHelperOutputContent(Environment.NewLine, string.Empty, "Text", "z0__Text") },
                     { models, typeof(Model), () => models[0].Text, "[0].Text",
-                        new TagHelperOutputContent("Hello World", "Hello World", "z0__Text") },
+                        new TagHelperOutputContent(string.Empty, Environment.NewLine, Environment.NewLine, "z0__Text") },
                     { models, typeof(Model), () => models[1].Text, "[1].Text",
-                        new TagHelperOutputContent("Hello World", "Hello World", "z1__Text") },
+                        new TagHelperOutputContent(Environment.NewLine, string.Empty, "Text", "z1__Text") },
+                    { models, typeof(Model), () => models[1].Text, "[1].Text",
+                        new TagHelperOutputContent(string.Empty, Environment.NewLine, Environment.NewLine, "z1__Text") },
+                    { models, typeof(Model), () => models[0].Text, "[0].Text",
+                        new TagHelperOutputContent(string.Empty, "Hello World", "Hello World", "z0__Text") },
+                    { models, typeof(Model), () => models[1].Text, "[1].Text",
+                        new TagHelperOutputContent(string.Empty, "Hello World", "Hello World", "z1__Text") },
+                    { models, typeof(Model), () => models[0].Text, "[0].Text",
+                        new TagHelperOutputContent("Hello World", null, null, "z0__Text") },
+                    { models, typeof(Model), () => models[1].Text, "[1].Text",
+                        new TagHelperOutputContent("Hello World", null, null, "z1__Text") },
+                    { models, typeof(Model), () => models[0].Text, "[0].Text",
+                        new TagHelperOutputContent("Hello World1", "Hello World2", "Hello World2", "z0__Text") },
+                    { models, typeof(Model), () => models[1].Text, "[1].Text",
+                        new TagHelperOutputContent("Hello World1", "Hello World2", "Hello World2", "z1__Text") },
 
                     { models, typeof(NestedModel), () => models[0].NestedModel.Text, "[0].NestedModel.Text",
-                        new TagHelperOutputContent(Environment.NewLine, "Text", "z0__NestedModel_Text") },
-                    { models, typeof(NestedModel), () => models[1].NestedModel.Text, "[1].NestedModel.Text",
-                        new TagHelperOutputContent(Environment.NewLine, "Text", "z1__NestedModel_Text") },
+                        new TagHelperOutputContent(Environment.NewLine, string.Empty, "Text", "z0__NestedModel_Text") },
                     { models, typeof(NestedModel), () => models[0].NestedModel.Text, "[0].NestedModel.Text",
-                        new TagHelperOutputContent("Hello World", "Hello World", "z0__NestedModel_Text") },
+                        new TagHelperOutputContent(string.Empty, Environment.NewLine, Environment.NewLine, "z0__NestedModel_Text") },
                     { models, typeof(NestedModel), () => models[1].NestedModel.Text, "[1].NestedModel.Text",
-                        new TagHelperOutputContent("Hello World", "Hello World", "z1__NestedModel_Text") },
+                        new TagHelperOutputContent(Environment.NewLine, string.Empty, "Text", "z1__NestedModel_Text") },
+                    { models, typeof(NestedModel), () => models[1].NestedModel.Text, "[1].NestedModel.Text",
+                        new TagHelperOutputContent(string.Empty, Environment.NewLine, Environment.NewLine, "z1__NestedModel_Text") },
+                    { models, typeof(NestedModel), () => models[0].NestedModel.Text, "[0].NestedModel.Text",
+                        new TagHelperOutputContent(string.Empty, "Hello World", "Hello World", "z0__NestedModel_Text") },
+                    { models, typeof(NestedModel), () => models[1].NestedModel.Text, "[1].NestedModel.Text",
+                        new TagHelperOutputContent(string.Empty, "Hello World", "Hello World", "z1__NestedModel_Text") },
+                    { models, typeof(NestedModel), () => models[0].NestedModel.Text, "[0].NestedModel.Text",
+                        new TagHelperOutputContent("Hello World", null, null, "z0__NestedModel_Text") },
+                    { models, typeof(NestedModel), () => models[1].NestedModel.Text, "[1].NestedModel.Text",
+                        new TagHelperOutputContent("Hello World", null, null, "z1__NestedModel_Text") },
+                    { models, typeof(NestedModel), () => models[0].NestedModel.Text, "[0].NestedModel.Text",
+                        new TagHelperOutputContent("Hello World1", "Hello World2", "Hello World2", "z0__NestedModel_Text") },
+                    { models, typeof(NestedModel), () => models[1].NestedModel.Text, "[1].NestedModel.Text",
+                        new TagHelperOutputContent("Hello World1", "Hello World2", "Hello World2", "z1__NestedModel_Text") },
                 };
             }
         }
@@ -112,24 +162,36 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 For = modelExpression,
             };
+            var expectedPreContent = "original pre-content";
+            var expectedPostContent = "original post-content";
 
-            var tagHelperContext = new TagHelperContext(allAttributes: new Dictionary<string, object>(), uniqueId: "test");
+            var context = new TagHelperContext(
+                allAttributes: new Dictionary<string, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult(tagHelperOutputContent.OriginalChildContent));
             var htmlAttributes = new Dictionary<string, string>
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(expectedTagName, htmlAttributes, tagHelperOutputContent.OriginalContent);
+            var output = new TagHelperOutput(expectedTagName, htmlAttributes)
+            {
+                PreContent = expectedPreContent,
+                Content = tagHelperOutputContent.OriginalContent,
+                PostContent = expectedPostContent,
+            };
             var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
             var viewContext = TestableHtmlGenerator.GetViewContext(model, htmlGenerator, metadataProvider);
             tagHelper.ViewContext = viewContext;
             tagHelper.Generator = htmlGenerator;
 
             // Act
-            await tagHelper.ProcessAsync(tagHelperContext, output);
+            await tagHelper.ProcessAsync(context, output);
 
             // Assert
             Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(tagHelperOutputContent.ExpectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.False(output.SelfClosing);
             Assert.Equal(expectedTagName, output.TagName);
         }
@@ -142,7 +204,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 { "class", "form-control" },
             };
+            var expectedPreContent = "original pre-content";
             var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var expectedTagName = "label";
 
             var metadataProvider = new DataAnnotationsModelMetadataProvider();
@@ -153,8 +217,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var modelExpression = new ModelExpression(nameof(Model.Text), metadata);
             var tagHelper = new LabelTagHelper();
 
-            var tagHelperContext = new TagHelperContext(allAttributes: new Dictionary<string, object>(), uniqueId: "test");
-            var output = new TagHelperOutput(expectedTagName, expectedAttributes, expectedContent);
+            var context = new TagHelperContext(allAttributes: new Dictionary<string, object>(),
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
+            var output = new TagHelperOutput(expectedTagName, expectedAttributes)
+            {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
+            };
 
             var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
             Model model = null;
@@ -163,22 +234,30 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             tagHelper.Generator = htmlGenerator;
 
             // Act
-            await tagHelper.ProcessAsync(tagHelperContext, output);
+            await tagHelper.ProcessAsync(context, output);
 
             // Assert
             Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.Equal(expectedTagName, output.TagName);
         }
 
         public class TagHelperOutputContent
         {
-            public TagHelperOutputContent(string outputContent, string expectedContent, string expectedId)
+            public TagHelperOutputContent(string originalChildContent,
+                                          string outputContent,
+                                          string expectedContent,
+                                          string expectedId)
             {
+                OriginalChildContent = originalChildContent;
                 OriginalContent = outputContent;
                 ExpectedContent = expectedContent;
                 ExpectedId = expectedId;
             }
+
+            public string OriginalChildContent { get; set; }
 
             public string OriginalContent { get; set; }
 

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/OptionTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/OptionTagHelperTest.cs
@@ -136,9 +136,12 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "selected", selected },
                 { "value", value },
             };
-            var tagHelperContext = new TagHelperContext(contextAttributes, uniqueId: "test");
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, originalContent)
+            var context = new TagHelperContext(contextAttributes,
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult(originalContent));
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
+                Content = originalContent,
                 SelfClosing = false,
             };
 
@@ -158,7 +161,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             };
 
             // Act
-            await tagHelper.ProcessAsync(tagHelperContext, output);
+            await tagHelper.ProcessAsync(context, output);
 
             // Assert
             Assert.Equal(
@@ -188,9 +191,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "selected", selected },
                 { "value", value },
             };
-            var tagHelperContext = new TagHelperContext(contextAttributes, uniqueId: "test");
-            var output = new TagHelperOutput(originalTagName, originalAttributes, originalContent)
+            var originalPreContent = "original pre-content";
+            var originalPostContent = "original post-content";
+            var context = new TagHelperContext(contextAttributes,
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult(originalContent));
+            var output = new TagHelperOutput(originalTagName, originalAttributes)
             {
+                PreContent = originalPreContent,
+                Content = originalContent,
+                PostContent = originalPostContent,
                 SelfClosing = false,
             };
 
@@ -210,7 +220,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             // Act & Assert (does not throw)
             // Tag helper would throw an NRE if it used Generator value.
-            await tagHelper.ProcessAsync(tagHelperContext, output);
+            await tagHelper.ProcessAsync(context, output);
         }
 
         [Theory]
@@ -235,9 +245,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "selected", selected },
                 { "value", value },
             };
-            var tagHelperContext = new TagHelperContext(contextAttributes, uniqueId: "test");
-            var output = new TagHelperOutput(originalTagName, originalAttributes, originalContent)
+            var originalPreContent = "original pre-content";
+            var originalPostContent = "original post-content";
+            var context = new TagHelperContext(contextAttributes,
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult(originalContent));
+            var output = new TagHelperOutput(originalTagName, originalAttributes)
             {
+                PreContent = originalPreContent,
+                Content = originalContent,
+                PostContent = originalPostContent,
                 SelfClosing = false,
             };
 
@@ -249,7 +266,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             // Act & Assert (does not throw)
             // Tag helper would throw an NRE if it used ViewContext or Generator values.
-            await tagHelper.ProcessAsync(tagHelperContext, output);
+            await tagHelper.ProcessAsync(context, output);
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/SelectTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/SelectTagHelperTest.cs
@@ -165,7 +165,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 { "class", "form-control" },
             };
-            var originalContent = "original content";
+            var originalPostContent = "original content";
 
             var expectedAttributes = new Dictionary<string, string>(originalAttributes)
             {
@@ -173,7 +173,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "name", nameAndId.Name },
                 { "valid", "from validation attributes" },
             };
-            var expectedContent = originalContent;
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
+            var expectedPostContent = originalPostContent;
             var expectedTagName = "not-select";
 
             var metadataProvider = new DataAnnotationsModelMetadataProvider();
@@ -182,9 +184,14 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var metadata = metadataProvider.GetMetadataForProperty(modelAccessor, containerType, propertyName: "Text");
             var modelExpression = new ModelExpression(nameAndId.Name, metadata);
 
-            var tagHelperContext = new TagHelperContext(new Dictionary<string, object>(), uniqueId: "test");
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, expectedContent)
+            var context = new TagHelperContext(allAttributes: new Dictionary<string, object>(),
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = originalPostContent,
                 SelfClosing = true,
             };
 
@@ -204,11 +211,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             };
 
             // Act
-            await tagHelper.ProcessAsync(tagHelperContext, output);
+            await tagHelper.ProcessAsync(context, output);
 
             // Assert
             Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.False(output.SelfClosing);
             Assert.Equal(expectedTagName, output.TagName);
 
@@ -235,7 +244,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 { "class", "form-control" },
             };
-            var originalContent = "original content";
+            var originalPostContent = "original content";
 
             var expectedAttributes = new Dictionary<string, string>(originalAttributes)
             {
@@ -243,7 +252,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "name", nameAndId.Name },
                 { "valid", "from validation attributes" },
             };
-            var expectedContent = originalContent + expectedOptions;
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
+            var expectedPostContent = originalPostContent + expectedOptions;
             var expectedTagName = "select";
 
             var metadataProvider = new DataAnnotationsModelMetadataProvider();
@@ -252,9 +263,14 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var metadata = metadataProvider.GetMetadataForProperty(modelAccessor, containerType, propertyName: "Text");
             var modelExpression = new ModelExpression(nameAndId.Name, metadata);
 
-            var tagHelperContext = new TagHelperContext(new Dictionary<string, object>(), uniqueId: "test");
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, originalContent)
+            var context = new TagHelperContext(allAttributes: new Dictionary<string, object>(),
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = originalPostContent,
                 SelfClosing = true,
             };
 
@@ -276,11 +292,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             };
 
             // Act
-            await tagHelper.ProcessAsync(tagHelperContext, output);
+            await tagHelper.ProcessAsync(context, output);
 
             // Assert
             Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.False(output.SelfClosing);
             Assert.Equal(expectedTagName, output.TagName);
 
@@ -308,12 +326,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "multiple", multiple },
             };
             var originalAttributes = new Dictionary<string, string>();
-            var content = "original content";
             var propertyName = "Property1";
             var expectedTagName = "select";
 
-            var tagHelperContext = new TagHelperContext(contextAttributes, uniqueId: "test");
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, content);
+            var context = new TagHelperContext(contextAttributes,
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
+            var output = new TagHelperOutput(expectedTagName, originalAttributes);
 
             // TODO: https://github.com/aspnet/Mvc/issues/1253
             // In real (model => model) scenario, ModelExpression should have name "" and
@@ -350,7 +369,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             };
 
             // Act
-            await tagHelper.ProcessAsync(tagHelperContext, output);
+            await tagHelper.ProcessAsync(context, output);
 
             // Assert
             htmlGenerator.Verify();
@@ -372,12 +391,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var contextAttributes = new Dictionary<string, object>();
             var originalAttributes = new Dictionary<string, string>();
-            var content = "original content";
             var propertyName = "Property1";
             var tagName = "select";
 
-            var tagHelperContext = new TagHelperContext(contextAttributes, uniqueId: "test");
-            var output = new TagHelperOutput(tagName, originalAttributes, content);
+            var context = new TagHelperContext(contextAttributes,
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
+            var output = new TagHelperOutput(tagName, originalAttributes);
 
             var metadataProvider = new EmptyModelMetadataProvider();
             var metadata = metadataProvider.GetMetadataForType(() => model, modelType);
@@ -407,7 +427,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             };
 
             // Act
-            await tagHelper.ProcessAsync(tagHelperContext, output);
+            await tagHelper.ProcessAsync(context, output);
 
             // Assert
             htmlGenerator.Verify();
@@ -437,12 +457,19 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             };
             var expectedAttributes = new Dictionary<string, string>(originalAttributes);
             expectedAttributes[attributeName] = (string)contextAttributes[attributeName];
+            var expectedPreContent = "original pre-content";
             var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var expectedTagName = "select";
 
-            var tagHelperContext = new TagHelperContext(contextAttributes, uniqueId: "test");
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, expectedContent)
+            var context = new TagHelperContext(contextAttributes,
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
                 SelfClosing = true,
             };
 
@@ -452,11 +479,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             };
 
             // Act
-            await tagHelper.ProcessAsync(tagHelperContext, output);
+            await tagHelper.ProcessAsync(context, output);
 
             // Assert
             Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.True(output.SelfClosing);
             Assert.Equal(expectedTagName, output.TagName);
         }
@@ -467,12 +496,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var contextAttributes = new Dictionary<string, object>();
             var originalAttributes = new Dictionary<string, string>();
-            var content = "original content";
             var expectedTagName = "select";
             var expectedMessage = "Cannot determine body for <select>. 'asp-items' must be null if 'asp-for' is null.";
 
-            var tagHelperContext = new TagHelperContext(contextAttributes, uniqueId: "test");
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, content);
+            var context = new TagHelperContext(contextAttributes,
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
+            var output = new TagHelperOutput(expectedTagName, originalAttributes);
             var tagHelper = new SelectTagHelper
             {
                 Items = Enumerable.Empty<SelectListItem>(),
@@ -480,7 +510,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             // Act & Assert
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                () => tagHelper.ProcessAsync(tagHelperContext, output));
+                () => tagHelper.ProcessAsync(context, output));
             Assert.Equal(expectedMessage, exception.Message);
         }
 
@@ -497,13 +527,14 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var contextAttributes = new Dictionary<string, object>();
             var originalAttributes = new Dictionary<string, string>();
-            var content = "original content";
             var expectedTagName = "select";
             var expectedMessage = "Cannot parse 'multiple' value '" + multiple +
                 "' for <select>. Acceptable values are 'false', 'true' and 'multiple'.";
 
-            var tagHelperContext = new TagHelperContext(contextAttributes, uniqueId: "test");
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, content);
+            var context = new TagHelperContext(contextAttributes,
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
+            var output = new TagHelperOutput(expectedTagName, originalAttributes);
 
             var metadataProvider = new EmptyModelMetadataProvider();
             string model = null;
@@ -518,7 +549,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             // Act & Assert
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                () => tagHelper.ProcessAsync(tagHelperContext, output));
+                () => tagHelper.ProcessAsync(context, output));
             Assert.Equal(expectedMessage, exception.Message);
         }
 

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TagHelperOutputExtensionsTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TagHelperOutputExtensionsTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 using Xunit;
@@ -19,14 +20,14 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>());
             var tagHelperContext = new TagHelperContext(
-                new Dictionary<string, object>(StringComparer.Ordinal)
+                allAttributes: new Dictionary<string, object>(StringComparer.Ordinal)
                 {
                     { attributeName, attributeValue }
                 },
-                uniqueId: "test");
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
             var expectedAttribute = new KeyValuePair<string, string>(attributeName, attributeValue);
 
             // Act
@@ -47,15 +48,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 attributes: new Dictionary<string, string>()
                 {
                     { attributeName, "world2" }
-                },
-                content: string.Empty);
+                });
             var expectedAttribute = new KeyValuePair<string, string>(attributeName, "world2");
             var tagHelperContext = new TagHelperContext(
-                new Dictionary<string, object>(StringComparer.Ordinal)
+                allAttributes: new Dictionary<string, object>(StringComparer.Ordinal)
                 {
                     { attributeName, "world" }
-                }
-                , uniqueId: "test");
+                },
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
 
             // Act
             tagHelperOutput.CopyHtmlAttribute(attributeName, tagHelperContext);
@@ -75,8 +76,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 {
                     { "route-Hello", "World" },
                     { "Route-I", "Am" }
-                },
-                content: string.Empty);
+                });
             var expectedAttribute = new KeyValuePair<string, string>("type", "btn");
             tagHelperOutput.Attributes.Add(expectedAttribute);
             var attributes = tagHelperOutput.FindPrefixedAttributes("route-");
@@ -99,8 +99,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 {
                     { "routeHello", "World" },
                     { "Routee-I", "Am" }
-                },
-                content: string.Empty);
+                });
 
             // Act
             var attributes = tagHelperOutput.FindPrefixedAttributes("route-");
@@ -119,8 +118,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>());
             var expectedAttribute = new KeyValuePair<string, string>("type", "btn");
             tagHelperOutput.Attributes.Add(expectedAttribute);
 
@@ -141,8 +139,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>());
             tagHelperOutput.Attributes.Add("class", "Hello");
 
             var tagBuilder = new TagBuilder("p");
@@ -168,8 +165,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>());
             tagHelperOutput.Attributes.Add(originalName, "Hello");
 
             var tagBuilder = new TagBuilder("p");
@@ -189,8 +185,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>());
 
             var tagBuilder = new TagBuilder("p");
             var expectedAttribute = new KeyValuePair<string, string>("visible", "val < 3");
@@ -210,8 +205,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>());
 
             var tagBuilder = new TagBuilder("p");
             var expectedAttribute1 = new KeyValuePair<string, string>("class", "btn");
@@ -236,8 +230,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>());
             var expectedAttribute = new KeyValuePair<string, string>("class", "btn");
             tagHelperOutput.Attributes.Add(expectedAttribute);
 
@@ -257,8 +250,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>());
             var expectedOutputAttribute = new KeyValuePair<string, string>("class", "btn");
             tagHelperOutput.Attributes.Add(expectedOutputAttribute);
 

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TextAreaTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TextAreaTagHelperTest.cs
@@ -107,13 +107,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 For = modelExpression,
             };
 
-            var tagHelperContext = new TagHelperContext(new Dictionary<string, object>(), uniqueId: "test");
+            var context = new TagHelperContext(allAttributes: new Dictionary<string, object>(),
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
             var htmlAttributes = new Dictionary<string, string>
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(expectedTagName, htmlAttributes, "original content")
+            var output = new TagHelperOutput(expectedTagName, htmlAttributes)
             {
+                Content = "original content",
                 SelfClosing = true,
             };
 
@@ -129,7 +132,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             tagHelper.Generator = htmlGenerator;
 
             // Act
-            await tagHelper.ProcessAsync(tagHelperContext, output);
+            await tagHelper.ProcessAsync(context, output);
 
             // Assert
             Assert.Equal(expectedAttributes, output.Attributes);
@@ -146,7 +149,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 { "class", "form-control" },
             };
+            var expectedPreContent = "original pre-content";
             var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var expectedTagName = "textarea";
 
             var metadataProvider = new DataAnnotationsModelMetadataProvider();
@@ -157,9 +162,14 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var modelExpression = new ModelExpression(nameof(Model.Text), metadata);
             var tagHelper = new TextAreaTagHelper();
 
-            var tagHelperContext = new TagHelperContext(new Dictionary<string, object>(), uniqueId: "test");
-            var output = new TagHelperOutput(expectedTagName, expectedAttributes, expectedContent)
+            var context = new TagHelperContext(allAttributes: new Dictionary<string, object>(),
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
+            var output = new TagHelperOutput(expectedTagName, expectedAttributes)
             {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
                 SelfClosing = true,
             };
 
@@ -176,7 +186,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             tagHelper.Generator = htmlGenerator;
 
             // Act
-            await tagHelper.ProcessAsync(tagHelperContext, output);
+            await tagHelper.ProcessAsync(context, output);
 
             // Assert
             Assert.Equal(expectedAttributes, output.Attributes);

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ValidationSummaryTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ValidationSummaryTagHelperTest.cs
@@ -28,14 +28,22 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 ValidationSummaryValue = "All"
             };
 
-            var tagHelperContext = new TagHelperContext(new Dictionary<string, object>(), uniqueId: "test");
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
+            var context = new TagHelperContext(allAttributes: new Dictionary<string, object>(),
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
             var output = new TagHelperOutput(
                 expectedTagName,
                 attributes: new Dictionary<string, string>
                 {
                     { "class", "form-control" }
-                },
-                content: "Custom Content");
+                })
+            {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = "Custom Content",
+            };
 
             var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
             Model model = null;
@@ -44,7 +52,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             validationSummaryTagHelper.Generator = htmlGenerator;
 
             // Act
-            await validationSummaryTagHelper.ProcessAsync(tagHelperContext, output);
+            await validationSummaryTagHelper.ProcessAsync(context, output);
 
             // Assert
             Assert.Equal(2, output.Attributes.Count);
@@ -52,8 +60,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal("form-control validation-summary-valid", attribute.Value);
             attribute = Assert.Single(output.Attributes, kvp => kvp.Key.Equals("data-valmsg-summary"));
             Assert.Equal("true", attribute.Value);
+            Assert.Equal(expectedPreContent, output.PreContent);
+            Assert.Equal(expectedContent, output.Content);
             Assert.Equal("Custom Content<ul><li style=\"display:none\"></li>" + Environment.NewLine + "</ul>",
-                         output.Content);
+                         output.PostContent);
             Assert.Equal(expectedTagName, output.TagName);
         }
 
@@ -65,10 +75,17 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 ValidationSummaryValue = "ModelOnly",
             };
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var output = new TagHelperOutput(
                 "div",
-                attributes: new Dictionary<string, string>(),
-                content: "Content of validation summary");
+                attributes: new Dictionary<string, string>())
+            {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
+            };
             var expectedViewContext = CreateViewContext();
             var generator = new Mock<IHtmlGenerator>();
             generator
@@ -84,7 +101,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             generator.Verify();
             Assert.Equal("div", output.TagName);
             Assert.Empty(output.Attributes);
-            Assert.Equal("Content of validation summary", output.Content);
+            Assert.Equal(expectedPreContent, output.PreContent);
+            Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
         }
 
         [Fact]
@@ -95,10 +114,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 ValidationSummaryValue = "ModelOnly"
             };
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
             var output = new TagHelperOutput(
                 "div",
-                attributes: new Dictionary<string, string>(),
-                content: "Content of validation summary");
+                attributes: new Dictionary<string, string>())
+            {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = "Content of validation summary"
+            };
             var tagBuilder = new TagBuilder("span2")
             {
                 InnerHtml = "New HTML"
@@ -133,7 +158,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal("world", attribute.Value);
             attribute = Assert.Single(output.Attributes, kvp => kvp.Key.Equals("anything"));
             Assert.Equal("something", attribute.Value);
-            Assert.Equal("Content of validation summaryNew HTML", output.Content);
+            Assert.Equal(expectedPreContent, output.PreContent);
+            Assert.Equal(expectedContent, output.Content);
+            Assert.Equal("Content of validation summaryNew HTML", output.PostContent);
         }
 
         [Theory]
@@ -146,10 +173,17 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 ValidationSummaryValue = validationSummaryValue
             };
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var output = new TagHelperOutput(
                 "div",
-                attributes: new Dictionary<string, string>(),
-                content: "Content of validation message");
+                attributes: new Dictionary<string, string>())
+            {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
+            };
 
             var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
             var viewContext = CreateViewContext();
@@ -162,7 +196,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Assert
             Assert.Equal("div", output.TagName);
             Assert.Empty(output.Attributes);
-            Assert.Equal("Content of validation message", output.Content);
+            Assert.Equal(expectedPreContent, output.PreContent);
+            Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
         }
 
         [Theory]
@@ -177,10 +213,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 ValidationSummaryValue = validationSummary
             };
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
             var output = new TagHelperOutput(
                 "div",
-                attributes: new Dictionary<string, string>(),
-                content: "Content of validation message");
+                attributes: new Dictionary<string, string>())
+            {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = "Content of validation message",
+            };
             var tagBuilder = new TagBuilder("span2")
             {
                 InnerHtml = "New HTML"
@@ -206,7 +248,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Assert
             Assert.Equal("div", output.TagName);
             Assert.Empty(output.Attributes);
-            Assert.Equal("Content of validation messageNew HTML", output.Content);
+            Assert.Equal(expectedPreContent, output.PreContent);
+            Assert.Equal(expectedContent, output.Content);
+            Assert.Equal("Content of validation messageNew HTML", output.PostContent);
             generator.Verify();
         }
 
@@ -220,10 +264,17 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 ValidationSummaryValue = validationSummary
             };
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var output = new TagHelperOutput(
                 "div",
-                attributes: new Dictionary<string, string>(),
-                content: "Content of validation message");
+                attributes: new Dictionary<string, string>())
+            {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
+            };
             var tagBuilder = new TagBuilder("span2")
             {
                 InnerHtml = "New HTML"
@@ -237,7 +288,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Assert
             Assert.Equal("div", output.TagName);
             Assert.Empty(output.Attributes);
-            Assert.Equal("Content of validation message", output.Content);
+            Assert.Equal(expectedPreContent, output.PreContent);
+            Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
         }
 
         [Fact]
@@ -250,8 +303,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             };
             var output = new TagHelperOutput(
                 "div",
-                attributes: new Dictionary<string, string>(),
-                content: "Content of validation message");
+                attributes: new Dictionary<string, string>());
             var expectedViewContext = CreateViewContext();
             var expectedMessage = "Cannot parse 'asp-validation-summary' value 'Hello World' for <div>. Acceptable " +
                                   "values are 'All', 'ModelOnly' and 'None'.";

--- a/test/WebSites/RequestServicesWebSite/RequestScopedTagHelper.cs
+++ b/test/WebSites/RequestServicesWebSite/RequestScopedTagHelper.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNet.Razor.TagHelpers;
 
 namespace RequestServicesWebSite
 {
-    [ContentBehavior(ContentBehavior.Replace)]
     public class RequestScopedTagHelper : TagHelper
     {
         [Activate]

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/ATagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/ATagHelper.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNet.Razor.TagHelpers;
 
 namespace TagHelpersWebSite.TagHelpers
 {
-    [ContentBehavior(ContentBehavior.Prepend)]
     public class ATagHelper : TagHelper
     {
         [Activate]
@@ -31,7 +30,7 @@ namespace TagHelpersWebSite.TagHelpers
 
                 output.Attributes["href"] = UrlHelper.Action(Action, Controller, methodParameters);
 
-                output.Content = "My ";
+                output.PreContent = "My ";
             }
         }
     }

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/AutoLinkerTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/AutoLinkerTagHelper.cs
@@ -2,20 +2,22 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 using Microsoft.AspNet.Razor.TagHelpers;
 
 namespace TagHelpersWebSite.TagHelpers
 {
     [TagName("p")]
-    [ContentBehavior(ContentBehavior.Modify)]
     public class AutoLinkerTagHelper : TagHelper
     {
-        public override void Process(TagHelperContext context, TagHelperOutput output)
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
+            var childContent = await context.GetChildContentAsync();
+
             // Find Urls in the content and replace them with their anchor tag equivalent.
             output.Content = Regex.Replace(
-                output.Content,
+                childContent,
                 @"\b(?:https?://|www\.)(\S+)\b",
                 "<strong><a target=\"_blank\" href=\"http://$0\">$0</a></strong>");
         }

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/ConditionTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/ConditionTagHelper.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNet.Razor.TagHelpers;
 namespace TagHelpersWebSite.TagHelpers
 {
     [TagName("div", "style", "p")]
-    [ContentBehavior(ContentBehavior.Modify)]
     public class ConditionTagHelper : TagHelper
     {
         public bool? Condition { get; set; }
@@ -17,8 +16,7 @@ namespace TagHelpersWebSite.TagHelpers
             // If a condition is set and evaluates to false, don't render the tag.
             if (Condition.HasValue && !Condition.Value)
             {
-                output.TagName = null;
-                output.Content = null;
+                output.SupressOutput();
             }
         }
     }

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/NestedViewStartTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/NestedViewStartTagHelper.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNet.Razor.TagHelpers;
 namespace TagHelpersWebSite.TagHelpers
 {
     [TagName("nested")]
-    [ContentBehavior(ContentBehavior.Modify)]
     public class NestedViewStartTagHelper : TagHelper
     {
         public override void Process(TagHelperContext context, TagHelperOutput output)

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/PrettyTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/PrettyTagHelper.cs
@@ -33,7 +33,8 @@ namespace TagHelpersWebSite.TagHelpers
 
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
-            if (MakePretty.HasValue && !MakePretty.Value)
+            if (MakePretty.HasValue && !MakePretty.Value || 
+                output.TagName == null)
             {
                 return;
             }

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/RootViewStartTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/RootViewStartTagHelper.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNet.Razor.TagHelpers;
 namespace TagHelpersWebSite.TagHelpers
 {
     [TagName("root")]
-    [ContentBehavior(ContentBehavior.Replace)]
     public class RootViewStartTagHelper : TagHelper
     {
         public override void Process(TagHelperContext context, TagHelperOutput output)

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/TagCloudViewComponentTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/TagCloudViewComponentTagHelper.cs
@@ -14,7 +14,6 @@ namespace MvcSample.Web.Components
 {
     [TagName("tag-cloud")]
     [ViewComponent(Name = "Tags")]
-    [ContentBehavior(ContentBehavior.Replace)]
     public class TagCloudViewComponentTagHelper : ITagHelper
     {
         private static readonly string[] Tags =

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/WebsiteInformationTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/WebsiteInformationTagHelper.cs
@@ -8,7 +8,6 @@ using TagHelpersWebSite.Models;
 
 namespace TagHelpersWebSite.TagHelpers
 {
-    [ContentBehavior(ContentBehavior.Append)]
     public class WebsiteInformationTagHelper : TagHelper
     {
         public WebsiteContext Info { get; set; }
@@ -16,7 +15,7 @@ namespace TagHelpersWebSite.TagHelpers
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
             output.TagName = "section";
-            output.Content = string.Format(
+            output.PreContent = string.Format(
                 "<p><strong>Version:</strong> {0}</p>" + Environment.NewLine +
                 "<p><strong>Copyright Year:</strong> {1}</p>" + Environment.NewLine +
                 "<p><strong>Approved:</strong> {2}</p>" + Environment.NewLine +


### PR DESCRIPTION
**Modify TagHelpers to use new content mode design.**
- React to aspnet/Razor#221
- Modified existing TagHelpers to no longer rely on ContentBehavior and to instead utilize GetChildContentAsync, PreContent, Content and PostContent.

**Modify TagHelper tests to abide by new content mode design.**
- React to aspnet/Razor#221
- Modified existing TagHelper tests to no longer rely on ContentBehavior.
- Updated signatures of TagHelperExecutionContext and TagHelperContext pieces.