### PR TITLE
Change `ValidationSummaryTagHelper`'s property to `ValidationSummary` enum

### DIFF
--- a/samples/TagHelperSample.Web/Views/Home/Create.cshtml
+++ b/samples/TagHelperSample.Web/Views/Home/Create.cshtml
@@ -14,13 +14,14 @@
     <div class="form-horizontal">
         @* validation summary tag helper will target just <div/> elements and append the list of errors *@
         @* - i.e. this helper, like <select/> helper, has ContentBehavior.Append *@
-        @* helper does nothing if model is valid and (client-side validation is disabled or asp-validation-summary="ModelOnly") *@
+        @* helper does nothing if model is valid and (client-side validation is disabled or
+           asp-validation-summary="ValidationSummary.ModelOnly") *@
         @* don't need a bound attribute to match Html.ValidationSummary()'s headerTag parameter; users wrap message as they wish *@
         @* initially at least, will not remove the <div/> if list isn't generated *@
         @* - should helper remove the <div/> if list isn't generated? *@
         @* - (Html.ValidationSummary returns empty string despite non-empty message parameter) *@
         @* Acceptable values are: "None", "ModelOnly" and "All" *@
-        <div asp-validation-summary="All" style="color:blue" id="validation_day" class="form-group">
+        <div asp-validation-summary="ValidationSummary.All" style="color:blue" id="validation_day" class="form-group">
             <span style="color:red">This is my message</span>
         </div>
 

--- a/samples/TagHelperSample.Web/Views/Home/Edit.cshtml
+++ b/samples/TagHelperSample.Web/Views/Home/Edit.cshtml
@@ -6,7 +6,7 @@
 
 <form>
     <div class="form-horizontal">
-        <div asp-validation-summary="All" />
+        <div asp-validation-summary="ValidationSummary.All" />
         <input type="hidden" asp-for="Id" />
 
         <div class="form-group">

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/Properties/Resources.Designer.cs
@@ -154,6 +154,22 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             return string.Format(CultureInfo.CurrentCulture, GetString("TagHelpers_NoProvidedMetadata"), p0, p1, p2, p3);
         }
 
+        /// <summary>
+        /// The value of argument '{0}' ({1}) is invalid for Enum type '{2}'.
+        /// </summary>
+        internal static string InvalidEnumArgument
+        {
+            get { return GetString("InvalidEnumArgument"); }
+        }
+
+        /// <summary>
+        /// The value of argument '{0}' ({1}) is invalid for Enum type '{2}'.
+        /// </summary>
+        internal static string FormatInvalidEnumArgument(object p0, object p1, object p2)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("InvalidEnumArgument"), p0, p1, p2);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/Resources.resx
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/Resources.resx
@@ -144,4 +144,7 @@
   <data name="TagHelpers_NoProvidedMetadata" xml:space="preserve">
     <value>The {2} was unable to provide metadata about '{1}' expression value '{3}' for {0}.</value>
   </data>
+  <data name="InvalidEnumArgument" xml:space="preserve">
+    <value>The value of argument '{0}' ({1}) is invalid for Enum type '{2}'.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationSummary.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationSummary.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.AspNet.Mvc.TagHelpers
+namespace Microsoft.AspNet.Mvc
 {
     /// <summary>
     /// Acceptable validation summary rendering modes.

--- a/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/CreateWarehouse.cshtml
+++ b/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/CreateWarehouse.cshtml
@@ -20,7 +20,7 @@
             <select asp-for="Product" asp-items="(IEnumerable<SelectListItem>)ViewBag.Items" />
             <span asp-validation-for="Product" />
         </div>
-        <div asp-validation-summary="All" class="warehouse" />
+        <div asp-validation-summary="ValidationSummary.All" class="warehouse" />
         <input type="submit" />
     }
 </body>

--- a/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/Order.cshtml
+++ b/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/Order.cshtml
@@ -75,7 +75,7 @@
             @Html.EditorFor(model => model.Customer.Gender)
             <span asp-validation-for="Customer.Gender" />
         </div>
-        <div asp-validation-summary="All" class="order" />
+        <div asp-validation-summary="ValidationSummary.All" class="order" />
         <input type="hidden" asp-for="Customer.Key" />
         <input type="submit" />
     </form>

--- a/test/WebSites/MvcTagHelpersWebSite/Views/Shared/Customer.cshtml
+++ b/test/WebSites/MvcTagHelpersWebSite/Views/Shared/Customer.cshtml
@@ -38,8 +38,8 @@
             <input asp-for="Gender" type="radio" value="Female" /> Female
             <span asp-validation-for="Gender" />
         </div>
-        <div asp-validation-summary="All" class="order" />
-        <div asp-validation-summary="ModelOnly" class="order" />
+        <div asp-validation-summary="ValidationSummary.All" class="order" />
+        <div asp-validation-summary="ValidationSummary.ModelOnly" class="order" />
         <input type="submit" />
     </form>
 </body>

--- a/test/WebSites/TagHelpersWebSite/Views/Employee/Create.cshtml
+++ b/test/WebSites/TagHelpersWebSite/Views/Employee/Create.cshtml
@@ -22,7 +22,7 @@
         <div class="form-horizontal">
             <h4>Employee</h4>
             <hr />
-            <div asp-validation-summary="All" class="text-danger">
+            <div asp-validation-summary="ValidationSummary.All" class="text-danger">
             </div>
             <div class="form-group">
                 <label asp-for="Age" class="control-label col-md-2" />


### PR DESCRIPTION
- #1685
- update tests and samples to match
- remove tests for case-insensitivity and invalid property values

Note .cshtml author is responsible for adding `@using Microsoft.AspNet.Mvc.TagHelpers`
- Microsoft.AspNet.Mvc.TagHelpers has no startup code and `MvcRazorHost` does
  not read `MvcOptions` anyhow