### PR TITLE
Prototype: Adding logging functional tests

### DIFF
--- a/Mvc.sln
+++ b/Mvc.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22410.0
+VisualStudioVersion = 14.0.22415.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{DAAE4C74-D06F-4874-A166-33305D2643CE}"
 EndProject
@@ -63,6 +63,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		global.json = global.json
 	EndProjectSection
+	ProjectSection(FolderGlobals) = preProject
+		global_1json__JSONSchema = http://json.schemastore.org/global
+	EndProjectSection
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "ConnegWebsite", "test\WebSites\ConnegWebSite\ConnegWebsite.kproj", "{C6E5AFFA-890A-448F-8DE3-878B1D3C9FC7}"
 EndProject
@@ -111,6 +114,8 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "CompositeViewEngineWebSite", "test\WebSites\CompositeViewEngineWebSite\CompositeViewEngineWebSite.kproj", "{A853B2BA-4449-4908-A416-5A3C027FC22B}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "ValueProvidersWebSite", "test\WebSites\ValueProvidersWebSite\ValueProvidersWebSite.kproj", "{14F79E79-AE79-48FA-95DE-D794EF4EABB3}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "LoggingWebSite", "test\WebSites\LoggingWebSite\LoggingWebSite.kproj", "{E8208076-0472-4F28-BBEC-67B8C290BA68}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -608,6 +613,18 @@ Global
 		{14F79E79-AE79-48FA-95DE-D794EF4EABB3}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{14F79E79-AE79-48FA-95DE-D794EF4EABB3}.Release|x86.ActiveCfg = Release|Any CPU
 		{14F79E79-AE79-48FA-95DE-D794EF4EABB3}.Release|x86.Build.0 = Release|Any CPU
+		{E8208076-0472-4F28-BBEC-67B8C290BA68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8208076-0472-4F28-BBEC-67B8C290BA68}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8208076-0472-4F28-BBEC-67B8C290BA68}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{E8208076-0472-4F28-BBEC-67B8C290BA68}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{E8208076-0472-4F28-BBEC-67B8C290BA68}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E8208076-0472-4F28-BBEC-67B8C290BA68}.Debug|x86.Build.0 = Debug|Any CPU
+		{E8208076-0472-4F28-BBEC-67B8C290BA68}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8208076-0472-4F28-BBEC-67B8C290BA68}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8208076-0472-4F28-BBEC-67B8C290BA68}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{E8208076-0472-4F28-BBEC-67B8C290BA68}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{E8208076-0472-4F28-BBEC-67B8C290BA68}.Release|x86.ActiveCfg = Release|Any CPU
+		{E8208076-0472-4F28-BBEC-67B8C290BA68}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -662,5 +679,6 @@ Global
 		{B18ADE62-35DE-4A06-8E1D-EDD6245F7F4D} = {16703B76-C9F7-4C75-AE6C-53D92E308E3C}
 		{A853B2BA-4449-4908-A416-5A3C027FC22B} = {16703B76-C9F7-4C75-AE6C-53D92E308E3C}
 		{14F79E79-AE79-48FA-95DE-D794EF4EABB3} = {16703B76-C9F7-4C75-AE6C-53D92E308E3C}
+		{E8208076-0472-4F28-BBEC-67B8C290BA68} = {16703B76-C9F7-4C75-AE6C-53D92E308E3C}
 	EndGlobalSection
 EndGlobal

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/LoggingTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/LoggingTests.cs
@@ -1,0 +1,177 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using LoggingWebSite.Controllers;
+using Microsoft.AspNet.Builder;
+using Microsoft.AspNet.Diagnostics.Elm;
+using Microsoft.AspNet.Mvc.Logging;
+using Microsoft.AspNet.TestHost;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.Logging;
+using Xunit;
+
+namespace Microsoft.AspNet.Mvc.FunctionalTests
+{
+    public class LoggingTests
+    {
+        private readonly Action<IApplicationBuilder> _app = new LoggingWebSite.Startup().Configure;
+        private const string RequestTraceIdKey = "RequestTraceId";
+        private const string StartupLogsKey = "StartupLogs";
+
+        [Fact]
+        public async Task ControllerDiscovery()
+        {
+            // Arrange
+            var elmStore = new ElmStore();
+            var server = TestServer.Create(GetServiceProvider(elmStore), _app);
+            var client = server.CreateClient();
+            
+            // Act & Assert
+
+            // regular request
+            var response = await client.GetAsync("http://localhost/Home/Index");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var data = await response.Content.ReadAsStringAsync();
+            Assert.Equal("Home.Index", data);
+
+            //verify logs
+            var logMessages = GetLogMessages(elmStore.GetActivities());
+            var controllerModelValuesList = logMessages.Where(msg =>
+            {
+                return msg.Name == "Microsoft.AspNet.Mvc.ControllerActionDescriptorProvider" &&
+                        msg.State != null 
+                        && msg.State.GetType().Equals(typeof(ControllerModelValues));
+            });
+
+            Assert.Equal(1, controllerModelValuesList.Count());
+            var homeControllerLogInfo = controllerModelValuesList.First().State as ControllerModelValues;
+            Assert.NotNull(homeControllerLogInfo);
+            Assert.Equal(typeof(HomeController), homeControllerLogInfo.ControllerType);
+            Assert.Equal("Home", homeControllerLogInfo.ControllerName);
+            Assert.Equal(1, homeControllerLogInfo.Actions.Count);
+            Assert.Equal("Index", homeControllerLogInfo.Actions[0].ActionName);
+        }
+
+        private IServiceProvider GetServiceProvider(ElmStore elmStore)
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<ILoggerFactory, LoggerFactory>(); //TODO: can TestHelper add this always?
+            services.AddInstance(elmStore);
+            return TestHelper.CreateServices("LoggingWebSite", services);
+        }
+
+        /// <summary>
+        /// Elm logs are arranged in the form of activities. Each activity could
+        /// represent a tree of nodes. So here we traverse through the tree to get a flat list of
+        /// log messages for us to enable verifying in the test.
+        /// </summary>
+        /// <param name="activities">ElmStore's log activities</param>
+        /// <returns>Log messages</returns>
+        private IList<LogInfo> GetLogMessages(IEnumerable<ActivityContext> activities)
+        {
+            // Build a flat list of log messages from the log node tree 
+            var logMessages = new List<LogInfo>();
+            foreach (var activity in activities.Reverse())
+            {
+                if (!activity.RepresentsScope)
+                {
+                    // message not within a scope
+                    var logInfo = activity.Root.Messages.FirstOrDefault();
+                    logMessages.Add(logInfo);
+                }
+                else
+                {
+                    Traverse(activity.Root, logMessages);
+                }
+            }
+
+            return logMessages;
+        }
+
+        private void Traverse(ScopeNode node, IList<LogInfo> logMessages)
+        {
+            // Capture start of scope
+            logMessages.Add(new LogInfo()
+            {
+                Name = node.Name,
+                Message = "Begin-Scope:" + node.State
+            });
+
+            // Since Elm's ScopeNode arranges the log information in two separate lists, 
+            // I am resorting to this weird way of comparing the entries. Following are some issues:
+            // a. https://github.com/aspnet/Diagnostics/issues/77
+            // b. Sorting by time does not yield correct numbers as I have noticed that the ticks between
+            //    the log entries sometimes do not change(probably because the log entries happen pretty fast)
+            //    and so the sort can give incorrect order sometimes. Ideally this is an issue with ElmLogger,
+            //    where they should maintain a single list of entries to which one can either add a regular message
+            //    node or a scope node.
+            var list = new List<object>();
+            list.AddRange(node.Messages);
+            list.AddRange(node.Children);
+            list.Sort(new LogTimeComparer());
+
+            foreach (var obj in list)
+            {
+                // check if the current node is a regular message node
+                // or a scope node
+                var logInfo = obj as LogInfo;
+
+                if (logInfo != null)
+                {
+                    logMessages.Add(logInfo);
+                }
+                else
+                {
+                    Traverse((ScopeNode)obj, logMessages);
+                }
+            }
+
+            // Capture end of scope
+            logMessages.Add(new LogInfo()
+            {
+                Name = node.Name,
+                Message = "End-Scope:" + node.State
+            });
+        }
+        
+        public class LogTimeComparer : IComparer<object>
+        {
+            public int Compare(object x, object y)
+            {
+                LogInfo xLogInfo = x as LogInfo;
+                ScopeNode xScopeNode = x as ScopeNode;
+
+                LogInfo yLogInfo = y as LogInfo;
+                ScopeNode yScopeNode = y as ScopeNode;
+
+                if (xLogInfo != null)
+                {
+                    if (yLogInfo != null)
+                    {
+                        return xLogInfo.Time.CompareTo(yLogInfo.Time);
+                    }
+                    else
+                    {
+                        return xLogInfo.Time.CompareTo(yScopeNode.StartTime);
+                    }
+                }
+                else
+                {
+                    if (yScopeNode != null)
+                    {
+                        return xScopeNode.StartTime.CompareTo(yScopeNode.StartTime);
+                    }
+                    else
+                    {
+                        return xScopeNode.StartTime.CompareTo(yLogInfo.Time);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/project.json
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/project.json
@@ -15,6 +15,7 @@
         "FiltersWebSite": "1.0.0",
         "FormatterWebSite": "1.0.0",
         "InlineConstraintsWebSite": "1.0.0",
+        "LoggingWebSite": "1.0.0",
         "ModelBindingWebSite": "1.0.0",
         "MvcSample.Web": "1.0.0",
         "PrecompilationWebSite": "1.0.0",

--- a/test/WebSites/LoggingWebSite/Controllers/HomeController.cs
+++ b/test/WebSites/LoggingWebSite/Controllers/HomeController.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Mvc;
+
+namespace LoggingWebSite.Controllers
+{
+    public class HomeController : Controller
+    {
+        public IActionResult Index()
+        {
+            return View();
+        }
+    }
+}

--- a/test/WebSites/LoggingWebSite/LoggingWebSite.kproj
+++ b/test/WebSites/LoggingWebSite/LoggingWebSite.kproj
@@ -1,17 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="__ToolsVersion__" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
-    <ProjectGuid>323d0c04-b518-4a8f-8a8e-3546ad153d34</ProjectGuid>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <ProjectGuid>e8208076-0472-4f28-bbec-67b8c290ba68</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'" Label="Configuration">
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
+    <DevelopmentServerPort>60762</DevelopmentServerPort>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
   <ProjectExtensions>

--- a/test/WebSites/LoggingWebSite/Startup.cs
+++ b/test/WebSites/LoggingWebSite/Startup.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Builder;
+using Microsoft.AspNet.Http;
+using Microsoft.AspNet.Mvc;
+using Microsoft.AspNet.Routing;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.AspNet.Diagnostics.Elm;
+using System.Collections.Generic;
+using Microsoft.Framework.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System.IO;
+using System.Text;
+
+namespace LoggingWebSite
+{
+    public class Startup
+    {
+        public void Configure(IApplicationBuilder app)
+        {
+            var configuration = app.GetTestConfiguration();
+
+            // Set up application services
+            app.UseServices(services =>
+            {
+                // TODO: Uncomment the following lines to enable running this website
+                //services.AddElm();
+
+                // Add MVC services to the services container
+                services.AddMvc(configuration);
+            });
+
+            //app.UseElmPage();
+
+            app.UseElmCapture();
+
+            // Add MVC to the request pipeline
+            app.UseMvc(routes =>
+            {
+                routes.MapRoute("Default", "{controller=Home}/{action=Index}");
+            });
+        }
+    }
+}

--- a/test/WebSites/LoggingWebSite/Views/Home/Index.cshtml
+++ b/test/WebSites/LoggingWebSite/Views/Home/Index.cshtml
@@ -1,0 +1,1 @@
+﻿Home.Index

--- a/test/WebSites/LoggingWebSite/project.json
+++ b/test/WebSites/LoggingWebSite/project.json
@@ -1,0 +1,20 @@
+{
+    "commands": {
+        "web": "Microsoft.AspNet.Hosting server=Microsoft.AspNet.Server.WebListener server.urls=http://localhost:5001",
+        "kestrel": "Microsoft.AspNet.Hosting --server Kestrel --server.urls http://localhost:5000"
+    },
+    "dependencies": {
+        "Kestrel": "1.0.0-*",
+        "Microsoft.AspNet.Mvc": "6.0.0-*",
+        "Microsoft.AspNet.Mvc.TestConfiguration": "1.0.0",
+        "Microsoft.AspNet.Server.IIS": "1.0.0-*",
+        "Microsoft.AspNet.Server.WebListener": "1.0.0-*",
+        "Microsoft.AspNet.StaticFiles": "1.0.0-*",
+        "Microsoft.AspNet.Diagnostics.Elm": "1.0.0-*"
+    },
+    "frameworks": {
+        "aspnet50": { },
+        "aspnetcore50": { }
+    },
+    "webroot": "wwwroot"
+}

--- a/test/WebSites/LoggingWebSite/wwwroot/readme.md
+++ b/test/WebSites/LoggingWebSite/wwwroot/readme.md
@@ -1,0 +1,1 @@
+Adding this file as Git does not allow to add empty folders into repository


### PR DESCRIPTION
Here I am using ElmLogger to capture log messages as it has functionality already built in to handle scopes etc. I felt that scoping related information is important to us as we might want to verify that too(TestLogger, TestScope pieces did not handle this).  ElmLogger has 2 parts, the UI piece which displays the log messages in a user friendly way and the capturing part. Here I am using only the capturing part.

Also these functional tests are using in-memory way of checking the logs messages as I felt it to be easier to verify than creating DTOs, serializing and de-serialzing them. Yeah, this will not enable us to run on a real server scenario, but do we need to for logging related verification tests?

There are couple of issues with ElmLogger because of which the code here looks a bit clunky:
ElmLogger arranges the log information in two separate lists, one for tracking scopes and other for just log messages. Due to this, following are some issues that I encountered:
a. https://github.com/aspnet/Diagnostics/issues/77
b. Sorting by time is not giving correct order as I have noticed that the ticks between
     the log entries sometimes do not change(probably because the log entries happen pretty fast). Ideally this is an issue with ElmLogger, where they should maintain a single list of entries to which one can either add a regular message node or a scope node and order can just be the list order

@rynowak @pranavkm  @Tratcher 