### PR TITLE
React to aspnet/Razor#221: Modify TagHelpers to utilize new ContentMode design.

### DIFF
--- a/samples/TagHelperSample.Web/Views/Home/Create.cshtml
+++ b/samples/TagHelperSample.Web/Views/Home/Create.cshtml
@@ -13,7 +13,7 @@
 <form asp-anti-forgery="false" asp-action="Create">
     <div class="form-horizontal">
         @* validation summary tag helper will target just <div/> elements and append the list of errors *@
-        @* - i.e. this helper, like <select/> helper, has ContentBehavior.Append *@
+        @* - i.e. this helper, like <select/> helper appends content. *@
         @* helper does nothing if model is valid and (client-side validation is disabled or
            asp-validation-summary="ValidationSummary.ModelOnly") *@
         @* don't need a bound attribute to match Html.ValidationSummary()'s headerTag parameter; users wrap message as they wish *@
@@ -48,7 +48,7 @@
         <div class="form-group">
             <label asp-for="YearsEmployeed" class="control-label col-md-2" />
             <div class="col-md-10">
-                @* <select/> tag helper has ContentBehavior.Append -- items render after static options *@
+                @* <select/> items render after static options *@
                 @{ var @object = "multiple"; }
                 <select asp-for="@(Model.YearsEmployeed)" asp-items="@((IEnumerable<SelectListItem>)ViewBag.Items)" size="2" class="form-control" multiple="@(@object)">
                     @* Static use of "selected" attribute may cause HTML errors if in a single-selection <select/> *@

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
@@ -156,6 +156,18 @@ namespace Microsoft.AspNet.Mvc.Razor
         /// </remarks>
         public void StartWritingScope()
         {
+            StartWritingScope(new StringWriter());
+        }
+
+        /// <summary>
+        /// Starts a new writing scope with the given <paramref name="writer"/>.
+        /// </summary>
+        /// <remarks>
+        /// All writes to the <see cref="Output"/> or <see cref="ViewContext.Writer"/> after calling this method will
+        /// be buffered until <see cref="EndWritingScope"/> is called.
+        /// </remarks>
+        public void StartWritingScope(TextWriter writer)
+        {
             // If there isn't a base writer take the ViewContext.Writer
             if (_originalWriter == null)
             {
@@ -164,7 +176,7 @@ namespace Microsoft.AspNet.Mvc.Razor
 
             // We need to replace the ViewContext's Writer to ensure that all content (including content written
             // from HTML helpers) is redirected.
-            ViewContext.Writer = new StringWriter();
+            ViewContext.Writer = writer;
 
             _writerScopes.Push(ViewContext.Writer);
         }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/FormTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/FormTagHelper.cs
@@ -6,14 +6,12 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
-using Microsoft.AspNet.Razor.TagHelpers;
 
 namespace Microsoft.AspNet.Mvc.TagHelpers
 {
     /// <summary>
     /// <see cref="ITagHelper"/> implementation targeting &lt;form&gt; elements.
     /// </summary>
-    [ContentBehavior(ContentBehavior.Append)]
     public class FormTagHelper : TagHelper
     {
         private const string ActionAttributeName = "asp-action";
@@ -106,7 +104,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 if (tagBuilder != null)
                 {
                     output.MergeAttributes(tagBuilder);
-                    output.Content += tagBuilder.InnerHtml;
+                    output.PostContent += tagBuilder.InnerHtml;
                     output.SelfClosing = false;
                 }
             }
@@ -116,7 +114,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 var antiForgeryTagBuilder = Generator.GenerateAntiForgery(ViewContext);
                 if (antiForgeryTagBuilder != null)
                 {
-                    output.Content += antiForgeryTagBuilder.ToString(TagRenderMode.SelfClosing);
+                    output.PostContent += antiForgeryTagBuilder.ToString(TagRenderMode.SelfClosing);
                 }
             }
         }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/InputTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/InputTagHelper.cs
@@ -15,7 +15,6 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     /// <summary>
     /// <see cref="ITagHelper"/> implementation targeting &lt;input&gt; elements with an <c>asp-for</c> attribute.
     /// </summary>
-    [ContentBehavior(ContentBehavior.Replace)]
     public class InputTagHelper : TagHelper
     {
         private const string ForAttributeName = "asp-for";

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/OptionTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/OptionTagHelper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 using Microsoft.AspNet.Razor.TagHelpers;
@@ -13,11 +14,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     /// <see cref="ITagHelper"/> implementation targeting &lt;option&gt; elements.
     /// </summary>
     /// <remarks>
-    /// This <see cref="ITagHelper"/> works in conjunction with <see cref="SelectTagHelper"/>. It has
-    /// <see cref="ContentBehavior.Modify"/> in order to read element's content but does not modify that content. The
-    /// only modification it makes is to add a <c>selected</c> attribute in some cases.
+    /// This <see cref="ITagHelper"/> works in conjunction with <see cref="SelectTagHelper"/>. It reads elements 
+    /// content but does not modify that content. The only modification it makes is to add a <c>selected</c> attribute 
+    /// in some cases.
     /// </remarks>
-    [ContentBehavior(ContentBehavior.Modify)]
     public class OptionTagHelper : TagHelper
     {
         // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
@@ -51,7 +51,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         /// <see cref="ICollection{string}"/> instance. Also does nothing if the associated &lt;option&gt; is already
         /// selected.
         /// </remarks>
-        public override void Process(TagHelperContext context, TagHelperOutput output)
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
             // Pass through attributes that are also well-known HTML attributes.
             if (Value != null)
@@ -84,9 +84,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     }
 
                     // Select this <option/> element if value attribute or content matches a selected value. Callers
-                    // encode values as-needed before setting TagHelperOutput.Content. But TagHelperOutput itself
+                    // encode values as-needed while executing child content. But TagHelperOutput itself
                     // encodes attribute values later, when GenerateStartTag() is called.
-                    var text = output.Content;
+                    var text = await context.GetChildContentAsync();
                     var selected = (Value != null) ? selectedValues.Contains(Value) : encodedValues.Contains(text);
                     if (selected)
                     {

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/SelectTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/SelectTagHelper.cs
@@ -15,7 +15,6 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     /// <summary>
     /// <see cref="ITagHelper"/> implementation targeting &lt;select&gt; elements with an <c>asp-for</c> attribute.
     /// </summary>
-    [ContentBehavior(ContentBehavior.Append)]
     public class SelectTagHelper : TagHelper
     {
         private const string ForAttributeName = "asp-for";
@@ -146,7 +145,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 if (tagBuilder != null)
                 {
                     output.MergeAttributes(tagBuilder);
-                    output.Content += tagBuilder.InnerHtml;
+                    output.PostContent += tagBuilder.InnerHtml;
                     output.SelfClosing = false;
                 }
 

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/TextAreaTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/TextAreaTagHelper.cs
@@ -10,7 +10,6 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     /// <summary>
     /// <see cref="ITagHelper"/> implementation targeting &lt;textarea&gt; elements with an <c>asp-for</c> attribute.
     /// </summary>
-    [ContentBehavior(ContentBehavior.Replace)]
     [HtmlElementName("textarea")]
     public class TextAreaTagHelper : TagHelper
     {

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationMessageTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationMessageTagHelper.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
-using Microsoft.AspNet.Razor.TagHelpers;
 
 namespace Microsoft.AspNet.Mvc.TagHelpers
 {
@@ -12,7 +12,6 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     /// attribute.
     /// </summary>
     [HtmlElementName("span")]
-    [ContentBehavior(ContentBehavior.Modify)]
     public class ValidationMessageTagHelper : TagHelper
     {
         private const string ValidationForAttributeName = "asp-validation-for";
@@ -33,7 +32,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
         /// <inheritdoc />
         /// <remarks>Does nothing if <see cref="For"/> is <c>null</c>.</remarks>
-        public override void Process(TagHelperContext context, TagHelperOutput output)
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
             if (For != null)
             {
@@ -50,9 +49,19 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     // We check for whitespace to detect scenarios such as:
                     // <span validation-for="Name">
                     // </span>
-                    if (string.IsNullOrWhiteSpace(output.Content))
+                    if (!output.ContentSet)
                     {
-                        output.Content = tagBuilder.InnerHtml;
+                        var childContent = await context.GetChildContentAsync();
+
+                        if (string.IsNullOrWhiteSpace(childContent))
+                        {
+                            // Provide default label text since there was nothing useful in the Razor source.
+                            output.Content = tagBuilder.InnerHtml;
+                        }
+                        else
+                        {
+                            output.Content = childContent;
+                        }
                     }
                 }
             }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationSummaryTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationSummaryTagHelper.cs
@@ -13,7 +13,6 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     /// attribute.
     /// </summary>
     [HtmlElementName("div")]
-    [ContentBehavior(ContentBehavior.Append)]
     public class ValidationSummaryTagHelper : TagHelper
     {
         private const string ValidationSummaryAttributeName = "asp-validation-summary";
@@ -81,7 +80,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             if (tagBuilder != null)
             {
                 output.MergeAttributes(tagBuilder);
-                output.Content += tagBuilder.InnerHtml;
+                output.PostContent += tagBuilder.InnerHtml;
             }
         }
     }

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/ModelExpressionTagHelper.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/ModelExpressionTagHelper.cs
@@ -45,7 +45,9 @@ namespace Asp
             BeginContext(120, 2, true);
             WriteLiteral("\r\n");
             EndContext();
-            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input-test", "test");
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input-test", "test", async() => {
+            }
+            , StartWritingScope, EndWritingScope);
             __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper = CreateTagHelper<Microsoft.AspNet.Mvc.Razor.InputTestTagHelper>();
             __tagHelperExecutionContext.Add(__Microsoft_AspNet_Mvc_Razor_InputTestTagHelper);
 #line 5 "TestFiles/Input/ModelExpressionTagHelper.cshtml"
@@ -56,12 +58,28 @@ __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For = CreateModelExpression(__mo
             __tagHelperExecutionContext.AddTagHelperAttribute("for", __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For);
             __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
             WriteLiteral(__tagHelperExecutionContext.Output.GenerateStartTag());
+            WriteLiteral(__tagHelperExecutionContext.Output.GeneratePreContent());
+            if (__tagHelperExecutionContext.Output.ContentSet)
+            {
+                WriteLiteral(__tagHelperExecutionContext.Output.GenerateContent());
+            }
+            else if (__tagHelperExecutionContext.ChildContentRetrieved)
+            {
+                WriteLiteral(__tagHelperExecutionContext.GetChildContentAsync().Result);
+            }
+            else
+            {
+                __tagHelperExecutionContext.ExecuteChildContentAsync().Wait();
+            }
+            WriteLiteral(__tagHelperExecutionContext.Output.GeneratePostContent());
             WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
             BeginContext(146, 2, true);
             WriteLiteral("\r\n");
             EndContext();
-            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input-test", "test");
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input-test", "test", async() => {
+            }
+            , StartWritingScope, EndWritingScope);
             __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper = CreateTagHelper<Microsoft.AspNet.Mvc.Razor.InputTestTagHelper>();
             __tagHelperExecutionContext.Add(__Microsoft_AspNet_Mvc_Razor_InputTestTagHelper);
 #line 6 "TestFiles/Input/ModelExpressionTagHelper.cshtml"
@@ -72,6 +90,20 @@ __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For = CreateModelExpression(__mo
             __tagHelperExecutionContext.AddTagHelperAttribute("for", __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For);
             __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
             WriteLiteral(__tagHelperExecutionContext.Output.GenerateStartTag());
+            WriteLiteral(__tagHelperExecutionContext.Output.GeneratePreContent());
+            if (__tagHelperExecutionContext.Output.ContentSet)
+            {
+                WriteLiteral(__tagHelperExecutionContext.Output.GenerateContent());
+            }
+            else if (__tagHelperExecutionContext.ChildContentRetrieved)
+            {
+                WriteLiteral(__tagHelperExecutionContext.GetChildContentAsync().Result);
+            }
+            else
+            {
+                __tagHelperExecutionContext.ExecuteChildContentAsync().Wait();
+            }
+            WriteLiteral(__tagHelperExecutionContext.Output.GeneratePostContent());
             WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
         }

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/AnchorTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/AnchorTagHelperTest.cs
@@ -32,15 +32,18 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     { "asp-host", "contoso.com" },
                     { "asp-protocol", "http" }
                 },
-                uniqueId: "test");
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something Else"));
             var output = new TagHelperOutput(
                 expectedTagName,
                 attributes: new Dictionary<string, string>
                 {
                     { "id", "myanchor" },
                     { "asp-route-foo", "bar" },
-                },
-                content: "Something");
+                })
+            {
+                Content = "Something"
+            };
 
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper
@@ -85,11 +88,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             // Arrange
             var context = new TagHelperContext(
-                allAttributes: new Dictionary<string, object>(), uniqueId: "test");
+                allAttributes: new Dictionary<string, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
             var output = new TagHelperOutput(
                 "a",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>())
+            {
+                Content = string.Empty
+            };
 
             var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
             generator
@@ -119,11 +126,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             // Arrange
             var context = new TagHelperContext(
-                allAttributes: new Dictionary<string, object>(), uniqueId: "test");
+                allAttributes: new Dictionary<string, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
             var output = new TagHelperOutput(
                 "a",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>())
+                {
+                    Content = string.Empty
+                };
 
             var generator = new Mock<IHtmlGenerator>();
             generator
@@ -166,8 +177,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 attributes: new Dictionary<string, string>()
                 {
                     { "href", "http://www.contoso.com" }
-                },
-                content: string.Empty);
+                });
             if (propertyName == "asp-route-")
             {
                 output.Attributes.Add("asp-route-foo", "bar");
@@ -202,8 +212,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             typeof(AnchorTagHelper).GetProperty(propertyName).SetValue(anchorTagHelper, "Home");
             var output = new TagHelperOutput(
                 "a",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>());
             var expectedErrorMessage = "Cannot determine an 'href' attribute for <a>. An <a> with a specified " +
                 "'asp-route' must not have an 'asp-action' or 'asp-controller' attribute.";
 

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/FormTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/FormTagHelperTest.cs
@@ -33,15 +33,18 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     { "method", "post" },
                     { "asp-anti-forgery", true }
                 },
-                uniqueId: "test");
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something Else"));
             var output = new TagHelperOutput(
                 expectedTagName,
                 attributes: new Dictionary<string, string>
                 {
                     { "id", "myform" },
                     { "asp-route-foo", "bar" },
-                },
-                content: "Something");
+                })
+            {
+                PostContent = "Something"
+            };
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper
                 .Setup(mock => mock.Action(It.IsAny<string>(),
@@ -56,8 +59,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var viewContext = TestableHtmlGenerator.GetViewContext(model: null,
                                                                    htmlGenerator: htmlGenerator,
                                                                    metadataProvider: metadataProvider);
-            var expectedContent = "Something" + htmlGenerator.GenerateAntiForgery(viewContext)
-                                                             .ToString(TagRenderMode.SelfClosing);
+            var expectedPostContent = "Something" + htmlGenerator.GenerateAntiForgery(viewContext)
+                                                                 .ToString(TagRenderMode.SelfClosing);
             var formTagHelper = new FormTagHelper
             {
                 Action = "index",
@@ -79,7 +82,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal("post", attribute.Value);
             attribute = Assert.Single(output.Attributes, kvp => kvp.Key.Equals("action"));
             Assert.Equal("home/index", attribute.Value);
-            Assert.Equal(expectedContent, output.Content);
+            Assert.Empty(output.PreContent);
+            Assert.Empty(output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.Equal(expectedTagName, output.TagName);
         }
 
@@ -87,16 +92,17 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         [InlineData(true, "<input />")]
         [InlineData(false, "")]
         [InlineData(null, "<input />")]
-        public async Task ProcessAsync_GeneratesAntiForgeryCorrectly(bool? antiForgery, string expectedContent)
+        public async Task ProcessAsync_GeneratesAntiForgeryCorrectly(bool? antiForgery, string expectedPostContent)
         {
             // Arrange
             var viewContext = CreateViewContext();
             var context = new TagHelperContext(
-                allAttributes: new Dictionary<string, object>(), uniqueId: "test");
+                allAttributes: new Dictionary<string, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
             var output = new TagHelperOutput(
                 "form",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>());
             var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
             generator
                 .Setup(mock => mock.GenerateForm(
@@ -124,7 +130,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Assert
             Assert.Equal("form", output.TagName);
             Assert.Empty(output.Attributes);
-            Assert.Equal(expectedContent, output.Content);
+            Assert.Empty(output.PreContent);
+            Assert.Empty(output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
         }
 
         [Fact]
@@ -133,7 +141,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var testViewContext = CreateViewContext();
             var context = new TagHelperContext(
-                allAttributes: new Dictionary<string, object>(), uniqueId: "test");
+                allAttributes: new Dictionary<string, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
             var expectedAttribute = new KeyValuePair<string, string>("asp-ROUTEE-NotRoute", "something");
             var output = new TagHelperOutput(
                 "form",
@@ -141,8 +151,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 {
                     { "asp-route-val", "hello" },
                     { "asp-roUte--Foo", "bar" }
-                },
-                content: string.Empty);
+                });
             output.Attributes.Add(expectedAttribute);
 
             var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
@@ -184,7 +193,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal("form", output.TagName);
             var attribute = Assert.Single(output.Attributes);
             Assert.Equal(expectedAttribute, attribute);
+            Assert.Empty(output.PreContent);
             Assert.Empty(output.Content);
+            Assert.Empty(output.PostContent);
             generator.Verify();
         }
 
@@ -194,11 +205,12 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var viewContext = CreateViewContext();
             var context = new TagHelperContext(
-                allAttributes: new Dictionary<string, object>(), uniqueId: "test");
+                allAttributes: new Dictionary<string, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
             var output = new TagHelperOutput(
                 "form",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>());
             var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
             generator
                 .Setup(mock => mock.GenerateForm(viewContext, "Index", "Home", null, "POST", null))
@@ -220,7 +232,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             Assert.Equal("form", output.TagName);
             Assert.Empty(output.Attributes);
+            Assert.Empty(output.PreContent);
             Assert.Empty(output.Content);
+            Assert.Empty(output.PostContent);
         }
 
         [Theory]
@@ -238,14 +252,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                                              attributes: new Dictionary<string, string>
                                              {
                                                  { "aCTiON", htmlAction },
-                                             },
-                                             content: string.Empty);
+                                             });
+
             var context = new TagHelperContext(
                 allAttributes: new Dictionary<string, object>()
                 {
                     { "METhod", "POST" }
                 },
-                uniqueId: "test");
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
 
             // Act
             await formTagHelper.ProcessAsync(context, output);
@@ -257,7 +272,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal(htmlAction, attribute.Value);
             attribute = Assert.Single(output.Attributes, kvp => kvp.Key.Equals("METhod"));
             Assert.Equal("POST", attribute.Value);
+            Assert.Empty(output.PreContent);
             Assert.Empty(output.Content);
+            Assert.Empty(output.PostContent);
         }
 
         [Theory]
@@ -266,11 +283,12 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         [InlineData(null, "")]
         public async Task ProcessAsync_SupportsAntiForgeryIfActionIsSpecified(
             bool? antiForgery,
-            string expectedContent)
+            string expectedPostContent)
         {
             // Arrange
             var viewContext = CreateViewContext();
             var generator = new Mock<IHtmlGenerator>();
+
             generator.Setup(mock => mock.GenerateAntiForgery(It.IsAny<ViewContext>()))
                      .Returns(new TagBuilder("input"));
             var formTagHelper = new FormTagHelper
@@ -284,9 +302,12 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                                              attributes: new Dictionary<string, string>
                                              {
                                                  { "aCTiON", "my-action" },
-                                             },
-                                             content: string.Empty);
-            var context = new TagHelperContext(allAttributes: new Dictionary<string, object>(), uniqueId: "test");
+                                             });
+            var context = new TagHelperContext(
+                allAttributes: new Dictionary<string, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
+
 
             // Act
             await formTagHelper.ProcessAsync(context, output);
@@ -295,7 +316,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal("form", output.TagName);
             var attribute = Assert.Single(output.Attributes);
             Assert.Equal(new KeyValuePair<string, string>("aCTiON", "my-action"), attribute);
-            Assert.Equal(expectedContent, output.Content);
+            Assert.Empty(output.PreContent);
+            Assert.Empty(output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
         }
 
         [Theory]
@@ -314,8 +337,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 attributes: new Dictionary<string, string>
                 {
                     { "action", "my-action" },
-                },
-                content: string.Empty);
+                });
             if (propertyName == "asp-route-")
             {
                 tagHelperOutput.Attributes.Add("asp-route-foo", "bar");

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/InputTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/InputTagHelperTest.cs
@@ -89,16 +89,23 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "valid", "from validation attributes" },
                 { "value", expectedValue },
             };
+            var expectedPreContent = "original pre-content";
             var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var expectedTagName = "not-input";
 
-            var context = new TagHelperContext(new Dictionary<string, object>(), uniqueId: "test");
+            var context = new TagHelperContext(allAttributes: new Dictionary<string, object>(),
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
             var originalAttributes = new Dictionary<string, string>
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, expectedContent)
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
                 SelfClosing = false,
             };
 
@@ -124,7 +131,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             // Assert
             Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.True(output.SelfClosing);
             Assert.Equal(expectedTagName, output.TagName);
         }
@@ -133,17 +142,24 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         public async Task ProcessAsync_CallsGenerateCheckBox_WithExpectedParameters()
         {
             // Arrange
-            var originalContent = "something";
+            var originalContent = "original content";
             var originalTagName = "not-input";
+            var expectedPreContent = "original pre-content";
             var expectedContent = originalContent + "<input class=\"form-control\" /><hidden />";
+            var expectedPostContent = "original post-content";
 
-            var context = new TagHelperContext(allAttributes: new Dictionary<string, object>(), uniqueId: "test");
+            var context = new TagHelperContext(allAttributes: new Dictionary<string, object>(),
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
             var originalAttributes = new Dictionary<string, string>
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(originalTagName, originalAttributes, content: originalContent)
+            var output = new TagHelperOutput(originalTagName, originalAttributes)
             {
+                PreContent = expectedPreContent,
+                Content = originalContent,
+                PostContent = expectedPostContent,
                 SelfClosing = true,
             };
 
@@ -180,9 +196,11 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             htmlGenerator.Verify();
 
             Assert.Empty(output.Attributes);    // Moved to Content and cleared
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.False(output.SelfClosing);
-            Assert.Empty(output.TagName);       // Cleared
+            Assert.Null(output.TagName);       // Cleared
         }
 
         [Theory]
@@ -214,16 +232,23 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "class", "form-control hidden-control" },
                 { "type", inputTypeName ?? "hidden" },      // Generator restores type attribute; adds "hidden" if none.
             };
-            var expectedContent = "something";
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var expectedTagName = "not-input";
 
-            var context = new TagHelperContext(allAttributes: contextAttributes, uniqueId: "test");
+            var context = new TagHelperContext(allAttributes: contextAttributes,
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
             var originalAttributes = new Dictionary<string, string>
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, content: expectedContent)
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
                 SelfClosing = false,
             };
 
@@ -257,7 +282,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             htmlGenerator.Verify();
 
             Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.True(output.SelfClosing);
             Assert.Equal(expectedTagName, output.TagName);
         }
@@ -291,16 +318,23 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "class", "form-control password-control" },
                 { "type", inputTypeName ?? "password" },    // Generator restores type attribute; adds "password" if none.
             };
-            var expectedContent = "something";
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var expectedTagName = "not-input";
 
-            var context = new TagHelperContext(allAttributes: contextAttributes, uniqueId: "test");
+            var context = new TagHelperContext(allAttributes: contextAttributes,
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
             var originalAttributes = new Dictionary<string, string>
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, content: expectedContent)
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
                 SelfClosing = false,
             };
 
@@ -333,7 +367,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             htmlGenerator.Verify();
 
             Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.True(output.SelfClosing);
             Assert.Equal(expectedTagName, output.TagName);
         }
@@ -365,16 +401,23 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "type", inputTypeName ?? "radio" },       // Generator restores type attribute; adds "radio" if none.
                 { "value", value },
             };
-            var expectedContent = "something";
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var expectedTagName = "not-input";
 
-            var context = new TagHelperContext(allAttributes: contextAttributes, uniqueId: "test");
+            var context = new TagHelperContext(allAttributes: contextAttributes,
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
             var originalAttributes = new Dictionary<string, string>
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, content: expectedContent)
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
                 SelfClosing = false,
             };
 
@@ -408,7 +451,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             htmlGenerator.Verify();
 
             Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.True(output.SelfClosing);
             Assert.Equal(expectedTagName, output.TagName);
         }
@@ -454,16 +499,23 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "class", "form-control text-control" },
                 { "type", inputTypeName ?? "text" },        // Generator restores type attribute; adds "text" if none.
             };
-            var expectedContent = "something";
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var expectedTagName = "not-input";
 
-            var context = new TagHelperContext(allAttributes: contextAttributes, uniqueId: "test");
+            var context = new TagHelperContext(allAttributes: contextAttributes,
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult("Something"));
             var originalAttributes = new Dictionary<string, string>
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, content: expectedContent)
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
                 SelfClosing = false,
             };
 
@@ -497,7 +549,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             htmlGenerator.Verify();
 
             Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.True(output.SelfClosing);
             Assert.Equal(expectedTagName, output.TagName);
         }
@@ -512,12 +566,20 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "type", "datetime" },
                 { "value", "2014-10-15T23:24:19.000-7:00" },
             };
+            var expectedPreContent = "original pre-content";
             var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var expectedTagName = "input";
 
-            var tagHelperContext = new TagHelperContext(new Dictionary<string, object>(), uniqueId: "test");
-            var output = new TagHelperOutput(expectedTagName, expectedAttributes, expectedContent)
+            var tagHelperContext = new TagHelperContext(
+                allAttributes: new Dictionary<string, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
+            var output = new TagHelperOutput(expectedTagName, expectedAttributes)
             {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
                 SelfClosing = false,
             };
 
@@ -536,7 +598,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             // Assert
             Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.False(output.SelfClosing);
             Assert.Equal(expectedTagName, output.TagName);
         }
@@ -558,13 +622,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var contextAttributes = new Dictionary<string, object>();
             var originalAttributes = new Dictionary<string, string>();
-            var content = "original content";
             var expectedTagName = "select";
             var expectedMessage = "Unable to format without a 'asp-for' expression for <input>. 'asp-format' must " +
                 "be null if 'asp-for' is null.";
 
-            var tagHelperContext = new TagHelperContext(contextAttributes, uniqueId: "test");
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, content);
+            var tagHelperContext = new TagHelperContext(
+                allAttributes: new Dictionary<string, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
+            var output = new TagHelperOutput(expectedTagName, originalAttributes);
             var tagHelper = new InputTagHelper
             {
                 Format = "{0}",

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LabelTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LabelTagHelperTest.cs
@@ -44,45 +44,111 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 return new TheoryData<object, Type, Func<object>, string, TagHelperOutputContent>
                 {
                     { null, typeof(Model), () => null, "Text",
-                        new TagHelperOutputContent(Environment.NewLine, "Text", "Text") },
+                        new TagHelperOutputContent(string.Empty, Environment.NewLine, Environment.NewLine, "Text") },
+                    { null, typeof(Model), () => null, "Text",
+                        new TagHelperOutputContent(Environment.NewLine, string.Empty, "Text", "Text") },
 
                     { modelWithNull, typeof(Model), () => modelWithNull.Text, "Text",
-                        new TagHelperOutputContent(Environment.NewLine, "Text", "Text") },
+                        new TagHelperOutputContent(string.Empty, Environment.NewLine, Environment.NewLine, "Text") },
+                    { modelWithNull, typeof(Model), () => modelWithNull.Text, "Text",
+                        new TagHelperOutputContent(Environment.NewLine, string.Empty, "Text", "Text") },
+                    { modelWithNull, typeof(Model), () => modelWithNull.Text, "Text",
+                        new TagHelperOutputContent(Environment.NewLine, "Hello World", "Hello World", "Text") },
                     { modelWithText, typeof(Model), () => modelWithText.Text, "Text",
-                        new TagHelperOutputContent(Environment.NewLine, "Text", "Text") },
+                        new TagHelperOutputContent(string.Empty, Environment.NewLine, Environment.NewLine, "Text") },
+                    { modelWithText, typeof(Model), () => modelWithText.Text, "Text",
+                        new TagHelperOutputContent(Environment.NewLine, string.Empty, "Text", "Text") },
+                    { modelWithText, typeof(Model), () => modelWithText.Text, "Text",
+                        new TagHelperOutputContent(Environment.NewLine, "Hello World", "Hello World", "Text") },
                     { modelWithText, typeof(Model), () => modelWithNull.Text, "Text",
-                        new TagHelperOutputContent("Hello World", "Hello World", "Text") },
+                        new TagHelperOutputContent(string.Empty, "Hello World", "Hello World", "Text") },
                     { modelWithText, typeof(Model), () => modelWithText.Text, "Text",
-                        new TagHelperOutputContent("Hello World", "Hello World", "Text") },
+                        new TagHelperOutputContent(string.Empty, "Hello World", "Hello World", "Text") },
+                    { modelWithText, typeof(Model), () => modelWithNull.Text, "Text",
+                        new TagHelperOutputContent("Hello World", string.Empty, "Hello World", "Text") },
+                    { modelWithText, typeof(Model), () => modelWithText.Text, "Text",
+                        new TagHelperOutputContent("Hello World", string.Empty, "Hello World", "Text") },
+                    { modelWithText, typeof(Model), () => modelWithNull.Text, "Text",
+                        new TagHelperOutputContent("Hello World1", "Hello World2", "Hello World2", "Text") },
+                    { modelWithText, typeof(Model), () => modelWithText.Text, "Text",
+                        new TagHelperOutputContent("Hello World1", "Hello World2", "Hello World2", "Text") },
 
                     { modelWithNull, typeof(NestedModel), () => modelWithNull.NestedModel.Text, "NestedModel.Text",
-                        new TagHelperOutputContent(Environment.NewLine, "Text", "NestedModel_Text") },
-                    { modelWithText, typeof(NestedModel), () => modelWithText.NestedModel.Text, "NestedModel.Text",
-                        new TagHelperOutputContent(Environment.NewLine, "Text", "NestedModel_Text") },
+                        new TagHelperOutputContent(Environment.NewLine, string.Empty, "Text", "NestedModel_Text") },
                     { modelWithNull, typeof(NestedModel), () => modelWithNull.NestedModel.Text, "NestedModel.Text",
-                        new TagHelperOutputContent("Hello World", "Hello World", "NestedModel_Text") },
+                        new TagHelperOutputContent(Environment.NewLine, "Hello World", "Hello World", "NestedModel_Text") },
+                    { modelWithNull, typeof(NestedModel), () => modelWithNull.NestedModel.Text, "NestedModel.Text",
+                        new TagHelperOutputContent(string.Empty, Environment.NewLine, Environment.NewLine, "NestedModel_Text") },
                     { modelWithText, typeof(NestedModel), () => modelWithText.NestedModel.Text, "NestedModel.Text",
-                        new TagHelperOutputContent("Hello World", "Hello World", "NestedModel_Text") },
+                        new TagHelperOutputContent(Environment.NewLine, string.Empty, "Text", "NestedModel_Text") },
+                    { modelWithText, typeof(NestedModel), () => modelWithText.NestedModel.Text, "NestedModel.Text",
+                        new TagHelperOutputContent(Environment.NewLine, "Hello World", "Hello World", "NestedModel_Text") },
+                    { modelWithText, typeof(NestedModel), () => modelWithText.NestedModel.Text, "NestedModel.Text",
+                        new TagHelperOutputContent(string.Empty, Environment.NewLine, Environment.NewLine, "NestedModel_Text") },
+                    { modelWithNull, typeof(NestedModel), () => modelWithNull.NestedModel.Text, "NestedModel.Text",
+                        new TagHelperOutputContent(string.Empty, "Hello World", "Hello World", "NestedModel_Text") },
+                    { modelWithText, typeof(NestedModel), () => modelWithText.NestedModel.Text, "NestedModel.Text",
+                        new TagHelperOutputContent(string.Empty, "Hello World", "Hello World", "NestedModel_Text") },
+                    { modelWithNull, typeof(NestedModel), () => modelWithNull.NestedModel.Text, "NestedModel.Text",
+                        new TagHelperOutputContent("Hello World", string.Empty, "Hello World", "NestedModel_Text") },
+                    { modelWithText, typeof(NestedModel), () => modelWithText.NestedModel.Text, "NestedModel.Text",
+                        new TagHelperOutputContent("Hello World", string.Empty, "Hello World", "NestedModel_Text") },
+                    { modelWithNull, typeof(NestedModel), () => modelWithNull.NestedModel.Text, "NestedModel.Text",
+                        new TagHelperOutputContent("Hello World1", "Hello World2", "Hello World2", "NestedModel_Text") },
+                    { modelWithText, typeof(NestedModel), () => modelWithText.NestedModel.Text, "NestedModel.Text",
+                        new TagHelperOutputContent("Hello World1", "Hello World2", "Hello World2", "NestedModel_Text") },
 
                     // Note: Tests cases below here will not work in practice due to current limitations on indexing
                     // into ModelExpressions. Will be fixed in https://github.com/aspnet/Mvc/issues/1345.
                     { models, typeof(Model), () => models[0].Text, "[0].Text",
-                        new TagHelperOutputContent(Environment.NewLine, "Text", "z0__Text") },
-                    { models, typeof(Model), () => models[1].Text, "[1].Text",
-                        new TagHelperOutputContent(Environment.NewLine, "Text", "z1__Text") },
+                        new TagHelperOutputContent(Environment.NewLine, string.Empty, "Text", "z0__Text") },
                     { models, typeof(Model), () => models[0].Text, "[0].Text",
-                        new TagHelperOutputContent("Hello World", "Hello World", "z0__Text") },
+                        new TagHelperOutputContent(Environment.NewLine, "Hello World", "Hello World", "z0__Text") },
+                    { models, typeof(Model), () => models[0].Text, "[0].Text",
+                        new TagHelperOutputContent(string.Empty, Environment.NewLine, Environment.NewLine, "z0__Text") },
                     { models, typeof(Model), () => models[1].Text, "[1].Text",
-                        new TagHelperOutputContent("Hello World", "Hello World", "z1__Text") },
+                        new TagHelperOutputContent(Environment.NewLine, string.Empty, "Text", "z1__Text") },
+                    { models, typeof(Model), () => models[1].Text, "[1].Text",
+                        new TagHelperOutputContent(Environment.NewLine, "Hello World", "Hello World", "z1__Text") },
+                    { models, typeof(Model), () => models[1].Text, "[1].Text",
+                        new TagHelperOutputContent(string.Empty, Environment.NewLine, Environment.NewLine, "z1__Text") },
+                    { models, typeof(Model), () => models[0].Text, "[0].Text",
+                        new TagHelperOutputContent(string.Empty, "Hello World", "Hello World", "z0__Text") },
+                    { models, typeof(Model), () => models[1].Text, "[1].Text",
+                        new TagHelperOutputContent(string.Empty, "Hello World", "Hello World", "z1__Text") },
+                    { models, typeof(Model), () => models[0].Text, "[0].Text",
+                        new TagHelperOutputContent("Hello World", string.Empty, "Hello World", "z0__Text") },
+                    { models, typeof(Model), () => models[1].Text, "[1].Text",
+                        new TagHelperOutputContent("Hello World", string.Empty, "Hello World", "z1__Text") },
+                    { models, typeof(Model), () => models[0].Text, "[0].Text",
+                        new TagHelperOutputContent("Hello World1", "Hello World2", "Hello World2", "z0__Text") },
+                    { models, typeof(Model), () => models[1].Text, "[1].Text",
+                        new TagHelperOutputContent("Hello World1", "Hello World2", "Hello World2", "z1__Text") },
 
                     { models, typeof(NestedModel), () => models[0].NestedModel.Text, "[0].NestedModel.Text",
-                        new TagHelperOutputContent(Environment.NewLine, "Text", "z0__NestedModel_Text") },
-                    { models, typeof(NestedModel), () => models[1].NestedModel.Text, "[1].NestedModel.Text",
-                        new TagHelperOutputContent(Environment.NewLine, "Text", "z1__NestedModel_Text") },
+                        new TagHelperOutputContent(Environment.NewLine, string.Empty, "Text", "z0__NestedModel_Text") },
                     { models, typeof(NestedModel), () => models[0].NestedModel.Text, "[0].NestedModel.Text",
-                        new TagHelperOutputContent("Hello World", "Hello World", "z0__NestedModel_Text") },
+                        new TagHelperOutputContent(Environment.NewLine, "Hello World", "Hello World", "z0__NestedModel_Text") },
+                    { models, typeof(NestedModel), () => models[0].NestedModel.Text, "[0].NestedModel.Text",
+                        new TagHelperOutputContent(string.Empty, Environment.NewLine, Environment.NewLine, "z0__NestedModel_Text") },
                     { models, typeof(NestedModel), () => models[1].NestedModel.Text, "[1].NestedModel.Text",
-                        new TagHelperOutputContent("Hello World", "Hello World", "z1__NestedModel_Text") },
+                        new TagHelperOutputContent(Environment.NewLine, string.Empty, "Text", "z1__NestedModel_Text") },
+                    { models, typeof(NestedModel), () => models[1].NestedModel.Text, "[1].NestedModel.Text",
+                        new TagHelperOutputContent(Environment.NewLine, "Hello World", "Hello World", "z1__NestedModel_Text") },
+                    { models, typeof(NestedModel), () => models[1].NestedModel.Text, "[1].NestedModel.Text",
+                        new TagHelperOutputContent(string.Empty, Environment.NewLine, Environment.NewLine, "z1__NestedModel_Text") },
+                    { models, typeof(NestedModel), () => models[0].NestedModel.Text, "[0].NestedModel.Text",
+                        new TagHelperOutputContent(string.Empty, "Hello World", "Hello World", "z0__NestedModel_Text") },
+                    { models, typeof(NestedModel), () => models[1].NestedModel.Text, "[1].NestedModel.Text",
+                        new TagHelperOutputContent(string.Empty, "Hello World", "Hello World", "z1__NestedModel_Text") },
+                    { models, typeof(NestedModel), () => models[0].NestedModel.Text, "[0].NestedModel.Text",
+                        new TagHelperOutputContent("Hello World", string.Empty, "Hello World", "z0__NestedModel_Text") },
+                    { models, typeof(NestedModel), () => models[1].NestedModel.Text, "[1].NestedModel.Text",
+                        new TagHelperOutputContent("Hello World", string.Empty, "Hello World", "z1__NestedModel_Text") },
+                    { models, typeof(NestedModel), () => models[0].NestedModel.Text, "[0].NestedModel.Text",
+                        new TagHelperOutputContent("Hello World1", "Hello World2", "Hello World2", "z0__NestedModel_Text") },
+                    { models, typeof(NestedModel), () => models[1].NestedModel.Text, "[1].NestedModel.Text",
+                        new TagHelperOutputContent("Hello World1", "Hello World2", "Hello World2", "z1__NestedModel_Text") },
                 };
             }
         }
@@ -112,13 +178,30 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 For = modelExpression,
             };
+            var expectedPreContent = "original pre-content";
+            var expectedPostContent = "original post-content";
 
-            var tagHelperContext = new TagHelperContext(allAttributes: new Dictionary<string, object>(), uniqueId: "test");
+            var tagHelperContext = new TagHelperContext(
+                allAttributes: new Dictionary<string, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult(tagHelperOutputContent.OriginalChildContent));
             var htmlAttributes = new Dictionary<string, string>
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(expectedTagName, htmlAttributes, tagHelperOutputContent.OriginalContent);
+            var output = new TagHelperOutput(expectedTagName, htmlAttributes)
+            {
+                PreContent = expectedPreContent,
+                PostContent = expectedPostContent,
+            };
+
+            // LabelTagHelper checks ContentSet so we don't want to forcibly set it if 
+            // tagHelperOutputContent.OriginalContent is going to be null or empty.
+            if (!string.IsNullOrEmpty(tagHelperOutputContent.OriginalContent))
+            {
+                output.Content = tagHelperOutputContent.OriginalContent;
+            }
+
             var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
             var viewContext = TestableHtmlGenerator.GetViewContext(model, htmlGenerator, metadataProvider);
             tagHelper.ViewContext = viewContext;
@@ -129,7 +212,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             // Assert
             Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(tagHelperOutputContent.ExpectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.False(output.SelfClosing);
             Assert.Equal(expectedTagName, output.TagName);
         }
@@ -142,7 +227,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 { "class", "form-control" },
             };
+            var expectedPreContent = "original pre-content";
             var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var expectedTagName = "label";
 
             var metadataProvider = new DataAnnotationsModelMetadataProvider();
@@ -153,8 +240,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var modelExpression = new ModelExpression(nameof(Model.Text), metadata);
             var tagHelper = new LabelTagHelper();
 
-            var tagHelperContext = new TagHelperContext(allAttributes: new Dictionary<string, object>(), uniqueId: "test");
-            var output = new TagHelperOutput(expectedTagName, expectedAttributes, expectedContent);
+            var tagHelperContext = new TagHelperContext(
+                allAttributes: new Dictionary<string, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
+            var output = new TagHelperOutput(expectedTagName, expectedAttributes)
+            {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
+            };
 
             var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
             Model model = null;
@@ -167,18 +262,26 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             // Assert
             Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.Equal(expectedTagName, output.TagName);
         }
 
         public class TagHelperOutputContent
         {
-            public TagHelperOutputContent(string outputContent, string expectedContent, string expectedId)
+            public TagHelperOutputContent(string originalChildContent,
+                                          string outputContent,
+                                          string expectedContent,
+                                          string expectedId)
             {
+                OriginalChildContent = originalChildContent;
                 OriginalContent = outputContent;
                 ExpectedContent = expectedContent;
                 ExpectedId = expectedId;
             }
+
+            public string OriginalChildContent { get; set; }
 
             public string OriginalContent { get; set; }
 

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/OptionTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/OptionTagHelperTest.cs
@@ -136,9 +136,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "selected", selected },
                 { "value", value },
             };
-            var tagHelperContext = new TagHelperContext(contextAttributes, uniqueId: "test");
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, originalContent)
+            var tagHelperContext = new TagHelperContext(
+                contextAttributes,
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult(originalContent));
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
+                Content = originalContent,
                 SelfClosing = false,
             };
 
@@ -188,9 +192,17 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "selected", selected },
                 { "value", value },
             };
-            var tagHelperContext = new TagHelperContext(contextAttributes, uniqueId: "test");
-            var output = new TagHelperOutput(originalTagName, originalAttributes, originalContent)
+            var originalPreContent = "original pre-content";
+            var originalPostContent = "original post-content";
+            var tagHelperContext = new TagHelperContext(
+                contextAttributes,
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult(originalContent));
+            var output = new TagHelperOutput(originalTagName, originalAttributes)
             {
+                PreContent = originalPreContent,
+                Content = originalContent,
+                PostContent = originalPostContent,
                 SelfClosing = false,
             };
 
@@ -235,9 +247,17 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "selected", selected },
                 { "value", value },
             };
-            var tagHelperContext = new TagHelperContext(contextAttributes, uniqueId: "test");
-            var output = new TagHelperOutput(originalTagName, originalAttributes, originalContent)
+            var originalPreContent = "original pre-content";
+            var originalPostContent = "original post-content";
+            var tagHelperContext = new TagHelperContext(
+                contextAttributes,
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult(originalContent));
+            var output = new TagHelperOutput(originalTagName, originalAttributes)
             {
+                PreContent = originalPreContent,
+                Content = originalContent,
+                PostContent = originalPostContent,
                 SelfClosing = false,
             };
 

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/SelectTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/SelectTagHelperTest.cs
@@ -165,7 +165,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 { "class", "form-control" },
             };
-            var originalContent = "original content";
+            var originalPostContent = "original content";
 
             var expectedAttributes = new Dictionary<string, string>(originalAttributes)
             {
@@ -173,7 +173,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "name", nameAndId.Name },
                 { "valid", "from validation attributes" },
             };
-            var expectedContent = originalContent;
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
+            var expectedPostContent = originalPostContent;
             var expectedTagName = "not-select";
 
             var metadataProvider = new DataAnnotationsModelMetadataProvider();
@@ -182,9 +184,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var metadata = metadataProvider.GetMetadataForProperty(modelAccessor, containerType, propertyName: "Text");
             var modelExpression = new ModelExpression(nameAndId.Name, metadata);
 
-            var tagHelperContext = new TagHelperContext(new Dictionary<string, object>(), uniqueId: "test");
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, expectedContent)
+            var tagHelperContext = new TagHelperContext(
+                allAttributes: new Dictionary<string, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = originalPostContent,
                 SelfClosing = true,
             };
 
@@ -208,7 +216,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             // Assert
             Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.False(output.SelfClosing);
             Assert.Equal(expectedTagName, output.TagName);
 
@@ -235,7 +245,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 { "class", "form-control" },
             };
-            var originalContent = "original content";
+            var originalPostContent = "original content";
 
             var expectedAttributes = new Dictionary<string, string>(originalAttributes)
             {
@@ -243,7 +253,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "name", nameAndId.Name },
                 { "valid", "from validation attributes" },
             };
-            var expectedContent = originalContent + expectedOptions;
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
+            var expectedPostContent = originalPostContent + expectedOptions;
             var expectedTagName = "select";
 
             var metadataProvider = new DataAnnotationsModelMetadataProvider();
@@ -252,9 +264,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var metadata = metadataProvider.GetMetadataForProperty(modelAccessor, containerType, propertyName: "Text");
             var modelExpression = new ModelExpression(nameAndId.Name, metadata);
 
-            var tagHelperContext = new TagHelperContext(new Dictionary<string, object>(), uniqueId: "test");
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, originalContent)
+            var tagHelperContext = new TagHelperContext(
+                allAttributes: new Dictionary<string, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = originalPostContent,
                 SelfClosing = true,
             };
 
@@ -280,7 +298,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             // Assert
             Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.False(output.SelfClosing);
             Assert.Equal(expectedTagName, output.TagName);
 
@@ -308,12 +328,14 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "multiple", multiple },
             };
             var originalAttributes = new Dictionary<string, string>();
-            var content = "original content";
             var propertyName = "Property1";
             var expectedTagName = "select";
 
-            var tagHelperContext = new TagHelperContext(contextAttributes, uniqueId: "test");
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, content);
+            var tagHelperContext = new TagHelperContext(
+                contextAttributes,
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
+            var output = new TagHelperOutput(expectedTagName, originalAttributes);
 
             var metadataProvider = new EmptyModelMetadataProvider();
             string model = null;
@@ -372,12 +394,14 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var contextAttributes = new Dictionary<string, object>();
             var originalAttributes = new Dictionary<string, string>();
-            var content = "original content";
             var propertyName = "Property1";
             var tagName = "select";
 
-            var tagHelperContext = new TagHelperContext(contextAttributes, uniqueId: "test");
-            var output = new TagHelperOutput(tagName, originalAttributes, content);
+            var tagHelperContext = new TagHelperContext(
+                contextAttributes,
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
+            var output = new TagHelperOutput(tagName, originalAttributes);
 
             var metadataProvider = new EmptyModelMetadataProvider();
             var metadata = metadataProvider.GetMetadataForType(() => model, modelType);
@@ -437,12 +461,20 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             };
             var expectedAttributes = new Dictionary<string, string>(originalAttributes);
             expectedAttributes[attributeName] = (string)contextAttributes[attributeName];
+            var expectedPreContent = "original pre-content";
             var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var expectedTagName = "select";
 
-            var tagHelperContext = new TagHelperContext(contextAttributes, uniqueId: "test");
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, expectedContent)
+            var tagHelperContext = new TagHelperContext(
+                contextAttributes,
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
                 SelfClosing = true,
             };
 
@@ -456,7 +488,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             // Assert
             Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedPreContent, output.PreContent);
             Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.True(output.SelfClosing);
             Assert.Equal(expectedTagName, output.TagName);
         }
@@ -467,12 +501,14 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var contextAttributes = new Dictionary<string, object>();
             var originalAttributes = new Dictionary<string, string>();
-            var content = "original content";
             var expectedTagName = "select";
             var expectedMessage = "Cannot determine body for <select>. 'asp-items' must be null if 'asp-for' is null.";
 
-            var tagHelperContext = new TagHelperContext(contextAttributes, uniqueId: "test");
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, content);
+            var tagHelperContext = new TagHelperContext(
+                contextAttributes,
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
+            var output = new TagHelperOutput(expectedTagName, originalAttributes);
             var tagHelper = new SelectTagHelper
             {
                 Items = Enumerable.Empty<SelectListItem>(),
@@ -497,13 +533,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var contextAttributes = new Dictionary<string, object>();
             var originalAttributes = new Dictionary<string, string>();
-            var content = "original content";
             var expectedTagName = "select";
             var expectedMessage = "Cannot parse 'multiple' value '" + multiple +
                 "' for <select>. Acceptable values are 'false', 'true' and 'multiple'.";
 
-            var tagHelperContext = new TagHelperContext(contextAttributes, uniqueId: "test");
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, content);
+            var tagHelperContext = new TagHelperContext(
+                contextAttributes,
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
+            var output = new TagHelperOutput(expectedTagName, originalAttributes);
 
             var metadataProvider = new EmptyModelMetadataProvider();
             string model = null;

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TagHelperOutputExtensionsTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TagHelperOutputExtensionsTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 using Xunit;
@@ -19,14 +20,14 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>());
             var tagHelperContext = new TagHelperContext(
-                new Dictionary<string, object>(StringComparer.Ordinal)
+                allAttributes: new Dictionary<string, object>(StringComparer.Ordinal)
                 {
                     { attributeName, attributeValue }
                 },
-                uniqueId: "test");
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
             var expectedAttribute = new KeyValuePair<string, string>(attributeName, attributeValue);
 
             // Act
@@ -47,15 +48,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 attributes: new Dictionary<string, string>()
                 {
                     { attributeName, "world2" }
-                },
-                content: string.Empty);
+                });
             var expectedAttribute = new KeyValuePair<string, string>(attributeName, "world2");
             var tagHelperContext = new TagHelperContext(
-                new Dictionary<string, object>(StringComparer.Ordinal)
+                allAttributes: new Dictionary<string, object>(StringComparer.Ordinal)
                 {
                     { attributeName, "world" }
-                }
-                , uniqueId: "test");
+                },
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
 
             // Act
             tagHelperOutput.CopyHtmlAttribute(attributeName, tagHelperContext);
@@ -75,8 +76,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 {
                     { "route-Hello", "World" },
                     { "Route-I", "Am" }
-                },
-                content: string.Empty);
+                });
             var expectedAttribute = new KeyValuePair<string, string>("type", "btn");
             tagHelperOutput.Attributes.Add(expectedAttribute);
             var attributes = tagHelperOutput.FindPrefixedAttributes("route-");
@@ -99,8 +99,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 {
                     { "routeHello", "World" },
                     { "Routee-I", "Am" }
-                },
-                content: string.Empty);
+                });
 
             // Act
             var attributes = tagHelperOutput.FindPrefixedAttributes("route-");
@@ -119,8 +118,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>());
             var expectedAttribute = new KeyValuePair<string, string>("type", "btn");
             tagHelperOutput.Attributes.Add(expectedAttribute);
 
@@ -141,8 +139,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>());
             tagHelperOutput.Attributes.Add("class", "Hello");
 
             var tagBuilder = new TagBuilder("p");
@@ -168,8 +165,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>());
             tagHelperOutput.Attributes.Add(originalName, "Hello");
 
             var tagBuilder = new TagBuilder("p");
@@ -189,8 +185,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>());
 
             var tagBuilder = new TagBuilder("p");
             var expectedAttribute = new KeyValuePair<string, string>("visible", "val < 3");
@@ -210,8 +205,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>());
 
             var tagBuilder = new TagBuilder("p");
             var expectedAttribute1 = new KeyValuePair<string, string>("class", "btn");
@@ -236,8 +230,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>());
             var expectedAttribute = new KeyValuePair<string, string>("class", "btn");
             tagHelperOutput.Attributes.Add(expectedAttribute);
 
@@ -257,8 +250,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                content: string.Empty);
+                attributes: new Dictionary<string, string>());
             var expectedOutputAttribute = new KeyValuePair<string, string>("class", "btn");
             tagHelperOutput.Attributes.Add(expectedOutputAttribute);
 

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TextAreaTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TextAreaTagHelperTest.cs
@@ -107,13 +107,17 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 For = modelExpression,
             };
 
-            var tagHelperContext = new TagHelperContext(new Dictionary<string, object>(), uniqueId: "test");
+            var tagHelperContext = new TagHelperContext(
+                allAttributes: new Dictionary<string, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
             var htmlAttributes = new Dictionary<string, string>
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(expectedTagName, htmlAttributes, "original content")
+            var output = new TagHelperOutput(expectedTagName, htmlAttributes)
             {
+                Content = "original content",
                 SelfClosing = true,
             };
 
@@ -146,7 +150,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 { "class", "form-control" },
             };
+            var expectedPreContent = "original pre-content";
             var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var expectedTagName = "textarea";
 
             var metadataProvider = new DataAnnotationsModelMetadataProvider();
@@ -157,9 +163,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var modelExpression = new ModelExpression(nameof(Model.Text), metadata);
             var tagHelper = new TextAreaTagHelper();
 
-            var tagHelperContext = new TagHelperContext(new Dictionary<string, object>(), uniqueId: "test");
-            var output = new TagHelperOutput(expectedTagName, expectedAttributes, expectedContent)
+            var tagHelperContext = new TagHelperContext(
+                allAttributes: new Dictionary<string, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
+            var output = new TagHelperOutput(expectedTagName, expectedAttributes)
             {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
                 SelfClosing = true,
             };
 

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ValidationMessageTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ValidationMessageTagHelperTest.cs
@@ -28,20 +28,29 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 For = modelExpression
             };
 
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
+
             var tagHelperContext = new TagHelperContext(
                 allAttributes: new Dictionary<string, object>
                 {
                     { "id", "myvalidationmessage" },
                     { "for", modelExpression },
                 },
-                uniqueId: "test");
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
             var output = new TagHelperOutput(
                 expectedTagName,
                 attributes: new Dictionary<string, string>
                 {
                     { "id", "myvalidationmessage" }
-                },
-                content: "Something");
+                })
+            {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
+            };
             var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
             var viewContext = TestableHtmlGenerator.GetViewContext(model: null,
                                                                    htmlGenerator: htmlGenerator,
@@ -62,7 +71,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal("Name", attribute.Value);
             attribute = Assert.Single(output.Attributes, kvp => kvp.Key.Equals("data-valmsg-replace"));
             Assert.Equal("true", attribute.Value);
-            Assert.Equal("Something", output.Content);
+            Assert.Equal(expectedPreContent, output.PreContent);
+            Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
             Assert.Equal(expectedTagName, output.TagName);
         }
 
@@ -74,10 +85,21 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 For = CreateModelExpression("Hello")
             };
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
+            var context = new TagHelperContext(
+                allAttributes: new Dictionary<string, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
             var output = new TagHelperOutput(
                 "span",
-                attributes: new Dictionary<string, string>(),
-                content: "Content of validation message");
+                attributes: new Dictionary<string, string>())
+            {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
+            };
             var expectedViewContext = CreateViewContext();
             var generator = new Mock<IHtmlGenerator>();
             generator
@@ -89,19 +111,22 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             validationMessageTagHelper.ViewContext = expectedViewContext;
 
             // Act & Assert
-            await validationMessageTagHelper.ProcessAsync(context: null, output: output);
+            await validationMessageTagHelper.ProcessAsync(context, output: output);
 
             generator.Verify();
             Assert.Equal("span", output.TagName);
             Assert.Empty(output.Attributes);
-            Assert.Equal("Content of validation message", output.Content);
+            Assert.Equal(expectedPreContent, output.PreContent);
+            Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
         }
 
         [Theory]
-        [InlineData("Content of validation message", "Content of validation message")]
-        [InlineData("\r\n  \r\n", "New HTML")]
-        public async Task ProcessAsync_MergesTagBuilderFromGenerateValidationMessage(
-            string outputContent, string expectedOutputContent)
+        [InlineData("Content of validation message", "Some Content", "Some Content")]
+        [InlineData("\r\n  \r\n", "\r\n Something Else \r\n", "\r\n Something Else \r\n")]
+        [InlineData("\r\n  \r\n", "Some Content", "Some Content")]
+        public async Task ProcessAsync_DoesNotOverrideOutputContent(
+            string childContent, string outputContent, string expectedOutputContent)
         {
             // Arrange
             var validationMessageTagHelper = new ValidationMessageTagHelper
@@ -110,8 +135,14 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             };
             var output = new TagHelperOutput(
                 "span",
-                attributes: new Dictionary<string, string>(),
-                content: outputContent);
+                attributes: new Dictionary<string, string>())
+            {
+                Content = outputContent
+            };
+
+            var context = new TagHelperContext(allAttributes: new Dictionary<string, object>(),
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult(childContent));
             var tagBuilder = new TagBuilder("span2")
             {
                 InnerHtml = "New HTML"
@@ -133,7 +164,58 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             validationMessageTagHelper.Generator = generator.Object;
 
             // Act
-            await validationMessageTagHelper.ProcessAsync(context: null, output: output);
+            await validationMessageTagHelper.ProcessAsync(context, output: output);
+
+            // Assert
+            Assert.Equal("span", output.TagName);
+            Assert.Equal(2, output.Attributes.Count);
+            var attribute = Assert.Single(output.Attributes, kvp => kvp.Key.Equals("data-foo"));
+            Assert.Equal("bar", attribute.Value);
+            attribute = Assert.Single(output.Attributes, kvp => kvp.Key.Equals("data-hello"));
+            Assert.Equal("world", attribute.Value);
+            Assert.Equal(expectedOutputContent, output.Content);
+        }
+
+        [Theory]
+        [InlineData("Content of validation message", "Content of validation message")]
+        [InlineData("\r\n  \r\n", "New HTML")]
+        public async Task ProcessAsync_MergesTagBuilderFromGenerateValidationMessage(
+            string childContent, string expectedOutputContent)
+        {
+            // Arrange
+            var validationMessageTagHelper = new ValidationMessageTagHelper
+            {
+                For = CreateModelExpression("Hello")
+            };
+            var output = new TagHelperOutput(
+                "span",
+                attributes: new Dictionary<string, string>());
+
+            var context = new TagHelperContext(allAttributes: new Dictionary<string, object>(),
+                                               uniqueId: "test",
+                                               getChildContentAsync: () => Task.FromResult(childContent));
+            var tagBuilder = new TagBuilder("span2")
+            {
+                InnerHtml = "New HTML"
+            };
+            tagBuilder.Attributes.Add("data-foo", "bar");
+            tagBuilder.Attributes.Add("data-hello", "world");
+
+            var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var setup = generator
+                .Setup(mock => mock.GenerateValidationMessage(
+                    It.IsAny<ViewContext>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<object>()))
+                .Returns(tagBuilder);
+            var viewContext = CreateViewContext();
+            validationMessageTagHelper.ViewContext = viewContext;
+            validationMessageTagHelper.Generator = generator.Object;
+
+            // Act
+            await validationMessageTagHelper.ProcessAsync(context, output: output);
 
             // Assert
             Assert.Equal("span", output.TagName);
@@ -150,10 +232,17 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             // Arrange
             var validationMessageTagHelper = new ValidationMessageTagHelper();
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var output = new TagHelperOutput(
                 "span",
-                attributes: new Dictionary<string, string>(),
-                content: "Content of validation message");
+                attributes: new Dictionary<string, string>())
+            {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
+            };
             var viewContext = CreateViewContext();
             var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
             validationMessageTagHelper.ViewContext = viewContext;
@@ -165,7 +254,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Assert
             Assert.Equal("span", output.TagName);
             Assert.Empty(output.Attributes);
-            Assert.Equal("Content of validation message", output.Content);
+            Assert.Equal(expectedPreContent, output.PreContent);
+            Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
         }
 
         private static ModelExpression CreateModelExpression(string name)

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ValidationSummaryTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ValidationSummaryTagHelperTest.cs
@@ -40,14 +40,23 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 ValidationSummary = ValidationSummary.All,
             };
 
-            var tagHelperContext = new TagHelperContext(new Dictionary<string, object>(), uniqueId: "test");
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
+            var tagHelperContext = new TagHelperContext(
+                allAttributes: new Dictionary<string, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () => Task.FromResult("Something"));
             var output = new TagHelperOutput(
                 expectedTagName,
                 attributes: new Dictionary<string, string>
                 {
                     { "class", "form-control" }
-                },
-                content: "Custom Content");
+                })
+            {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = "Custom Content",
+            };
 
             var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
             Model model = null;
@@ -64,8 +73,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal("form-control validation-summary-valid", attribute.Value);
             attribute = Assert.Single(output.Attributes, kvp => kvp.Key.Equals("data-valmsg-summary"));
             Assert.Equal("true", attribute.Value);
+            Assert.Equal(expectedPreContent, output.PreContent);
+            Assert.Equal(expectedContent, output.Content);
             Assert.Equal("Custom Content<ul><li style=\"display:none\"></li>" + Environment.NewLine + "</ul>",
-                         output.Content);
+                         output.PostContent);
             Assert.Equal(expectedTagName, output.TagName);
         }
 
@@ -81,10 +92,17 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 ValidationSummary = validationSummary,
             };
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var output = new TagHelperOutput(
                 "div",
-                attributes: new Dictionary<string, string>(),
-                content: "Content of validation summary");
+                attributes: new Dictionary<string, string>())
+            {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
+            };
             var expectedViewContext = CreateViewContext();
             var generator = new Mock<IHtmlGenerator>();
             generator
@@ -105,7 +123,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             generator.Verify();
             Assert.Equal("div", output.TagName);
             Assert.Empty(output.Attributes);
-            Assert.Equal("Content of validation summary", output.Content);
+            Assert.Equal(expectedPreContent, output.PreContent);
+            Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
         }
 
         [Fact]
@@ -116,10 +136,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 ValidationSummary = ValidationSummary.ModelOnly,
             };
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
             var output = new TagHelperOutput(
                 "div",
-                attributes: new Dictionary<string, string>(),
-                content: "Content of validation summary");
+                attributes: new Dictionary<string, string>())
+            {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = "Content of validation summary"
+            };
             var tagBuilder = new TagBuilder("span2")
             {
                 InnerHtml = "New HTML"
@@ -154,7 +180,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal("world", attribute.Value);
             attribute = Assert.Single(output.Attributes, kvp => kvp.Key.Equals("anything"));
             Assert.Equal("something", attribute.Value);
-            Assert.Equal("Content of validation summaryNew HTML", output.Content);
+            Assert.Equal(expectedPreContent, output.PreContent);
+            Assert.Equal(expectedContent, output.Content);
+            Assert.Equal("Content of validation summaryNew HTML", output.PostContent);
         }
 
         [Fact]
@@ -165,10 +193,17 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 ValidationSummary = ValidationSummary.None,
             };
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
+            var expectedPostContent = "original post-content";
             var output = new TagHelperOutput(
                 "div",
-                attributes: new Dictionary<string, string>(),
-                content: "Content of validation message");
+                attributes: new Dictionary<string, string>())
+            {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = expectedPostContent,
+            };
 
             var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
             var viewContext = CreateViewContext();
@@ -181,7 +216,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Assert
             Assert.Equal("div", output.TagName);
             Assert.Empty(output.Attributes);
-            Assert.Equal("Content of validation message", output.Content);
+            Assert.Equal(expectedPreContent, output.PreContent);
+            Assert.Equal(expectedContent, output.Content);
+            Assert.Equal(expectedPostContent, output.PostContent);
         }
 
         [Theory]
@@ -194,10 +231,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 ValidationSummary = validationSummary,
             };
+            var expectedPreContent = "original pre-content";
+            var expectedContent = "original content";
             var output = new TagHelperOutput(
                 "div",
-                attributes: new Dictionary<string, string>(),
-                content: "Content of validation message");
+                attributes: new Dictionary<string, string>())
+            {
+                PreContent = expectedPreContent,
+                Content = expectedContent,
+                PostContent = "Content of validation message",
+            };
             var tagBuilder = new TagBuilder("span2")
             {
                 InnerHtml = "New HTML"
@@ -223,7 +266,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Assert
             Assert.Equal("div", output.TagName);
             Assert.Empty(output.Attributes);
-            Assert.Equal("Content of validation messageNew HTML", output.Content);
+            Assert.Equal(expectedPreContent, output.PreContent);
+            Assert.Equal(expectedContent, output.Content);
+            Assert.Equal("Content of validation messageNew HTML", output.PostContent);
             generator.Verify();
         }
 

--- a/test/WebSites/ActivatorWebSite/TagHelpers/HiddenTagHelper.cs
+++ b/test/WebSites/ActivatorWebSite/TagHelpers/HiddenTagHelper.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
-using System.Threading.Tasks;
 
 namespace ActivatorWebSite.TagHelpers
 {

--- a/test/WebSites/ActivatorWebSite/TagHelpers/HiddenTagHelper.cs
+++ b/test/WebSites/ActivatorWebSite/TagHelpers/HiddenTagHelper.cs
@@ -4,12 +4,11 @@
 using Microsoft.AspNet.Mvc;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
-using Microsoft.AspNet.Razor.TagHelpers;
+using System.Threading.Tasks;
 
 namespace ActivatorWebSite.TagHelpers
 {
     [HtmlElementName("span")]
-    [ContentBehavior(ContentBehavior.Modify)]
     public class HiddenTagHelper : TagHelper
     {
         public string Name { get; set; }
@@ -17,9 +16,11 @@ namespace ActivatorWebSite.TagHelpers
         [Activate]
         public IHtmlHelper HtmlHelper { get; set; }
 
-        public override void Process(TagHelperContext context, TagHelperOutput output)
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
-            output.Content = HtmlHelper.Hidden(Name, output.Content).ToString();
+            var content = await context.GetChildContentAsync();
+
+            output.Content = HtmlHelper.Hidden(Name, content).ToString();
         }
     }
 }

--- a/test/WebSites/ActivatorWebSite/TagHelpers/RepeatContentTagHelper.cs
+++ b/test/WebSites/ActivatorWebSite/TagHelpers/RepeatContentTagHelper.cs
@@ -4,12 +4,11 @@
 using Microsoft.AspNet.Mvc;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
-using Microsoft.AspNet.Razor.TagHelpers;
+using System.Threading.Tasks;
 
 namespace ActivatorWebSite.TagHelpers
 {
     [HtmlElementName("div")]
-    [ContentBehavior(ContentBehavior.Modify)]
     public class RepeatContentTagHelper : TagHelper
     {
         public int RepeatContent { get; set; }
@@ -19,14 +18,14 @@ namespace ActivatorWebSite.TagHelpers
         [Activate]
         public IHtmlHelper HtmlHelper { get; set; }
 
-        public override void Process(TagHelperContext context, TagHelperOutput output)
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
+            var content = await context.GetChildContentAsync();
             var repeatContent = HtmlHelper.Encode(Expression.Metadata.Model.ToString());
 
             if (string.IsNullOrEmpty(repeatContent))
             {
-                repeatContent = output.Content;
-                output.Content = string.Empty;
+                repeatContent = content;
             }
 
             for (int i = 0; i < RepeatContent; i++)

--- a/test/WebSites/ActivatorWebSite/TagHelpers/RepeatContentTagHelper.cs
+++ b/test/WebSites/ActivatorWebSite/TagHelpers/RepeatContentTagHelper.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
-using System.Threading.Tasks;
 
 namespace ActivatorWebSite.TagHelpers
 {

--- a/test/WebSites/ActivatorWebSite/TagHelpers/TitleTagHelper.cs
+++ b/test/WebSites/ActivatorWebSite/TagHelpers/TitleTagHelper.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNet.Razor.TagHelpers;
 namespace ActivatorWebSite.TagHelpers
 {
     [HtmlElementName("body")]
-    [ContentBehavior(ContentBehavior.Prepend)]
     public class TitleTagHelper : TagHelper
     {
         [Activate]
@@ -23,7 +22,7 @@ namespace ActivatorWebSite.TagHelpers
             var builder = new TagBuilder("h2");
             var title = ViewContext.ViewBag.Title;
             builder.InnerHtml = HtmlHelper.Encode(title);
-            output.Content = builder.ToString();
+            output.PreContent = builder.ToString();
         }
     }
 }

--- a/test/WebSites/RequestServicesWebSite/RequestScopedTagHelper.cs
+++ b/test/WebSites/RequestServicesWebSite/RequestScopedTagHelper.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNet.Razor.TagHelpers;
 
 namespace RequestServicesWebSite
 {
-    [ContentBehavior(ContentBehavior.Replace)]
     public class RequestScopedTagHelper : TagHelper
     {
         [Activate]

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/ATagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/ATagHelper.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNet.Razor.TagHelpers;
 
 namespace TagHelpersWebSite.TagHelpers
 {
-    [ContentBehavior(ContentBehavior.Prepend)]
     public class ATagHelper : TagHelper
     {
         [Activate]
@@ -31,7 +30,7 @@ namespace TagHelpersWebSite.TagHelpers
 
                 output.Attributes["href"] = UrlHelper.Action(Action, Controller, methodParameters);
 
-                output.Content = "My ";
+                output.PreContent = "My ";
             }
         }
     }

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/AutoLinkerTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/AutoLinkerTagHelper.cs
@@ -2,20 +2,22 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 using Microsoft.AspNet.Razor.TagHelpers;
 
 namespace TagHelpersWebSite.TagHelpers
 {
     [HtmlElementName("p")]
-    [ContentBehavior(ContentBehavior.Modify)]
     public class AutoLinkerTagHelper : TagHelper
     {
-        public override void Process(TagHelperContext context, TagHelperOutput output)
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
+            var childContent = await context.GetChildContentAsync();
+
             // Find Urls in the content and replace them with their anchor tag equivalent.
             output.Content = Regex.Replace(
-                output.Content,
+                childContent,
                 @"\b(?:https?://|www\.)(\S+)\b",
                 "<strong><a target=\"_blank\" href=\"http://$0\">$0</a></strong>");
         }

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/ConditionTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/ConditionTagHelper.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNet.Razor.TagHelpers;
 namespace TagHelpersWebSite.TagHelpers
 {
     [HtmlElementName("div", "style", "p")]
-    [ContentBehavior(ContentBehavior.Modify)]
     public class ConditionTagHelper : TagHelper
     {
         public bool? Condition { get; set; }
@@ -17,8 +16,7 @@ namespace TagHelpersWebSite.TagHelpers
             // If a condition is set and evaluates to false, don't render the tag.
             if (Condition.HasValue && !Condition.Value)
             {
-                output.TagName = null;
-                output.Content = null;
+                output.SuppressOutput();
             }
         }
     }

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/NestedViewStartTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/NestedViewStartTagHelper.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNet.Razor.TagHelpers;
 namespace TagHelpersWebSite.TagHelpers
 {
     [HtmlElementName("nested")]
-    [ContentBehavior(ContentBehavior.Modify)]
     public class NestedViewStartTagHelper : TagHelper
     {
         public override void Process(TagHelperContext context, TagHelperOutput output)

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/PrettyTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/PrettyTagHelper.cs
@@ -33,7 +33,10 @@ namespace TagHelpersWebSite.TagHelpers
 
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
-            if (MakePretty.HasValue && !MakePretty.Value)
+            // Need to check if output.TagName == null in-case the ConditionTagHelper calls into SuppressOutput and 
+            // therefore sets the TagName to null.
+            if (MakePretty.HasValue && !MakePretty.Value ||
+                output.TagName == null)
             {
                 return;
             }

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/RootViewStartTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/RootViewStartTagHelper.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNet.Razor.TagHelpers;
 namespace TagHelpersWebSite.TagHelpers
 {
     [HtmlElementName("root")]
-    [ContentBehavior(ContentBehavior.Replace)]
     public class RootViewStartTagHelper : TagHelper
     {
         public override void Process(TagHelperContext context, TagHelperOutput output)

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/TagCloudViewComponentTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/TagCloudViewComponentTagHelper.cs
@@ -14,7 +14,6 @@ namespace MvcSample.Web.Components
 {
     [HtmlElementName("tag-cloud")]
     [ViewComponent(Name = "Tags")]
-    [ContentBehavior(ContentBehavior.Replace)]
     public class TagCloudViewComponentTagHelper : ITagHelper
     {
         private static readonly string[] Tags =

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/WebsiteInformationTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/WebsiteInformationTagHelper.cs
@@ -3,12 +3,10 @@
 
 using System;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
-using Microsoft.AspNet.Razor.TagHelpers;
 using TagHelpersWebSite.Models;
 
 namespace TagHelpersWebSite.TagHelpers
 {
-    [ContentBehavior(ContentBehavior.Append)]
     public class WebsiteInformationTagHelper : TagHelper
     {
         public WebsiteContext Info { get; set; }
@@ -16,7 +14,7 @@ namespace TagHelpersWebSite.TagHelpers
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
             output.TagName = "section";
-            output.Content = string.Format(
+            output.PostContent = string.Format(
                 "<p><strong>Version:</strong> {0}</p>" + Environment.NewLine +
                 "<p><strong>Copyright Year:</strong> {1}</p>" + Environment.NewLine +
                 "<p><strong>Approved:</strong> {2}</p>" + Environment.NewLine +


### PR DESCRIPTION
**Modify TagHelpers to use new content mode design.**
- React to aspnet/Razor#221
- Modified existing TagHelpers to no longer rely on ContentBehavior and to instead utilize GetChildContentAsync, PreContent, Content and PostContent.

**Modify TagHelper tests to abide by new content mode design.**
- React to aspnet/Razor#221
- Modified existing TagHelper tests to no longer rely on ContentBehavior.
- Updated signatures of TagHelperExecutionContext and TagHelperContext pieces.