### PR TITLE
Use optimal StringComparison for symbol strings

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/AttributeRouteModel.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/AttributeRouteModel.cs
@@ -123,7 +123,7 @@ namespace Microsoft.AspNet.Mvc.ApplicationModels
                 return right;
             }
 
-            if (left.EndsWith("/", StringComparison.OrdinalIgnoreCase))
+            if (left.EndsWith("/", StringComparison.Ordinal))
             {
                 return left + right;
             }
@@ -135,16 +135,16 @@ namespace Microsoft.AspNet.Mvc.ApplicationModels
         private static bool IsOverridePattern(string template)
         {
             return template != null &&
-                (template.StartsWith("~/", StringComparison.OrdinalIgnoreCase) ||
-                template.StartsWith("/", StringComparison.OrdinalIgnoreCase));
+                (template.StartsWith("~/", StringComparison.Ordinal) ||
+                template.StartsWith("/", StringComparison.Ordinal));
         }
 
         private static bool IsEmptyLeftSegment(string template)
         {
             return template == null ||
-                template.Equals(string.Empty, StringComparison.OrdinalIgnoreCase) ||
-                template.Equals("~/", StringComparison.OrdinalIgnoreCase) ||
-                template.Equals("/", StringComparison.OrdinalIgnoreCase);
+                template.Equals(string.Empty, StringComparison.Ordinal) ||
+                template.Equals("~/", StringComparison.Ordinal) ||
+                template.Equals("/", StringComparison.Ordinal);
         }
 
         private static string CleanTemplate(string result)
@@ -157,17 +157,17 @@ namespace Microsoft.AspNet.Mvc.ApplicationModels
             // This is an invalid combined template, so we don't want to
             // accidentally clean it and produce a valid template. For that
             // reason we ignore the clean up process for it.
-            if (result.Equals("//", StringComparison.OrdinalIgnoreCase))
+            if (result.Equals("//", StringComparison.Ordinal))
             {
                 return result;
             }
 
             var startIndex = 0;
-            if (result.StartsWith("/", StringComparison.OrdinalIgnoreCase))
+            if (result.StartsWith("/", StringComparison.Ordinal))
             {
                 startIndex = 1;
             }
-            else if (result.StartsWith("~/", StringComparison.OrdinalIgnoreCase))
+            else if (result.StartsWith("~/", StringComparison.Ordinal))
             {
                 startIndex = 2;
             }
@@ -179,7 +179,7 @@ namespace Microsoft.AspNet.Mvc.ApplicationModels
             }
 
             var subStringLength = result.Length - startIndex;
-            if (result.EndsWith("/", StringComparison.OrdinalIgnoreCase))
+            if (result.EndsWith("/", StringComparison.Ordinal))
             {
                 subStringLength--;
             }

--- a/src/Microsoft.AspNet.Mvc.Core/Formatters/OutputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Formatters/OutputFormatter.cs
@@ -222,7 +222,7 @@ namespace Microsoft.AspNet.Mvc
                                                         supportedEncoding =>
                                                             charset.Equals(supportedEncoding.WebName,
                                                                            StringComparison.OrdinalIgnoreCase) ||
-                                                            charset.Equals("*", StringComparison.OrdinalIgnoreCase));
+                                                            charset.Equals("*", StringComparison.Ordinal));
                         if (encoding != null)
                         {
                             return encoding;

--- a/src/Microsoft.AspNet.Mvc.Core/Formatters/StringWithQualityHeaderValueComparer.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Formatters/StringWithQualityHeaderValueComparer.cs
@@ -56,11 +56,11 @@ namespace Microsoft.AspNet.Mvc
 
             if (!String.Equals(stringWithQuality1.Value, stringWithQuality2.Value, StringComparison.OrdinalIgnoreCase))
             {
-                if (String.Equals(stringWithQuality1.Value, "*", StringComparison.OrdinalIgnoreCase))
+                if (String.Equals(stringWithQuality1.Value, "*", StringComparison.Ordinal))
                 {
                     return -1;
                 }
-                else if (String.Equals(stringWithQuality2.Value, "*", StringComparison.OrdinalIgnoreCase))
+                else if (String.Equals(stringWithQuality2.Value, "*", StringComparison.Ordinal))
                 {
                     return 1;
                 }

--- a/src/Microsoft.AspNet.Mvc.Core/ViewComponents/DefaultViewComponentSelector.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ViewComponents/DefaultViewComponentSelector.cs
@@ -82,7 +82,7 @@ namespace Microsoft.AspNet.Mvc
             };
 
             Debug.Assert(!string.IsNullOrEmpty(candidate.FullName));
-            var separatorIndex = candidate.FullName.LastIndexOf(".");
+            var separatorIndex = candidate.FullName.LastIndexOf('.');
             if (separatorIndex >= 0)
             {
                 candidate.ShortName = candidate.FullName.Substring(separatorIndex + 1);

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/ContentNegotiator/DefaultContentNegotiator.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/ContentNegotiator/DefaultContentNegotiator.cs
@@ -273,7 +273,7 @@ namespace System.Net.Http.Formatting
                         Encoding encoding = supportedEncodings[i];
                         if (encoding != null && acceptCharset.Quality != FormattingUtilities.NoMatch &&
                             (acceptCharset.Value.Equals(encoding.WebName, StringComparison.OrdinalIgnoreCase) ||
-                            acceptCharset.Value.Equals("*", StringComparison.OrdinalIgnoreCase)))
+                            acceptCharset.Value.Equals("*", StringComparison.Ordinal)))
                         {
                             return encoding;
                         }

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/ContentNegotiator/StringWithQualityHeaderValueComparer.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/ContentNegotiator/StringWithQualityHeaderValueComparer.cs
@@ -60,11 +60,11 @@ namespace System.Net.Http.Formatting
 
             if (!String.Equals(stringWithQuality1.Value, stringWithQuality2.Value, StringComparison.OrdinalIgnoreCase))
             {
-                if (String.Equals(stringWithQuality1.Value, "*", StringComparison.OrdinalIgnoreCase))
+                if (String.Equals(stringWithQuality1.Value, "*", StringComparison.Ordinal))
                 {
                     return -1;
                 }
-                else if (String.Equals(stringWithQuality2.Value, "*", StringComparison.OrdinalIgnoreCase))
+                else if (String.Equals(stringWithQuality2.Value, "*", StringComparison.Ordinal))
                 {
                     return 1;
                 }


### PR DESCRIPTION
A few searches for symbols ("/", "*", "~/", etc) in strings were using a case insensitive comparison when they can get better performance from an ordinal compare.

- The comparison type used against string.empty is not important but it reads better if it is the same as the rest of that group.
- The LastIndexOf call is using the default comparison which is CurrentCulture. This can be made into a char search which is Ordinal.