### PR TITLE
Prototype Authentication filter

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/FilterActionInvoker.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/FilterActionInvoker.cs
@@ -25,6 +25,7 @@ namespace Microsoft.AspNet.Mvc
         private IFilter[] _filters;
         private FilterCursor _cursor;
 
+        private AuthenticationContext _authenticationContext;
         private AuthorizationContext _authorizationContext;
 
         private ResourceExecutingContext _resourceExecutingContext;
@@ -97,6 +98,8 @@ namespace Microsoft.AspNet.Mvc
             _filters = GetFilters();
             _cursor = new FilterCursor(_filters);
 
+            await InvokeAllAuthenticationFiltersAsync();
+
             await InvokeAllAuthorizationFiltersAsync();
 
             // If Authorization Filters return a result, it's a short circuit because
@@ -148,6 +151,30 @@ namespace Microsoft.AspNet.Mvc
             _filterProvider.Invoke(filterProviderContext);
 
             return filterProviderContext.Results.Select(item => item.Filter).Where(filter => filter != null).ToArray();
+        }
+
+        private async Task InvokeAllAuthenticationFiltersAsync()
+        {
+            _cursor.SetStage(FilterStage.AuthenticationFilters);
+
+            _authenticationContext = new AuthenticationContext(ActionContext, _filters);
+            await InvokeAuthenticationFilterAsync();
+        }
+
+        private async Task InvokeAuthenticationFilterAsync()
+        {
+            // We should never get here if we already have a result.
+            Debug.Assert(_authenticationContext != null);
+
+            var current = _cursor.GetNextFilter<IAuthenticationFilter, IAsyncAuthenticationFilter>();
+            if (current.FilterAsync != null)
+            {
+                await current.FilterAsync.OnAuthenticationAsync(_authenticationContext);
+            }
+            else if (current.Filter != null)
+            {
+                current.Filter.OnAuthentication(_authenticationContext);
+            }
         }
 
         private async Task InvokeAllAuthorizationFiltersAsync()
@@ -653,6 +680,7 @@ namespace Microsoft.AspNet.Mvc
         private enum FilterStage
         {
             Undefined,
+            AuthenticationFilters,
             AuthorizationFilters,
             ResourceFilters,
             ExceptionFilters,

--- a/src/Microsoft.AspNet.Mvc.Core/Filters/AuthenticateAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Filters/AuthenticateAttribute.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNet.Mvc
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+    public class AuthenticateAttribute :
+        Attribute, IAsyncAuthenticationFilter, IAuthenticationFilter
+    {
+        private string _authTypes;
+        private string[] _authTypesSplit;
+
+        public AuthenticateAttribute() { }
+
+        public AuthenticateAttribute(string authenticationTypes)
+        {
+            AuthenticationTypes = authenticationTypes;
+        }
+
+        /// <summary>
+        /// Comma separated list of authentication types
+        /// </summary>
+        public string AuthenticationTypes {
+            get { return _authTypes; }
+            set
+            {
+                _authTypes = value;
+                _authTypesSplit = string.IsNullOrWhiteSpace(_authTypes) ? null : _authTypes.Split(',');
+            }
+        }
+
+        public virtual async Task OnAuthenticationAsync([NotNull] AuthenticationContext context)
+        {
+            // REVIEW: Do nothing if no auth types requested?
+            if (_authTypesSplit == null)
+            {
+                return;
+            }
+            var results = await context.HttpContext.AuthenticateAsync(_authTypesSplit);
+            context.HttpContext.User = new ClaimsPrincipal(results.Select(r => r.Identity));
+        }
+
+        public virtual void OnAuthentication([NotNull] AuthenticationContext context)
+        {
+            // REVIEW: Do nothing if no auth types requested?
+            if (_authTypesSplit == null)
+            {
+                return;
+            }
+            var results = context.HttpContext.Authenticate(_authTypesSplit);
+            context.HttpContext.User = new ClaimsPrincipal(results.Select(r => r.Identity));
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Filters/AuthenticationContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Filters/AuthenticationContext.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNet.Mvc
+{
+    public class AuthenticationContext : FilterContext
+    {
+        public AuthenticationContext(
+            [NotNull] ActionContext actionContext,
+            [NotNull] IList<IFilter> filters)
+            : base(actionContext, filters)
+        {
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Filters/IAsyncAuthenticationFilter.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Filters/IAsyncAuthenticationFilter.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNet.Mvc
+{
+    public interface IAsyncAuthenticationFilter : IFilter
+    {
+        Task OnAuthenticationAsync([NotNull] AuthenticationContext context);
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Filters/IAuthenticationFilter.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Filters/IAuthenticationFilter.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNet.Mvc
+{
+    public interface IAuthenticationFilter : IFilter
+    {
+        void OnAuthentication([NotNull] AuthenticationContext context);
+    }
+}

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Filters/AuthenticationAttributeTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Filters/AuthenticationAttributeTest.cs
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Http;
+using Microsoft.AspNet.Http.Security;
+using Microsoft.AspNet.Routing;
+using Microsoft.AspNet.Security;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNet.Mvc.Test
+{
+    public class AuthenticationAttributeTest
+    {
+        private AuthenticationContext GetAuthenticationContext(Action<ServiceCollection> registerServices = null)
+        {
+            var basicId = new ClaimsIdentity(
+                    new Claim[] {
+                        new Claim("Permission", "CanViewPage"),
+                        new Claim(ClaimTypes.Role, "Administrator"),
+                        new Claim(ClaimTypes.Role, "User"),
+                        new Claim(ClaimTypes.NameIdentifier, "John")},
+                        "Basic");
+            var bearerId = new ClaimsIdentity(
+                    new Claim[] {
+                        new Claim("Permission", "CupBearer"),
+                        new Claim(ClaimTypes.Role, "Token"),
+                        new Claim(ClaimTypes.NameIdentifier, "John Bear")},
+                        "Bearer");
+
+            // ServiceProvider
+            var serviceCollection = new ServiceCollection();
+            if (registerServices != null)
+            {
+                registerServices(serviceCollection);
+            }
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            // HttpContext
+            var httpContext = new Mock<HttpContext>();
+            httpContext.SetupProperty(c => c.User);
+            httpContext.SetupGet(c => c.RequestServices).Returns(serviceProvider);
+            var authResults = new AuthenticationResult[]
+            {
+                new AuthenticationResult(basicId, new AuthenticationProperties(), new AuthenticationDescription()),
+                new AuthenticationResult(bearerId, new AuthenticationProperties(), new AuthenticationDescription())
+            };
+            httpContext.Setup(c => c.Authenticate(It.IsAny<string[]>()))
+                .Returns(authResults);
+            httpContext.Setup(c => c.AuthenticateAsync(It.IsAny<string[]>()))
+                .ReturnsAsync(authResults);
+
+            // AuthenticationContext
+            var actionContext = new ActionContext(
+                httpContext: httpContext.Object,
+                routeData: new RouteData(),
+                actionDescriptor: null
+                );
+
+            var authenticationContext = new AuthenticationContext(
+                actionContext,
+                Enumerable.Empty<IFilter>().ToList()
+            );
+
+            return authenticationContext;
+        }
+
+        [Fact]
+        public async Task Invoke_NoAuthenticationTypesLeavesUserAlone()
+        {
+            // Arrange
+            var authenticationAttribute = new AuthenticateAttribute();
+            var authenticationContext = GetAuthenticationContext();
+
+            // Act
+            await authenticationAttribute.OnAuthenticationAsync(authenticationContext);
+
+            // Assert
+            Assert.Null(authenticationContext.HttpContext.User);
+        }
+
+        [Fact]
+        public async Task Invoke_ReplacesUserWithPrincipalAuthenticationTypes()
+        {
+            // Arrange
+            var authenticationAttribute = new AuthenticateAttribute() { AuthenticationTypes = "Basic,Bearer" };
+            var authenticationContext = GetAuthenticationContext();
+
+            // Act
+            await authenticationAttribute.OnAuthenticationAsync(authenticationContext);
+
+            // Assert
+            Assert.Equal(2, authenticationContext.HttpContext.User.Identities.Count());
+        }
+    }
+}

--- a/test/WebSites/FiltersWebSite/Controllers/AuthorizeUserController.cs
+++ b/test/WebSites/FiltersWebSite/Controllers/AuthorizeUserController.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNet.Security;
 
 namespace FiltersWebSite
 {
-    [AuthorizeUser]
+    [Authenticate("Basic")]
     [Authorize("RequireBasic")]
     public class AuthorizeUserController : Controller
     {


### PR DESCRIPTION
Add [Authenticate(AuthenticationTypes = "AuthType1,AuthType2")] which run before Authorize filters, and is responsible for building a new ClaimsPrincipal if desired.

- Questions: Should more than one of these attributes be concatinating?  Each currently will replace the principal right now

Builds on https://github.com/aspnet/Mvc/pull/1900

cc @yishaigalatzer @harshgMSFT @rynowak @blowdart @lodejard 
