### PR TITLE
Remove IsActionNameMatchRequired

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/ActionModel.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/ActionModel.cs
@@ -27,7 +27,6 @@ namespace Microsoft.AspNet.Mvc.ApplicationModels
         {
             ActionMethod = other.ActionMethod;
             ActionName = other.ActionName;
-            IsActionNameMatchRequired = other.IsActionNameMatchRequired;
 
             // Not making a deep copy of the controller, this action still belongs to the same controller.
             Controller = other.Controller;
@@ -73,8 +72,6 @@ namespace Microsoft.AspNet.Mvc.ApplicationModels
         public List<IFilter> Filters { get; private set; }
 
         public List<string> HttpMethods { get; private set; }
-
-        public bool IsActionNameMatchRequired { get; set; }
 
         public List<ParameterModel> Parameters { get; private set; }
 

--- a/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/DefaultActionModelBuilder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/DefaultActionModelBuilder.cs
@@ -252,10 +252,7 @@ namespace Microsoft.AspNet.Mvc.ApplicationModels
             [NotNull] MethodInfo methodInfo,
             [NotNull] IReadOnlyList<object> attributes)
         {
-            var actionModel = new ActionModel(methodInfo, attributes)
-            {
-                IsActionNameMatchRequired = true,
-            };
+            var actionModel = new ActionModel(methodInfo, attributes);
 
             actionModel.ActionConstraints.AddRange(attributes.OfType<IActionConstraintMetadata>());
             actionModel.Filters.AddRange(attributes.OfType<IFilter>());

--- a/src/Microsoft.AspNet.Mvc.Core/ControllerActionDescriptorBuilder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ControllerActionDescriptorBuilder.cs
@@ -430,18 +430,9 @@ namespace Microsoft.AspNet.Mvc
             // Lastly add the 'default' values
             if (!HasConstraint(actionDescriptor.RouteConstraints, "action"))
             {
-                if (action.IsActionNameMatchRequired)
-                {
-                    actionDescriptor.RouteConstraints.Add(new RouteDataActionConstraint(
-                        "action",
-                        action.ActionName));
-                }
-                else
-                {
-                    actionDescriptor.RouteConstraints.Add(new RouteDataActionConstraint(
-                        "action",
-                        string.Empty));
-                }
+                actionDescriptor.RouteConstraints.Add(new RouteDataActionConstraint(
+                    "action",
+                    action.ActionName ?? string.Empty));
             }
 
             if (!HasConstraint(actionDescriptor.RouteConstraints, "controller"))

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/Conventions/WebApiActionConventionsApplicationModelConvention.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/Conventions/WebApiActionConventionsApplicationModelConvention.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShim
                     var namedAction = action;
 
                     var unnamedAction = new ActionModel(namedAction);
-                    unnamedAction.IsActionNameMatchRequired = false;
+                    unnamedAction.RouteConstraints.Add(new UnnamedActionRouteConstraint());
                     newActions.Add(unnamedAction);
                 }
             }
@@ -90,6 +90,24 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShim
 
             // If no convention matches, then assume POST
             action.HttpMethods.Add("POST");
+        }
+
+        private class UnnamedActionRouteConstraint : IRouteConstraintProvider
+        {
+            public UnnamedActionRouteConstraint()
+            {
+                RouteKey = "action";
+                RouteKeyHandling = RouteKeyHandling.DenyKey;
+                RouteValue = null;
+            }
+
+            public string RouteKey { get; }
+
+            public RouteKeyHandling RouteKeyHandling { get; }
+
+            public string RouteValue { get; }
+
+            public bool BlockNonAttributedActions { get; }
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ApplicationModel/ActionModelTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ApplicationModel/ActionModelTest.cs
@@ -52,7 +52,6 @@ namespace Microsoft.AspNet.Mvc.ApplicationModels
                                                     new List<object>());
             action.Filters.Add(new AuthorizeAttribute());
             action.HttpMethods.Add("GET");
-            action.IsActionNameMatchRequired = true;
             action.RouteConstraints.Add(new AreaAttribute("Admin"));
 
             // Act

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ApplicationModel/DefaultActionModelBuilderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ApplicationModel/DefaultActionModelBuilderTest.cs
@@ -294,7 +294,6 @@ namespace Microsoft.AspNet.Mvc.ApplicationModels
             // Assert
             var action = Assert.Single(actions);
             Assert.Equal("Edit", action.ActionName);
-            Assert.True(action.IsActionNameMatchRequired);
             Assert.Empty(action.HttpMethods);
             Assert.Null(action.AttributeRouteModel);
             Assert.Empty(action.Attributes);
@@ -317,7 +316,6 @@ namespace Microsoft.AspNet.Mvc.ApplicationModels
             Assert.Contains("PATCH", action.HttpMethods);
 
             Assert.Equal("Update", action.ActionName);
-            Assert.True(action.IsActionNameMatchRequired);
             Assert.Null(action.AttributeRouteModel);
             Assert.IsType<CustomHttpMethodsAttribute>(Assert.Single(action.Attributes));
         }
@@ -336,7 +334,6 @@ namespace Microsoft.AspNet.Mvc.ApplicationModels
             // Assert
             var action = Assert.Single(actions);
             Assert.Equal("Delete", action.ActionName);
-            Assert.True(action.IsActionNameMatchRequired);
 
             var httpMethod = Assert.Single(action.HttpMethods);
             Assert.Equal("DELETE", httpMethod);
@@ -361,7 +358,6 @@ namespace Microsoft.AspNet.Mvc.ApplicationModels
             Assert.Contains("GET", action.HttpMethods);
             Assert.Contains("POST", action.HttpMethods);
             Assert.Equal("Details", action.ActionName);
-            Assert.True(action.IsActionNameMatchRequired);
             Assert.Null(action.AttributeRouteModel);
         }
 
@@ -382,7 +378,6 @@ namespace Microsoft.AspNet.Mvc.ApplicationModels
             Assert.Contains("PUT", action.HttpMethods);
             Assert.Contains("POST", action.HttpMethods);
             Assert.Equal("List", action.ActionName);
-            Assert.True(action.IsActionNameMatchRequired);
             Assert.Null(action.AttributeRouteModel);
         }
 
@@ -401,7 +396,6 @@ namespace Microsoft.AspNet.Mvc.ApplicationModels
             var action = Assert.Single(actions);
 
             Assert.Equal("Edit", action.ActionName);
-            Assert.True(action.IsActionNameMatchRequired);
 
             var httpMethod = Assert.Single(action.HttpMethods);
             Assert.Equal("POST", httpMethod);
@@ -427,7 +421,6 @@ namespace Microsoft.AspNet.Mvc.ApplicationModels
             var action = Assert.Single(actions);
 
             Assert.Equal("Update", action.ActionName);
-            Assert.True(action.IsActionNameMatchRequired);
 
             Assert.Empty(action.HttpMethods);
 
@@ -452,7 +445,6 @@ namespace Microsoft.AspNet.Mvc.ApplicationModels
             var action = Assert.Single(actions);
 
             Assert.Equal("List", action.ActionName);
-            Assert.True(action.IsActionNameMatchRequired);
 
             Assert.Equal(new[] { "GET", "HEAD" }, action.HttpMethods.OrderBy(m => m, StringComparer.Ordinal));
 
@@ -479,8 +471,6 @@ namespace Microsoft.AspNet.Mvc.ApplicationModels
             foreach (var action in actions)
             {
                 Assert.Equal("Index", action.ActionName);
-                Assert.True(action.IsActionNameMatchRequired);
-
                 Assert.NotNull(action.AttributeRouteModel);
             }
 
@@ -510,7 +500,6 @@ namespace Microsoft.AspNet.Mvc.ApplicationModels
             var action = Assert.Single(actions);
 
             Assert.Equal("Remove", action.ActionName);
-            Assert.True(action.IsActionNameMatchRequired);
 
             Assert.Empty(action.HttpMethods);
 
@@ -535,7 +524,6 @@ namespace Microsoft.AspNet.Mvc.ApplicationModels
             var action = Assert.Single(actions);
 
             Assert.Equal("Delete", action.ActionName);
-            Assert.True(action.IsActionNameMatchRequired);
 
             Assert.Empty(action.HttpMethods);
 
@@ -562,7 +550,6 @@ namespace Microsoft.AspNet.Mvc.ApplicationModels
             foreach (var action in actions)
             {
                 Assert.Equal("Index", action.ActionName);
-                Assert.True(action.IsActionNameMatchRequired);
 
                 var httpMethod = Assert.Single(action.HttpMethods);
                 Assert.Equal("GET", httpMethod);

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ControllerActionDescriptorProviderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ControllerActionDescriptorProviderTests.cs
@@ -475,11 +475,9 @@ namespace Microsoft.AspNet.Mvc.Test
 
             var getPerson = Assert.Single(controller.Actions, a => a.ActionName == "GetPerson");
             Assert.Empty(getPerson.HttpMethods);
-            Assert.True(getPerson.IsActionNameMatchRequired);
 
             var showPeople = Assert.Single(controller.Actions, a => a.ActionName == "ShowPeople");
             Assert.Empty(showPeople.HttpMethods);
-            Assert.True(showPeople.IsActionNameMatchRequired);
         }
 
         [Fact]


### PR DESCRIPTION
This change removes IsActionNameMatchRequired from the action model. The
WebAPI shim uses a custom route data constraint to get the same effect.
