### PR TITLE
Deep copy user's select list before making changes

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/DefaultHtmlGenerator.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/DefaultHtmlGenerator.cs
@@ -1059,12 +1059,20 @@ namespace Microsoft.AspNet.Mvc.Rendering
             values = values.Concat(enumValues);
 
             selectedValues = new HashSet<string>(values, StringComparer.OrdinalIgnoreCase);
+
+            // Perform deep copy of selectList to avoid changing user's Selected property values.
             var newSelectList = new List<SelectListItem>();
             foreach (SelectListItem item in selectList)
             {
-                item.Selected =
-                    (item.Value != null) ? selectedValues.Contains(item.Value) : selectedValues.Contains(item.Text);
-                newSelectList.Add(item);
+                var newItem = new SelectListItem
+                {
+                    Disabled = item.Disabled,
+                    Group = item.Group,
+                    Selected = selectedValues.Contains(item.Value ?? item.Text),
+                    Text = item.Text,
+                    Value = item.Value,
+                };
+                newSelectList.Add(newItem);
             }
 
             return newSelectList;

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Rendering/HtmlHelperSelectTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Rendering/HtmlHelperSelectTest.cs
@@ -1,0 +1,532 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.AspNet.Mvc.Rendering
+{
+    public class HtmlHelperSelectTest
+    {
+        private static readonly SelectListGroup GroupOne = new SelectListGroup { Name = "Group One", };
+        private static readonly SelectListGroup GroupTwo = new SelectListGroup { Name = "Group Two", };
+        private static readonly SelectListGroup DisabledGroup = new SelectListGroup
+        {
+            Disabled = true,
+            Name = "Disabled Group",
+        };
+
+        private static readonly List<SelectListItem> BasicSelectList = new List<SelectListItem>
+        {
+            new SelectListItem { Text = "Zero",  Value = "0"},
+            new SelectListItem { Text = "One",   Value = "1"},
+            new SelectListItem { Text = "Two",   Value = "2"},
+            new SelectListItem { Text = "Three", Value = "3"},
+        };
+        private static readonly List<SelectListItem> SomeDisabledOneSelectedSelectList = new List<SelectListItem>
+        {
+            new SelectListItem { Disabled = false, Selected = false, Text = "Zero",  Value = "0"},
+            new SelectListItem { Disabled = true,  Selected = true,  Text = "One",   Value = "1"},
+            new SelectListItem { Disabled = false, Selected = false, Text = "Two",  Value = "2"},
+            new SelectListItem { Disabled = true,  Selected = false, Text = "Three", Value = "3"},
+        };
+        private static readonly List<SelectListItem> SomeGroupedSomeSelectedSelectList = new List<SelectListItem>
+        {
+            new SelectListItem { Group = GroupOne, Selected = true,  Text = "Zero",  Value = "0"},
+            new SelectListItem { Group = GroupTwo, Selected = false, Text = "One",   Value = "1"},
+            new SelectListItem { Group = GroupOne, Selected = true,  Text = "Two",   Value = "2"},
+            new SelectListItem { Group = null,     Selected = false, Text = "Three", Value = "3"},
+        };
+        private static readonly List<SelectListItem> OneGroupSomeSelectedSelectList = new List<SelectListItem>
+        {
+            new SelectListItem { Group = GroupOne, Selected = true,  Text = "Zero",  Value = "0"},
+            new SelectListItem { Group = GroupOne, Selected = true,  Text = "One",   Value = "1"},
+            new SelectListItem { Group = GroupOne, Selected = false, Text = "Two",   Value = "2"},
+            new SelectListItem { Group = GroupOne, Selected = false, Text = "Three", Value = "3"},
+        };
+        private static readonly List<SelectListItem> OneDisabledGroupAllSelectedSelectList = new List<SelectListItem>
+        {
+            new SelectListItem { Group = DisabledGroup, Selected = true, Text = "Zero",  Value = "0"},
+            new SelectListItem { Group = DisabledGroup, Selected = true, Text = "One",   Value = "1"},
+            new SelectListItem { Group = DisabledGroup, Selected = true, Text = "Two",   Value = "2"},
+            new SelectListItem { Group = DisabledGroup, Selected = true, Text = "Three", Value = "3"},
+        };
+
+        // Select list -> expected HTML with null model, expected HTML with model containing "2".
+        public static TheoryData<IEnumerable<SelectListItem>, string, string> DropDownListDataSet
+        {
+            get
+            {
+                return new TheoryData<IEnumerable<SelectListItem>, string, string>
+                {
+                    {
+                        BasicSelectList,
+                        "<select id=\"Property1\" name=\"Property1\"><option value=\"0\">Zero</option>" +
+                        Environment.NewLine +
+                        "<option value=\"1\">One</option>" + Environment.NewLine +
+                        "<option value=\"2\">Two</option>" + Environment.NewLine +
+                        "<option value=\"3\">Three</option>" + Environment.NewLine +
+                        "</select>",
+                        "<select id=\"Property1\" name=\"Property1\"><option value=\"0\">Zero</option>" +
+                        Environment.NewLine +
+                        "<option value=\"1\">One</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"2\">Two</option>" + Environment.NewLine +
+                        "<option value=\"3\">Three</option>" + Environment.NewLine +
+                        "</select>"
+                    },
+                    {
+                        SomeDisabledOneSelectedSelectList,
+                        "<select id=\"Property1\" name=\"Property1\"><option value=\"0\">Zero</option>" +
+                        Environment.NewLine +
+                        "<option disabled=\"disabled\" selected=\"selected\" value=\"1\">One</option>" +
+                        Environment.NewLine +
+                        "<option value=\"2\">Two</option>" + Environment.NewLine +
+                        "<option disabled=\"disabled\" value=\"3\">Three</option>" + Environment.NewLine +
+                        "</select>",
+                        "<select id=\"Property1\" name=\"Property1\"><option value=\"0\">Zero</option>" +
+                        Environment.NewLine +
+                        "<option disabled=\"disabled\" value=\"1\">One</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"2\">Two</option>" + Environment.NewLine +
+                        "<option disabled=\"disabled\" value=\"3\">Three</option>" + Environment.NewLine +
+                        "</select>"
+                    },
+                    {
+                        SomeGroupedSomeSelectedSelectList,
+                        "<select id=\"Property1\" name=\"Property1\"><optgroup label=\"Group One\">" +
+                        Environment.NewLine +
+                        "<option selected=\"selected\" value=\"0\">Zero</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"2\">Two</option>" + Environment.NewLine +
+                        "</optgroup>" + Environment.NewLine +
+                        "<optgroup label=\"Group Two\">" + Environment.NewLine +
+                        "<option value=\"1\">One</option>" + Environment.NewLine +
+                        "</optgroup>" + Environment.NewLine +
+                        "<option value=\"3\">Three</option>" + Environment.NewLine +
+                        "</select>",
+                        "<select id=\"Property1\" name=\"Property1\"><optgroup label=\"Group One\">" +
+                        Environment.NewLine +
+                        "<option value=\"0\">Zero</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"2\">Two</option>" + Environment.NewLine +
+                        "</optgroup>" + Environment.NewLine +
+                        "<optgroup label=\"Group Two\">" + Environment.NewLine +
+                        "<option value=\"1\">One</option>" + Environment.NewLine +
+                        "</optgroup>" + Environment.NewLine +
+                        "<option value=\"3\">Three</option>" + Environment.NewLine +
+                        "</select>"
+                    },
+                    {
+                        OneGroupSomeSelectedSelectList,
+                        "<select id=\"Property1\" name=\"Property1\"><optgroup label=\"Group One\">" +
+                        Environment.NewLine +
+                        "<option selected=\"selected\" value=\"0\">Zero</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"1\">One</option>" + Environment.NewLine +
+                        "<option value=\"2\">Two</option>" + Environment.NewLine +
+                        "<option value=\"3\">Three</option>" + Environment.NewLine +
+                        "</optgroup>" + Environment.NewLine +
+                        "</select>",
+                        "<select id=\"Property1\" name=\"Property1\"><optgroup label=\"Group One\">" +
+                        Environment.NewLine +
+                        "<option value=\"0\">Zero</option>" + Environment.NewLine +
+                        "<option value=\"1\">One</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"2\">Two</option>" + Environment.NewLine +
+                        "<option value=\"3\">Three</option>" + Environment.NewLine +
+                        "</optgroup>" + Environment.NewLine +
+                        "</select>"
+                    },
+                    {
+                        OneDisabledGroupAllSelectedSelectList,
+                        "<select id=\"Property1\" name=\"Property1\"><optgroup disabled=\"disabled\" label=\"Disabled Group\">" +
+                        Environment.NewLine +
+                        "<option selected=\"selected\" value=\"0\">Zero</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"1\">One</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"2\">Two</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"3\">Three</option>" + Environment.NewLine +
+                        "</optgroup>" + Environment.NewLine +
+                        "</select>",
+                        "<select id=\"Property1\" name=\"Property1\"><optgroup disabled=\"disabled\" label=\"Disabled Group\">" +
+                        Environment.NewLine +
+                        "<option value=\"0\">Zero</option>" + Environment.NewLine +
+                        "<option value=\"1\">One</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"2\">Two</option>" + Environment.NewLine +
+                        "<option value=\"3\">Three</option>" + Environment.NewLine +
+                        "</optgroup>" + Environment.NewLine +
+                        "</select>"
+                    },
+                };
+            }
+        }
+
+        // Select list -> expected HTML with null model, with model containing "2", and with model containing "1", "3".
+        public static TheoryData<IEnumerable<SelectListItem>, string, string, string> ListBoxDataSet
+        {
+            get
+            {
+                return new TheoryData<IEnumerable<SelectListItem>, string, string, string>
+                {
+                    {
+                        BasicSelectList,
+                        "<select id=\"Property1\" multiple=\"multiple\" name=\"Property1\"><option value=\"0\">Zero</option>" +
+                        Environment.NewLine +
+                        "<option value=\"1\">One</option>" + Environment.NewLine +
+                        "<option value=\"2\">Two</option>" + Environment.NewLine +
+                        "<option value=\"3\">Three</option>" + Environment.NewLine +
+                        "</select>",
+                        "<select id=\"Property1\" multiple=\"multiple\" name=\"Property1\"><option value=\"0\">Zero</option>" +
+                        Environment.NewLine +
+                        "<option value=\"1\">One</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"2\">Two</option>" + Environment.NewLine +
+                        "<option value=\"3\">Three</option>" + Environment.NewLine +
+                        "</select>",
+                        "<select id=\"Property1\" multiple=\"multiple\" name=\"Property1\"><option value=\"0\">Zero</option>" +
+                        Environment.NewLine +
+                        "<option selected=\"selected\" value=\"1\">One</option>" + Environment.NewLine +
+                        "<option value=\"2\">Two</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"3\">Three</option>" + Environment.NewLine +
+                        "</select>"
+                    },
+                    {
+                        SomeDisabledOneSelectedSelectList,
+                        "<select id=\"Property1\" multiple=\"multiple\" name=\"Property1\"><option value=\"0\">Zero</option>" +
+                        Environment.NewLine +
+                        "<option disabled=\"disabled\" selected=\"selected\" value=\"1\">One</option>" +
+                        Environment.NewLine +
+                        "<option value=\"2\">Two</option>" + Environment.NewLine +
+                        "<option disabled=\"disabled\" value=\"3\">Three</option>" + Environment.NewLine +
+                        "</select>",
+                        "<select id=\"Property1\" multiple=\"multiple\" name=\"Property1\"><option value=\"0\">Zero</option>" +
+                        Environment.NewLine +
+                        "<option disabled=\"disabled\" value=\"1\">One</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"2\">Two</option>" + Environment.NewLine +
+                        "<option disabled=\"disabled\" value=\"3\">Three</option>" + Environment.NewLine +
+                        "</select>",
+                        "<select id=\"Property1\" multiple=\"multiple\" name=\"Property1\"><option value=\"0\">Zero</option>" +
+                        Environment.NewLine +
+                        "<option disabled=\"disabled\" selected=\"selected\" value=\"1\">One</option>" + Environment.NewLine +
+                        "<option value=\"2\">Two</option>" + Environment.NewLine +
+                        "<option disabled=\"disabled\" selected=\"selected\" value=\"3\">Three</option>" + Environment.NewLine +
+                        "</select>"
+                    },
+                    {
+                        SomeGroupedSomeSelectedSelectList,
+                        "<select id=\"Property1\" multiple=\"multiple\" name=\"Property1\"><optgroup label=\"Group One\">" +
+                        Environment.NewLine +
+                        "<option selected=\"selected\" value=\"0\">Zero</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"2\">Two</option>" + Environment.NewLine +
+                        "</optgroup>" + Environment.NewLine +
+                        "<optgroup label=\"Group Two\">" + Environment.NewLine +
+                        "<option value=\"1\">One</option>" + Environment.NewLine +
+                        "</optgroup>" + Environment.NewLine +
+                        "<option value=\"3\">Three</option>" + Environment.NewLine +
+                        "</select>",
+                        "<select id=\"Property1\" multiple=\"multiple\" name=\"Property1\"><optgroup label=\"Group One\">" +
+                        Environment.NewLine +
+                        "<option value=\"0\">Zero</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"2\">Two</option>" + Environment.NewLine +
+                        "</optgroup>" + Environment.NewLine +
+                        "<optgroup label=\"Group Two\">" + Environment.NewLine +
+                        "<option value=\"1\">One</option>" + Environment.NewLine +
+                        "</optgroup>" + Environment.NewLine +
+                        "<option value=\"3\">Three</option>" + Environment.NewLine +
+                        "</select>",
+                        "<select id=\"Property1\" multiple=\"multiple\" name=\"Property1\"><optgroup label=\"Group One\">" +
+                        Environment.NewLine +
+                        "<option value=\"0\">Zero</option>" + Environment.NewLine +
+                        "<option value=\"2\">Two</option>" + Environment.NewLine +
+                        "</optgroup>" + Environment.NewLine +
+                        "<optgroup label=\"Group Two\">" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"1\">One</option>" + Environment.NewLine +
+                        "</optgroup>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"3\">Three</option>" + Environment.NewLine +
+                        "</select>"
+                    },
+                    {
+                        OneGroupSomeSelectedSelectList,
+                        "<select id=\"Property1\" multiple=\"multiple\" name=\"Property1\"><optgroup label=\"Group One\">" +
+                        Environment.NewLine +
+                        "<option selected=\"selected\" value=\"0\">Zero</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"1\">One</option>" + Environment.NewLine +
+                        "<option value=\"2\">Two</option>" + Environment.NewLine +
+                        "<option value=\"3\">Three</option>" + Environment.NewLine +
+                        "</optgroup>" + Environment.NewLine +
+                        "</select>",
+                        "<select id=\"Property1\" multiple=\"multiple\" name=\"Property1\"><optgroup label=\"Group One\">" +
+                        Environment.NewLine +
+                        "<option value=\"0\">Zero</option>" + Environment.NewLine +
+                        "<option value=\"1\">One</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"2\">Two</option>" + Environment.NewLine +
+                        "<option value=\"3\">Three</option>" + Environment.NewLine +
+                        "</optgroup>" + Environment.NewLine +
+                        "</select>",
+                        "<select id=\"Property1\" multiple=\"multiple\" name=\"Property1\"><optgroup label=\"Group One\">" +
+                        Environment.NewLine +
+                        "<option value=\"0\">Zero</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"1\">One</option>" + Environment.NewLine +
+                        "<option value=\"2\">Two</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"3\">Three</option>" + Environment.NewLine +
+                        "</optgroup>" + Environment.NewLine +
+                        "</select>"
+                    },
+                    {
+                        OneDisabledGroupAllSelectedSelectList,
+                        "<select id=\"Property1\" multiple=\"multiple\" name=\"Property1\">" +
+                        "<optgroup disabled=\"disabled\" label=\"Disabled Group\">" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"0\">Zero</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"1\">One</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"2\">Two</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"3\">Three</option>" + Environment.NewLine +
+                        "</optgroup>" + Environment.NewLine +
+                        "</select>",
+                        "<select id=\"Property1\" multiple=\"multiple\" name=\"Property1\">" +
+                        "<optgroup disabled=\"disabled\" label=\"Disabled Group\">" + Environment.NewLine +
+                        "<option value=\"0\">Zero</option>" + Environment.NewLine +
+                        "<option value=\"1\">One</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"2\">Two</option>" + Environment.NewLine +
+                        "<option value=\"3\">Three</option>" + Environment.NewLine +
+                        "</optgroup>" + Environment.NewLine +
+                        "</select>",
+                        "<select id=\"Property1\" multiple=\"multiple\" name=\"Property1\">" +
+                        "<optgroup disabled=\"disabled\" label=\"Disabled Group\">" + Environment.NewLine +
+                        "<option value=\"0\">Zero</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"1\">One</option>" + Environment.NewLine +
+                        "<option value=\"2\">Two</option>" + Environment.NewLine +
+                        "<option selected=\"selected\" value=\"3\">Three</option>" + Environment.NewLine +
+                        "</optgroup>" + Environment.NewLine +
+                        "</select>"
+                    },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(DropDownListDataSet))]
+        public void DropDownList_WithNullModel_GeneratesExpectedValue_DoesNotChangeSelectList(
+            IEnumerable<SelectListItem> selectList,
+            string expectedHtml,
+            string ignoredHtml)
+        {
+            // Arrange
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper();
+            var savedDisabled = selectList.Select(item => item.Disabled).ToList();
+            var savedGroup = selectList.Select(item => item.Group).ToList();
+            var savedSelected = selectList.Select(item => item.Selected).ToList();
+            var savedText = selectList.Select(item => item.Text).ToList();
+            var savedValue = selectList.Select(item => item.Value).ToList();
+
+            // Act
+            var html = helper.DropDownList("Property1", selectList, optionLabel: null, htmlAttributes: null);
+
+            // Assert
+            Assert.Equal(expectedHtml, html.ToString());
+            Assert.Equal(savedDisabled, selectList.Select(item => item.Disabled));
+            Assert.Equal(savedGroup, selectList.Select(item => item.Group));
+            Assert.Equal(savedSelected, selectList.Select(item => item.Selected));
+            Assert.Equal(savedText, selectList.Select(item => item.Text));
+            Assert.Equal(savedValue, selectList.Select(item => item.Value));
+        }
+
+        [Theory]
+        [MemberData(nameof(DropDownListDataSet))]
+        public void DropDownList_WithModelValue_GeneratesExpectedValue(
+            IEnumerable<SelectListItem> selectList,
+            string ignoredHtml,
+            string expectedHtml)
+        {
+            // Arrange
+            var model = new DefaultTemplatesUtilities.ObjectTemplateModel { Property1 = "2" };
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
+            var savedSelected = selectList.Select(item => item.Selected).ToList();
+
+            // Act
+            var html = helper.DropDownList("Property1", selectList, optionLabel: null, htmlAttributes: null);
+
+            // Assert
+            Assert.Equal(expectedHtml, html.ToString());
+            Assert.Equal(savedSelected, selectList.Select(item => item.Selected));
+        }
+
+        [Theory]
+        [MemberData(nameof(DropDownListDataSet))]
+        public void DropDownListFor_WithNullModel_GeneratesExpectedValue(
+            IEnumerable<SelectListItem> selectList,
+            string expectedHtml,
+            string ignoredHtml)
+        {
+            // Arrange
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper();
+            var savedSelected = selectList.Select(item => item.Selected).ToList();
+
+            // Act
+            var html = helper.DropDownListFor(
+                value => value.Property1,
+                selectList,
+                optionLabel: null,
+                htmlAttributes: null);
+
+            // Assert
+            Assert.Equal(expectedHtml, html.ToString());
+            Assert.Equal(savedSelected, selectList.Select(item => item.Selected));
+        }
+
+        [Theory]
+        [MemberData(nameof(DropDownListDataSet))]
+        public void DropDownListFor_WithModelValue_GeneratesExpectedValue(
+            IEnumerable<SelectListItem> selectList,
+            string ignoredHtml,
+            string expectedHtml)
+        {
+            // Arrange
+            var model = new DefaultTemplatesUtilities.ObjectTemplateModel { Property1 = "2" };
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
+            var savedSelected = selectList.Select(item => item.Selected).ToList();
+
+            // Act
+            var html = helper.DropDownListFor(
+                value => value.Property1,
+                selectList,
+                optionLabel: null,
+                htmlAttributes: null);
+
+            // Assert
+            Assert.Equal(expectedHtml, html.ToString());
+            Assert.Equal(savedSelected, selectList.Select(item => item.Selected));
+        }
+
+        [Theory]
+        [MemberData(nameof(ListBoxDataSet))]
+        public void ListBox_WithNullModel_GeneratesExpectedValue_DoesNotChangeSelectList(
+            IEnumerable<SelectListItem> selectList,
+            string expectedHtml,
+            string ignoredHtml1,
+            string ignoredHtml2)
+        {
+            // Arrange
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper<ModelContainingList>(model: null);
+            var savedDisabled = selectList.Select(item => item.Disabled).ToList();
+            var savedGroup = selectList.Select(item => item.Group).ToList();
+            var savedSelected = selectList.Select(item => item.Selected).ToList();
+            var savedText = selectList.Select(item => item.Text).ToList();
+            var savedValue = selectList.Select(item => item.Value).ToList();
+
+            // Act
+            var html = helper.ListBox("Property1", selectList, htmlAttributes: null);
+
+            // Assert
+            Assert.Equal(expectedHtml, html.ToString());
+            Assert.Equal(savedDisabled, selectList.Select(item => item.Disabled));
+            Assert.Equal(savedGroup, selectList.Select(item => item.Group));
+            Assert.Equal(savedSelected, selectList.Select(item => item.Selected));
+            Assert.Equal(savedText, selectList.Select(item => item.Text));
+            Assert.Equal(savedValue, selectList.Select(item => item.Value));
+        }
+
+        [Theory]
+        [MemberData(nameof(ListBoxDataSet))]
+        public void ListBox_WithModelValue_GeneratesExpectedValue(
+            IEnumerable<SelectListItem> selectList,
+            string ignoredHtml1,
+            string expectedHtml,
+            string ignoredHtml2)
+        {
+            // Arrange
+            var model = new ModelContainingList { Property1 = { "2" } };
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
+            var savedSelected = selectList.Select(item => item.Selected).ToList();
+
+            // Act
+            var html = helper.ListBox("Property1", selectList, htmlAttributes: null);
+
+            // Assert
+            Assert.Equal(expectedHtml, html.ToString());
+            Assert.Equal(savedSelected, selectList.Select(item => item.Selected));
+        }
+
+        [Theory]
+        [MemberData(nameof(ListBoxDataSet))]
+        public void ListBox_WithMultipleModelValues_GeneratesExpectedValue(
+            IEnumerable<SelectListItem> selectList,
+            string ignoredHtml1,
+            string ignoredHtml2,
+            string expectedHtml)
+        {
+            // Arrange
+            var model = new ModelContainingList { Property1 = { "1", "3" } };
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
+            var savedSelected = selectList.Select(item => item.Selected).ToList();
+
+            // Act
+            var html = helper.ListBox("Property1", selectList, htmlAttributes: null);
+
+            // Assert
+            Assert.Equal(expectedHtml, html.ToString());
+            Assert.Equal(savedSelected, selectList.Select(item => item.Selected));
+        }
+
+        [Theory]
+        [MemberData(nameof(ListBoxDataSet))]
+        public void ListBoxFor_WithNullModel_GeneratesExpectedValue(
+            IEnumerable<SelectListItem> selectList,
+            string expectedHtml,
+            string ignoredHtml1,
+            string ignoredHtml2)
+        {
+            // Arrange
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper<ModelContainingList>(model: null);
+            var savedSelected = selectList.Select(item => item.Selected).ToList();
+
+            // Act
+            var html = helper.ListBoxFor(value => value.Property1, selectList, htmlAttributes: null);
+
+            // Assert
+            Assert.Equal(expectedHtml, html.ToString());
+            Assert.Equal(savedSelected, selectList.Select(item => item.Selected));
+        }
+
+        [Theory]
+        [MemberData(nameof(ListBoxDataSet))]
+        public void ListBoxFor_WithModelValue_GeneratesExpectedValue(
+            IEnumerable<SelectListItem> selectList,
+            string ignoredHtml1,
+            string expectedHtml,
+            string ignoredHtml2)
+        {
+            // Arrange
+            var model = new ModelContainingList { Property1 = { "2" } };
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
+            var savedSelected = selectList.Select(item => item.Selected).ToList();
+
+            // Act
+            var html = helper.ListBoxFor(value => value.Property1, selectList, htmlAttributes: null);
+
+            // Assert
+            Assert.Equal(expectedHtml, html.ToString());
+            Assert.Equal(savedSelected, selectList.Select(item => item.Selected));
+        }
+
+        [Theory]
+        [MemberData(nameof(ListBoxDataSet))]
+        public void ListBoxFor_WithMultipleModelValues_GeneratesExpectedValue(
+            IEnumerable<SelectListItem> selectList,
+            string ignoredHtml1,
+            string ignoredHtml2,
+            string expectedHtml)
+        {
+            // Arrange
+            var model = new ModelContainingList { Property1 = { "1", "3" } };
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
+            var savedSelected = selectList.Select(item => item.Selected).ToList();
+
+            // Act
+            var html = helper.ListBoxFor(value => value.Property1, selectList, htmlAttributes: null);
+
+            // Assert
+            Assert.Equal(expectedHtml, html.ToString());
+            Assert.Equal(savedSelected, selectList.Select(item => item.Selected));
+        }
+
+        private class ModelContainingList
+        {
+            public List<string> Property1 { get; } = new List<string>();
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Order.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Order.html
@@ -19,7 +19,15 @@
         <div>
             <label class="order" for="Products">Products</label>
 
-            <select multiple="multiple" id="Products" name="Products"><option value="0">Product_0</option>
+            <select multiple="multiple" id="Products" name="Products"><option selected="selected" value="0">Product_0</option>
+<option selected="selected" value="1">Product_1</option>
+<option value="2">Product_2</option>
+</select>
+        </div>
+        <div>
+            <label class="order" for="SubstituteProducts">SubstituteProducts</label>
+            
+            <select id="SubstituteProducts" multiple="multiple" name="SubstituteProducts"><option value="0">Product_0</option>
 <option value="1">Product_1</option>
 <option selected="selected" value="2">Product_2</option>
 </select>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.OrderUsingHtmlHelpers.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.OrderUsingHtmlHelpers.html
@@ -19,7 +19,15 @@
         <div>
             <label class="order" for="Products">Products</label>
 
-            <select id="Products" multiple="multiple" name="Products"><option value="0">Product_0</option>
+            <select id="Products" multiple="multiple" name="Products"><option selected="selected" value="0">Product_0</option>
+<option selected="selected" value="1">Product_1</option>
+<option value="2">Product_2</option>
+</select>
+        </div>
+        <div>
+            <label class="order" for="SubstituteProducts">SubstituteProducts</label>
+            
+            <select id="SubstituteProducts" multiple="multiple" name="SubstituteProducts"><option value="0">Product_0</option>
 <option value="1">Product_1</option>
 <option selected="selected" value="2">Product_2</option>
 </select>

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/SelectTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/SelectTagHelperTest.cs
@@ -243,7 +243,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
         [Theory]
         [MemberData(nameof(GeneratesExpectedDataSet))]
-        public async Task ProcessAsync_GeneratesExpectedOutput_WithItems(
+        public async Task ProcessAsync_WithItems_GeneratesExpectedOutput_DoesNotChangeSelectList(
             object model,
             Type containerType,
             Func<object> modelAccessor,
@@ -286,7 +286,6 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 SelfClosing = true,
             };
 
-            var items = new SelectList(new[] { "", "outer text", "inner text", "other text" });
             var htmlGenerator = new TestableHtmlGenerator(metadataProvider)
             {
                 ValidationAttributes =
@@ -295,6 +294,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 }
             };
             var viewContext = TestableHtmlGenerator.GetViewContext(model, htmlGenerator, metadataProvider);
+
+            var items = new SelectList(new[] { "", "outer text", "inner text", "other text" });
+            var savedDisabled = items.Select(item => item.Disabled).ToList();
+            var savedGroup = items.Select(item => item.Group).ToList();
+            var savedSelected = items.Select(item => item.Selected).ToList();
+            var savedText = items.Select(item => item.Text).ToList();
+            var savedValue = items.Select(item => item.Value).ToList();
             var tagHelper = new SelectTagHelper
             {
                 For = modelExpression,
@@ -321,6 +327,12 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.NotNull(keyValuePair.Value);
             var selectedValues = Assert.IsAssignableFrom<ICollection<string>>(keyValuePair.Value);
             Assert.InRange(selectedValues.Count, 0, 1);
+
+            Assert.Equal(savedDisabled, items.Select(item => item.Disabled));
+            Assert.Equal(savedGroup, items.Select(item => item.Group));
+            Assert.Equal(savedSelected, items.Select(item => item.Selected));
+            Assert.Equal(savedText, items.Select(item => item.Text));
+            Assert.Equal(savedValue, items.Select(item => item.Value));
         }
 
         [Theory]

--- a/test/WebSites/MvcTagHelpersWebSite/Controllers/MvcTagHelper_HomeController.cs
+++ b/test/WebSites/MvcTagHelpersWebSite/Controllers/MvcTagHelper_HomeController.cs
@@ -45,6 +45,7 @@ namespace MvcTagHelpersWebSite.Controllers
             },
             NeedSpecialHandle = true,
             PaymentMethod = new List<string> { "Check" },
+            Products = new List<int> { 0, 1 },
         };
 
         public MvcTagHelper_HomeController()

--- a/test/WebSites/MvcTagHelpersWebSite/Models/Order.cs
+++ b/test/WebSites/MvcTagHelpersWebSite/Models/Order.cs
@@ -44,6 +44,12 @@ namespace MvcTagHelpersWebSite.Models
             set;
         }
 
+        public IEnumerable<int> SubstituteProducts
+        {
+            get;
+            set;
+        }
+
         public Customer Customer
         {
             get;

--- a/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/Order.cshtml
+++ b/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/Order.cshtml
@@ -33,6 +33,11 @@
             <select asp-for="@Model.Products" asp-items="@((IEnumerable<SelectListItem>)ViewBag.Items)" multiple="@(@object)" />
         </div>
         <div>
+            <label asp-for="SubstituteProducts" class="order" />
+            @* Use same select list as Products. Selection when Products is non-null is not used here. *@
+            <select asp-for="SubstituteProducts" asp-items="@((IEnumerable<SelectListItem>)ViewBag.Items)" />
+        </div>
+        <div>
             <label asp-for="OrderDate" class="order" />
             <input asp-for="OrderDate" type="datetime" asp-format="{0:yyyy/MM/dd/ g}" />
         </div>

--- a/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/OrderUsingHtmlHelpers.cshtml
+++ b/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/OrderUsingHtmlHelpers.cshtml
@@ -28,6 +28,11 @@ Html.BeginForm(actionName: "Submit", controllerName: "MvcTagHelper_Order"))
             @Html.ListBoxFor(m => m.Products, productSelectList)
         </div>
         <div>
+            @Html.LabelFor(m => m.SubstituteProducts, htmlAttributes: new { @class = "order" })
+            @* Use same select list as Products. Selection when Products is non-null is not used here. *@
+            @Html.ListBoxFor(m => m.SubstituteProducts, productSelectList)
+        </div>
+        <div>
             @Html.LabelFor(m => m.OrderDate, htmlAttributes: new { @class = "order" })
             @Html.TextBoxFor(m => m.OrderDate, format: "{0:yyyy/MM/dd/ g}", htmlAttributes: new { type = "datetime" })
         </div>


### PR DESCRIPTION
- #524
- add tests of `DropDownList` and `ListBox` HTML helpers
- extend tests of `<select/>` tag helper
- add scenario to a functional test

New `HtmlHelperSelectTest` does not cover everything. In future (see #453):
- use non-`null` `optionLabel` and `htmlAttributes` arguments
- confirm value sources and their priorities
- mock an `IHtmlGenerator` and confirm how it is called
- mock an `IHtmlHelper` and confirm how extension methods call that