### PR TITLE
Fix for #1538 and #1891

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/MvcOptions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/MvcOptions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Microsoft.AspNet.Mvc.ApplicationModels;
 using Microsoft.AspNet.Mvc.Core;
 using Microsoft.AspNet.Mvc.OptionDescriptors;
+using Microsoft.AspNet.Mvc.ModelBinding;
 
 namespace Microsoft.AspNet.Mvc
 {
@@ -15,7 +16,7 @@ namespace Microsoft.AspNet.Mvc
     public class MvcOptions
     {
         private AntiForgeryOptions _antiForgeryOptions = new AntiForgeryOptions();
-        private int _maxModelStateErrors = 200;
+        private int _maxModelStateErrors = ModelStateDictionary.DefaultMaxAllowedErrors;
 
         public MvcOptions()
         {

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/ModelStateDictionary.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/ModelStateDictionary.cs
@@ -15,13 +15,30 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
     /// </summary>
     public class ModelStateDictionary : IDictionary<string, ModelState>
     {
+        // Make sure to update the doc headers if this value is changed.
+        /// <summary>
+        /// The default value for <see cref="MaxAllowedErrors"/> of <c>200</c>.
+        /// </summary>
+        public static readonly int DefaultMaxAllowedErrors = 200;
+
         private readonly IDictionary<string, ModelState> _innerDictionary;
+        private int _maxAllowedErrors;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelStateDictionary"/> class.
         /// </summary>
         public ModelStateDictionary()
+            : this(DefaultMaxAllowedErrors)
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModelStateDictionary"/> class.
+        /// </summary>
+        public ModelStateDictionary(int maxAllowedErrors)
+        {
+            MaxAllowedErrors = maxAllowedErrors;
+
             _innerDictionary = new Dictionary<string, ModelState>(StringComparer.OrdinalIgnoreCase);
         }
 
@@ -41,29 +58,50 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         }
 
         /// <summary>
-        /// Gets or sets the maximum allowed errors in this instance of <see cref="ModelStateDictionary"/>.
-        /// Defaults to <see cref="int.MaxValue"/>.
+        /// Gets or sets the maximum allowed model state errors in this instance of <see cref="ModelStateDictionary"/>.
+        /// Defaults to <c>200</c>.
         /// </summary>
         /// <remarks>
-        /// The value of this property is used to track the total number of calls to
-        /// <see cref="AddModelError(string, Exception)"/> and <see cref="AddModelError(string, string)"/> after which
-        /// an error is thrown for further invocations. Errors added via modifying <see cref="ModelState"/> do not
-        /// count towards this limit.
+        /// <see cref="ModelStateDictionary"/> tracks model errors added by calls to
+        /// <see cref="AddModelError(string, Exception)"/> or <see cref="TryAddModelError(string, Exception)"/>.
+        /// Once the value of <code>MaxAllowedErrors - 1</code> is reached, if another attempt is made to add an error,
+        /// the error message will be ignored and a <see cref="TooManyModelErrorsException"/> will be added.
+        /// 
+        /// Errors added via modifying <see cref="ModelState"/> directly do not count towards this limit.
         /// </remarks>
-        public int MaxAllowedErrors { get; set; } = int.MaxValue;
+        public int MaxAllowedErrors
+        {
+            get
+            {
+                return _maxAllowedErrors;
+            }
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                _maxAllowedErrors = value;
+            }
+        }
 
         /// <summary>
-        /// Gets a flag that determines if the total number of added errors (given by <see cref="ErrorCount"/>) is
-        /// fewer than <see cref="MaxAllowedErrors"/>.
+        /// Gets a value indicating whether or not the maximum number of errors have been
+        /// recorded.
         /// </summary>
-        public bool CanAddErrors
+        /// <remarks>
+        /// Will return <c>true</c> if a <see cref="TooManyModelErrorsException"/> has been recorded;
+        /// otherwise <c>false</c>.
+        /// </remarks>
+        public bool HasReachedMaxErrors
         {
-            get { return ErrorCount < MaxAllowedErrors; }
+            get { return ErrorCount >= MaxAllowedErrors; }
         }
 
         /// <summary>
         /// Gets the number of errors added to this instance of <see cref="ModelStateDictionary"/> via
-        /// <see cref="AddModelError(string, Exception)"/> and <see cref="AddModelError(string, string)"/>.
+        /// <see cref="AddModelError"/> or <see cref="TryAddModelError"/>.
         /// </summary>
         public int ErrorCount { get; private set; }
 
@@ -149,11 +187,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// </summary>
         /// <param name="key">The key of the <see cref="ModelState"/> to add errors to.</param>
         /// <param name="exception">The <see cref="Exception"/> to add.</param>
-        /// <returns>True if the error was added, false if the dictionary has already recorded
-        /// at least <see cref="MaxAllowedErrors"/> number of errors.</returns>
-        /// <remarks>
-        /// This method only allows adding up to <see cref="MaxAllowedErrors"/> - 1. <see cref="MaxAllowedErrors"/>nt
-        /// invocation would result in adding a <see cref="TooManyModelErrorsException"/> to the dictionary.
+        /// <returns>
+        /// <c>True</c> if the error was added, <c>false</c> if the error was ignored.
+        /// See <see cref="MaxAllowedErrors"/>.
         /// </remarks>
         public bool TryAddModelError([NotNull] string key, [NotNull] Exception exception)
         {
@@ -186,11 +222,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// </summary>
         /// <param name="key">The key of the <see cref="ModelState"/> to add errors to.</param>
         /// <param name="errorMessage">The error message to add.</param>
-        /// <returns>True if the error was added, false if the dictionary has already recorded
-        /// at least <see cref="MaxAllowedErrors"/> number of errors.</returns>
-        /// <remarks>
-        /// This method only allows adding up to <see cref="MaxAllowedErrors"/> - 1. <see cref="MaxAllowedErrors"/>nt
-        /// invocation would result in adding a <see cref="TooManyModelErrorsException"/> to the dictionary.
+        /// <returns>
+        /// <c>True</c> if the error was added, <c>false</c> if the error was ignored.
+        /// See <see cref="MaxAllowedErrors"/>.
         /// </remarks>
         public bool TryAddModelError([NotNull] string key, [NotNull] string errorMessage)
         {

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Validation/ModelValidationNode.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Validation/ModelValidationNode.cs
@@ -102,7 +102,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
         public void Validate([NotNull] ModelValidationContext validationContext, ModelValidationNode parentNode)
         {
-            if (SuppressValidation || !validationContext.ModelState.CanAddErrors)
+            if (SuppressValidation || validationContext.ModelState.HasReachedMaxErrors)
             {
                 // Short circuit if validation does not need to be applied or if we've reached the max number of
                 // validation errors.

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ControllerActionInvokerTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ControllerActionInvokerTest.cs
@@ -2043,7 +2043,7 @@ namespace Microsoft.AspNet.Mvc
                 controllerFactory.Object,
                 actionDescriptor,
                 inputFormattersProvider.Object,
-                new DefaultControllerActionArgumentBinder(new EmptyModelMetadataProvider()),
+                new DefaultControllerActionArgumentBinder(new EmptyModelMetadataProvider(), new MockMvcOptionsAccessor()),
                 new MockModelBinderProvider() { ModelBinders = new List<IModelBinder>() { binder.Object } },
                 new MockModelValidatorProviderProvider(),
                 new MockValueProviderFactoryProvider(),

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Binders/CompositeModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Binders/CompositeModelBinderTest.cs
@@ -375,6 +375,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
                 { "user.password", "password" },
                 { "user.confirmpassword", "password2" },
             };
+
             var bindingContext = CreateBindingContext(binder, valueProvider, typeof(User), validatorProvider);
             bindingContext.ModelState.MaxAllowedErrors = 2;
             bindingContext.ModelState.AddModelError("key1", "error1");

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Validation/ModelStateDictionaryTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Validation/ModelStateDictionaryTest.cs
@@ -385,7 +385,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             dictionary.AddModelError("key6", "error6");
 
             // Act and Assert
-            Assert.False(dictionary.CanAddErrors);
+            Assert.True(dictionary.HasReachedMaxErrors);
             Assert.Equal(5, dictionary.ErrorCount);
             var error = Assert.Single(dictionary[""].Errors);
             Assert.IsType<TooManyModelErrorsException>(error.Exception);
@@ -415,7 +415,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             result = dictionary.TryAddModelError("key4", "error4");
             Assert.False(result);
 
-            Assert.False(dictionary.CanAddErrors);
+            Assert.True(dictionary.HasReachedMaxErrors);
             Assert.Equal(3, dictionary.ErrorCount);
             Assert.Equal(3, dictionary.Count);
 
@@ -441,7 +441,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             dictionary.AddModelError("key5", new FormatException());
 
             // Act and Assert
-            Assert.False(dictionary.CanAddErrors);
+            Assert.True(dictionary.HasReachedMaxErrors);
             Assert.Equal(4, dictionary.ErrorCount);
             Assert.Equal(4, dictionary.Count);
             var error = Assert.Single(dictionary[""].Errors);
@@ -498,6 +498,31 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             Assert.IsType<TooManyModelErrorsException>(error.Exception);
             Assert.Equal(expected, error.Exception.Message);
         }
+
+        [Theory]
+        [InlineData(2, false)]
+        [InlineData(3, true)]
+        [InlineData(4, true)]
+        public void ModelStateDictionary_HasReachedMaxErrors(int errorCount, bool expected)
+        {
+            // Arrange
+            var dictionary = new ModelStateDictionary()
+            {
+                MaxAllowedErrors = 3
+            };
+
+            for (var i = 0; i < errorCount; i++)
+            {
+                dictionary.AddModelError("key" + i, "error");
+            }
+
+            // Act
+            var canAdd = dictionary.HasReachedMaxErrors;
+
+            // Assert
+            Assert.Equal(expected, canAdd);
+        }
+
 
         private static ValueProviderResult GetValueProviderResult(object rawValue = null, string attemptedValue = null)
         {


### PR DESCRIPTION
Changes here are all focused around MaxModelErrors on
ModelStateDictionary.

MaxAllowedErrors now defaults to 200 (same as options). This means that
constructing a new ModelStateDictionary with the default constructor will
use this default. There's a new constructor for creating a
MaxAllowedErrors with a non-default value.

The ControllerActionArgumentBinder is now responsible for setting the
value from options onto ActionContext.ModelState. This results in better
layering and guarantees the option is respected if someone uses
extensibility to call model binding.

ModelStateDictionary.CanAddErrors is renamed to MaxErrorsReached. We
wanted to change the behavior of this property, but realized that it's
very useful inside the model validation code, so opted to renamed.

There's also a bunch of doc cleanup inside ModelStateDictionary to
simplify things and improve clarity.