### PR TITLE
Fix for #563 - FromForm, FromQuery and FromValue allow providing a Name ...

### DIFF
--- a/src/Microsoft.AspNet.Mvc.ModelBinding/BinderMetadata/FromFormAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/BinderMetadata/FromFormAttribute.cs
@@ -10,9 +10,12 @@ namespace Microsoft.AspNet.Mvc
     /// Specifies that a parameter or property should be bound using form-data in the request body.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-    public class FromFormAttribute : Attribute, IBindingSourceMetadata
+    public class FromFormAttribute : Attribute, IBindingSourceMetadata, IModelNameProvider
     {
         /// <inheritdoc />
         public BindingSource BindingSource { get { return BindingSource.Form; } }
+
+        /// <inheritdoc />
+        public string Name { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/BinderMetadata/FromQueryAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/BinderMetadata/FromQueryAttribute.cs
@@ -10,9 +10,12 @@ namespace Microsoft.AspNet.Mvc
     /// Specifies that a parameter or property should be bound using the request query string.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-    public class FromQueryAttribute : Attribute, IBindingSourceMetadata
+    public class FromQueryAttribute : Attribute, IBindingSourceMetadata, IModelNameProvider
     {
         /// <inheritdoc />
         public BindingSource BindingSource { get { return BindingSource.Query; } }
+
+        /// <inheritdoc />
+        public string Name { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/BinderMetadata/FromRouteAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/BinderMetadata/FromRouteAttribute.cs
@@ -10,9 +10,12 @@ namespace Microsoft.AspNet.Mvc
     /// Specifies that a parameter or property should be bound using route-data from the current request.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-    public class FromRouteAttribute : Attribute, IBindingSourceMetadata
+    public class FromRouteAttribute : Attribute, IBindingSourceMetadata, IModelNameProvider
     {
         /// <inheritdoc />
         public BindingSource BindingSource { get { return BindingSource.Path; } }
+
+        /// <inheritdoc />
+        public string Name { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/ComplexModelDtoModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/ComplexModelDtoModelBinder.cs
@@ -19,8 +19,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 var dto = (ComplexModelDto)bindingContext.Model;
                 foreach (var propertyMetadata in dto.PropertyMetadata)
                 {
-                    var propertyModelName = ModelBindingHelper.CreatePropertyModelName(bindingContext.ModelName,
-                                                                                       propertyMetadata.PropertyName);
+                    var propertyModelName =
+                        ModelBindingHelper.CreatePropertyModelName(
+                            bindingContext.ModelName,
+                            propertyMetadata.BinderModelName ?? propertyMetadata.PropertyName);
 
                     var propertyBindingContext = new ModelBindingContext(bindingContext,
                                                                          propertyModelName,

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/ComplexModelDtoModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/ComplexModelDtoModelBinder.cs
@@ -19,8 +19,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 var dto = (ComplexModelDto)bindingContext.Model;
                 foreach (var propertyMetadata in dto.PropertyMetadata)
                 {
-                    var propertyModelName =
-                        ModelBindingHelper.CreatePropertyModelName(
+                    var propertyModelName = ModelBindingHelper.CreatePropertyModelName(
                             bindingContext.ModelName,
                             propertyMetadata.BinderModelName ?? propertyMetadata.PropertyName);
 

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/CompositeModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/CompositeModelBinder.cs
@@ -141,7 +141,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             // to just those that match. We can skip filtering when IsGreedy == true, because that can't use
             // value providers.
             //
-            // We also want to base this filtering on the - top-level value profider in case the data source
+            // We also want to base this filtering on the - top-level value provider in case the data source
             // on this property doesn't intersect with the ambient data source.
             //
             // Ex:

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/HeaderModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/HeaderModelBinder.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNet.Mvc.ModelBinding.Internal;
 namespace Microsoft.AspNet.Mvc.ModelBinding
 {
     /// <summary>
-    /// An <see cref="IModelBinder"/> which binds models from the request headers when a model 
+    /// An <see cref="IModelBinder"/> which binds models from the request headers when a model
     /// has the binding source <see cref="BindingSource.Header"/>/
     /// </summary>
     public class HeaderModelBinder : BindingSourceModelBinder
@@ -28,7 +28,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var request = bindingContext.OperationBindingContext.HttpContext.Request;
             var modelMetadata = bindingContext.ModelMetadata;
 
-            // Property name can be null if the model metadata represents a type (rahter than a property or parameter).
+            // Property name can be null if the model metadata represents a type (rather than a property or parameter).
             var headerName = modelMetadata.BinderModelName ?? modelMetadata.PropertyName ?? bindingContext.ModelName;
             if (bindingContext.ModelType == typeof(string))
             {

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/MutableObjectModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/MutableObjectModelBinder.cs
@@ -177,9 +177,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 }
             }
 
-            var propertyModelName = ModelBindingHelper.CreatePropertyModelName(bindingContext.ModelName,
-                                                                               metadata.BinderModelName ??
-                                                                               metadata.PropertyName);
+            var propertyModelName = ModelBindingHelper.CreatePropertyModelName(
+                bindingContext.ModelName,
+                metadata.BinderModelName ?? metadata.PropertyName);
 
             if (await valueProvider.ContainsPrefixAsync(propertyModelName))
             {
@@ -395,7 +395,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 // We want to add a validation error using any custom model name that has been provided.
                 var propertyName = propertyMetadata.BinderModelName ?? missingRequiredProperty;
                 var modelStateKey = ModelBindingHelper.CreatePropertyModelName(
-                    bindingContext.ValidationNode.ModelStateKey, propertyName);
+                    bindingContext.ValidationNode.ModelStateKey,
+                    propertyName);
 
                 // Execute validator (if any) to get custom error message.
                 IModelValidator validator;

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Validation/ModelValidationNode.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Validation/ModelValidationNode.cs
@@ -160,7 +160,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 // Only want to add errors to ModelState if something doesn't already exist for the property node,
                 // else we could end up with duplicate or irrelevant error messages.
                 var propertyKeyRoot = ModelBindingHelper.CreatePropertyModelName(ModelStateKey,
-                                                                                 propertyMetadata.PropertyName);
+                                                                                 propertyMetadata.BinderModelName
+                                                                                 ?? propertyMetadata.PropertyName);
 
                 if (modelState.GetFieldValidationState(propertyKeyRoot) == ModelValidationState.Unvalidated)
                 {

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Validation/ModelValidationNode.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Validation/ModelValidationNode.cs
@@ -159,9 +159,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             {
                 // Only want to add errors to ModelState if something doesn't already exist for the property node,
                 // else we could end up with duplicate or irrelevant error messages.
-                var propertyKeyRoot = ModelBindingHelper.CreatePropertyModelName(ModelStateKey,
-                                                                                 propertyMetadata.BinderModelName
-                                                                                 ?? propertyMetadata.PropertyName);
+                var propertyKeyRoot = ModelBindingHelper.CreatePropertyModelName(
+                    ModelStateKey,
+                    propertyMetadata.BinderModelName ?? propertyMetadata.PropertyName);
 
                 if (modelState.GetFieldValidationState(propertyKeyRoot) == ModelValidationState.Unvalidated)
                 {

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingFromFormTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingFromFormTest.cs
@@ -1,0 +1,170 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Builder;
+using Microsoft.AspNet.TestHost;
+using ModelBindingWebSite;
+using ModelBindingWebSite.Controllers;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.AspNet.Mvc.FunctionalTests
+{
+    public class ModelBindingFromFormTest
+    {
+        private readonly IServiceProvider _services = TestHelper.CreateServices(nameof(ModelBindingWebSite));
+        private readonly Action<IApplicationBuilder> _app = new ModelBindingWebSite.Startup().Configure;
+
+        [Fact]
+        public async Task FromFormAttribute_CustomModelPrefix_ForParameter()
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // [FromForm(Name = "customPrefix")] is used to apply a prefix
+            var url = "http://localhost/FromFormAttribute_Company/CreateCompany";
+            var request = new HttpRequestMessage(HttpMethod.Post, url);
+            var nameValueCollection = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string,string>("customPrefix.Employees[0].Name", "somename"),
+            };
+
+            request.Content = new FormUrlEncodedContent(nameValueCollection);
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            var body = await response.Content.ReadAsStringAsync();
+            var company = JsonConvert.DeserializeObject<Company>(body);
+
+            var employee = Assert.Single(company.Employees);
+
+            Assert.Equal("somename", employee.Name);
+        }
+
+        [Fact]
+        public async Task FromForm_CustomModelPrefix_ForCollectionParameter()
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // [FromForm(Name = "customPrefix")] is used to apply a prefix
+            var url =
+               "http://localhost/FromFormAttribute_Company/CreateCompanyFromEmployees";
+            var request = new HttpRequestMessage(HttpMethod.Post, url);
+            var nameValueCollection = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("customPrefix[0].EmployeeSSN", "123132131"),
+            };
+            request.Content = new FormUrlEncodedContent(nameValueCollection);
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            var body = await response.Content.ReadAsStringAsync();
+            var company = JsonConvert.DeserializeObject<Company>(body);
+
+            var employee = Assert.Single(company.Employees);
+            Assert.Equal("123132131", employee.SSN);
+        }
+
+        [Fact]
+        public async Task FromFormAttribute_CustomModelPrefix_ForProperty()
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // [FromForm(Name = "EmployeeSSN")] is used to apply a prefix
+            var url =
+                "http://localhost/FromFormAttribute_Company/CreateCompany";
+            var request = new HttpRequestMessage(HttpMethod.Post, url);
+            var nameValueCollection = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("customPrefix.Employees[0].EmployeeSSN", "123132131"),
+            };
+            request.Content = new FormUrlEncodedContent(nameValueCollection);
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            var body = await response.Content.ReadAsStringAsync();
+            var company = JsonConvert.DeserializeObject<Company>(body);
+
+            var employee = Assert.Single(company.Employees);
+            Assert.Equal("123132131", employee.SSN);
+        }
+
+        [Fact]
+        public async Task FromFormAttribute_CustomModelPrefix_ForCollectionProperty()
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // [FromForm(Name = "TestEmployees")] is used to apply a prefix
+            var url =
+                "http://localhost/FromFormAttribute_Company/CreateDepartment";
+            var request = new HttpRequestMessage(HttpMethod.Post, url);
+            var nameValueCollection = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("department.TestEmployees[0].EmployeeSSN", "123132131"),
+            };
+            request.Content = new FormUrlEncodedContent(nameValueCollection);
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            var body = await response.Content.ReadAsStringAsync();
+            var department = JsonConvert.DeserializeObject<
+                FromFormAttribute_CompanyController.FromForm_Department>(body);
+
+            var employee = Assert.Single(department.Employees);
+            Assert.Equal("123132131", employee.SSN);
+        }
+
+        [Fact]
+        public async Task FromForm_NonExistingValueAddsValidationErrors_OnProperty_UsingCustomModelPrefix()
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // [FromForm(Name = "TestEmployees")] is used to apply a prefix
+            var url =
+                "http://localhost/FromFormAttribute_Company/ValidateDepartment";
+            var request = new HttpRequestMessage(HttpMethod.Post, url);
+
+            // No values.
+            var nameValueCollection = new List<KeyValuePair<string, string>>();
+            request.Content = new FormUrlEncodedContent(nameValueCollection);
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            var body = await response.Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<Result>(body);
+            Assert.Null(result.Value);
+            var error = Assert.Single(result.ModelStateErrors);
+            Assert.Equal("TestEmployees", error);
+        }
+
+        private class Result
+        {
+            public object Value { get; set; }
+
+            public string[] ModelStateErrors { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingFromFormTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingFromFormTest.cs
@@ -20,13 +20,12 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         private readonly Action<IApplicationBuilder> _app = new ModelBindingWebSite.Startup().Configure;
 
         [Fact]
-        public async Task FromFormAttribute_CustomModelPrefix_ForParameter()
+        public async Task FromForm_CustomModelPrefix_ForParameter()
         {
             // Arrange
             var server = TestServer.Create(_services, _app);
             var client = server.CreateClient();
 
-            // [FromForm(Name = "customPrefix")] is used to apply a prefix
             var url = "http://localhost/FromFormAttribute_Company/CreateCompany";
             var request = new HttpRequestMessage(HttpMethod.Post, url);
             var nameValueCollection = new List<KeyValuePair<string, string>>
@@ -55,13 +54,11 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var server = TestServer.Create(_services, _app);
             var client = server.CreateClient();
 
-            // [FromForm(Name = "customPrefix")] is used to apply a prefix
-            var url =
-               "http://localhost/FromFormAttribute_Company/CreateCompanyFromEmployees";
+            var url = "http://localhost/FromFormAttribute_Company/CreateCompanyFromEmployees";
             var request = new HttpRequestMessage(HttpMethod.Post, url);
             var nameValueCollection = new List<KeyValuePair<string, string>>
             {
-                new KeyValuePair<string, string>("customPrefix[0].EmployeeSSN", "123132131"),
+                new KeyValuePair<string, string>("customPrefix[0].Department", "Contoso"),
             };
             request.Content = new FormUrlEncodedContent(nameValueCollection);
 
@@ -73,19 +70,17 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var company = JsonConvert.DeserializeObject<Company>(body);
 
             var employee = Assert.Single(company.Employees);
-            Assert.Equal("123132131", employee.SSN);
+            Assert.Equal("Contoso", employee.Department);
         }
 
         [Fact]
-        public async Task FromFormAttribute_CustomModelPrefix_ForProperty()
+        public async Task FromForm_CustomModelPrefix_ForProperty()
         {
             // Arrange
             var server = TestServer.Create(_services, _app);
             var client = server.CreateClient();
 
-            // [FromForm(Name = "EmployeeSSN")] is used to apply a prefix
-            var url =
-                "http://localhost/FromFormAttribute_Company/CreateCompany";
+            var url = "http://localhost/FromFormAttribute_Company/CreateCompany";
             var request = new HttpRequestMessage(HttpMethod.Post, url);
             var nameValueCollection = new List<KeyValuePair<string, string>>
             {
@@ -105,15 +100,13 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         }
 
         [Fact]
-        public async Task FromFormAttribute_CustomModelPrefix_ForCollectionProperty()
+        public async Task FromForm_CustomModelPrefix_ForCollectionProperty()
         {
             // Arrange
             var server = TestServer.Create(_services, _app);
             var client = server.CreateClient();
 
-            // [FromForm(Name = "TestEmployees")] is used to apply a prefix
-            var url =
-                "http://localhost/FromFormAttribute_Company/CreateDepartment";
+            var url = "http://localhost/FromFormAttribute_Company/CreateDepartment";
             var request = new HttpRequestMessage(HttpMethod.Post, url);
             var nameValueCollection = new List<KeyValuePair<string, string>>
             {
@@ -140,9 +133,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var server = TestServer.Create(_services, _app);
             var client = server.CreateClient();
 
-            // [FromForm(Name = "TestEmployees")] is used to apply a prefix
-            var url =
-                "http://localhost/FromFormAttribute_Company/ValidateDepartment";
+            var url = "http://localhost/FromFormAttribute_Company/ValidateDepartment";
             var request = new HttpRequestMessage(HttpMethod.Post, url);
 
             // No values.
@@ -158,13 +149,6 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Null(result.Value);
             var error = Assert.Single(result.ModelStateErrors);
             Assert.Equal("TestEmployees", error);
-        }
-
-        private class Result
-        {
-            public object Value { get; set; }
-
-            public string[] ModelStateErrors { get; set; }
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingFromHeaderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingFromHeaderTest.cs
@@ -93,7 +93,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var result = JsonConvert.DeserializeObject<Result>(body);
             Assert.Equal<string>(tags, result.HeaderValues);
             var error = Assert.Single(result.ModelStateErrors);
-            Assert.Equal("Title", error);
+            Assert.Equal("BlogTitle", error);
         }
         // The action that this test hits will echo back the model-bound value
         [Fact]

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingFromQueryTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingFromQueryTest.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Builder;
+using Microsoft.AspNet.TestHost;
+using ModelBindingWebSite;
+using Newtonsoft.Json;
+using Xunit;
+using ModelBindingWebSite.Controllers;
+
+namespace Microsoft.AspNet.Mvc.FunctionalTests
+{
+    public class FromQueryAttributeTest
+    {
+        private readonly IServiceProvider _services = TestHelper.CreateServices(nameof(ModelBindingWebSite));
+        private readonly Action<IApplicationBuilder> _app = new ModelBindingWebSite.Startup().Configure;
+
+        [Fact]
+        public async Task FromQuery_CustomModelPrefix_ForParameter()
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // [FromQuery(Name = "customPrefix")] is used to apply a prefix
+            var url =
+                "http://localhost/FromQueryAttribute_Company/CreateCompany?customPrefix.Employees[0].Name=somename";
+
+            // Act
+            var response = await client.GetAsync(url);
+
+            // Assert
+            var body = await response.Content.ReadAsStringAsync();
+            var company = JsonConvert.DeserializeObject<Company>(body);
+
+            var employee = Assert.Single(company.Employees);
+            Assert.Equal("somename", employee.Name);
+        }
+
+        [Fact]
+        public async Task FromQuery_CustomModelPrefix_ForCollectionParameter()
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // [FromQuery(Name = "customPrefix")] is used to apply a prefix
+            var url =
+                "http://localhost/FromQueryAttribute_Company/CreateCompanyFromEmployees?customPrefix[0].Name=somename";
+
+            // Act
+            var response = await client.GetAsync(url);
+
+            // Assert
+            var body = await response.Content.ReadAsStringAsync();
+            var company = JsonConvert.DeserializeObject<Company>(body);
+
+            var employee = Assert.Single(company.Employees);
+            Assert.Equal("somename", employee.Name);
+        }
+
+        [Fact]
+        public async Task FromQuery_CustomModelPrefix_ForProperty()
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // [FromQuery(Name = "EmployeeId")] is used to apply a prefix
+            var url =
+                "http://localhost/FromQueryAttribute_Company/CreateCompany?customPrefix.Employees[0].EmployeeId=1234";
+
+            // Act
+            var response = await client.GetAsync(url);
+
+            // Assert
+            var body = await response.Content.ReadAsStringAsync();
+            var company = JsonConvert.DeserializeObject<Company>(body);
+
+            var employee = Assert.Single(company.Employees);
+
+            Assert.Equal(1234, employee.Id);
+        }
+
+        [Fact]
+        public async Task FromQuery_CustomModelPrefix_ForCollectionProperty()
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // [FromQuery(Name = "TestEmployees")] is used to apply a prefix
+            var url =
+                "http://localhost/FromQueryAttribute_Company/CreateDepartment?TestEmployees[0].EmployeeId=1234";
+
+
+            // Act
+            var response = await client.GetAsync(url);
+
+            // Assert
+            var body = await response.Content.ReadAsStringAsync();
+            var department = JsonConvert.DeserializeObject<
+                FromQueryAttribute_CompanyController.FromQuery_Department>(body);
+
+            var employee = Assert.Single(department.Employees);
+            Assert.Equal(1234, employee.Id);
+        }
+
+        [Fact]
+        public async Task FromQuery_NonExistingValueAddsValidationErrors_OnProperty_UsingCustomModelPrefix()
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // [FromQuery(Name = "TestEmployees")] is used to apply a prefix
+            var url =
+                "http://localhost/FromQueryAttribute_Company/ValidateDepartment?Employees[0].EmployeeId=1234";
+
+
+            // Act
+            var response = await client.GetAsync(url);
+
+            // Assert
+            var body = await response.Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<Result>(body);
+            Assert.Null(result.Value);
+            var error = Assert.Single(result.ModelStateErrors);
+            Assert.Equal("TestEmployees", error);
+        }
+
+        private class Result
+        {
+            public object Value { get; set; }
+
+            public string[] ModelStateErrors { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingFromQueryTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingFromQueryTest.cs
@@ -14,7 +14,7 @@ using ModelBindingWebSite.Controllers;
 
 namespace Microsoft.AspNet.Mvc.FunctionalTests
 {
-    public class FromQueryAttributeTest
+    public class ModelBindingFromQueryTest
     {
         private readonly IServiceProvider _services = TestHelper.CreateServices(nameof(ModelBindingWebSite));
         private readonly Action<IApplicationBuilder> _app = new ModelBindingWebSite.Startup().Configure;
@@ -131,13 +131,6 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Null(result.Value);
             var error = Assert.Single(result.ModelStateErrors);
             Assert.Equal("TestEmployees", error);
-        }
-
-        private class Result
-        {
-            public object Value { get; set; }
-
-            public string[] ModelStateErrors { get; set; }
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingFromRouteTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingFromRouteTest.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Builder;
+using Microsoft.AspNet.TestHost;
+using ModelBindingWebSite;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.AspNet.Mvc.FunctionalTests
+{
+    public class ModelBindingFromRouteTest
+    {
+        private readonly IServiceProvider _services = TestHelper.CreateServices(nameof(ModelBindingWebSite));
+        private readonly Action<IApplicationBuilder> _app = new ModelBindingWebSite.Startup().Configure;
+
+        [Fact]
+        public async Task FromRoute_CustomModelPrefix_ForParameter()
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // [FromRoute(Name = "customPrefix")] is used to apply a prefix
+            var url =
+                "http://localhost/FromRouteAttribute_Company/CreateEmployee/somename";
+
+            // Act
+            var response = await client.GetAsync(url);
+
+            // Assert
+            var body = await response.Content.ReadAsStringAsync();
+            var employee = JsonConvert.DeserializeObject<Employee>(body);
+            Assert.Equal("somename", employee.Name);
+        }
+
+        [Fact]
+        public async Task FromRoute_CustomModelPrefix_ForProperty()
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // [FromRoute(Name = "EmployeeId")] is used to apply a prefix
+            var url =
+                "http://localhost/FromRouteAttribute_Company/CreateEmployee/somename/1234";
+
+            // Act
+            var response = await client.GetAsync(url);
+
+            // Assert
+            var body = await response.Content.ReadAsStringAsync();
+            var employee = JsonConvert.DeserializeObject<Employee>(body);
+            Assert.Equal(1234, employee.TaxId);
+        }
+
+
+        [Fact]
+        public async Task FromRoute_NonExistingValueAddsValidationErrors_OnProperty_UsingCustomModelPrefix()
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            // [FromRoute(Name = "TestEmployees")] is used to apply a prefix
+            var url =
+                "http://localhost/FromRouteAttribute_Company/ValidateDepartment";
+            var request = new HttpRequestMessage(HttpMethod.Post, url);
+
+            // No values.
+            var nameValueCollection = new List<KeyValuePair<string, string>>();
+            request.Content = new FormUrlEncodedContent(nameValueCollection);
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            var body = await response.Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<Result>(body);
+            Assert.Null(result.Value);
+            var error = Assert.Single(result.ModelStateErrors);
+            Assert.Equal("TestEmployees", error);
+        }
+
+        private class Result
+        {
+            public object Value { get; set; }
+
+            public string[] ModelStateErrors { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingFromRouteTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingFromRouteTest.cs
@@ -89,12 +89,5 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var error = Assert.Single(result.ModelStateErrors);
             Assert.Equal("TestEmployees", error);
         }
-
-        private class Result
-        {
-            public object Value { get; set; }
-
-            public string[] ModelStateErrors { get; set; }
-        }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingFromRouteTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingFromRouteTest.cs
@@ -72,7 +72,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 
             // [FromRoute(Name = "TestEmployees")] is used to apply a prefix
             var url =
-                "http://localhost/FromRouteAttribute_Company/ValidateDepartment";
+                "http://localhost/FromRouteAttribute_Company/ValidateDepartment/contoso";
             var request = new HttpRequestMessage(HttpMethod.Post, url);
 
             // No values.

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingModelBinderAttributeTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingModelBinderAttributeTest.cs
@@ -44,6 +44,27 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("somename", employee.Name);
         }
 
+        [Fact]
+        public async Task ModelBinderAttribute_CustomModelPrefix_OnProperty()
+        {
+            // Arrange
+            var server = TestServer.Create(_services, _app);
+            var client = server.CreateClient();
+
+            var url =
+                "http://localhost/ModelBinderAttribute_Company/CreateCompany?employees[0].Alias=somealias";
+
+            // Act
+            var response = await client.GetAsync(url);
+
+            // Assert
+            var body = await response.Content.ReadAsStringAsync();
+            var company = JsonConvert.DeserializeObject<Company>(body);
+
+            var employee = Assert.Single(company.Employees);
+            Assert.Equal("somealias", employee.EmailAlias);
+        }
+
         [Theory]
         [InlineData("GetBinderType_UseModelBinderOnType")]
         [InlineData("GetBinderType_UseModelBinderProviderOnType")]

--- a/test/WebSites/ModelBindingWebSite/Controllers/FromFormAttribute_CompanyController.cs
+++ b/test/WebSites/ModelBindingWebSite/Controllers/FromFormAttribute_CompanyController.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Microsoft.AspNet.Mvc;
+
+namespace ModelBindingWebSite.Controllers
+{
+    [Route("FromFormAttribute_Company/[action]")]
+    public class FromFormAttribute_CompanyController : Controller
+    {
+        // Uses Name to set a custom prefix.
+        public Company CreateCompany([FromForm(Name = "customPrefix")] Company company)
+        {
+            return company;
+        }
+
+        public FromForm_Department CreateDepartment(FromForm_Department department)
+        {
+            return department;
+        }
+
+        public Company CreateCompanyFromEmployees([FromForm(Name = "customPrefix")] IList<Employee> employees)
+        {
+            return new Company { Employees = employees };
+        }
+
+        public object ValidateDepartment(FromForm_Department department)
+        {
+            return new Result()
+            {
+                Value = department.Employees,
+                ModelStateErrors = ModelState.Where(kvp => kvp.Value.Errors.Count > 0).Select(kvp => kvp.Key).ToArray(),
+            };
+        }
+
+        public class FromForm_Department
+        {
+            [FromForm(Name = "TestEmployees")]
+            [Required]
+            public IEnumerable<Employee> Employees { get; set; }
+        }
+
+        private class Result
+        {
+            public object Value { get; set; }
+
+            public string[] ModelStateErrors { get; set; }
+        }
+    }
+}

--- a/test/WebSites/ModelBindingWebSite/Controllers/FromFormAttribute_CompanyController.cs
+++ b/test/WebSites/ModelBindingWebSite/Controllers/FromFormAttribute_CompanyController.cs
@@ -11,7 +11,6 @@ namespace ModelBindingWebSite.Controllers
     [Route("FromFormAttribute_Company/[action]")]
     public class FromFormAttribute_CompanyController : Controller
     {
-        // Uses Name to set a custom prefix.
         public Company CreateCompany([FromForm(Name = "customPrefix")] Company company)
         {
             return company;
@@ -41,13 +40,6 @@ namespace ModelBindingWebSite.Controllers
             [FromForm(Name = "TestEmployees")]
             [Required]
             public IEnumerable<Employee> Employees { get; set; }
-        }
-
-        private class Result
-        {
-            public object Value { get; set; }
-
-            public string[] ModelStateErrors { get; set; }
         }
     }
 }

--- a/test/WebSites/ModelBindingWebSite/Controllers/FromQueryAttribute_CompanyController.cs
+++ b/test/WebSites/ModelBindingWebSite/Controllers/FromQueryAttribute_CompanyController.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Microsoft.AspNet.Mvc;
+
+namespace ModelBindingWebSite.Controllers
+{
+    [Route("FromQueryAttribute_Company/[action]")]
+    public class FromQueryAttribute_CompanyController : Controller
+    {
+        // Uses Name to set a custom prefix.
+        public Company CreateCompany([FromQuery(Name = "customPrefix")] Company company)
+        {
+            return company;
+        }
+
+        public Company CreateCompanyFromEmployees([FromQuery(Name = "customPrefix")] IList<Employee> employees)
+        {
+            return new Company { Employees = employees };
+        }
+
+        public FromQuery_Department CreateDepartment(FromQuery_Department department)
+        {
+            return department;
+        }
+
+        public object ValidateDepartment(FromQuery_Department department)
+        {
+            return new Result()
+            {
+                Value = department.Employees,
+                ModelStateErrors = ModelState.Where(kvp => kvp.Value.Errors.Count > 0).Select(kvp => kvp.Key).ToArray(),
+            };
+        }
+
+        public class FromQuery_Department
+        {
+            [FromQuery(Name = "TestEmployees")]
+            [Required]
+            public IEnumerable<Employee> Employees { get; set; }
+        }
+
+        private class Result
+        {
+            public object Value { get; set; }
+
+            public string[] ModelStateErrors { get; set; }
+        }
+    }
+}

--- a/test/WebSites/ModelBindingWebSite/Controllers/FromQueryAttribute_CompanyController.cs
+++ b/test/WebSites/ModelBindingWebSite/Controllers/FromQueryAttribute_CompanyController.cs
@@ -11,7 +11,6 @@ namespace ModelBindingWebSite.Controllers
     [Route("FromQueryAttribute_Company/[action]")]
     public class FromQueryAttribute_CompanyController : Controller
     {
-        // Uses Name to set a custom prefix.
         public Company CreateCompany([FromQuery(Name = "customPrefix")] Company company)
         {
             return company;
@@ -41,13 +40,6 @@ namespace ModelBindingWebSite.Controllers
             [FromQuery(Name = "TestEmployees")]
             [Required]
             public IEnumerable<Employee> Employees { get; set; }
-        }
-
-        private class Result
-        {
-            public object Value { get; set; }
-
-            public string[] ModelStateErrors { get; set; }
         }
     }
 }

--- a/test/WebSites/ModelBindingWebSite/Controllers/FromRouteAttribute_CompanyController.cs
+++ b/test/WebSites/ModelBindingWebSite/Controllers/FromRouteAttribute_CompanyController.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Microsoft.AspNet.Mvc;
+
+namespace ModelBindingWebSite.Controllers
+{
+    [Route("FromRouteAttribute_Company/[action]/{customPrefix.Name}")]
+    public class FromRouteAttribute_CompanyController : Controller
+    {
+        [HttpGet("{customPrefix.EmployeeTaxId?}")]
+        // Uses Name to set a custom prefix.
+        public Employee CreateEmployee([FromRoute(Name = "customPrefix")] Employee employee)
+        {
+            return employee;
+        }
+
+        public Company CreateCompanyFromEmployees([FromRoute(Name = "customPrefix")] IList<Employee> employees)
+        {
+            return new Company { Employees = employees };
+        }
+
+        public object ValidateDepartment(FromRoute_Department department)
+        {
+            return new Result()
+            {
+                Value = department.Employees,
+                ModelStateErrors = ModelState.Where(kvp => kvp.Value.Errors.Count > 0).Select(kvp => kvp.Key).ToArray(),
+            };
+        }
+
+        public class FromRoute_Department
+        {
+            [FromRoute(Name = "TestEmployees")]
+            [Required]
+            public IEnumerable<Employee> Employees { get; set; }
+        }
+
+        private class Result
+        {
+            public object Value { get; set; }
+
+            public string[] ModelStateErrors { get; set; }
+        }
+    }
+}

--- a/test/WebSites/ModelBindingWebSite/Controllers/FromRouteAttribute_CompanyController.cs
+++ b/test/WebSites/ModelBindingWebSite/Controllers/FromRouteAttribute_CompanyController.cs
@@ -12,7 +12,6 @@ namespace ModelBindingWebSite.Controllers
     public class FromRouteAttribute_CompanyController : Controller
     {
         [HttpGet("{customPrefix.EmployeeTaxId?}")]
-        // Uses Name to set a custom prefix.
         public Employee CreateEmployee([FromRoute(Name = "customPrefix")] Employee employee)
         {
             return employee;
@@ -37,13 +36,6 @@ namespace ModelBindingWebSite.Controllers
             [FromRoute(Name = "TestEmployees")]
             [Required]
             public IEnumerable<Employee> Employees { get; set; }
-        }
-
-        private class Result
-        {
-            public object Value { get; set; }
-
-            public string[] ModelStateErrors { get; set; }
         }
     }
 }

--- a/test/WebSites/ModelBindingWebSite/Controllers/ModelBinderAttribute_CompanyController.cs
+++ b/test/WebSites/ModelBindingWebSite/Controllers/ModelBinderAttribute_CompanyController.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using Microsoft.AspNet.Mvc;
 
 namespace ModelBindingWebSite.Controllers
@@ -12,6 +13,11 @@ namespace ModelBindingWebSite.Controllers
         public Company GetCompany([ModelBinder(Name = "customPrefix")] Company company)
         {
             return company;
+        }
+
+        public Company CreateCompany(IList<Employee> employees)
+        {
+            return new Company { Employees = employees };
         }
     }
 }

--- a/test/WebSites/ModelBindingWebSite/Models/Employee.cs
+++ b/test/WebSites/ModelBindingWebSite/Models/Employee.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 
+using Microsoft.AspNet.Mvc;
+
 namespace ModelBindingWebSite
 {
     public class Employee : Person
@@ -9,5 +11,14 @@ namespace ModelBindingWebSite
         public string Department { get; set; }
 
         public string Location { get; set; }
+
+        [FromQuery(Name = "EmployeeId")]
+        public int Id { get; set; }
+
+        [FromRoute(Name = "EmployeeTaxId")]
+        public int TaxId { get; set; }
+
+        [FromForm(Name = "EmployeeSSN")]
+        public string SSN { get; set; }
     }
 }

--- a/test/WebSites/ModelBindingWebSite/Models/Employee.cs
+++ b/test/WebSites/ModelBindingWebSite/Models/Employee.cs
@@ -20,5 +20,8 @@ namespace ModelBindingWebSite
 
         [FromForm(Name = "EmployeeSSN")]
         public string SSN { get; set; }
+
+        [ModelBinder(Name = "Alias")]
+        public string EmailAlias { get; set; }
     }
 }

--- a/test/WebSites/ModelBindingWebSite/Result.cs
+++ b/test/WebSites/ModelBindingWebSite/Result.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace ModelBindingWebSite
+{
+    public class Result
+    {
+        public object Value { get; set; }
+
+        public string[] ModelStateErrors { get; set; }
+    }
+}


### PR DESCRIPTION
...which is used as a prefix. Also the name is used for reporting model state errors.