### PR TITLE
React to aspnet/Razor#268 changes

### DIFF
--- a/samples/TagHelperSample.Web/Views/Home/Create.cshtml
+++ b/samples/TagHelperSample.Web/Views/Home/Create.cshtml
@@ -48,7 +48,8 @@
             <label asp-for="YearsEmployeed" class="control-label col-md-2" />
             <div class="col-md-10">
                 @* <select/> tag helper has ContentBehavior.Append -- items render after static options *@
-                <select asp-for="YearsEmployeed" asp-items="(IEnumerable<SelectListItem>)ViewBag.Items" size="2" class="form-control">
+                @{ var @object = "multiple"; }
+                <select asp-for="@(Model.YearsEmployeed)" asp-items="@((IEnumerable<SelectListItem>)ViewBag.Items)" size="2" class="form-control" multiple="@(@object)">
                     @* Static use of "selected" attribute may cause HTML errors if in a single-selection <select/> *@
                     @* - @NTaylorMullen thinks <option/> tag helper could tell <select/> helper not to select anything from "items" *@
                     @* - wouldn't help if user selected one static <option/> and expression indicated another, especially one earlier in the <select/> *@

--- a/samples/TagHelperSample.Web/Views/Home/Index.cshtml
+++ b/samples/TagHelperSample.Web/Views/Home/Index.cshtml
@@ -9,28 +9,20 @@
         @for (var index = 0; index < Model.Count(); ++index)
         {
             <div class="form-group">
-                @Html.LabelFor(m => m[index].Name)
-                @Html.TextBoxFor(m => m[index].Name, htmlAttributes: new { disabled = "disabled", @readonly= "readonly" })
-                @*<label asp-for="[index].Name" />
-                <input type="text" asp-for="[index].Name" disabled="disabled" readonly="readonly" />*@
+                <label asp-for="@Model[index].Name" />
+                <input type="text" asp-for="@Model[index].Name" disabled="disabled" readonly="readonly" />
             </div>
             <div class="form-group">
-                @Html.LabelFor(m => m[index].DateOfBirth)
-                @Html.TextBoxFor(m => m[index].DateOfBirth, format: "{0:yyyy-MM-dd}", htmlAttributes: new { disabled = "disabled", @readonly = "readonly", type="date" })
-                @*<label asp-for="[index].DateOfBirth" />
-                <input type="date" asp-for="[index].DateOfBirth" disabled="disabled" readonly="readonly" />*@
+                <label asp-for="@Model[index].DateOfBirth" />
+                <input type="date" asp-for="@Model[index].DateOfBirth" asp-format="{0:yyyy-MM-dd}" disabled="disabled" readonly="readonly" />
             </div>
             <div class="form-group">
-                @Html.LabelFor(m => m[index].YearsEmployeed)
-                @Html.TextBoxFor(m => m[index].YearsEmployeed, htmlAttributes: new { disabled = "disabled", @readonly = "readonly", type="number" })
-                @*<label asp-for="[index].YearsEmployeed" />
-                <input type="number" asp-for="[index].YearsEmployeed" disabled="disabled" readonly="readonly" />*@
+                <label asp-for="@Model[index].YearsEmployeed" />
+                <input type="number" asp-for="@Model[index].YearsEmployeed" disabled="disabled" readonly="readonly" />
             </div>
             <div class="form-group">
-                @Html.LabelFor(m => m[index].Blurb)
-                @Html.TextAreaFor(m => m[index].Blurb, htmlAttributes: new { disabled = "disabled", @readonly = "readonly" })
-                @*<label asp-for="[index].Blurb" />
-                <textarea rows="4" asp-for="[index].Blurb" disabled="disabled" readonly="readonly" />*@
+                <label asp-for="@Model[index].Blurb" />
+                <textarea rows="4" asp-for="@Model[index].Blurb" disabled="disabled" readonly="readonly" />
             </div>
 
             <p>

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/ModelExpression.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/ModelExpression.cs
@@ -21,13 +21,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <param name="metadata">
         /// Metadata about the <see cref="System.Linq.Expressions.Expression"/> of interest.
         /// </param>
-        public ModelExpression(string name, [NotNull] ModelMetadata metadata)
+        public ModelExpression([NotNull] string name, [NotNull] ModelMetadata metadata)
         {
-            if (string.IsNullOrEmpty(name))
-            {
-                throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(name));
-            }
-
             Name = name;
             Metadata = metadata;
         }

--- a/src/Microsoft.AspNet.Mvc.Razor.Host/MvcTagHelperAttributeValueCodeRenderer.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/MvcTagHelperAttributeValueCodeRenderer.cs
@@ -26,21 +26,28 @@ namespace Microsoft.AspNet.Mvc.Razor
 
         /// <inheritdoc />
         /// <remarks>If the attribute being rendered is of the type
-        /// <see cref="GeneratedTagHelperAttributeContext.ModelExpressionTypeName"/> then a model expression will be
+        /// <see cref="GeneratedTagHelperAttributeContext.ModelExpressionTypeName"/>, then a model expression will be
         /// created by calling into <see cref="GeneratedTagHelperAttributeContext.CreateModelExpressionMethodName"/>.
         /// </remarks>
         public override void RenderAttributeValue([NotNull] TagHelperAttributeDescriptor attributeDescriptor,
                                                   [NotNull] CSharpCodeWriter writer,
                                                   [NotNull] CodeBuilderContext codeBuilderContext,
-                                                  [NotNull] Action<CSharpCodeWriter> renderAttributeValue)
+                                                  [NotNull] Action<CSharpCodeWriter> renderAttributeValue,
+                                                  bool complexValue)
         {
             if (attributeDescriptor.TypeName.Equals(_context.ModelExpressionTypeName, StringComparison.Ordinal))
             {
-                writer.WriteStartMethodInvocation(_context.CreateModelExpressionMethodName)
-                      .Write(ModelLambdaVariableName)
-                      .Write(" => ")
-                      .Write(ModelLambdaVariableName)
-                      .Write(".");
+                writer
+                    .WriteStartMethodInvocation(_context.CreateModelExpressionMethodName)
+                    .Write(ModelLambdaVariableName)
+                    .Write(" => ");
+                if (!complexValue)
+                {
+                    writer
+                        .Write(ModelLambdaVariableName)
+                        .Write(".");
+
+                }
 
                 renderAttributeValue(writer);
 
@@ -48,7 +55,12 @@ namespace Microsoft.AspNet.Mvc.Razor
             }
             else
             {
-                base.RenderAttributeValue(attributeDescriptor, writer, codeBuilderContext, renderAttributeValue);
+                base.RenderAttributeValue(
+                    attributeDescriptor,
+                    writer,
+                    codeBuilderContext,
+                    renderAttributeValue,
+                    complexValue);
             }
         }
     }

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Order.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Order.html
@@ -65,7 +65,7 @@
         <div>
             <label class="order" for="Customer_Gender">Gender</label>
             <input type="radio" value="Male" id="Customer_Gender" name="Customer.Gender" /> Male
-            <input type="radio" value="Female" checked="checked" id="Customer_Gender" name="Customer.Gender" /> Female
+<input type="radio" value="Female" checked="checked" id="Customer_Gender" name="Customer.Gender" /> Female
             <span class="field-validation-valid" data-valmsg-for="Customer.Gender" data-valmsg-replace="true"></span>
         </div>
         <div class="order validation-summary-valid" data-valmsg-summary="true"><ul><li style="display:none"></li>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Order.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Order.html
@@ -18,6 +18,7 @@
         </div>
         <div>
             <label class="order" for="Products">Products</label>
+
             <select multiple="multiple" id="Products" name="Products"><option value="0">Product_0</option>
 <option value="1">Product_1</option>
 <option selected="selected" value="2">Product_2</option>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.ProductList.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.ProductList.html
@@ -4,56 +4,56 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<form action="/MvcTagHelper_Product" method="post">
+<form action="/MvcTagHelper_Product" method="post">            <div>
+                <label class="product" for="z0__HomePage">HomePage</label>
+                <input size="50" disabled="disabled" readonly="readonly" type="url" id="z0__HomePage" name="[0].HomePage" value="http://www.contoso.com/" />
+            </div>
+
 <div>
-    <label class="product" for="HomePage">HomePage</label>
-    <input size="50" type="url" id="HomePage" name="HomePage" value="http://www.contoso.com/" />
+    <label class="product" for="z0__Number">Number</label>
+    <input type="number" id="z0__Number" name="[0].Number" value="0" />
 </div>
 <div>
-    <label class="product" for="Number">Number</label>
-    <input type="number" id="Number" name="Number" value="0" />
+    <label class="product" for="z0__ProductName">ProductName</label>
+    <input type="text" data-val="true" data-val-required="The ProductName field is required." id="z0__ProductName" name="[0].ProductName" value="Product_0" />
 </div>
 <div>
-    <label class="product" for="ProductName">ProductName</label>
-    <input type="text" data-val="true" data-val-required="The ProductName field is required." id="ProductName" name="ProductName" value="Product_0" />
-</div>
-<div>
-    <label class="product" for="Description">Description</label>
-    <textarea rows="4" cols="50" class="product" id="Description" name="Description">
+    <label class="product" for="z0__Description">Description</label>
+    <textarea rows="4" cols="50" class="product" id="z0__Description" name="[0].Description">
 </textarea>
+</div>            <div>
+                <label class="product" for="z1__HomePage">HomePage</label>
+                <input size="50" disabled="disabled" readonly="readonly" type="url" id="z1__HomePage" name="[1].HomePage" value="" />
+            </div>
+
+<div>
+    <label class="product" for="z1__Number">Number</label>
+    <input type="number" id="z1__Number" name="[1].Number" value="1" />
 </div>
 <div>
-    <label class="product" for="HomePage">HomePage</label>
-    <input size="50" type="url" id="HomePage" name="HomePage" value="" />
+    <label class="product" for="z1__ProductName">ProductName</label>
+    <input type="text" data-val="true" data-val-required="The ProductName field is required." id="z1__ProductName" name="[1].ProductName" value="Product_1" />
 </div>
 <div>
-    <label class="product" for="Number">Number</label>
-    <input type="number" id="Number" name="Number" value="1" />
-</div>
-<div>
-    <label class="product" for="ProductName">ProductName</label>
-    <input type="text" id="ProductName" name="ProductName" value="Product_1" />
-</div>
-<div>
-    <label class="product" for="Description">Description</label>
-    <textarea rows="4" cols="50" class="product" id="Description" name="Description">
+    <label class="product" for="z1__Description">Description</label>
+    <textarea rows="4" cols="50" class="product" id="z1__Description" name="[1].Description">
 </textarea>
+</div>            <div>
+                <label class="product" for="z2__HomePage">HomePage</label>
+                <input size="50" disabled="disabled" readonly="readonly" type="url" id="z2__HomePage" name="[2].HomePage" value="" />
+            </div>
+
+<div>
+    <label class="product" for="z2__Number">Number</label>
+    <input type="number" id="z2__Number" name="[2].Number" value="2" />
 </div>
 <div>
-    <label class="product" for="HomePage">HomePage</label>
-    <input size="50" type="url" id="HomePage" name="HomePage" value="" />
+    <label class="product" for="z2__ProductName">ProductName</label>
+    <input type="text" data-val="true" data-val-required="The ProductName field is required." id="z2__ProductName" name="[2].ProductName" value="Product_2" />
 </div>
 <div>
-    <label class="product" for="Number">Number</label>
-    <input type="number" id="Number" name="Number" value="2" />
-</div>
-<div>
-    <label class="product" for="ProductName">ProductName</label>
-    <input type="text" id="ProductName" name="ProductName" value="Product_2" />
-</div>
-<div>
-    <label class="product" for="Description">Description</label>
-    <textarea rows="4" cols="50" class="product" id="Description" name="Description">
+    <label class="product" for="z2__Description">Description</label>
+    <textarea rows="4" cols="50" class="product" id="z2__Description" name="[2].Description">
 Product_2 desription</textarea>
 </div>        <input type="submit"></input>
 </form></body>

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/InjectChunkVisitorTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/InjectChunkVisitorTest.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.AspNet.Razor.Generator;
 using Microsoft.AspNet.Razor.Generator.Compiler;
 using Microsoft.AspNet.Razor.Generator.Compiler.CSharp;
+using Microsoft.AspNet.Razor.Parser;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Xunit;
 
@@ -149,7 +150,8 @@ MyType1
                                          "MyClass",
                                          "MyNamespace",
                                          string.Empty,
-                                         shouldGenerateLinePragmas: true));
+                                         shouldGenerateLinePragmas: true),
+                new ParserErrorSink());
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/ModelChunkVisitorTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/ModelChunkVisitorTest.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.AspNet.Razor.Generator;
 using Microsoft.AspNet.Razor.Generator.Compiler;
 using Microsoft.AspNet.Razor.Generator.Compiler.CSharp;
+using Microsoft.AspNet.Razor.Parser;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Xunit;
 
@@ -105,7 +106,8 @@ Environment.NewLine +
                                          "MyClass",
                                          "MyNamespace",
                                          string.Empty,
-                                         shouldGenerateLinePragmas: true));
+                                         shouldGenerateLinePragmas: true),
+                new ParserErrorSink());
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/MvcRazorHostTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/MvcRazorHostTest.cs
@@ -58,7 +58,15 @@ namespace Microsoft.AspNet.Mvc.Razor
                                  generatedAbsoluteIndex: 2105,
                                  generatedLineIndex: 53,
                                  generatedCharacterIndex: 95,
-                                 contentLength: 3)
+                                 contentLength: 3),
+                BuildLineMapping(
+                    documentAbsoluteIndex: 166,
+                    documentLineIndex: 5,
+                    documentCharacterIndex: 18,
+                    generatedAbsoluteIndex: 2418,
+                    generatedLineIndex: 59,
+                    generatedCharacterIndex: 87,
+                    contentLength: 5),
             };
 
             // Act and Assert

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/MvcRazorHostTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/MvcRazorHostTest.cs
@@ -55,9 +55,9 @@ namespace Microsoft.AspNet.Mvc.Razor
                 BuildLineMapping(documentAbsoluteIndex: 139,
                                  documentLineIndex: 4,
                                  documentCharacterIndex: 17,
-                                 generatedAbsoluteIndex: 2058,
-                                 generatedLineIndex: 52,
-                                 generatedCharacterIndex: 107,
+                                 generatedAbsoluteIndex: 2105,
+                                 generatedLineIndex: 53,
+                                 generatedCharacterIndex: 95,
                                  contentLength: 3)
             };
 

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/MvcTagHelperAttributeValueCodeRendererTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/MvcTagHelperAttributeValueCodeRendererTest.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNet.Razor.Generator;
 using Microsoft.AspNet.Razor.Generator.Compiler.CSharp;
+using Microsoft.AspNet.Razor.Parser;
 using Microsoft.AspNet.Razor.TagHelpers;
 using Xunit;
 
@@ -31,14 +32,16 @@ namespace Microsoft.AspNet.Mvc.Razor
                                                             rootNamespace: string.Empty,
                                                             sourceFile: string.Empty,
                                                             shouldGenerateLinePragmas: true);
-            var context = new CodeBuilderContext(generatorContext);
+            var errorSink = new ParserErrorSink();
+            var context = new CodeBuilderContext(generatorContext, errorSink);
 
             // Act
             renderer.RenderAttributeValue(attributeDescriptor, writer, context,
             (codeWriter) =>
             {
                 codeWriter.Write("MyValue");
-            });
+            },
+            complexValue: false);
 
             // Assert
             Assert.Equal(expectedValue, writer.GenerateCode());

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Input/ModelExpressionTagHelper.cshtml
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Input/ModelExpressionTagHelper.cshtml
@@ -3,3 +3,4 @@
 @addtaghelper "Microsoft.AspNet.Mvc.Razor.InputTestTagHelper, Microsoft.AspNet.Mvc.Razor.Host.Test"
 
 <input-test for="Now" />
+<input-test for="@Model" />

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/ModelExpressionTagHelper.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/ModelExpressionTagHelper.cs
@@ -50,7 +50,11 @@
         public override async Task ExecuteAsync()
         {
             __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper = CreateTagHelper<Microsoft.AspNet.Mvc.Razor.InputTestTagHelper>();
-            __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For = CreateModelExpression(__model => __model.Now);
+#line 5 "TestFiles/Input/ModelExpressionTagHelper.cshtml"
+__Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For = CreateModelExpression(__model => __model.Now);
+
+#line default
+#line hidden
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/ModelExpressionTagHelper.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/ModelExpressionTagHelper.cs
@@ -55,6 +55,12 @@ __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For = CreateModelExpression(__mo
 
 #line default
 #line hidden
+            __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper = CreateTagHelper<Microsoft.AspNet.Mvc.Razor.InputTestTagHelper>();
+#line 6 "TestFiles/Input/ModelExpressionTagHelper.cshtml"
+__Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For = CreateModelExpression(__model => Model);
+
+#line default
+#line hidden
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/ModelExpressionTagHelper.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/ModelExpressionTagHelper.cs
@@ -1,4 +1,4 @@
-﻿#pragma checksum "TestFiles/Input/ModelExpressionTagHelper.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "5de24be79bca2d0ce7e180eab7b197442352f137"
+﻿#pragma checksum "TestFiles/Input/ModelExpressionTagHelper.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "f068e0ad45f53d090f04213f542f87fb2cf750d2"
 namespace Asp
 {
     using Microsoft.AspNet.Razor.Runtime.TagHelpers;
@@ -50,6 +50,22 @@ namespace Asp
             __tagHelperExecutionContext.Add(__Microsoft_AspNet_Mvc_Razor_InputTestTagHelper);
 #line 5 "TestFiles/Input/ModelExpressionTagHelper.cshtml"
 __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For = CreateModelExpression(__model => __model.Now);
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("for", __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For);
+            __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
+            WriteLiteral(__tagHelperExecutionContext.Output.GenerateStartTag());
+            WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            BeginContext(146, 2, true);
+            WriteLiteral("\r\n");
+            EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input-test", "test");
+            __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper = CreateTagHelper<Microsoft.AspNet.Mvc.Razor.InputTestTagHelper>();
+            __tagHelperExecutionContext.Add(__Microsoft_AspNet_Mvc_Razor_InputTestTagHelper);
+#line 6 "TestFiles/Input/ModelExpressionTagHelper.cshtml"
+__Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For = CreateModelExpression(__model => Model);
 
 #line default
 #line hidden

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/ModelExpressionTagHelper.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/ModelExpressionTagHelper.cs
@@ -48,7 +48,11 @@ namespace Asp
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input-test", "test");
             __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper = CreateTagHelper<Microsoft.AspNet.Mvc.Razor.InputTestTagHelper>();
             __tagHelperExecutionContext.Add(__Microsoft_AspNet_Mvc_Razor_InputTestTagHelper);
-            __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For = CreateModelExpression(__model => __model.Now);
+#line 5 "TestFiles/Input/ModelExpressionTagHelper.cshtml"
+__Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For = CreateModelExpression(__model => __model.Now);
+
+#line default
+#line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("for", __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For);
             __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
             WriteLiteral(__tagHelperExecutionContext.Output.GenerateStartTag());

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/Compilation/RazorCompilationServiceTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/Compilation/RazorCompilationServiceTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Microsoft.AspNet.FileSystems;
 using Microsoft.AspNet.Razor;
 using Microsoft.AspNet.Razor.Generator.Compiler;
+using Microsoft.AspNet.Razor.Parser;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.TagHelpers;
 using Moq;
@@ -49,10 +50,12 @@ namespace Microsoft.AspNet.Mvc.Razor.Test
         public void Compile_ReturnsFailedResultIfParseFails()
         {
             // Arrange
+            var errorSink = new ParserErrorSink();
+            errorSink.OnError(new RazorError("some message", 1, 1, 1, 1));
             var generatorResult = new GeneratorResults(
                     new Block(new BlockBuilder { Type = BlockType.Comment }),
                     Enumerable.Empty<TagHelperDescriptor>(),
-                    new RazorError[] { new RazorError("some message", 1, 1, 1, 1) },
+                    errorSink,
                     new CodeBuilderResult("", new LineMapping[0]),
                     new CodeTree());
             var host = new Mock<IMvcRazorHost>();
@@ -87,7 +90,7 @@ namespace Microsoft.AspNet.Mvc.Razor.Test
             var generatorResult = new GeneratorResults(
                     new Block(new BlockBuilder { Type = BlockType.Comment }),
                     Enumerable.Empty<TagHelperDescriptor>(),
-                    new RazorError[0],
+                    new ParserErrorSink(),
                     new CodeBuilderResult(code, new LineMapping[0]),
                     new CodeTree());
             var host = new Mock<IMvcRazorHost>();
@@ -119,7 +122,7 @@ namespace Microsoft.AspNet.Mvc.Razor.Test
             return new GeneratorResults(
                     new Block(new BlockBuilder { Type = BlockType.Comment }),
                     Enumerable.Empty<TagHelperDescriptor>(),
-                    new RazorError[0],
+                    new ParserErrorSink(),
                     new CodeBuilderResult("", new LineMapping[0]),
                     new CodeTree());
         }

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/SelectTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/SelectTagHelperTest.cs
@@ -315,24 +315,24 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var tagHelperContext = new TagHelperContext(contextAttributes, uniqueId: "test");
             var output = new TagHelperOutput(expectedTagName, originalAttributes, content);
 
-            // TODO: https://github.com/aspnet/Mvc/issues/1253
-            // In real (model => model) scenario, ModelExpression should have name "" and
-            // TemplateInfo.HtmlFieldPrefix should be "Property1" but empty ModelExpression name is not currently
-            // supported, see also #1408.
             var metadataProvider = new EmptyModelMetadataProvider();
             string model = null;
             var metadata = metadataProvider.GetMetadataForType(() => model, typeof(string));
-            var modelExpression = new ModelExpression(propertyName, metadata);
 
             var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
             var viewContext = TestableHtmlGenerator.GetViewContext(model, htmlGenerator.Object, metadataProvider);
+
+            // Simulate a (model => model) scenario. E.g. the calling helper may appear in a low-level template.
+            var modelExpression = new ModelExpression(string.Empty, metadata);
+            viewContext.ViewData.TemplateInfo.HtmlFieldPrefix = propertyName;
+
             ICollection<string> selectedValues = new string[0];
             htmlGenerator
                 .Setup(real => real.GenerateSelect(
                     viewContext,
                     metadata,
                     null,         // optionLabel
-                    propertyName, // name
+                    string.Empty, // name
                     expectedItems,
                     expectedAllowMultiple,
                     null,         // htmlAttributes

--- a/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/EditorTemplates/Gender.cshtml
+++ b/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/EditorTemplates/Gender.cshtml
@@ -1,0 +1,5 @@
+﻿@using MvcTagHelpersWebSite.Models
+@model Gender
+@addtaghelper "Microsoft.AspNet.Mvc.TagHelpers"
+<input asp-for="@Model" type="radio" value="Male" /> Male
+<input asp-for="@Model" type="radio" value="Female" /> Female

--- a/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/EmployeeList.cshtml
+++ b/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/EmployeeList.cshtml
@@ -10,9 +10,9 @@
 <body>
     @if (Model != null && Model.Count() != 0)
     {
-        @using (@Html.BeginForm("EmployeeList", "MvcTagHelper_Home", FormMethod.Post))
+        using (@Html.BeginForm("EmployeeList", "MvcTagHelper_Home", FormMethod.Post))
         {
-            @for (int i = 0; i < Model.Count; ++i)
+            for (int i = 0; i < Model.Count; ++i)
             {
                 @Html.EditorFor(m => m[i])
             }

--- a/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/Order.cshtml
+++ b/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/Order.cshtml
@@ -72,8 +72,7 @@
         </div>
         <div>
             <label asp-for="Customer.Gender" class="order" />
-            <input asp-for="Customer.Gender" type="radio" value="Male" /> Male
-            <input asp-for="Customer.Gender" type="radio" value="Female" /> Female
+            @Html.EditorFor(model => model.Customer.Gender)
             <span asp-validation-for="Customer.Gender" />
         </div>
         <div asp-validation-summary="All" class="order" />

--- a/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/Order.cshtml
+++ b/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/Order.cshtml
@@ -29,7 +29,8 @@
         </div>
         <div>
             <label asp-for="Products" class="order" />
-            <select asp-for="Products" asp-items="(IEnumerable<SelectListItem>)ViewBag.Items" multiple="multiple" />
+            @{ var @object = "multiple"; }
+            <select asp-for="@Model.Products" asp-items="@((IEnumerable<SelectListItem>)ViewBag.Items)" multiple="@(@object)" />
         </div>
         <div>
             <label asp-for="OrderDate" class="order" />

--- a/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/ProductList.cshtml
+++ b/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/ProductList.cshtml
@@ -10,9 +10,18 @@
 <body>
     @using (@Html.BeginForm("Index", "MvcTagHelper_Product", FormMethod.Post))
     {
-        @foreach (var product in Model)
+        var index = 0;
+        var fieldPrefix = ViewData.TemplateInfo.HtmlFieldPrefix;
+        foreach (var model in Model)
         {
-            @await Html.PartialAsync("_ProductPartial", product)
+            @* Update HtmlFieldPrefix so generated for, id and name attribute values are correct. *@
+            ViewData.TemplateInfo.HtmlFieldPrefix = fieldPrefix + string.Format("[{0}]", index++);
+            <div>
+                <label asp-for="@(model.HomePage)" class="product" />
+                <input asp-for="@(model.HomePage)" type="url" size="50" disabled="disabled" readonly="readonly" />
+            </div>
+            @await Html.PartialAsync("_ProductPartial", model)
+            ViewData.TemplateInfo.HtmlFieldPrefix = fieldPrefix;
         }
         <input type="submit" />
     }

--- a/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/_ProductPartial.cshtml
+++ b/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/_ProductPartial.cshtml
@@ -3,10 +3,6 @@
 @addtaghelper "Microsoft.AspNet.Mvc.TagHelpers"
 
 <div>
-    <label asp-for="HomePage" class="product" />
-    <input asp-for="HomePage" type="url" size="50" />
-</div>
-<div>
     <label asp-for="Number" class="product" />
     <input asp-for="Number" type="number"/>
 </div>


### PR DESCRIPTION
- address #1253 using new Razor capabilities
- update baselines to match latest code generation
- use new `CodeBuilderContext` and `TagHelperAttributeValueCodeRenderer` signatures
- test complex expressions in bound non-string attribute values