### PR TITLE
[Fixes #1713]WebApiCompatShim doesn't work with TransferEncoding:chunked

### DIFF
--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/Formatters/HttpResponseMessageOutputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/Formatters/HttpResponseMessageOutputFormatter.cs
@@ -72,14 +72,7 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShim
                     // Copy the response content headers only after ensuring they are complete.
                     // We ask for Content-Length first because HttpContent lazily computes this
                     // and only afterwards writes the value into the content headers.
-                    try
-                    {
-                        var unused = contentHeaders.ContentLength;
-                    }
-                    catch (Exception)
-                    {
-                        throw;
-                    }
+                    var unused = contentHeaders.ContentLength;
                     
                     foreach (var header in contentHeaders)
                     {

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/Formatters/HttpResponseMessageOutputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/Formatters/HttpResponseMessageOutputFormatter.cs
@@ -42,6 +42,10 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShim
 
             using (responseMessage)
             {
+                // Ignore the chunked Transfer-Encoding header if its set by the user. 
+                // We let the host decide about whether the response should be chunked or not.
+                responseMessage.Headers.TransferEncodingChunked = false;
+
                 response.StatusCode = (int)responseMessage.StatusCode;
 
                 var responseFeature = context.ActionContext.HttpContext.GetFeature<IHttpResponseFeature>();

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/WebApiCompatShimBasicTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/WebApiCompatShimBasicTest.cs
@@ -275,32 +275,6 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal(38, response.Content.Headers.ContentLength);
         }
 
-        [Fact]
-        public async Task ApiController_ResponseReturned_Chunked()
-        {
-            // Arrange
-            var server = TestServer.Create(_provider, _app);
-            var client = server.CreateClient();
-
-            var expected =
-                "POST Hello, HttpResponseMessage world!";
-
-            // Act
-            var response = await client.PostAsync(
-                "http://localhost/api/Blog/HttpRequestMessage/EchoWithResponseMessageChunked",
-                new StringContent("Hello, HttpResponseMessage world!"));
-            var content = await response.Content.ReadAsStringAsync();
-
-            // Assert
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal(expected, content);
-
-            IEnumerable<string> values;
-            Assert.True(response.Headers.TryGetValues("X-Test", out values));
-            Assert.Equal(new string[] { "Hello!" }, values);
-            Assert.Equal(true, response.Headers.TransferEncodingChunked);
-        }
-
         [Theory]
         [InlineData("application/json", "application/json")]
         [InlineData("text/xml", "text/xml")]

--- a/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/HttpResponseMessageOutputFormatterTests.cs
+++ b/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/HttpResponseMessageOutputFormatterTests.cs
@@ -60,6 +60,7 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShimTest
 
             // Assert
             Assert.False(httpContext.Response.Headers.ContainsKey("Transfer-Encoding"));
+            Assert.NotNull(httpContext.Response.ContentLength);
         }
 
         [Fact]
@@ -82,6 +83,7 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShimTest
 
             // Assert
             Assert.False(httpContext.Response.Headers.ContainsKey(transferEncodingHeaderKey));
+            Assert.NotNull(httpContext.Response.ContentLength);
         }
 
         [Fact]
@@ -106,6 +108,7 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShimTest
             Assert.True(httpContext.Response.Headers.ContainsKey(transferEncodingHeaderKey));
             Assert.Equal(new string[] { "identity", "chunked" }, 
                         httpContext.Response.Headers.GetValues(transferEncodingHeaderKey));
+            Assert.NotNull(httpContext.Response.ContentLength);
         }
 
         [Fact]
@@ -131,6 +134,7 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShimTest
             Assert.True(httpContext.Response.Headers.ContainsKey(transferEncodingHeaderKey));
             Assert.Equal(new string[] { "identity", "chunked" },
                         httpContext.Response.Headers.GetValues(transferEncodingHeaderKey));
+            Assert.NotNull(httpContext.Response.ContentLength);
         }
 
         private OutputFormatterContext GetOutputFormatterContext(object outputValue, Type outputType,

--- a/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/HttpResponseMessageOutputFormatterTests.cs
+++ b/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/HttpResponseMessageOutputFormatterTests.cs
@@ -4,9 +4,12 @@
 #if !ASPNETCORE50
 
 using System;
+using System.Linq;
 using System.IO;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Mvc.WebApiCompatShim;
 using Microsoft.AspNet.PipelineCore;
 using Moq;
@@ -26,7 +29,10 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShimTest
             streamContent.Protected().Setup("Dispose", true).Verifiable();
             var httpResponseMessage = new HttpResponseMessage();
             httpResponseMessage.Content = streamContent.Object;
-            var outputFormatterContext = GetOutputFormatterContext(httpResponseMessage, typeof(HttpResponseMessage));
+            var outputFormatterContext = GetOutputFormatterContext(
+                                                httpResponseMessage, 
+                                                typeof(HttpResponseMessage),
+                                                new DefaultHttpContext());
 
             // Act
             await formatter.WriteAsync(outputFormatterContext);
@@ -35,13 +41,56 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShimTest
             streamContent.Protected().Verify("Dispose", Times.Once(), true);
         }
 
-        private OutputFormatterContext GetOutputFormatterContext(object outputValue, Type outputType)
+        [Fact]
+        public async Task ExplicitlySet_ChunkedEncodingFlag_IsIgnored()
+        {
+            // Arrange
+            var httpResponseMessage = new HttpResponseMessage();
+            httpResponseMessage.Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes("Hello, World")));
+            httpResponseMessage.Headers.TransferEncodingChunked = true;
+
+            var httpContext = new DefaultHttpContext();
+            var formatter = new HttpResponseMessageOutputFormatter();
+            var outputFormatterContext = GetOutputFormatterContext(
+                                                httpResponseMessage,
+                                                typeof(HttpResponseMessage),
+                                                httpContext);
+            // Act
+            await formatter.WriteAsync(outputFormatterContext);
+
+            // Assert
+            Assert.False(httpContext.Response.Headers.ContainsKey("Transfer-Encoding"));
+        }
+
+        [Fact]
+        public async Task ExplicitlySet_ChunkedEncodingHeader_IsIgnored()
+        {
+            // Arrange
+            var httpResponseMessage = new HttpResponseMessage();
+            httpResponseMessage.Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes("Hello, World")));
+            httpResponseMessage.Headers.Add("Transfer-Encoding", "chunked");
+
+            var httpContext = new DefaultHttpContext();
+            var formatter = new HttpResponseMessageOutputFormatter();
+            var outputFormatterContext = GetOutputFormatterContext(
+                                                httpResponseMessage,
+                                                typeof(HttpResponseMessage),
+                                                httpContext);
+            // Act
+            await formatter.WriteAsync(outputFormatterContext);
+
+            // Assert
+            Assert.False(httpContext.Response.Headers.ContainsKey("Transfer-Encoding"));
+        }
+        
+        private OutputFormatterContext GetOutputFormatterContext(object outputValue, Type outputType, 
+                                                                    HttpContext httpContext)
         {
             return new OutputFormatterContext
             {
                 Object = outputValue,
                 DeclaredType = outputType,
-                ActionContext = new ActionContext(new DefaultHttpContext(), routeData: null, actionDescriptor: null)
+                ActionContext = new ActionContext(httpContext, routeData: null, actionDescriptor: null)
             };
         }
     }

--- a/test/WebSites/WebApiCompatShimWebSite/Controllers/HttpRequestMessage/HttpRequestMessageController.cs
+++ b/test/WebSites/WebApiCompatShimWebSite/Controllers/HttpRequestMessage/HttpRequestMessageController.cs
@@ -47,6 +47,20 @@ namespace WebApiCompatShimWebSite
             return response;
         }
 
+        public async Task<HttpResponseMessage> EchoWithResponseMessageChunked(HttpRequestMessage request)
+        {
+            var message = string.Format(
+                "{0} {1}",
+                request.Method.ToString(),
+                await request.Content.ReadAsStringAsync());
+
+            var response = request.CreateResponse(HttpStatusCode.OK);
+            response.Content = new StringContent(message);
+            response.Headers.TransferEncodingChunked = true;
+            response.Headers.TryAddWithoutValidation("X-Test", "Hello!");
+            return response;
+        }
+
         public HttpResponseMessage GetUser(string mediaType = null)
         {
             var user = new User()

--- a/test/WebSites/WebApiCompatShimWebSite/Controllers/HttpRequestMessage/HttpRequestMessageController.cs
+++ b/test/WebSites/WebApiCompatShimWebSite/Controllers/HttpRequestMessage/HttpRequestMessageController.cs
@@ -47,20 +47,6 @@ namespace WebApiCompatShimWebSite
             return response;
         }
 
-        public async Task<HttpResponseMessage> EchoWithResponseMessageChunked(HttpRequestMessage request)
-        {
-            var message = string.Format(
-                "{0} {1}",
-                request.Method.ToString(),
-                await request.Content.ReadAsStringAsync());
-
-            var response = request.CreateResponse(HttpStatusCode.OK);
-            response.Content = new StringContent(message);
-            response.Headers.TransferEncodingChunked = true;
-            response.Headers.TryAddWithoutValidation("X-Test", "Hello!");
-            return response;
-        }
-
         public HttpResponseMessage GetUser(string mediaType = null)
         {
             var user = new User()


### PR DESCRIPTION
@rynowak 