### PR TITLE
Some cleanup of ActionResults - #657

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/ContentResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/ContentResult.cs
@@ -15,6 +15,11 @@ namespace Microsoft.AspNet.Mvc
 
         public string ContentType { get; set; }
 
+        /// <summary>
+        /// Gets or sets the HTTP status code.
+        /// </summary>
+        public int? StatusCode { get; set; }
+
         public override async Task ExecuteResultAsync([NotNull] ActionContext context)
         {
             var response = context.HttpContext.Response;
@@ -22,6 +27,11 @@ namespace Microsoft.AspNet.Mvc
             if (!string.IsNullOrEmpty(ContentType))
             {
                 response.ContentType = ContentType;
+            }
+
+            if (StatusCode != null)
+            {
+                response.StatusCode = StatusCode.Value;
             }
 
             if (Content != null)

--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/CreatedAtActionResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/CreatedAtActionResult.cs
@@ -41,17 +41,17 @@ namespace Microsoft.AspNet.Mvc
         /// <summary>
         /// Gets the name of the action to use for generating the URL.
         /// </summary>
-        public string ActionName { get; private set; }
+        public string ActionName { get; set; }
 
         /// <summary>
         /// Gets the name of the controller to use for generating the URL.
         /// </summary>
-        public string ControllerName { get; private set; }
+        public string ControllerName { get; set; }
 
         /// <summary>
         /// Gets the route data to use for generating the URL.
         /// </summary>
-        public IDictionary<string, object> RouteValues { get; private set; }
+        public IDictionary<string, object> RouteValues { get; set; }
 
         /// <inheritdoc />
         protected override void OnFormatting([NotNull] ActionContext context)

--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/CreatedAtRouteResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/CreatedAtRouteResult.cs
@@ -49,12 +49,12 @@ namespace Microsoft.AspNet.Mvc
         /// <summary>
         /// Gets the name of the route to use for generating the URL.
         /// </summary>
-        public string RouteName { get; private set; }
+        public string RouteName { get; set; }
 
         /// <summary>
         /// Gets the route data to use for generating the URL.
         /// </summary>
-        public IDictionary<string, object> RouteValues { get; private set; }
+        public IDictionary<string, object> RouteValues { get; set; }
 
         /// <inheritdoc />
         protected override void OnFormatting([NotNull] ActionContext context)

--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/CreatedResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/CreatedResult.cs
@@ -10,6 +10,8 @@ namespace Microsoft.AspNet.Mvc
     /// </summary>
     public class CreatedResult : ObjectResult
     {
+        private string _location;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CreatedResult"/> class with the values
         /// provided.
@@ -26,7 +28,22 @@ namespace Microsoft.AspNet.Mvc
         /// <summary>
         /// Gets the location at which the content has been created.
         /// </summary>
-        public string Location { get; private set; }
+        public string Location
+        {
+            get
+            {
+                return _location;
+            }
+            set
+            {
+                if (_location == null)
+                {
+                    throw new ArgumentNullException("value");
+                }
+
+                _location = value;
+            }
+        }
 
         /// <inheritdoc />
         protected override void OnFormatting([NotNull] ActionContext context)

--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/FileContentResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/FileContentResult.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
@@ -13,6 +14,8 @@ namespace Microsoft.AspNet.Mvc
     /// </summary>
     public class FileContentResult : FileResult
     {
+        private byte[] _fileContents;
+
         /// <summary>
         /// Creates a new <see cref="FileContentResult"/> instance with
         /// the provided <paramref name="fileContents"/> and the
@@ -29,7 +32,22 @@ namespace Microsoft.AspNet.Mvc
         /// <summary>
         /// Gets the file contents.
         /// </summary>
-        public byte[] FileContents { get; private set; }
+        public byte[] FileContents
+        {
+            get
+            {
+                return _fileContents;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException("value");
+                }
+
+                _fileContents = value;
+            }
+        }
 
         /// <inheritdoc />
         protected override Task WriteFileAsync(HttpResponse response, CancellationToken cancellation)

--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/FilePathResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/FilePathResult.cs
@@ -23,6 +23,8 @@ namespace Microsoft.AspNet.Mvc
     {
         private const int DefaultBufferSize = 0x1000;
 
+        private string _fileName;
+
         /// <summary>
         /// Creates a new <see cref="FilePathResult"/> instance with
         /// the provided <paramref name="fileName"/> and the
@@ -48,7 +50,7 @@ namespace Microsoft.AspNet.Mvc
         public FilePathResult(
             [NotNull] string fileName,
             [NotNull] string contentType,
-            [NotNull] IFileSystem fileSystem)
+            IFileSystem fileSystem)
             : base(contentType)
         {
             FileName = fileName;
@@ -58,12 +60,27 @@ namespace Microsoft.AspNet.Mvc
         /// <summary>
         /// Gets the path to the file that will be sent back as the response.
         /// </summary>
-        public string FileName { get; private set; }
+        public string FileName
+        {
+            get
+            {
+                return _fileName;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException("value");
+                }
+
+                _fileName = value;
+            }
+        }
 
         /// <summary>
         /// Gets the <see cref="IFileSystem"/> used to resolve paths.
         /// </summary>
-        public IFileSystem FileSystem { get; private set; }
+        public IFileSystem FileSystem { get; set; }
 
         /// <inheritdoc />
         protected override Task WriteFileAsync(HttpResponse response, CancellationToken cancellation)

--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/FileResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/FileResult.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNet.Mvc
         /// <summary>
         /// Gets the Content-Type header value that will be written to the response.
         /// </summary>
-        public string ContentType { get; private set; }
+        public string ContentType { get; set; }
 
         /// <summary>
         /// Gets the file name that will be used in the Content-Disposition header of the response.

--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/FileStreamResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/FileStreamResult.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,6 +18,8 @@ namespace Microsoft.AspNet.Mvc
         // default buffer size as defined in BufferedStream type
         private const int BufferSize = 0x1000;
 
+        private Stream _fileStream;
+
         /// <summary>
         /// Creates a new <see cref="FileStreamResult"/> instance with
         /// the provided <paramref name="fileStream"/> and the
@@ -24,7 +27,7 @@ namespace Microsoft.AspNet.Mvc
         /// </summary>
         /// <param name="fileStream">The stream with the file.</param>
         /// <param name="contentType">The Content-Type header of the response.</param>
-        public FileStreamResult([NotNull] Stream fileStream, string contentType)
+        public FileStreamResult([NotNull] Stream fileStream, [NotNull] string contentType)
             : base(contentType)
         {
             FileStream = fileStream;
@@ -33,7 +36,22 @@ namespace Microsoft.AspNet.Mvc
         /// <summary>
         /// Gets the stream with the file that will be sent back as the response.
         /// </summary>
-        public Stream FileStream { get; private set; }
+        public Stream FileStream
+        {
+            get
+            {
+                return _fileStream;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException("value");
+                }
+
+                _fileStream = value;
+            }
+        }
 
         /// <inheritdoc />
         protected async override Task WriteFileAsync(HttpResponse response, CancellationToken cancellation)

--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/JsonResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/JsonResult.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Framework.DependencyInjection;
@@ -56,6 +57,11 @@ namespace Microsoft.AspNet.Mvc
         public IOutputFormatter Formatter { get; set; }
 
         /// <summary>
+        /// Gets or sets the HTTP status code.
+        /// </summary>
+        public int? StatusCode { get; set; }
+
+        /// <summary>
         /// Gets or sets the value to be formatted.
         /// </summary>
         public object Value { get; set; }
@@ -87,6 +93,13 @@ namespace Microsoft.AspNet.Mvc
             };
 
             var formatter = SelectFormatter(objectResult, formatterContext);
+            Debug.Assert(formatter != null);
+
+            if (StatusCode != null)
+            {
+                context.HttpContext.Response.StatusCode = StatusCode.Value;
+            }
+
             await formatter.WriteAsync(formatterContext);
         }
 

--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/NoContentResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/NoContentResult.cs
@@ -1,23 +1,13 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if ASPNET50
-using System.Net;
-#endif
-
 namespace Microsoft.AspNet.Mvc
 {
-    public class NoContentResult : ActionResult
+    public class NoContentResult : HttpStatusCodeResult
     {
-        public override void ExecuteResult([NotNull] ActionContext context)
+        public NoContentResult()
+            : base(204)
         {
-            var response = context.HttpContext.Response;
-
-#if ASPNET50
-            response.StatusCode = (int)HttpStatusCode.NoContent;
-#else
-            response.StatusCode = 204;
-#endif
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/PartialViewResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/PartialViewResult.cs
@@ -14,6 +14,11 @@ namespace Microsoft.AspNet.Mvc
     public class PartialViewResult : ActionResult
     {
         /// <summary>
+        /// Gets or sets the HTTP status code.
+        /// </summary>
+        public int? StatusCode { get; set; }
+
+        /// <summary>
         /// Gets or sets the name of the partial view to render.
         /// </summary>
         /// <remarks>
@@ -43,6 +48,11 @@ namespace Microsoft.AspNet.Mvc
             var view = viewEngine.FindPartialView(context, viewName)
                                  .EnsureSuccessful()
                                  .View;
+
+            if (StatusCode != null)
+            {
+                context.HttpContext.Response.StatusCode = StatusCode.Value;
+            }
 
             using (view as IDisposable)
             {

--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/RedirectResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/RedirectResult.cs
@@ -25,24 +25,29 @@ namespace Microsoft.AspNet.Mvc
             Url = url;
         }
 
-        public bool Permanent { get; private set; }
+        public bool Permanent { get; set; }
 
-        public string Url { get; private set; }
+        public string Url { get; set; }
+
+        public IUrlHelper UrlHelper { get; set; }
 
         public override void ExecuteResult([NotNull] ActionContext context)
         {
-            var destinationUrl = Url;
-            var urlHelper = context.HttpContext
-                                   .RequestServices
-                                   .GetRequiredService<IUrlHelper>();
+            var urlHelper = GetUrlHelper(context);
 
             // IsLocalUrl is called to handle  Urls starting with '~/'.
+            var destinationUrl = Url;
             if (urlHelper.IsLocalUrl(destinationUrl))
             {
                 destinationUrl = urlHelper.Content(Url);
             }
 
             context.HttpContext.Response.Redirect(destinationUrl, Permanent);
+        }
+
+        private IUrlHelper GetUrlHelper(ActionContext context)
+        {
+            return UrlHelper ?? context.HttpContext.RequestServices.GetRequiredService<IUrlHelper>();
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/RedirectToActionResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/RedirectToActionResult.cs
@@ -4,47 +4,58 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNet.Mvc.Core;
+using Microsoft.Framework.DependencyInjection;
 
 namespace Microsoft.AspNet.Mvc
 {
     public class RedirectToActionResult : ActionResult
     {
-        public RedirectToActionResult([NotNull] IUrlHelper urlHelper, string actionName,
-                                            string controllerName, IDictionary<string, object> routeValues)
-            : this(urlHelper, actionName, controllerName, routeValues, permanent: false)
+        public RedirectToActionResult(
+            string actionName,
+            string controllerName,
+            IDictionary<string, object> routeValues)
+            : this(actionName, controllerName, routeValues, permanent: false)
         {
         }
 
-        public RedirectToActionResult([NotNull] IUrlHelper urlHelper, string actionName,
-                                        string controllerName, IDictionary<string, object> routeValues, bool permanent)
+        public RedirectToActionResult(
+            string actionName,
+            string controllerName,
+            IDictionary<string, object> routeValues,
+            bool permanent)
         {
-            UrlHelper = urlHelper;
             ActionName = actionName;
             ControllerName = controllerName;
             RouteValues = routeValues;
             Permanent = permanent;
         }
 
-        public IUrlHelper UrlHelper { get; private set; }
+        public IUrlHelper UrlHelper { get; set; }
 
-        public string ActionName { get; private set; }
+        public string ActionName { get; set; }
 
-        public string ControllerName { get; private set; }
+        public string ControllerName { get; set; }
 
-        public IDictionary<string, object> RouteValues { get; private set; }
+        public IDictionary<string, object> RouteValues { get; set; }
 
-        public bool Permanent { get; private set; }
+        public bool Permanent { get; set; }
 
         public override void ExecuteResult([NotNull] ActionContext context)
         {
-            var destinationUrl = UrlHelper.Action(ActionName, ControllerName, RouteValues);
+            var urlHelper = GetUrlHelper(context);
 
+            var destinationUrl = urlHelper.Action(ActionName, ControllerName, RouteValues);
             if (string.IsNullOrEmpty(destinationUrl))
             {
                 throw new InvalidOperationException(Resources.NoRoutesMatched);
             }
 
             context.HttpContext.Response.Redirect(destinationUrl, Permanent);
+        }
+
+        private IUrlHelper GetUrlHelper(ActionContext context)
+        {
+            return UrlHelper ?? context.HttpContext.RequestServices.GetRequiredService<IUrlHelper>();
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/RedirectToRouteResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/RedirectToRouteResult.cs
@@ -4,53 +4,58 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNet.Mvc.Core;
+using Microsoft.Framework.DependencyInjection;
 
 namespace Microsoft.AspNet.Mvc
 {
     public class RedirectToRouteResult : ActionResult
     {
-        public RedirectToRouteResult([NotNull] IUrlHelper urlHelper,
-                                     object routeValues)
-            : this(urlHelper, routeName: null, routeValues: routeValues)
+        public RedirectToRouteResult(object routeValues)
+            : this(routeName: null, routeValues: routeValues)
         {
         }
 
-        public RedirectToRouteResult([NotNull] IUrlHelper urlHelper,
-                                     string routeName,
-                                     object routeValues)
-            : this(urlHelper, routeName, routeValues, permanent: false)
+        public RedirectToRouteResult(
+            string routeName,
+            object routeValues)
+            : this(routeName, routeValues, permanent: false)
         {
         }
 
-        public RedirectToRouteResult([NotNull] IUrlHelper urlHelper,
-                                     string routeName,
-                                     object routeValues,
-                                     bool permanent)
+        public RedirectToRouteResult(
+            string routeName,
+            object routeValues,
+            bool permanent)
         {
-            UrlHelper = urlHelper;
             RouteName = routeName;
             RouteValues = TypeHelper.ObjectToDictionary(routeValues);
             Permanent = permanent;
         }
 
-        public IUrlHelper UrlHelper { get; private set; }
+        public IUrlHelper UrlHelper { get; set; }
 
-        public string RouteName { get; private set; }
+        public string RouteName { get; set; }
 
-        public IDictionary<string, object> RouteValues { get; private set; }
+        public IDictionary<string, object> RouteValues { get; set; }
 
-        public bool Permanent { get; private set; }
+        public bool Permanent { get; set; }
 
         public override void ExecuteResult([NotNull] ActionContext context)
         {
-            var destinationUrl = UrlHelper.RouteUrl(RouteValues);
+            var urlHelper = GetUrlHelper(context);
 
+            var destinationUrl = urlHelper.RouteUrl(RouteValues);
             if (string.IsNullOrEmpty(destinationUrl))
             {
                 throw new InvalidOperationException(Resources.NoRoutesMatched);
             }
 
             context.HttpContext.Response.Redirect(destinationUrl, Permanent);
+        }
+
+        private IUrlHelper GetUrlHelper(ActionContext context)
+        {
+            return UrlHelper ?? context.HttpContext.RequestServices.GetRequiredService<IUrlHelper>();
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/ViewResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/ViewResult.cs
@@ -14,6 +14,11 @@ namespace Microsoft.AspNet.Mvc
     public class ViewResult : ActionResult
     {
         /// <summary>
+        /// Gets or sets the HTTP status code.
+        /// </summary>
+        public int? StatusCode { get; set; }
+
+        /// <summary>
         /// Gets or sets the name of the view to render.
         /// </summary>
         /// <remarks>
@@ -43,6 +48,11 @@ namespace Microsoft.AspNet.Mvc
             var view = viewEngine.FindView(context, viewName)
                                  .EnsureSuccessful()
                                  .View;
+
+            if (StatusCode != null)
+            {
+                context.HttpContext.Response.StatusCode = StatusCode.Value;
+            }
 
             using (view as IDisposable)
             {

--- a/src/Microsoft.AspNet.Mvc.Core/Controller.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Controller.cs
@@ -394,8 +394,10 @@ namespace Microsoft.AspNet.Mvc
         public virtual RedirectToActionResult RedirectToAction(string actionName, string controllerName,
                                         object routeValues)
         {
-            return new RedirectToActionResult(Url, actionName, controllerName,
-                                                TypeHelper.ObjectToDictionary(routeValues));
+            return new RedirectToActionResult(actionName, controllerName, TypeHelper.ObjectToDictionary(routeValues))
+            {
+                UrlHelper = Url,
+            };
         }
 
         /// <summary>
@@ -449,8 +451,14 @@ namespace Microsoft.AspNet.Mvc
         public virtual RedirectToActionResult RedirectToActionPermanent(string actionName, string controllerName,
                                         object routeValues)
         {
-            return new RedirectToActionResult(Url, actionName, controllerName,
-                                                TypeHelper.ObjectToDictionary(routeValues), permanent: true);
+            return new RedirectToActionResult(
+                actionName,
+                controllerName,
+                TypeHelper.ObjectToDictionary(routeValues),
+                permanent: true)
+            {
+                UrlHelper = Url,
+            };
         }
 
         /// <summary>
@@ -485,7 +493,10 @@ namespace Microsoft.AspNet.Mvc
         [NonAction]
         public virtual RedirectToRouteResult RedirectToRoute(string routeName, object routeValues)
         {
-            return new RedirectToRouteResult(Url, routeName, routeValues);
+            return new RedirectToRouteResult(routeName, routeValues)
+            {
+                UrlHelper = Url,
+            };
         }
 
         /// <summary>
@@ -522,7 +533,10 @@ namespace Microsoft.AspNet.Mvc
         [NonAction]
         public virtual RedirectToRouteResult RedirectToRoutePermanent(string routeName, object routeValues)
         {
-            return new RedirectToRouteResult(Url, routeName, routeValues, permanent: true);
+            return new RedirectToRouteResult(routeName, routeValues, permanent: true)
+            {
+                UrlHelper = Url,
+            };
         }
 
         /// <summary>


### PR DESCRIPTION
In general all properties are get/set so filters can change them.
 - some validate for not-null
 - where we use services it's get/set also

Services are resolved in the Execute method if not provided.

A few more ActionResults that return a body have the ability to set a
status code now (optional).