### PR TITLE
Simplify `<select/>` tag helper `multiple` attribute handling

### DIFF
--- a/src/Microsoft.AspNet.Mvc.TagHelpers/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/Properties/Resources.Designer.cs
@@ -123,22 +123,6 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         }
 
         /// <summary>
-        /// Cannot parse '{1}' value '{2}' for {0}. Acceptable values are '{3}', '{4}' and '{5}'.
-        /// </summary>
-        internal static string TagHelpers_InvalidValue_ThreeAcceptableValues
-        {
-            get { return GetString("TagHelpers_InvalidValue_ThreeAcceptableValues"); }
-        }
-
-        /// <summary>
-        /// Cannot parse '{1}' value '{2}' for {0}. Acceptable values are '{3}', '{4}' and '{5}'.
-        /// </summary>
-        internal static string FormatTagHelpers_InvalidValue_ThreeAcceptableValues(object p0, object p1, object p2, object p3, object p4, object p5)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelpers_InvalidValue_ThreeAcceptableValues"), p0, p1, p2, p3, p4, p5);
-        }
-
-        /// <summary>
         /// The {2} was unable to provide metadata about '{1}' expression value '{3}' for {0}.
         /// </summary>
         internal static string TagHelpers_NoProvidedMetadata

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/Resources.resx
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/Resources.resx
@@ -138,9 +138,6 @@
   <data name="SelectTagHelper_CannotDetermineContentWhenOnlyItemsSpecified" xml:space="preserve">
     <value>Cannot determine body for {0}. '{2}' must be null if '{1}' is null.</value>
   </data>
-  <data name="TagHelpers_InvalidValue_ThreeAcceptableValues" xml:space="preserve">
-    <value>Cannot parse '{1}' value '{2}' for {0}. Acceptable values are '{3}', '{4}' and '{5}'.</value>
-  </data>
   <data name="TagHelpers_NoProvidedMetadata" xml:space="preserve">
     <value>The {2} was unable to provide metadata about '{1}' expression value '{3}' for {0}.</value>
   </data>


### PR DESCRIPTION
- #1516
- `allowMultiple == true` when model has a collection type
 - ignore any `multiple` attribute in Razor source when generating element
- simplify tests too: fewer error cases

Note Razor author could allow browser user to submit values model binding
will likely ignore: Could mix a `multiple` attribute with a non-collection
`asp-for` expression.