### PR TITLE
[Perf] #1550 - Turn ModelMetadataProvider into a singleton

### DIFF
--- a/src/Microsoft.AspNet.Mvc/MvcServices.cs
+++ b/src/Microsoft.AspNet.Mvc/MvcServices.cs
@@ -79,7 +79,9 @@ namespace Microsoft.AspNet.Mvc
 
             // Dataflow - ModelBinding, Validation and Formatting
 
-            yield return describe.Transient<IModelMetadataProvider, DataAnnotationsModelMetadataProvider>();
+            // The DataAnnotationsModelMetadataProvider does significant caching of reflection/attributes
+            // and thus needs to be singleton. 
+            yield return describe.Singleon<IModelMetadataProvider, DataAnnotationsModelMetadataProvider>();
 
             yield return describe.Transient<IInputFormatterSelector, DefaultInputFormatterSelector>();
             yield return describe.Scoped<IInputFormattersProvider, DefaultInputFormattersProvider>();


### PR DESCRIPTION
The modelmetadataprovider does significant reflection caching, which shows
up as a hotspot. It's only of our most commonly used services, so not only
do a TON of instances get created, they are very heavy-weight because of
the two ConcurrentDictionary instances they have.