### PR TITLE
Correct `CheckBoxFor` to ignore `ViewData`

### DIFF
--- a/samples/MvcSample.Web/HomeController.cs
+++ b/samples/MvcSample.Web/HomeController.cs
@@ -89,6 +89,8 @@ namespace MvcSample.Web
         /// </summary>
         public ActionResult SaveUser(User user)
         {
+            ViewData["Alive"] = true;
+            ViewData["Dependent.Alive"] = true;
             return View("MyView", user);
         }
 
@@ -117,6 +119,8 @@ namespace MvcSample.Web
         /// </summary>
         public ActionResult Post([FromBody]User user)
         {
+            ViewData["Alive"] = true;
+            ViewData["Dependent.Alive"] = true;
             return View("MyView", user);
         }
 

--- a/samples/MvcSample.Web/Views/Shared/MyView.cshtml
+++ b/samples/MvcSample.Web/Views/Shared/MyView.cshtml
@@ -182,19 +182,19 @@
                     </td>
                 </tr>
                 <tr>
-                    <td>
-                        @Html.Label("Alive")
-                    </td>
-                    <td>
-                        @Html.CheckBox("Alive")
-                        or
-                        @Html.RadioButton("Alive", value: false) False
-                        @Html.RadioButton("Alive", value: true) True
-                    </td>
+                <td>
+                    @Html.LabelFor(m => m.Alive)
+                </td>
+                <td>
+                    @Html.CheckBoxFor(m => m.Alive)
+                    or
+                    @Html.RadioButtonFor(m => m.Alive, value: false) False
+                    @Html.RadioButtonFor(m => m.Alive, value: true) True
+                </td>
                 </tr>
                 <tr>
                     <td>
-                        @Html.LabelFor(m => m.Dependent.Alive)
+                        @Html.LabelFor(m => m.Dependent.Alive, labelText: "Dependent Alive?")
                     </td>
                     <td>
                         @Html.CheckBoxFor(m => m.Dependent.Alive)

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/DefaultHtmlGenerator.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/DefaultHtmlGenerator.cs
@@ -123,7 +123,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 metadata,
                 name,
                 value: "true",
-                useViewData: !explicitValue,
+                useViewData: (metadata == null && !explicitValue),
                 isChecked: isChecked ?? false,
                 setId: true,
                 isExplicitValue: false,

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Rendering/HtmlHelperCheckboxTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Rendering/HtmlHelperCheckboxTest.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Microsoft.AspNet.Mvc.Rendering
 {
-    public class HtmlHelperCheckboxTest
+    public class HtmlHelperCheckBoxTest
     {
         [Fact]
         public void CheckBoxOverridesCalculatedValuesWithValuesFromHtmlAttributes()
@@ -214,16 +214,46 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         [Fact]
-        public void CheckBoxForWithInvalidBooleanThrows()
+        public void CheckBoxForWithNullContainer_TreatsBooleanAsFalse()
         {
             // Arrange
-            var expected = "String was not recognized as a valid Boolean.";
-            var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetTestModelViewData());
+            var expected = @"<input id=""Property1"" name=""Property1"" type=""checkbox"" value=""true"" />" +
+                           @"<input name=""Property1"" type=""hidden"" value=""false"" />";
+            var viewData = GetTestModelViewData();
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper(viewData);
+            var valueProviderResult = new ValueProviderResult("false", "false", CultureInfo.InvariantCulture);
+            viewData.ModelState.SetModelValue("Property1", valueProviderResult);
 
-            // Act & Assert
-            // "Property2" in ViewData isn't a valid boolean
-            var ex = Assert.Throws<FormatException>(() => helper.CheckBoxFor(m => m.Property2));
-            Assert.Equal(expected, ex.Message);
+            // Act
+            var html = helper.CheckBoxFor(m => m.Property1);
+
+            // Assert
+            Assert.Equal(expected, html.ToString());
+        }
+
+        [Theory]
+        [InlineData(false, "")]
+        [InlineData(true, "checked=\"checked\" ")]
+        public void CheckBoxForWithNonNullContainer_UsesPropertyValue(bool value, string expectedChecked)
+        {
+            // Arrange
+            var expected = @"<input {0}id=""Property1"" name=""Property1"" type=""checkbox"" value=""true"" />" +
+                           @"<input name=""Property1"" type=""hidden"" value=""false"" />";
+            expected = string.Format(expected, expectedChecked);
+
+            var viewData = GetTestModelViewData();
+            viewData.Model = new TestModel
+            {
+                Property1 = value,
+            };
+
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper(viewData);
+
+            // Act
+            var html = helper.CheckBoxFor(m => m.Property1);
+
+            // Assert
+            Assert.Equal(expected, html.ToString());
         }
 
         [Fact]
@@ -262,15 +292,20 @@ namespace Microsoft.AspNet.Mvc.Rendering
             Assert.Equal(expected, html.ToString());
         }
 
-        [Fact]
-        public void CheckBoxForUsesModelStateAttemptedValue()
+        [Theory]
+        [InlineData("false", "")]
+        [InlineData("true", "checked=\"checked\" ")]
+        public void CheckBoxFor_UsesModelStateAttemptedValue(string attemptedValue, string expectedChecked)
         {
             // Arrange
-            var expected = @"<input id=""Property1"" name=""Property1"" type=""checkbox"" value=""true"" />" +
+            var expected = @"<input {0}id=""Property1"" name=""Property1"" type=""checkbox"" value=""true"" />" +
                            @"<input name=""Property1"" type=""hidden"" value=""false"" />";
+            expected = string.Format(expected, expectedChecked);
+
             var viewData = GetTestModelViewData();
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(viewData);
-            var valueProviderResult = new ValueProviderResult("false", "false", CultureInfo.InvariantCulture);
+            var valueProviderResult =
+                new ValueProviderResult(attemptedValue, attemptedValue, CultureInfo.InvariantCulture);
             viewData.ModelState.SetModelValue("Property1", valueProviderResult);
 
             // Act
@@ -281,10 +316,10 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         [Fact]
-        public void CheckBoxForWithObjectAttributeWithUnderscores()
+        public void CheckBoxFor_WithObjectAttribute_MapsUnderscoresInNamesToDashes()
         {
             // Arrange
-            var expected = @"<input checked=""checked"" id=""Property1"" name=""Property1"" " +
+            var expected = @"<input id=""Property1"" name=""Property1"" " +
                            @"Property1-Property3=""Property3ObjValue"" type=""checkbox"" value=""true"" /><input " +
                            @"name=""Property1"" type=""hidden"" value=""false"" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetTestModelViewData());
@@ -298,10 +333,10 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         [Fact]
-        public void CheckBoxForWithAttributeDictionary()
+        public void CheckBoxForWith_AttributeDictionary_GeneratesExpectedAttributes()
         {
             // Arrange
-            var expected = @"<input checked=""checked"" id=""Property1"" name=""Property1"" " +
+            var expected = @"<input id=""Property1"" name=""Property1"" " +
                            @"Property3=""Property3Value"" type=""checkbox"" value=""true"" /><input " +
                            @"name=""Property1"" type=""hidden"" value=""false"" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetTestModelViewData());
@@ -333,10 +368,10 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         [Fact]
-        public void CheckboxForWithComplexExpressionsUsesValuesFromViewDataDictionary()
+        public void CheckBoxFor_WithComplexExpressions_DoesNotUseValuesFromViewDataDictionary()
         {
             // Arrange
-            var expected = @"<input checked=""checked"" id=""ComplexProperty_Property1"" name=""ComplexProperty." +
+            var expected = @"<input id=""ComplexProperty_Property1"" name=""ComplexProperty." +
                         @"Property1"" type=""checkbox"" value=""true"" /><input name=""ComplexProperty.Property1"" " +
                         @"type=""hidden"" value=""false"" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetModelWithValidationViewData());


### PR DESCRIPTION
- #1483
- update tests to match
- also demonstrate problem (then fix) in MVC sample

nits:
- cover a couple more `CheckBoxFor` test cases
- capitalize "CheckBox" consistently