### PR TITLE
Add `deep-clean` to `verify` target

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -8,3 +8,5 @@ k-standard-goals
 
 #xml-docs-test .clean .build-compile description='Check generated XML documentation files for errors' target='test'
   k-xml-docs-test
+
+#do-deep-clean .deep-clean target='verify'


### PR DESCRIPTION
- help CI machines with directory cleanup
- this target is not normally used except on CI machines