### PR TITLE
Rename TextPlainFormatter and remove other minor warnings

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/Formatters/StringOutputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Formatters/StringOutputFormatter.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.IO;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Http;
 using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNet.Mvc
@@ -10,9 +10,9 @@ namespace Microsoft.AspNet.Mvc
     /// <summary>
     /// Always writes a string value to the response, regardless of requested content type.
     /// </summary>
-    public class TextPlainFormatter : OutputFormatter
+    public class StringOutputFormatter : OutputFormatter
     {
-        public TextPlainFormatter()
+        public StringOutputFormatter()
         {
             SupportedEncodings.Add(Encodings.UTF8EncodingWithoutBOM);
             SupportedEncodings.Add(Encodings.UTF16EncodingLittleEndian);
@@ -39,19 +39,14 @@ namespace Microsoft.AspNet.Mvc
         public override async Task WriteResponseBodyAsync(OutputFormatterContext context)
         {
             var valueAsString = (string)context.Object;
-            if (valueAsString == null)
+            if (string.IsNullOrEmpty(valueAsString))
             {
-                // if the value is null don't write anything.
                 return;
             }
 
             var response = context.ActionContext.HttpContext.Response;
 
-            using (var delegatingStream = new DelegatingStream(response.Body))
-            using (var writer = new StreamWriter(delegatingStream, context.SelectedEncoding, 1024, leaveOpen: true))
-            {
-                await writer.WriteAsync(valueAsString);
-            }
+            await response.WriteAsync(valueAsString, context.SelectedEncoding);
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc/MvcOptionsSetup.cs
+++ b/src/Microsoft.AspNet.Mvc/MvcOptionsSetup.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNet.Mvc
 
             // Set up default output formatters.
             options.OutputFormatters.Add(new HttpNoContentOutputFormatter());
-            options.OutputFormatters.Add(new TextPlainFormatter());
+            options.OutputFormatters.Add(new StringOutputFormatter());
             options.OutputFormatters.Add(new JsonOutputFormatter());
             options.OutputFormatters.Add(
                 new XmlDataContractSerializerOutputFormatter(XmlOutputFormatter.GetDefaultXmlWriterSettings()));

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ActionResults/CreatedAtActionResultTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ActionResults/CreatedAtActionResultTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.AspNet.Mvc
                 {
                     return new List<IOutputFormatter>()
                             {
-                                new TextPlainFormatter(),
+                                new StringOutputFormatter(),
                                 new JsonOutputFormatter()
                             };
                 }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ActionResults/CreatedAtRouteResultTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ActionResults/CreatedAtRouteResultTests.cs
@@ -122,7 +122,7 @@ namespace Microsoft.AspNet.Mvc
                 {
                     return new List<IOutputFormatter>()
                             {
-                                new TextPlainFormatter(),
+                                new StringOutputFormatter(),
                                 new JsonOutputFormatter()
                             };
                 }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ActionResults/CreatedResultTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ActionResults/CreatedResultTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNet.Mvc
                 {
                     return new List<IOutputFormatter>()
                             {
-                                new TextPlainFormatter(),
+                                new StringOutputFormatter(),
                                 new JsonOutputFormatter()
                             };
                 }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ActionResults/ObjectResultTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ActionResults/ObjectResultTests.cs
@@ -557,7 +557,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test.ActionResults
                 {
                     return new List<IOutputFormatter>()
                         {
-                            new TextPlainFormatter(),
+                            new StringOutputFormatter(),
                             new JsonOutputFormatter()
                         };
                 }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/StringOutputFormatterTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/StringOutputFormatterTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNet.Mvc
         public void CanWriteResult_ReturnsTrueForStringTypes(object value, bool useDeclaredTypeAsString, bool expectedCanWriteResult)
         {
             // Arrange
-            var formatter = new TextPlainFormatter();
+            var formatter = new StringOutputFormatter();
             var typeToUse = useDeclaredTypeAsString ? typeof(string) : typeof(object);
             var formatterContext = new OutputFormatterContext()
             {
@@ -59,7 +59,7 @@ namespace Microsoft.AspNet.Mvc
             var mockHttpContext = new Mock<HttpContext>();
             mockHttpContext.Setup(o => o.Response).Returns(response.Object);
 
-            var formatter = new TextPlainFormatter();
+            var formatter = new StringOutputFormatter();
             var formatterContext = new OutputFormatterContext()
             {
                 Object = null,

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/OutputFormatterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/OutputFormatterTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         [InlineData("ReturnTaskOfObject_StringValue")]
         [InlineData("ReturnString")]
         [InlineData("ReturnObject_StringValue")]
-        public async Task TextPlainFormatter_ForStringValues_GetsSelectedReturnsTextPlainContentType(string actionName)
+        public async Task StringOutputFormatter_ForStringValues_GetsSelectedReturnsTextPlainContentType(string actionName)
         {
             // Arrange
             var server = TestServer.Create(_provider, _app);

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/RazorPageTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/RazorPageTest.cs
@@ -17,7 +17,9 @@ namespace Microsoft.AspNet.Mvc.Razor
 {
     public class RazorPageTest
     {
+#pragma warning disable 1998
         private readonly RenderAsyncDelegate _nullRenderAsyncDelegate = async writer => { };
+#pragma warning restore 1998
 
         [Fact]
         public async Task WritingScopesRedirectContentWrittenToViewContextWriter()

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/RazorViewTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/RazorViewTest.cs
@@ -16,7 +16,10 @@ namespace Microsoft.AspNet.Mvc.Razor
     public class RazorViewTest
     {
         private const string LayoutPath = "~/Shared/_Layout.cshtml";
+
+#pragma warning disable 1998
         private readonly RenderAsyncDelegate _nullRenderAsyncDelegate = async writer => { };
+#pragma warning restore 1998
 
         [Fact]
         public async Task RenderAsync_AsPartial_DoesNotBufferOutput()

--- a/test/Microsoft.AspNet.Mvc.Test/MvcOptionSetupTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Test/MvcOptionSetupTest.cs
@@ -85,7 +85,7 @@ namespace Microsoft.AspNet.Mvc
             // Assert
             Assert.Equal(4, mvcOptions.OutputFormatters.Count);
             Assert.IsType<HttpNoContentOutputFormatter>(mvcOptions.OutputFormatters[0].Instance);
-            Assert.IsType<TextPlainFormatter>(mvcOptions.OutputFormatters[1].Instance);
+            Assert.IsType<StringOutputFormatter>(mvcOptions.OutputFormatters[1].Instance);
             Assert.IsType<JsonOutputFormatter>(mvcOptions.OutputFormatters[2].Instance);
             Assert.IsType<XmlDataContractSerializerOutputFormatter>(mvcOptions.OutputFormatters[3].Instance);
         }


### PR DESCRIPTION
Rename `TextPlainFormatter` to `StringOutputFormatter`

And some minor cleanup along the way, including suppressing two build warnings in tests