### PR TITLE
Add `ModelMetadata.AdditionalValues` property bag

### DIFF
--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/AssociatedMetadataProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/AssociatedMetadataProvider.cs
@@ -71,13 +71,38 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             return GetMetadataForParameterCore(modelAccessor, parameterName, parameter);
         }
 
-        // Override for creating the prototype metadata (without the accessor)
+        // Override for creating the prototype metadata (without the model accessor).
+        /// <summary>
+        /// Creates a new <typeparamref name="TModelMetadata"/> instance.
+        /// </summary>
+        /// <param name="attributes">The set of attributes relevant for the new instance.</param>
+        /// <param name="containerType">
+        /// <see cref="Type"/> containing this property. <c>null</c> unless this <typeparamref name="TModelMetadata"/>
+        /// describes a property.
+        /// </param>
+        /// <param name="modelType"><see cref="Type"/> this <typeparamref name="TModelMetadata"/> describes.</param>
+        /// <param name="propertyName">
+        /// Name of the property (in <paramref name="containerType"/>) or parameter this
+        /// <typeparamref name="TModelMetadata"/> describes. <c>null</c> or empty if this
+        /// <typeparamref name="TModelMetadata"/> describes a <see cref="Type"/>.
+        /// </param>
+        /// <returns>A new <typeparamref name="TModelMetadata"/> instance.</returns>
         protected abstract TModelMetadata CreateMetadataPrototype(IEnumerable<object> attributes,
                                                                   Type containerType,
                                                                   Type modelType,
                                                                   string propertyName);
 
-        // Override for applying the prototype + modelAccess to yield the final metadata
+        // Override for applying the prototype + model accessor to yield the final metadata.
+        /// <summary>
+        /// Creates a new <typeparamref name="TModelMetadata"/> instance based on a <paramref name="prototype"/>.
+        /// </summary>
+        /// <param name="prototype">
+        /// <typeparamref name="TModelMetadata"/> that provides the basis for new instance.
+        /// </param>
+        /// <param name="modelAccessor">Accessor for model value of new instance.</param>
+        /// <returns>
+        /// A new <typeparamref name="TModelMetadata"/> instance based on <paramref name="prototype"/>.
+        /// </returns>
         protected abstract TModelMetadata CreateMetadataFromPrototype(TModelMetadata prototype,
                                                                       Func<object> modelAccessor);
 

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/CachedModelMetadata.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/CachedModelMetadata.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.AspNet.Mvc.ModelBinding
 {
@@ -80,6 +81,17 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             : base(provider, containerType, modelAccessor: null, modelType: modelType, propertyName: propertyName)
         {
             PrototypeCache = prototypeCache;
+        }
+
+        // Sealing for consistency with other properties.
+        // ModelMetadata already caches the collection and we have no use case for a ComputeAdditionalValues() method.
+        /// <inheritdoc />
+        public sealed override IDictionary<string, object> AdditionalValues
+        {
+            get
+            {
+                return base.AdditionalValues;
+            }
         }
 
         /// <inheritdoc />
@@ -416,6 +428,17 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             {
                 _propertyBindingPredicateProvider = value;
                 _propertyBindingPredicateProviderComputed = true;
+            }
+        }
+
+        // Sealing for consistency with other properties.
+        // ModelMetadata already caches the collection and we have no use case for a ComputeProperties() method.
+        /// <inheritdoc />
+        public override ModelPropertyCollection Properties
+        {
+            get
+            {
+                return base.Properties;
             }
         }
 

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/CachedModelMetadata.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/CachedModelMetadata.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         // Sealing for consistency with other properties.
         // ModelMetadata already caches the collection and we have no use case for a ComputeAdditionalValues() method.
         /// <inheritdoc />
-        public sealed override IDictionary<string, object> AdditionalValues
+        public sealed override IDictionary<object, object> AdditionalValues
         {
             get
             {
@@ -113,7 +113,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 _binderMetadata = value;
                 _isBinderMetadataComputed = true;
             }
-            }
+        }
 
         /// <inheritdoc />
         public sealed override string BinderModelName

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/DataAnnotationsModelMetadataProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/DataAnnotationsModelMetadataProvider.cs
@@ -6,8 +6,14 @@ using System.Collections.Generic;
 
 namespace Microsoft.AspNet.Mvc.ModelBinding
 {
+    /// <summary>
+    /// An <see cref="IModelMetadataProvider"/> implementation that provides
+    /// <see cref="CachedDataAnnotationsModelMetadata"/> instances. Those instances primarily calculate property values
+    /// using attributes from the <see cref="System.ComponentModel.DataAnnotations"/> namespace.
+    /// </summary>
     public class DataAnnotationsModelMetadataProvider : AssociatedMetadataProvider<CachedDataAnnotationsModelMetadata>
     {
+        /// <inheritdoc />
         protected override CachedDataAnnotationsModelMetadata CreateMetadataPrototype(
             IEnumerable<object> attributes,
             Type containerType,
@@ -17,11 +23,21 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             return new CachedDataAnnotationsModelMetadata(this, containerType, modelType, propertyName, attributes);
         }
 
+        /// <inheritdoc />
+        /// <remarks>
+        /// Copies only a few values from the <paramref name="prototype"/>. Unlikely the rest have been computed.
+        /// </remarks>
         protected override CachedDataAnnotationsModelMetadata CreateMetadataFromPrototype(
             CachedDataAnnotationsModelMetadata prototype,
             Func<object> modelAccessor)
         {
-            return new CachedDataAnnotationsModelMetadata(prototype, modelAccessor);
+            var metadata = new CachedDataAnnotationsModelMetadata(prototype, modelAccessor);
+            foreach (var keyValuePair in prototype.AdditionalValues)
+            {
+                metadata.AdditionalValues.Add(keyValuePair);
+            }
+
+            return metadata;
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/EmptyModelMetadataProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/EmptyModelMetadataProvider.cs
@@ -6,24 +6,50 @@ using System.Collections.Generic;
 
 namespace Microsoft.AspNet.Mvc.ModelBinding
 {
+    /// <summary>
+    /// An <see cref="IModelMetadataProvider"/> that provides base <see cref="ModelMetadata"/> instances and does not
+    /// set most <see cref="ModelMetadata"/> properties. For example this provider does not use data annotations.
+    /// </summary>
+    /// <remarks>
+    /// Provided for efficiency in scenarios that require minimal <see cref="ModelMetadata"/> information.
+    /// </remarks>
     public class EmptyModelMetadataProvider : AssociatedMetadataProvider<ModelMetadata>
     {
+        /// <inheritdoc />
+        /// <remarks>Ignores <paramref name="attributes"/>.</remarks>
         protected override ModelMetadata CreateMetadataPrototype(IEnumerable<object> attributes,
                                                                  Type containerType,
-                                                                 Type modelType,
+                                                                 [NotNull] Type modelType,
                                                                  string propertyName)
         {
-            return new ModelMetadata(this, containerType, null, modelType, propertyName);
+            return new ModelMetadata(
+                this,
+                containerType,
+                modelAccessor: null,
+                modelType: modelType,
+                propertyName: propertyName);
         }
 
-        protected override ModelMetadata CreateMetadataFromPrototype(ModelMetadata prototype,
+        /// <inheritdoc />
+        /// <remarks>
+        /// Copies very few values from the <paramref name="prototype"/>. Likely <paramref name="prototype"/> has not
+        /// been modified except to add <see cref="ModelMetadata.AdditionalValues"/> entries.
+        /// </remarks>
+        protected override ModelMetadata CreateMetadataFromPrototype([NotNull] ModelMetadata prototype,
                                                                      Func<object> modelAccessor)
         {
-            return new ModelMetadata(this,
-                                     prototype.ContainerType,
-                                     modelAccessor,
-                                     prototype.ModelType,
-                                     prototype.PropertyName);
+            var metadata = new ModelMetadata(
+                this,
+                prototype.ContainerType,
+                modelAccessor,
+                prototype.ModelType,
+                prototype.PropertyName);
+            foreach (var keyValuePair in prototype.AdditionalValues)
+            {
+                metadata.AdditionalValues.Add(keyValuePair);
+            }
+
+            return metadata;
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/ModelMetadata.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/ModelMetadata.cs
@@ -48,6 +48,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         }
 
         /// <summary>
+        /// Gets a collection of additional information about the model.
+        /// </summary>
+        public virtual IDictionary<string, object> AdditionalValues { get; }
+            = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
         /// Gets or sets the name of a model if specified explicitly using <see cref="IModelNameProvider"/>.
         /// </summary>
         public virtual string BinderModelName { get; set; }

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/ModelMetadata.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/ModelMetadata.cs
@@ -50,8 +50,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// <summary>
         /// Gets a collection of additional information about the model.
         /// </summary>
-        public virtual IDictionary<string, object> AdditionalValues { get; }
-            = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+        public virtual IDictionary<object, object> AdditionalValues { get; } = new Dictionary<object, object>();
 
         /// <summary>
         /// Gets or sets the name of a model if specified explicitly using <see cref="IModelNameProvider"/>.

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingTest.cs
@@ -1551,5 +1551,55 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var result = await response.Content.ReadAsStringAsync();
             Assert.Equal("The value 'random string' is not valid for birthdate.", result);
         }
+
+        [Fact]
+        public async Task OverriddenMetadataProvider_CanChangeAdditionalValues()
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+            var url = "http://localhost/AdditionalValues";
+            var expectedDictionary = new Dictionary<string, string>
+            {
+                { "key1", "7d6d0de2-8d59-49ac-99cc-881423b75a76" },
+                { "key2", "value2" },
+            };
+
+            // Act
+            var response = await client.GetAsync(url);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var responseContent = await response.Content.ReadAsStringAsync();
+            var dictionary = JsonConvert.DeserializeObject<IDictionary<string, string>>(responseContent);
+            Assert.Equal(expectedDictionary, dictionary);
+        }
+
+        [Fact]
+        public async Task OverriddenMetadataProvider_CanUseAttributesToChangeAdditionalValues()
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+            var url = "http://localhost/GroupNames";
+            var expectedDictionary = new Dictionary<string, string>
+            {
+                { "Model", "MakeAndModelGroup" },
+                { "Make", "MakeAndModelGroup" },
+                { "Vin", null },
+                { "Year", null },
+                { "InspectedDates", null },
+                { "LastUpdatedTrackingId", "TrackingIdGroup" },
+            };
+
+            // Act
+            var response = await client.GetAsync(url);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var responseContent = await response.Content.ReadAsStringAsync();
+            var dictionary = JsonConvert.DeserializeObject<IDictionary<string, string>>(responseContent);
+            Assert.Equal(expectedDictionary, dictionary);
+        }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/CachedDataAnnotationsModelMetadataTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/CachedDataAnnotationsModelMetadataTest.cs
@@ -29,11 +29,18 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 attributes: attributes);
 
             // Assert
+            Assert.NotNull(metadata.AdditionalValues);
+            Assert.Empty(metadata.AdditionalValues);
+            Assert.Null(metadata.Container);
+            Assert.Null(metadata.ContainerType);
+
             Assert.True(metadata.ConvertEmptyStringToNull);
             Assert.False(metadata.HasNonDefaultEditFormat);
             Assert.False(metadata.HideSurroundingHtml);
             Assert.True(metadata.HtmlEncode);
+            Assert.False(metadata.IsCollectionType);
             Assert.True(metadata.IsComplexType);
+            Assert.False(metadata.IsNullableValueType);
             Assert.False(metadata.IsReadOnly);
             Assert.False(metadata.IsRequired);
             Assert.True(metadata.ShowForDisplay);
@@ -47,6 +54,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             Assert.Null(metadata.NullDisplayText);
             Assert.Null(metadata.SimpleDisplayText);
             Assert.Null(metadata.TemplateHint);
+
+            Assert.Null(metadata.Model);
+            Assert.Equal(typeof(object), metadata.ModelType);
+            Assert.Equal(typeof(object), metadata.RealModelType);
+            Assert.Null(metadata.PropertyName);
 
             Assert.Equal(ModelMetadata.DefaultOrder, metadata.Order);
 

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/ModelMetadataTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/ModelMetadataTest.cs
@@ -150,7 +150,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 modelAccessor: () => null,
                 modelType: typeof(object),
                 propertyName: null);
-            var valuesDictionary = new Dictionary<string, object>
+            var valuesDictionary = new Dictionary<object, object>
             {
                 { "key1", new object() },
                 { "key2", "value2" },

--- a/test/WebSites/ModelBindingWebSite/AdditionalValuesMetadataProvider.cs
+++ b/test/WebSites/ModelBindingWebSite/AdditionalValuesMetadataProvider.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Microsoft.AspNet.Mvc.ModelBinding;
+using ModelBindingWebSite.Models;
+
+namespace ModelBindingWebSite
+{
+    public class AdditionalValuesMetadataProvider : DataAnnotationsModelMetadataProvider
+    {
+        public static readonly string GroupNameKey = "__GroupName";
+        private static Guid _guid = new Guid("7d6d0de2-8d59-49ac-99cc-881423b75a76");
+
+        protected override CachedDataAnnotationsModelMetadata CreateMetadataFromPrototype(
+            CachedDataAnnotationsModelMetadata prototype,
+            Func<object> modelAccessor)
+        {
+            var metadata = base.CreateMetadataFromPrototype(prototype, modelAccessor);
+            foreach (var keyValuePair in prototype.AdditionalValues)
+            {
+                metadata.AdditionalValues.Add(keyValuePair);
+            }
+
+            return metadata;
+        }
+
+        protected override CachedDataAnnotationsModelMetadata CreateMetadataPrototype(
+            IEnumerable<object> attributes,
+            Type containerType,
+            Type modelType,
+            string propertyName)
+        {
+            var metadata = base.CreateMetadataPrototype(attributes, containerType, modelType, propertyName);
+            if (modelType == typeof(LargeModelWithValidation))
+            {
+                metadata.AdditionalValues.Add("key1", _guid);
+                metadata.AdditionalValues.Add("key2", "value2");
+            }
+
+            var displayAttribute = attributes.OfType<DisplayAttribute>().FirstOrDefault();
+            var groupName = displayAttribute?.GroupName;
+            if (!string.IsNullOrEmpty(groupName))
+            {
+                metadata.AdditionalValues[GroupNameKey] = groupName;
+            }
+
+            return metadata;
+        }
+    }
+}

--- a/test/WebSites/ModelBindingWebSite/AdditionalValuesMetadataProvider.cs
+++ b/test/WebSites/ModelBindingWebSite/AdditionalValuesMetadataProvider.cs
@@ -15,19 +15,6 @@ namespace ModelBindingWebSite
         public static readonly string GroupNameKey = "__GroupName";
         private static Guid _guid = new Guid("7d6d0de2-8d59-49ac-99cc-881423b75a76");
 
-        protected override CachedDataAnnotationsModelMetadata CreateMetadataFromPrototype(
-            CachedDataAnnotationsModelMetadata prototype,
-            Func<object> modelAccessor)
-        {
-            var metadata = base.CreateMetadataFromPrototype(prototype, modelAccessor);
-            foreach (var keyValuePair in prototype.AdditionalValues)
-            {
-                metadata.AdditionalValues.Add(keyValuePair);
-            }
-
-            return metadata;
-        }
-
         protected override CachedDataAnnotationsModelMetadata CreateMetadataPrototype(
             IEnumerable<object> attributes,
             Type containerType,

--- a/test/WebSites/ModelBindingWebSite/Controllers/ModelMetadataController.cs
+++ b/test/WebSites/ModelBindingWebSite/Controllers/ModelMetadataController.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.AspNet.Mvc;
+using Microsoft.AspNet.Mvc.ModelBinding;
+using ModelBindingWebSite.Models;
+using ModelBindingWebSite.ViewModels;
+
+namespace ModelBindingWebSite.Controllers
+{
+    public class ModelMetadataController
+    {
+        [HttpGet(template: "/AdditionalValues")]
+        public IDictionary<string, object> GetAdditionalValues([FromServices] IModelMetadataProvider provider)
+        {
+            var metadata = provider.GetMetadataForType(
+                modelAccessor: null,
+                modelType: typeof(LargeModelWithValidation));
+
+            return metadata.AdditionalValues;
+        }
+
+        [HttpGet(template: "/GroupNames")]
+        public IDictionary<string, string> GetGroupNames([FromServices] IModelMetadataProvider provider)
+        {
+            var groupNames = new Dictionary<string, string>();
+            var metadata = provider.GetMetadataForType(
+                modelAccessor: null,
+                modelType: typeof(VehicleViewModel));
+            foreach (var property in metadata.Properties)
+            {
+                groupNames.Add(property.PropertyName, property.GetGroupName());
+            }
+
+            return groupNames;
+        }
+    }
+}

--- a/test/WebSites/ModelBindingWebSite/Controllers/ModelMetadataController.cs
+++ b/test/WebSites/ModelBindingWebSite/Controllers/ModelMetadataController.cs
@@ -12,7 +12,7 @@ namespace ModelBindingWebSite.Controllers
     public class ModelMetadataController
     {
         [HttpGet(template: "/AdditionalValues")]
-        public IDictionary<string, object> GetAdditionalValues([FromServices] IModelMetadataProvider provider)
+        public IDictionary<object, object> GetAdditionalValues([FromServices] IModelMetadataProvider provider)
         {
             var metadata = provider.GetMetadataForType(
                 modelAccessor: null,

--- a/test/WebSites/ModelBindingWebSite/ModelMetadataExtensions.cs
+++ b/test/WebSites/ModelBindingWebSite/ModelMetadataExtensions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Mvc.ModelBinding;
+
+namespace ModelBindingWebSite
+{
+    /// <summary>
+    /// Extensions for <see cref="ModelMetadata"/>.
+    /// </summary>
+    public static class ModelMetadataExtensions
+    {
+        /// <summary>
+        /// Gets the group name associated with given <paramref name="modelMetadata"/>.
+        /// </summary>
+        /// <param name="modelMetadata">The <see cref="ModelMetadata"/></param>
+        /// <returns>Group name associated with given <paramref name="modelMetadata"/>.</returns>
+        public static string GetGroupName(this ModelMetadata modelMetadata)
+        {
+            object groupName;
+            modelMetadata.AdditionalValues.TryGetValue(AdditionalValuesMetadataProvider.GroupNameKey, out groupName);
+
+            return groupName as string;
+        }
+    }
+}

--- a/test/WebSites/ModelBindingWebSite/Startup.cs
+++ b/test/WebSites/ModelBindingWebSite/Startup.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Mvc;
+using Microsoft.AspNet.Mvc.ModelBinding;
 using Microsoft.Framework.DependencyInjection;
 using ModelBindingWebSite.Services;
 
@@ -17,6 +18,10 @@ namespace ModelBindingWebSite
             // Set up application services
             app.UseServices(services =>
             {
+                // Override the IModelMetadataProvider AddMvc would normally use. Make service a singleton though
+                // AddMvc would configure DataAnnotationsModelMetadataProvider as transient.
+                services.AddSingleton<IModelMetadataProvider, AdditionalValuesMetadataProvider>();
+
                 // Add MVC services to the services container
                 services.AddMvc(configuration)
                         .Configure<MvcOptions>(m =>

--- a/test/WebSites/ModelBindingWebSite/Startup.cs
+++ b/test/WebSites/ModelBindingWebSite/Startup.cs
@@ -18,8 +18,8 @@ namespace ModelBindingWebSite
             // Set up application services
             app.UseServices(services =>
             {
-                // Override the IModelMetadataProvider AddMvc would normally use. Make service a singleton though
-                // AddMvc would configure DataAnnotationsModelMetadataProvider as transient.
+                // Override the IModelMetadataProvider AddMvc would normally add.
+                // ModelMetadataController relies on additional values AdditionalValuesMetadataProvider provides.
                 services.AddSingleton<IModelMetadataProvider, AdditionalValuesMetadataProvider>();
 
                 // Add MVC services to the services container

--- a/test/WebSites/ModelBindingWebSite/ViewModels/VehicleViewModel.cs
+++ b/test/WebSites/ModelBindingWebSite/ViewModels/VehicleViewModel.cs
@@ -15,10 +15,10 @@ namespace ModelBindingWebSite.ViewModels
         [StringLength(8)]
         public string Vin { get; set; }
 
-        [Display(Order = 1)]
+        [Display(Order = 1, GroupName = "MakeAndModelGroup")]
         public string Make { get; set; }
 
-        [Display(Order = 0)]
+        [Display(Order = 0, GroupName = "MakeAndModelGroup")]
         public string Model { get; set; }
 
         // Placed using default Order (10000).
@@ -31,7 +31,7 @@ namespace ModelBindingWebSite.ViewModels
         [MaxLength(10)]
         public DateTimeOffset[] InspectedDates { get; set; }
 
-        [Display(Order = 20000)]
+        [Display(Order = 20000, GroupName = "TrackingIdGroup")]
         public string LastUpdatedTrackingId { get; set; }
 
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)


### PR DESCRIPTION
- #1758
- provide the property bag in `ModelMetadata`; seal it in `CachedModelMetadata`
- add unit tests
- include use of `AdditionalValues` in model binding functional test

nits:
- expose `AdditionalValues` as an `IDictionary` though MVC 5 uses `Dictionary`
- seal `ModelMetadata.Properties` collection as well
- cover a few properties previously missed in `CachedDataAnnotationsModelMetadataTest`
- correct two `ModelMetadataTest` method names