### PR TITLE
React to quick cleanup in Routing

### DIFF
--- a/test/Microsoft.AspNet.Mvc.Core.Test/RemoteAttributeTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/RemoteAttributeTest.cs
@@ -577,11 +577,8 @@ namespace Microsoft.AspNet.Mvc
                 .SetupGet(options => options.Options)
                 .Returns(routeOptions);
 
-            // DefaultInlineConstraintResolver constructor does not currently check its serviceProvider parameter (e.g.
-            // for null) and the class does not look up any services.
-            serviceCollection.AddInstance<IInlineConstraintResolver>(new DefaultInlineConstraintResolver(
-                serviceProvider: null,
-                routeOptions: accessor.Object));
+            serviceCollection.AddInstance<IInlineConstraintResolver>(
+                new DefaultInlineConstraintResolver(accessor.Object));
 
             return serviceCollection;
         }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Routing/AttributeRouteTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Routing/AttributeRouteTest.cs
@@ -1448,13 +1448,11 @@ namespace Microsoft.AspNet.Mvc.Routing
 
         private static DefaultInlineConstraintResolver CreateConstraintResolver()
         {
-            var services = Mock.Of<IServiceProvider>();
-
             var options = new RouteOptions();
             var optionsMock = new Mock<IOptions<RouteOptions>>();
             optionsMock.SetupGet(o => o.Options).Returns(options);
 
-            return new DefaultInlineConstraintResolver(services, optionsMock.Object);
+            return new DefaultInlineConstraintResolver(optionsMock.Object);
         }
 
         private static AttributeRoute CreateAttributeRoute(AttributeRouteLinkGenerationEntry entry)

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Routing/AttributeRoutingTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Routing/AttributeRoutingTest.cs
@@ -168,7 +168,7 @@ namespace Microsoft.AspNet.Mvc.Routing
 
             services
                 .Setup(s => s.GetService(typeof(IInlineConstraintResolver)))
-                .Returns(new DefaultInlineConstraintResolver(services.Object, routeOptions.Object));
+                .Returns(new DefaultInlineConstraintResolver(routeOptions.Object));
 
             return services.Object;
         }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/UrlHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/UrlHelperTest.cs
@@ -716,8 +716,7 @@ namespace Microsoft.AspNet.Mvc
             var accessorMock = new Mock<IOptions<RouteOptions>>();
             accessorMock.SetupGet(o => o.Options).Returns(new RouteOptions());
             serviceProviderMock.Setup(o => o.GetService(typeof(IInlineConstraintResolver)))
-                               .Returns(new DefaultInlineConstraintResolver(serviceProviderMock.Object,
-                                                                            accessorMock.Object));
+                               .Returns(new DefaultInlineConstraintResolver(accessorMock.Object));
 
             rt.ServiceProvider = serviceProviderMock.Object;
             rt.MapRoute(string.Empty,


### PR DESCRIPTION
- see aspnet/Routing#144
- `DefaultInlineConstraintResolver` has no need of a `IServiceProvider`