### PR TITLE
Changing when controllers are created

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ActionContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionContext.cs
@@ -14,7 +14,6 @@ namespace Microsoft.AspNet.Mvc
             : this(actionContext.HttpContext, actionContext.RouteData, actionContext.ActionDescriptor)
         {
             ModelState = actionContext.ModelState;
-            Controller = actionContext.Controller;
         }
 
         public ActionContext([NotNull] RouteContext routeContext, [NotNull] ActionDescriptor actionDescriptor)
@@ -39,10 +38,5 @@ namespace Microsoft.AspNet.Mvc
         public ModelStateDictionary ModelState { get; private set; }
 
         public ActionDescriptor ActionDescriptor { get; private set; }
-
-        /// <summary>
-        /// The controller is available only after the controller factory runs.
-        /// </summary>
-        public object Controller { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ControllerActionInvoker.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ControllerActionInvoker.cs
@@ -50,21 +50,16 @@ namespace Microsoft.AspNet.Mvc
             }
         }
 
-        public async override Task InvokeAsync()
+        protected override object CreateInstance()
         {
             // The binding context is used in activation
             Debug.Assert(ActionBindingContext != null);
-            var controller = _controllerFactory.CreateController(ActionContext);
+            return _controllerFactory.CreateController(ActionContext);
+        }
 
-            try
-            {
-                ActionContext.Controller = controller;
-                await base.InvokeAsync();
-            }
-            finally
-            {
-                _controllerFactory.ReleaseController(ActionContext.Controller);
-            }
+        protected override void ReleaseInstance(object instance)
+        {
+            _controllerFactory.ReleaseController(instance);
         }
 
         protected override async Task<IActionResult> InvokeActionAsync(ActionExecutingContext actionExecutingContext)
@@ -72,7 +67,7 @@ namespace Microsoft.AspNet.Mvc
             var actionMethodInfo = _descriptor.MethodInfo;
             var actionReturnValue = await ControllerActionExecutor.ExecuteAsync(
                 actionMethodInfo,
-                ActionContext.Controller,
+                actionExecutingContext.Controller,
                 actionExecutingContext.ActionArguments);
 
             var actionResult = CreateActionResult(

--- a/src/Microsoft.AspNet.Mvc.Core/DefaultControllerFactory.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/DefaultControllerFactory.cs
@@ -37,7 +37,6 @@ namespace Microsoft.AspNet.Mvc
                 _serviceProvider,
                 actionDescriptor.ControllerTypeInfo.AsType());
 
-            actionContext.Controller = controller;
             _controllerActivator.Activate(controller, actionContext);
 
             return controller;

--- a/src/Microsoft.AspNet.Mvc.Core/Filters/ActionExecutedContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Filters/ActionExecutedContext.cs
@@ -14,12 +14,16 @@ namespace Microsoft.AspNet.Mvc
 
         public ActionExecutedContext(
             [NotNull] ActionContext actionContext,
-            [NotNull] IList<IFilter> filters)
+            [NotNull] IList<IFilter> filters,
+            object controller)
             : base(actionContext, filters)
         {
+            Controller = controller;
         }
 
         public virtual bool Canceled { get; set; }
+
+        public virtual object Controller { get; }
 
         public virtual Exception Exception
         {

--- a/src/Microsoft.AspNet.Mvc.Core/Filters/ActionExecutingContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Filters/ActionExecutingContext.cs
@@ -10,14 +10,18 @@ namespace Microsoft.AspNet.Mvc
         public ActionExecutingContext(
             [NotNull] ActionContext actionContext,
             [NotNull] IList<IFilter> filters,
-            [NotNull] IDictionary<string, object> actionArguments)
+            [NotNull] IDictionary<string, object> actionArguments,
+            object controller)
             : base(actionContext, filters)
         {
             ActionArguments = actionArguments;
+            Controller = controller;
         }
 
         public virtual IActionResult Result { get; set; }
 
-        public virtual IDictionary<string, object> ActionArguments { get; private set; }
+        public virtual IDictionary<string, object> ActionArguments { get; }
+
+        public virtual object Controller { get; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/Filters/ResultExecutedContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Filters/ResultExecutedContext.cs
@@ -15,13 +15,17 @@ namespace Microsoft.AspNet.Mvc
         public ResultExecutedContext(
             [NotNull] ActionContext actionContext,
             [NotNull] IList<IFilter> filters,
-            [NotNull] IActionResult result)
+            [NotNull] IActionResult result,
+            object controller)
             : base(actionContext, filters)
         {
             Result = result;
+            Controller = controller;
         }
 
         public virtual bool Canceled { get; set; }
+
+        public virtual object Controller { get; }
 
         public virtual Exception Exception
         {

--- a/src/Microsoft.AspNet.Mvc.Core/Filters/ResultExecutingContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Filters/ResultExecutingContext.cs
@@ -10,11 +10,15 @@ namespace Microsoft.AspNet.Mvc
         public ResultExecutingContext(
             [NotNull] ActionContext actionContext,
             [NotNull] IList<IFilter> filters,
-            [NotNull] IActionResult result)
+            [NotNull] IActionResult result,
+            object controller)
             : base(actionContext, filters)
         {
             Result = result;
+            Controller = controller;
         }
+
+        public virtual object Controller { get; }
 
         public virtual IActionResult Result { get; set; }
 

--- a/test/Microsoft.AspNet.Mvc.Core.Test/DefaultControllerActivatorTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/DefaultControllerActivatorTest.cs
@@ -29,10 +29,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
                        .Returns(services);
             var routeContext = new RouteContext(httpContext.Object);
             var controller = new TestController();
-            var context = new ActionContext(routeContext, new ActionDescriptor())
-            {
-                Controller = controller
-            };
+            var context = new ActionContext(routeContext, new ActionDescriptor());
             var activator = new DefaultControllerActivator();
 
             // Act
@@ -55,10 +52,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
                        .Returns(services);
             var routeContext = new RouteContext(httpContext.Object);
             var controller = new TestController();
-            var context = new ActionContext(routeContext, new ActionDescriptor())
-            {
-                Controller = controller
-            };
+            var context = new ActionContext(routeContext, new ActionDescriptor());
             var activator = new DefaultControllerActivator();
 
             // Act
@@ -83,10 +77,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
             var routeContext = new RouteContext(httpContext.Object);
 
             var controller = new TestController();
-            var context = new ActionContext(routeContext, new ActionDescriptor())
-            {
-                Controller = controller
-            };
+            var context = new ActionContext(routeContext, new ActionDescriptor());
 
             var activator = new DefaultControllerActivator();
 
@@ -109,10 +100,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
                        .Returns(services);
             var routeContext = new RouteContext(httpContext.Object);
             var controller = new TestController();
-            var context = new ActionContext(routeContext, new ActionDescriptor())
-            {
-                Controller = controller
-            };
+            var context = new ActionContext(routeContext, new ActionDescriptor());
             var activator = new DefaultControllerActivator();
 
             // Act
@@ -135,10 +123,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
                        .Returns(services);
             var routeContext = new RouteContext(httpContext.Object);
             var controller = new TestController();
-            var context = new ActionContext(routeContext, new ActionDescriptor())
-            {
-                Controller = controller
-            };
+            var context = new ActionContext(routeContext, new ActionDescriptor());
             var activator = new DefaultControllerActivator();
 
             // Act

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Filters/ActionFilterAttributeTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Filters/ActionFilterAttributeTests.cs
@@ -227,12 +227,13 @@ namespace Microsoft.AspNet.Mvc.Test
             return new ActionExecutingContext(
                 CreateActionContext(),
                 new IFilter[] { filter, },
-                new Dictionary<string, object>());
+                new Dictionary<string, object>(),
+                controller: new object());
         }
 
         private static ActionExecutedContext CreateActionExecutedContext(ActionExecutingContext context)
         {
-            return new ActionExecutedContext(context, context.Filters)
+            return new ActionExecutedContext(context, context.Filters, context.Controller)
             {
                 Result = context.Result,
             };
@@ -243,12 +244,13 @@ namespace Microsoft.AspNet.Mvc.Test
             return new ResultExecutingContext(
                 CreateActionContext(),
                 new IFilter[] { filter, },
-                new NoOpResult());
+                new NoOpResult(),
+                controller: new object());
         }
 
         private static ResultExecutedContext CreateResultExecutedContext(ResultExecutingContext context)
         {
-            return new ResultExecutedContext(context, context.Filters, context.Result);
+            return new ResultExecutedContext(context, context.Filters, context.Result, context.Controller);
         }
 
         private static ActionContext CreateActionContext()

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Filters/ProducesAttributeTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Filters/ProducesAttributeTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNet.Mvc.Test
 
         private static ResultExecutedContext CreateResultExecutedContext(ResultExecutingContext context)
         {
-            return new ResultExecutedContext(context, context.Filters, context.Result);
+            return new ResultExecutedContext(context, context.Filters, context.Result, context.Controller);
         }
 
         private static ResultExecutingContext CreateResultExecutingContext(IFilter filter)
@@ -70,7 +70,8 @@ namespace Microsoft.AspNet.Mvc.Test
             return new ResultExecutingContext(
                 CreateActionContext(),
                 new IFilter[] { filter, },
-                new ObjectResult("Some Value"));
+                new ObjectResult("Some Value"),
+                controller: new object());
         }
 
         private static ActionContext CreateActionContext()

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ParameterBinding/ControllerActionArgumentBinderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ParameterBinding/ControllerActionArgumentBinderTests.cs
@@ -185,12 +185,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
                 .Setup(b => b.BindModelAsync(It.IsAny<ModelBindingContext>()))
                 .Returns(Task.FromResult(result: false));
 
-            var actionContext = new ActionContext(
-                new RouteContext(Mock.Of<HttpContext>()),
-                actionDescriptor)
-            {
-                Controller = Mock.Of<object>(),
-            };
+            var actionContext = new ActionContext(new RouteContext(Mock.Of<HttpContext>()), actionDescriptor);
 
             var actionBindingContext = new ActionBindingContext()
             {
@@ -245,12 +240,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
                 })
                 .Returns(Task.FromResult(result: true));
 
-            var actionContext = new ActionContext(
-                new RouteContext(Mock.Of<HttpContext>()),
-                actionDescriptor)
-            {
-                Controller = Mock.Of<object>(),
-            };
+            var actionContext = new ActionContext(new RouteContext(Mock.Of<HttpContext>()), actionDescriptor);
 
             var actionBindingContext = new ActionBindingContext()
             {

--- a/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/HttpResponseExceptionActionFilterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/HttpResponseExceptionActionFilterTest.cs
@@ -34,12 +34,17 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShim
         {
             // Arrange
             var filter = new HttpResponseExceptionActionFilter();
-            var context = new ActionExecutingContext(new ActionContext(
-                            new DefaultHttpContext(),
-                            new RouteData(),
-                            actionDescriptor: Mock.Of<ActionDescriptor>()),
-                            filters: Mock.Of<IList<IFilter>>(),
-                            actionArguments: new Dictionary<string, object>());
+
+            var actionContext = new ActionContext(
+                                new DefaultHttpContext(),
+                                new RouteData(),
+                                Mock.Of<ActionDescriptor>());
+
+            var context = new ActionExecutingContext(
+                actionContext,
+                filters: new List<IFilter>(),
+                actionArguments: new Dictionary<string, object>(),
+                controller: new object());
 
             // Act
             filter.OnActionExecuting(context);
@@ -56,12 +61,16 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShim
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Method = "GET";
 
+            var actionContext = new ActionContext(
+                                new DefaultHttpContext(),
+                                new RouteData(),
+                                Mock.Of<ActionDescriptor>());
+
             var context = new ActionExecutedContext(
-                new ActionContext(
-                            httpContext,
-                            new RouteData(),
-                            actionDescriptor: Mock.Of<ActionDescriptor>()),
-                filters: null);
+                actionContext,
+                filters: new List<IFilter>(),
+                controller: new object());
+
             context.Exception = new HttpResponseException(HttpStatusCode.BadRequest);
 
             // Act


### PR DESCRIPTION
This change moves controller creation to the stage immediately before
model binding. The controller will be disposed/released before Resource
Filters run their 'OnResourceExecuted' method. Previously the controller's
lifetime surrounded all filter invocation.

Additionally, the Controller property is now gone from ActionContext, and
is moved to the 4 filter contexts that should have access to it
Action*Context and Result*Context.