### PR TITLE
Make HTML helper parameter names consistent

### DIFF
--- a/samples/MvcSample.Web/Views/Shared/EditorTemplates/Decimal.cshtml
+++ b/samples/MvcSample.Web/Views/Shared/EditorTemplates/Decimal.cshtml
@@ -13,6 +13,6 @@
 }
 
 @Html.TextBox(
-    name: null,
+    expression: null,
     value: FormattedValue,
     htmlAttributes: new { @class = "text-box single-line", style = "font-weight: bold", })

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Expressions/ExpressionHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Expressions/ExpressionHelper.cs
@@ -16,10 +16,7 @@ namespace Microsoft.AspNet.Mvc.Rendering.Expressions
         public static string GetExpressionText(string expression)
         {
             // If it's exactly "model", then give them an empty string, to replicate the lambda behavior.
-            return
-                string.Equals(expression, "model", StringComparison.OrdinalIgnoreCase)
-                    ? string.Empty
-                    : expression;
+            return string.Equals(expression, "model", StringComparison.OrdinalIgnoreCase) ? string.Empty : expression;
         }
 
         public static string GetExpressionText([NotNull] LambdaExpression expression)
@@ -91,7 +88,8 @@ namespace Microsoft.AspNet.Mvc.Rendering.Expressions
             return string.Empty;
         }
 
-        private static string GetIndexerInvocation([NotNull] Expression expression,
+        private static string GetIndexerInvocation(
+            [NotNull] Expression expression,
             [NotNull] ParameterExpression[] parameters)
         {
             var converted = Expression.Convert(expression, typeof(object));

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Expressions/ExpressionMetadataProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Expressions/ExpressionMetadataProvider.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.AspNet.Mvc.Core;
@@ -12,9 +11,9 @@ namespace Microsoft.AspNet.Mvc.Rendering.Expressions
 {
     public static class ExpressionMetadataProvider
     {
-        public static ModelMetadata FromLambdaExpression<TParameter, TValue>(
-            [NotNull] Expression<Func<TParameter, TValue>> expression,
-            [NotNull] ViewDataDictionary<TParameter> viewData,
+        public static ModelMetadata FromLambdaExpression<TModel, TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            [NotNull] ViewDataDictionary<TModel> viewData,
             IModelMetadataProvider metadataProvider)
         {
             string propertyName = null;
@@ -70,7 +69,7 @@ namespace Microsoft.AspNet.Mvc.Rendering.Expressions
 
             return GetMetadataFromProvider(
                 modelAccessor,
-                typeof(TValue),
+                typeof(TResult),
                 propertyName,
                 container,
                 containerType,

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/DefaultDisplayTemplates.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/DefaultDisplayTemplates.cs
@@ -15,16 +15,16 @@ namespace Microsoft.AspNet.Mvc.Rendering
 {
     public static class DefaultDisplayTemplates
     {
-        public static string BooleanTemplate(IHtmlHelper html)
+        public static string BooleanTemplate(IHtmlHelper htmlHelper)
         {
             bool? value = null;
-            if (html.ViewData.Model != null)
+            if (htmlHelper.ViewData.Model != null)
             {
-                value = Convert.ToBoolean(html.ViewData.Model, CultureInfo.InvariantCulture);
+                value = Convert.ToBoolean(htmlHelper.ViewData.Model, CultureInfo.InvariantCulture);
             }
 
-            return html.ViewData.ModelMetadata.IsNullableValueType ?
-                BooleanTemplateDropDownList(html, value) :
+            return htmlHelper.ViewData.ModelMetadata.IsNullableValueType ?
+                BooleanTemplateDropDownList(htmlHelper, value) :
                 BooleanTemplateCheckbox(value ?? false);
         }
 
@@ -42,7 +42,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return inputTag.ToString(TagRenderMode.SelfClosing);
         }
 
-        private static string BooleanTemplateDropDownList(IHtmlHelper html, bool? value)
+        private static string BooleanTemplateDropDownList(IHtmlHelper htmlHelper, bool? value)
         {
             var selectTag = new TagBuilder("select");
             selectTag.AddCssClass("list-box");
@@ -54,7 +54,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
             foreach (var item in TriStateValues(value))
             {
-                var encodedText = html.Encode(item.Text);
+                var encodedText = htmlHelper.Encode(item.Text);
                 var option = DefaultHtmlGenerator.GenerateOption(item, encodedText);
                 builder.Append(option);
             }
@@ -89,9 +89,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
             };
         }
 
-        public static string CollectionTemplate(IHtmlHelper html)
+        public static string CollectionTemplate(IHtmlHelper htmlHelper)
         {
-            var model = html.ViewData.ModelMetadata.Model;
+            var model = htmlHelper.ViewData.ModelMetadata.Model;
             if (model == null)
             {
                 return string.Empty;
@@ -114,16 +114,16 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
             var typeInCollectionIsNullableValueType = typeInCollection.IsNullableValueType();
 
-            var oldPrefix = html.ViewData.TemplateInfo.HtmlFieldPrefix;
+            var oldPrefix = htmlHelper.ViewData.TemplateInfo.HtmlFieldPrefix;
 
             try
             {
-                html.ViewData.TemplateInfo.HtmlFieldPrefix = string.Empty;
+                htmlHelper.ViewData.TemplateInfo.HtmlFieldPrefix = string.Empty;
 
                 var fieldNameBase = oldPrefix;
                 var result = new StringBuilder();
 
-                var serviceProvider = html.ViewContext.HttpContext.RequestServices;
+                var serviceProvider = htmlHelper.ViewContext.HttpContext.RequestServices;
                 var metadataProvider = serviceProvider.GetRequiredService<IModelMetadataProvider>();
                 var viewEngine = serviceProvider.GetRequiredService<ICompositeViewEngine>();
 
@@ -141,8 +141,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
                     var templateBuilder = new TemplateBuilder(
                         viewEngine,
-                        html.ViewContext,
-                        html.ViewData,
+                        htmlHelper.ViewContext,
+                        htmlHelper.ViewData,
                         metadata,
                         htmlFieldName: fieldName,
                         templateName: null,
@@ -157,51 +157,51 @@ namespace Microsoft.AspNet.Mvc.Rendering
             }
             finally
             {
-                html.ViewData.TemplateInfo.HtmlFieldPrefix = oldPrefix;
+                htmlHelper.ViewData.TemplateInfo.HtmlFieldPrefix = oldPrefix;
             }
         }
 
-        public static string DecimalTemplate(IHtmlHelper html)
+        public static string DecimalTemplate(IHtmlHelper htmlHelper)
         {
-            if (html.ViewData.TemplateInfo.FormattedModelValue == html.ViewData.ModelMetadata.Model)
+            if (htmlHelper.ViewData.TemplateInfo.FormattedModelValue == htmlHelper.ViewData.ModelMetadata.Model)
             {
-                html.ViewData.TemplateInfo.FormattedModelValue =
-                    string.Format(CultureInfo.CurrentCulture, "{0:0.00}", html.ViewData.ModelMetadata.Model);
+                htmlHelper.ViewData.TemplateInfo.FormattedModelValue =
+                    string.Format(CultureInfo.CurrentCulture, "{0:0.00}", htmlHelper.ViewData.ModelMetadata.Model);
             }
 
-            return StringTemplate(html);
+            return StringTemplate(htmlHelper);
         }
 
-        public static string EmailAddressTemplate(IHtmlHelper html)
+        public static string EmailAddressTemplate(IHtmlHelper htmlHelper)
         {
-            var uriString = "mailto:" + ((html.ViewData.Model == null) ?
+            var uriString = "mailto:" + ((htmlHelper.ViewData.Model == null) ?
                 string.Empty :
-                html.ViewData.Model.ToString());
-            var linkedText = (html.ViewData.TemplateInfo.FormattedModelValue == null) ?
+                htmlHelper.ViewData.Model.ToString());
+            var linkedText = (htmlHelper.ViewData.TemplateInfo.FormattedModelValue == null) ?
                 string.Empty :
-                html.ViewData.TemplateInfo.FormattedModelValue.ToString();
+                htmlHelper.ViewData.TemplateInfo.FormattedModelValue.ToString();
 
             return HyperlinkTemplate(uriString, linkedText);
         }
 
-        public static string HiddenInputTemplate(IHtmlHelper html)
+        public static string HiddenInputTemplate(IHtmlHelper htmlHelper)
         {
-            if (html.ViewData.ModelMetadata.HideSurroundingHtml)
+            if (htmlHelper.ViewData.ModelMetadata.HideSurroundingHtml)
             {
                 return string.Empty;
             }
 
-            return StringTemplate(html);
+            return StringTemplate(htmlHelper);
         }
 
-        public static string HtmlTemplate(IHtmlHelper html)
+        public static string HtmlTemplate(IHtmlHelper htmlHelper)
         {
-            return html.ViewData.TemplateInfo.FormattedModelValue.ToString();
+            return htmlHelper.ViewData.TemplateInfo.FormattedModelValue.ToString();
         }
 
-        public static string ObjectTemplate(IHtmlHelper html)
+        public static string ObjectTemplate(IHtmlHelper htmlHelper)
         {
-            var viewData = html.ViewData;
+            var viewData = htmlHelper.ViewData;
             var templateInfo = viewData.TemplateInfo;
             var modelMetadata = viewData.ModelMetadata;
             var builder = new StringBuilder();
@@ -216,13 +216,13 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 var text = modelMetadata.SimpleDisplayText;
                 if (modelMetadata.HtmlEncode)
                 {
-                    text = html.Encode(text);
+                    text = htmlHelper.Encode(text);
                 }
 
                 return text;
             }
 
-            var serviceProvider = html.ViewContext.HttpContext.RequestServices;
+            var serviceProvider = htmlHelper.ViewContext.HttpContext.RequestServices;
             var viewEngine = serviceProvider.GetRequiredService<ICompositeViewEngine>();
 
             foreach (var propertyMetadata in modelMetadata.Properties.Where(pm => ShouldShow(pm, templateInfo)))
@@ -248,8 +248,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
                 var templateBuilder = new TemplateBuilder(
                     viewEngine,
-                    html.ViewContext,
-                    html.ViewData,
+                    htmlHelper.ViewContext,
+                    htmlHelper.ViewData,
                     propertyMetadata,
                     htmlFieldName: propertyMetadata.PropertyName,
                     templateName: null,
@@ -275,17 +275,17 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 !templateInfo.Visited(metadata);
         }
 
-        public static string StringTemplate(IHtmlHelper html)
+        public static string StringTemplate(IHtmlHelper htmlHelper)
         {
-            return html.Encode(html.ViewData.TemplateInfo.FormattedModelValue);
+            return htmlHelper.Encode(htmlHelper.ViewData.TemplateInfo.FormattedModelValue);
         }
 
-        public static string UrlTemplate(IHtmlHelper html)
+        public static string UrlTemplate(IHtmlHelper htmlHelper)
         {
-            var uriString = (html.ViewData.Model == null) ? string.Empty : html.ViewData.Model.ToString();
-            var linkedText = (html.ViewData.TemplateInfo.FormattedModelValue == null) ?
+            var uriString = (htmlHelper.ViewData.Model == null) ? string.Empty : htmlHelper.ViewData.Model.ToString();
+            var linkedText = (htmlHelper.ViewData.TemplateInfo.FormattedModelValue == null) ?
                 string.Empty :
-                html.ViewData.TemplateInfo.FormattedModelValue.ToString();
+                htmlHelper.ViewData.TemplateInfo.FormattedModelValue.ToString();
 
             return HyperlinkTemplate(uriString, linkedText);
         }

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/DefaultDisplayTemplates.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/DefaultDisplayTemplates.cs
@@ -224,8 +224,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
             var serviceProvider = htmlHelper.ViewContext.HttpContext.RequestServices;
             var viewEngine = serviceProvider.GetRequiredService<ICompositeViewEngine>();
-
-            foreach (var propertyMetadata in modelMetadata.Properties.Where(pm => ShouldShow(pm, templateInfo)))
+            var properties = modelMetadata.Properties.Where(metadata => ShouldShow(metadata, templateInfo));
+            foreach (var propertyMetadata in properties)
             {
                 var divTag = new TagBuilder("div");
 

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/DefaultEditorTemplates.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/DefaultEditorTemplates.cs
@@ -17,41 +17,41 @@ namespace Microsoft.AspNet.Mvc.Rendering
     {
         private const string HtmlAttributeKey = "htmlAttributes";
 
-        public static string BooleanTemplate(IHtmlHelper html)
+        public static string BooleanTemplate(IHtmlHelper htmlHelper)
         {
             bool? value = null;
-            if (html.ViewData.Model != null)
+            if (htmlHelper.ViewData.Model != null)
             {
-                value = Convert.ToBoolean(html.ViewData.Model, CultureInfo.InvariantCulture);
+                value = Convert.ToBoolean(htmlHelper.ViewData.Model, CultureInfo.InvariantCulture);
             }
 
-            return html.ViewData.ModelMetadata.IsNullableValueType ?
-                BooleanTemplateDropDownList(html, value) :
-                BooleanTemplateCheckbox(html, value ?? false);
+            return htmlHelper.ViewData.ModelMetadata.IsNullableValueType ?
+                BooleanTemplateDropDownList(htmlHelper, value) :
+                BooleanTemplateCheckbox(htmlHelper, value ?? false);
         }
 
-        private static string BooleanTemplateCheckbox(IHtmlHelper html, bool value)
+        private static string BooleanTemplateCheckbox(IHtmlHelper htmlHelper, bool value)
         {
-            return html.CheckBox(
-                name: null,
+            return htmlHelper.CheckBox(
+                expression: null,
                 isChecked: value,
-                htmlAttributes: CreateHtmlAttributes(html, "check-box"))
+                htmlAttributes: CreateHtmlAttributes(htmlHelper, "check-box"))
                     .ToString();
         }
 
-        private static string BooleanTemplateDropDownList(IHtmlHelper html, bool? value)
+        private static string BooleanTemplateDropDownList(IHtmlHelper htmlHelper, bool? value)
         {
-            return html.DropDownList(
-                name: null,
+            return htmlHelper.DropDownList(
+                expression: null,
                 selectList: DefaultDisplayTemplates.TriStateValues(value),
                 optionLabel: null,
-                htmlAttributes: CreateHtmlAttributes(html, "list-box tri-state"))
+                htmlAttributes: CreateHtmlAttributes(htmlHelper, "list-box tri-state"))
                     .ToString();
         }
 
-        public static string CollectionTemplate(IHtmlHelper html)
+        public static string CollectionTemplate(IHtmlHelper htmlHelper)
         {
-            var viewData = html.ViewData;
+            var viewData = htmlHelper.ViewData;
             var model = viewData.ModelMetadata.Model;
             if (model == null)
             {
@@ -83,7 +83,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 var fieldNameBase = oldPrefix;
                 var result = new StringBuilder();
 
-                var serviceProvider = html.ViewContext.HttpContext.RequestServices;
+                var serviceProvider = htmlHelper.ViewContext.HttpContext.RequestServices;
                 var metadataProvider = serviceProvider.GetRequiredService<IModelMetadataProvider>();
                 var viewEngine = serviceProvider.GetRequiredService<ICompositeViewEngine>();
 
@@ -101,8 +101,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
                     var templateBuilder = new TemplateBuilder(
                         viewEngine,
-                        html.ViewContext,
-                        html.ViewData,
+                        htmlHelper.ViewContext,
+                        htmlHelper.ViewData,
                         metadata,
                         htmlFieldName: fieldName,
                         templateName: null,
@@ -121,20 +121,20 @@ namespace Microsoft.AspNet.Mvc.Rendering
             }
         }
 
-        public static string DecimalTemplate(IHtmlHelper html)
+        public static string DecimalTemplate(IHtmlHelper htmlHelper)
         {
-            if (html.ViewData.TemplateInfo.FormattedModelValue == html.ViewData.ModelMetadata.Model)
+            if (htmlHelper.ViewData.TemplateInfo.FormattedModelValue == htmlHelper.ViewData.ModelMetadata.Model)
             {
-                html.ViewData.TemplateInfo.FormattedModelValue =
-                    string.Format(CultureInfo.CurrentCulture, "{0:0.00}", html.ViewData.ModelMetadata.Model);
+                htmlHelper.ViewData.TemplateInfo.FormattedModelValue =
+                    string.Format(CultureInfo.CurrentCulture, "{0:0.00}", htmlHelper.ViewData.ModelMetadata.Model);
             }
 
-            return StringTemplate(html);
+            return StringTemplate(htmlHelper);
         }
 
-        public static string HiddenInputTemplate(IHtmlHelper html)
+        public static string HiddenInputTemplate(IHtmlHelper htmlHelper)
         {
-            var viewData = html.ViewData;
+            var viewData = htmlHelper.ViewData;
             var model = viewData.Model;
 
             string result;
@@ -144,7 +144,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             }
             else
             {
-                result = DefaultDisplayTemplates.StringTemplate(html);
+                result = DefaultDisplayTemplates.StringTemplate(htmlHelper);
             }
 
             // Special-case opaque values and arbitrary binary data.
@@ -155,18 +155,18 @@ namespace Microsoft.AspNet.Mvc.Rendering
             }
 
             var htmlAttributesObject = viewData[HtmlAttributeKey];
-            var hiddenResult = html.Hidden(name: null, value: model, htmlAttributes: htmlAttributesObject);
+            var hiddenResult = htmlHelper.Hidden(expression: null, value: model, htmlAttributes: htmlAttributesObject);
             result += hiddenResult.ToString();
 
             return result;
         }
 
         private static IDictionary<string, object> CreateHtmlAttributes(
-            IHtmlHelper html,
+            IHtmlHelper htmlHelper,
             string className,
             string inputType = null)
         {
-            var htmlAttributesObject = html.ViewData[HtmlAttributeKey];
+            var htmlAttributesObject = htmlHelper.ViewData[HtmlAttributeKey];
             if (htmlAttributesObject != null)
             {
                 return MergeHtmlAttributes(htmlAttributesObject, className, inputType);
@@ -212,20 +212,20 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return htmlAttributes;
         }
 
-        public static string MultilineTemplate(IHtmlHelper html)
+        public static string MultilineTemplate(IHtmlHelper htmlHelper)
         {
-            var htmlString = html.TextArea(
-                name: string.Empty,
-                value: html.ViewContext.ViewData.TemplateInfo.FormattedModelValue.ToString(),
+            var htmlString = htmlHelper.TextArea(
+                expression: string.Empty,
+                value: htmlHelper.ViewContext.ViewData.TemplateInfo.FormattedModelValue.ToString(),
                 rows: 0,
                 columns: 0,
-                htmlAttributes: CreateHtmlAttributes(html, "text-box multi-line"));
+                htmlAttributes: CreateHtmlAttributes(htmlHelper, "text-box multi-line"));
             return htmlString.ToString();
         }
 
-        public static string ObjectTemplate(IHtmlHelper html)
+        public static string ObjectTemplate(IHtmlHelper htmlHelper)
         {
-            var viewData = html.ViewData;
+            var viewData = htmlHelper.ViewData;
             var templateInfo = viewData.TemplateInfo;
             var modelMetadata = viewData.ModelMetadata;
             var builder = new StringBuilder();
@@ -240,13 +240,13 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 var text = modelMetadata.SimpleDisplayText;
                 if (modelMetadata.HtmlEncode)
                 {
-                    text = html.Encode(text);
+                    text = htmlHelper.Encode(text);
                 }
 
                 return text;
             }
 
-            var serviceProvider = html.ViewContext.HttpContext.RequestServices;
+            var serviceProvider = htmlHelper.ViewContext.HttpContext.RequestServices;
             var viewEngine = serviceProvider.GetRequiredService<ICompositeViewEngine>();
 
             foreach (var propertyMetadata in modelMetadata.Properties.Where(pm => ShouldShow(pm, templateInfo)))
@@ -255,7 +255,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
                 if (!propertyMetadata.HideSurroundingHtml)
                 {
-                    var label = html.Label(
+                    var label = htmlHelper.Label(
                         propertyMetadata.PropertyName,
                         labelText: null,
                         htmlAttributes: null)
@@ -276,8 +276,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
                 var templateBuilder = new TemplateBuilder(
                     viewEngine,
-                    html.ViewContext,
-                    html.ViewData,
+                    htmlHelper.ViewContext,
+                    htmlHelper.ViewData,
                     propertyMetadata,
                     htmlFieldName: propertyMetadata.PropertyName,
                     templateName: null,
@@ -289,7 +289,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 if (!propertyMetadata.HideSurroundingHtml)
                 {
                     builder.Append(" ");
-                    builder.Append(html.ValidationMessage(
+                    builder.Append(htmlHelper.ValidationMessage(
                         propertyMetadata.PropertyName,
                         message: null,
                         htmlAttributes: null,
@@ -302,12 +302,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return builder.ToString();
         }
 
-        public static string PasswordTemplate(IHtmlHelper html)
+        public static string PasswordTemplate(IHtmlHelper htmlHelper)
         {
-            return html.Password(
-                name: null,
-                value: html.ViewData.TemplateInfo.FormattedModelValue,
-                htmlAttributes: CreateHtmlAttributes(html, "text-box single-line password"))
+            return htmlHelper.Password(
+                expression: null,
+                value: htmlHelper.ViewData.TemplateInfo.FormattedModelValue,
+                htmlAttributes: CreateHtmlAttributes(htmlHelper, "text-box single-line password"))
                     .ToString();
         }
 
@@ -319,88 +319,91 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 && !templateInfo.Visited(metadata);
         }
 
-        public static string StringTemplate(IHtmlHelper html)
+        public static string StringTemplate(IHtmlHelper htmlHelper)
         {
-            return GenerateTextBox(html);
+            return GenerateTextBox(htmlHelper);
         }
 
-        public static string PhoneNumberInputTemplate(IHtmlHelper html)
+        public static string PhoneNumberInputTemplate(IHtmlHelper htmlHelper)
         {
-            return GenerateTextBox(html, inputType: "tel");
+            return GenerateTextBox(htmlHelper, inputType: "tel");
         }
 
-        public static string UrlInputTemplate(IHtmlHelper html)
+        public static string UrlInputTemplate(IHtmlHelper htmlHelper)
         {
-            return GenerateTextBox(html, inputType: "url");
+            return GenerateTextBox(htmlHelper, inputType: "url");
         }
 
-        public static string EmailAddressInputTemplate(IHtmlHelper html)
+        public static string EmailAddressInputTemplate(IHtmlHelper htmlHelper)
         {
-            return GenerateTextBox(html, inputType: "email");
+            return GenerateTextBox(htmlHelper, inputType: "email");
         }
 
-        public static string DateTimeInputTemplate(IHtmlHelper html)
+        public static string DateTimeInputTemplate(IHtmlHelper htmlHelper)
         {
-            ApplyRfc3339DateFormattingIfNeeded(html, "{0:yyyy-MM-ddTHH:mm:ss.fffK}");
-            return GenerateTextBox(html, inputType: "datetime");
+            ApplyRfc3339DateFormattingIfNeeded(htmlHelper, "{0:yyyy-MM-ddTHH:mm:ss.fffK}");
+            return GenerateTextBox(htmlHelper, inputType: "datetime");
         }
 
-        public static string DateTimeLocalInputTemplate(IHtmlHelper html)
+        public static string DateTimeLocalInputTemplate(IHtmlHelper htmlHelper)
         {
-            ApplyRfc3339DateFormattingIfNeeded(html, "{0:yyyy-MM-ddTHH:mm:ss.fff}");
-            return GenerateTextBox(html, inputType: "datetime-local");
+            ApplyRfc3339DateFormattingIfNeeded(htmlHelper, "{0:yyyy-MM-ddTHH:mm:ss.fff}");
+            return GenerateTextBox(htmlHelper, inputType: "datetime-local");
         }
 
-        public static string DateInputTemplate(IHtmlHelper html)
+        public static string DateInputTemplate(IHtmlHelper htmlHelper)
         {
-            ApplyRfc3339DateFormattingIfNeeded(html, "{0:yyyy-MM-dd}");
-            return GenerateTextBox(html, inputType: "date");
+            ApplyRfc3339DateFormattingIfNeeded(htmlHelper, "{0:yyyy-MM-dd}");
+            return GenerateTextBox(htmlHelper, inputType: "date");
         }
 
-        public static string TimeInputTemplate(IHtmlHelper html)
+        public static string TimeInputTemplate(IHtmlHelper htmlHelper)
         {
-            ApplyRfc3339DateFormattingIfNeeded(html, "{0:HH:mm:ss.fff}");
-            return GenerateTextBox(html, inputType: "time");
+            ApplyRfc3339DateFormattingIfNeeded(htmlHelper, "{0:HH:mm:ss.fff}");
+            return GenerateTextBox(htmlHelper, inputType: "time");
         }
 
-        public static string NumberInputTemplate(IHtmlHelper html)
+        public static string NumberInputTemplate(IHtmlHelper htmlHelper)
         {
-            return GenerateTextBox(html, inputType: "number");
+            return GenerateTextBox(htmlHelper, inputType: "number");
         }
 
-        private static void ApplyRfc3339DateFormattingIfNeeded(IHtmlHelper html, string format)
+        private static void ApplyRfc3339DateFormattingIfNeeded(IHtmlHelper htmlHelper, string format)
         {
-            if (html.Html5DateRenderingMode != Html5DateRenderingMode.Rfc3339)
+            if (htmlHelper.Html5DateRenderingMode != Html5DateRenderingMode.Rfc3339)
             {
                 return;
             }
 
-            var metadata = html.ViewData.ModelMetadata;
+            var metadata = htmlHelper.ViewData.ModelMetadata;
             var value = metadata.Model;
-            if (html.ViewData.TemplateInfo.FormattedModelValue != value && metadata.HasNonDefaultEditFormat)
+            if (htmlHelper.ViewData.TemplateInfo.FormattedModelValue != value && metadata.HasNonDefaultEditFormat)
             {
                 return;
             }
 
             if (value is DateTime || value is DateTimeOffset)
             {
-                html.ViewData.TemplateInfo.FormattedModelValue =
+                htmlHelper.ViewData.TemplateInfo.FormattedModelValue =
                     string.Format(CultureInfo.InvariantCulture, format, value);
             }
         }
 
-        private static string GenerateTextBox(IHtmlHelper html, string inputType = null)
+        private static string GenerateTextBox(IHtmlHelper htmlHelper, string inputType = null)
         {
-            return GenerateTextBox(html, inputType, html.ViewData.TemplateInfo.FormattedModelValue);
+            return GenerateTextBox(htmlHelper, inputType, htmlHelper.ViewData.TemplateInfo.FormattedModelValue);
         }
 
-        private static string GenerateTextBox(IHtmlHelper html, string inputType, object value)
+        private static string GenerateTextBox(IHtmlHelper htmlHelper, string inputType, object value)
         {
-            return html.TextBox(
-                name: null,
+            var htmlAttributes =
+                CreateHtmlAttributes(htmlHelper, className: "text-box single-line", inputType: inputType);
+
+            return htmlHelper.TextBox(
+                current: null,
                 value: value,
                 format: null,
-                htmlAttributes: CreateHtmlAttributes(html, className: "text-box single-line", inputType: inputType))
+                htmlAttributes: htmlAttributes)
                     .ToString();
         }
     }

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/DefaultEditorTemplates.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/DefaultEditorTemplates.cs
@@ -248,8 +248,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
             var serviceProvider = htmlHelper.ViewContext.HttpContext.RequestServices;
             var viewEngine = serviceProvider.GetRequiredService<ICompositeViewEngine>();
-
-            foreach (var propertyMetadata in modelMetadata.Properties.Where(pm => ShouldShow(pm, templateInfo)))
+            var properties = modelMetadata.Properties.Where(metadata => ShouldShow(metadata, templateInfo));
+            foreach (var propertyMetadata in properties)
             {
                 var divTag = new TagBuilder("div");
 
@@ -315,8 +315,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         {
             return
                 metadata.ShowForEdit &&
-                !metadata.IsComplexType
-                && !templateInfo.Visited(metadata);
+                !metadata.IsComplexType &&
+                !templateInfo.Visited(metadata);
         }
 
         public static string StringTemplate(IHtmlHelper htmlHelper)

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/DefaultHtmlGenerator.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/DefaultHtmlGenerator.cs
@@ -1024,14 +1024,17 @@ namespace Microsoft.AspNet.Mvc.Rendering
             if (value == null)
             {
                 throw new InvalidOperationException(Resources.FormatHtmlHelper_MissingSelectData(
-                    "IEnumerable<SelectListItem>", expression));
+                    $"IEnumerable<{nameof(SelectListItem)}>",
+                    expression));
             }
 
             var selectList = value as IEnumerable<SelectListItem>;
             if (selectList == null)
             {
                 throw new InvalidOperationException(Resources.FormatHtmlHelper_WrongSelectDataType(
-                    expression, value.GetType().FullName, "IEnumerable<SelectListItem>"));
+                    expression,
+                    value.GetType().FullName,
+                    $"IEnumerable<{nameof(SelectListItem)}>"));
             }
 
             return selectList;

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/HtmlHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/HtmlHelper.cs
@@ -113,18 +113,18 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// value to the dictionary. It will expose public properties from derived types as well. This is typically
         /// used with objects of an anonymous type.
         ///
-        /// If the object is already an <see cref="IDictionary{string, object}"/> instance, then it is
-        /// returned as-is.
+        /// If the <paramref name="value"/> is already an <see cref="IDictionary{string, object}"/> instance, then it
+        /// is returned as-is.
         /// <example>
         /// <c>new { data_name="value" }</c> will translate to the entry <c>{ "data_name", "value" }</c>
         /// in the resulting dictionary.
         /// </example>
         /// </summary>
-        /// <param name="obj">The object to be converted.</param>
+        /// <param name="value">The <see cref="object"/> to be converted.</param>
         /// <returns>The created dictionary of property names and property values.</returns>
-        public static IDictionary<string, object> ObjectToDictionary(object obj)
+        public static IDictionary<string, object> ObjectToDictionary(object value)
         {
-            return TypeHelper.ObjectToDictionary(obj);
+            return TypeHelper.ObjectToDictionary(value);
         }
 
         /// <summary>
@@ -231,9 +231,13 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <inheritdoc />
-        public HtmlString CheckBox(string name, bool? isChecked, object htmlAttributes)
+        public HtmlString CheckBox(string expression, bool? isChecked, object htmlAttributes)
         {
-            return GenerateCheckBox(metadata: null, name: name, isChecked: isChecked, htmlAttributes: htmlAttributes);
+            return GenerateCheckBox(
+                metadata: null,
+                expression: expression,
+                isChecked: isChecked,
+                htmlAttributes: htmlAttributes);
         }
 
         /// <inheritdoc />
@@ -255,9 +259,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <inheritdoc />
-        public string GenerateIdFromName([NotNull] string name)
+        public string GenerateIdFromName([NotNull] string fullName)
         {
-            return TagBuilder.CreateSanitizedId(name, IdAttributeDotReplacement);
+            return TagBuilder.CreateSanitizedId(fullName, IdAttributeDotReplacement);
         }
 
         /// <inheritdoc />
@@ -282,26 +286,32 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <inheritdoc />
-        public string DisplayText(string name)
+        public string DisplayText(string expression)
         {
-            var metadata = ExpressionMetadataProvider.FromStringExpression(name, ViewData, MetadataProvider);
+            var metadata = ExpressionMetadataProvider.FromStringExpression(expression, ViewData, MetadataProvider);
             return GenerateDisplayText(metadata);
         }
 
         /// <inheritdoc />
-        public HtmlString DropDownList(string name, IEnumerable<SelectListItem> selectList, string optionLabel,
+        public HtmlString DropDownList(
+            string expression,
+            IEnumerable<SelectListItem> selectList,
+            string optionLabel,
             object htmlAttributes)
         {
             return GenerateDropDown(
                 metadata: null,
-                expression: name,
+                expression: expression,
                 selectList: selectList,
                 optionLabel: optionLabel,
                 htmlAttributes: htmlAttributes);
         }
 
         /// <inheritdoc />
-        public HtmlString Editor(string expression, string templateName, string htmlFieldName,
+        public HtmlString Editor(
+            string expression,
+            string templateName,
+            string htmlFieldName,
             object additionalViewData)
         {
             var metadata = ExpressionMetadataProvider.FromStringExpression(expression, ViewData, MetadataProvider);
@@ -314,16 +324,20 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <inheritdoc />
-        public HtmlString Hidden(string name, object value, object htmlAttributes)
+        public HtmlString Hidden(string expression, object value, object htmlAttributes)
         {
-            return GenerateHidden(metadata: null, name: name, value: value, useViewData: (value == null),
+            return GenerateHidden(
+                metadata: null,
+                expression: expression,
+                value: value,
+                useViewData: (value == null),
                 htmlAttributes: htmlAttributes);
         }
 
         /// <inheritdoc />
-        public string Id(string name)
+        public string Id(string expression)
         {
-            return GenerateId(name);
+            return GenerateId(expression);
         }
 
         /// <inheritdoc />
@@ -331,27 +345,33 @@ namespace Microsoft.AspNet.Mvc.Rendering
         {
             var metadata = ExpressionMetadataProvider.FromStringExpression(expression, ViewData, MetadataProvider);
             return GenerateLabel(
-                            metadata,
-                            expression,
-                            labelText,
-                            htmlAttributes);
+                metadata,
+                expression,
+                labelText,
+                htmlAttributes);
         }
 
         /// <inheritdoc />
-        public HtmlString ListBox(string name, IEnumerable<SelectListItem> selectList, object htmlAttributes)
+        public HtmlString ListBox(string expression, IEnumerable<SelectListItem> selectList, object htmlAttributes)
         {
-            return GenerateListBox(metadata: null, name: name, selectList: selectList, htmlAttributes: htmlAttributes);
+            return GenerateListBox(
+                metadata: null,
+                expression: expression,
+                selectList: selectList,
+                htmlAttributes: htmlAttributes);
         }
 
         /// <inheritdoc />
-        public string Name(string name)
+        public string Name(string expression)
         {
-            return GenerateName(name);
+            return GenerateName(expression);
         }
 
         /// <inheritdoc />
-        public async Task<HtmlString> PartialAsync([NotNull] string partialViewName, object model,
-                                                   ViewDataDictionary viewData)
+        public async Task<HtmlString> PartialAsync(
+            [NotNull] string partialViewName,
+            object model,
+            ViewDataDictionary viewData)
         {
             using (var writer = new StringCollectionTextWriter(Encoding.UTF8))
             {
@@ -419,15 +439,23 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <inheritdoc />
-        public HtmlString Password(string name, object value, object htmlAttributes)
+        public HtmlString Password(string expression, object value, object htmlAttributes)
         {
-            return GeneratePassword(metadata: null, name: name, value: value, htmlAttributes: htmlAttributes);
+            return GeneratePassword(
+                metadata: null,
+                expression: expression,
+                value: value,
+                htmlAttributes: htmlAttributes);
         }
 
         /// <inheritdoc />
-        public HtmlString RadioButton(string name, object value, bool? isChecked, object htmlAttributes)
+        public HtmlString RadioButton(string expression, object value, bool? isChecked, object htmlAttributes)
         {
-            return GenerateRadioButton(metadata: null, name: name, value: value, isChecked: isChecked,
+            return GenerateRadioButton(
+                metadata: null,
+                expression: expression,
+                value: value,
+                isChecked: isChecked,
                 htmlAttributes: htmlAttributes);
         }
 
@@ -504,28 +532,28 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <inheritdoc />
-        public HtmlString TextArea(string name, string value, int rows, int columns, object htmlAttributes)
+        public HtmlString TextArea(string expression, string value, int rows, int columns, object htmlAttributes)
         {
-            var metadata = ExpressionMetadataProvider.FromStringExpression(name, ViewData, MetadataProvider);
+            var metadata = ExpressionMetadataProvider.FromStringExpression(expression, ViewData, MetadataProvider);
             if (value != null)
             {
                 metadata.Model = value;
             }
 
-            return GenerateTextArea(metadata, name, rows, columns, htmlAttributes);
+            return GenerateTextArea(metadata, expression, rows, columns, htmlAttributes);
         }
 
         /// <inheritdoc />
-        public HtmlString TextBox(string name, object value, string format, object htmlAttributes)
+        public HtmlString TextBox(string expression, object value, string format, object htmlAttributes)
         {
-            return GenerateTextBox(metadata: null, name: name, value: value, format: format,
+            return GenerateTextBox(metadata: null, expression: expression, value: value, format: format,
                 htmlAttributes: htmlAttributes);
         }
 
         /// <inheritdoc />
-        public string Value(string name, string format)
+        public string Value(string expression, string format)
         {
-            return GenerateValue(name, value: null, format: format, useViewData: true);
+            return GenerateValue(expression, value: null, format: format, useViewData: true);
         }
 
         /// <summary>
@@ -538,16 +566,19 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return new MvcForm(ViewContext);
         }
 
-        protected virtual HtmlString GenerateCheckBox(ModelMetadata metadata, string name, bool? isChecked,
+        protected virtual HtmlString GenerateCheckBox(
+            ModelMetadata metadata,
+            string expression,
+            bool? isChecked,
             object htmlAttributes)
         {
             var checkbox = _htmlGenerator.GenerateCheckBox(
                 ViewContext,
                 metadata,
-                name,
+                expression,
                 isChecked,
                 htmlAttributes);
-            var hidden = _htmlGenerator.GenerateHiddenForCheckbox(ViewContext, metadata, name);
+            var hidden = _htmlGenerator.GenerateHiddenForCheckbox(ViewContext, metadata, expression);
             if (checkbox == null || hidden == null)
             {
                 return HtmlString.Empty;
@@ -558,7 +589,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return new HtmlString(elements);
         }
 
-        protected virtual string GenerateDisplayName([NotNull] ModelMetadata metadata, string htmlFieldName)
+        protected virtual string GenerateDisplayName([NotNull] ModelMetadata metadata, string expression)
         {
             // We don't call ModelMetadata.GetDisplayName here because
             // we want to fall back to the field name rather than the ModelType.
@@ -567,7 +598,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             if (resolvedDisplayName == null)
             {
                 resolvedDisplayName =
-                    string.IsNullOrEmpty(htmlFieldName) ? string.Empty : htmlFieldName.Split('.').Last();
+                    string.IsNullOrEmpty(expression) ? string.Empty : expression.Split('.').Last();
             }
 
             return resolvedDisplayName;
@@ -578,14 +609,18 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return metadata.SimpleDisplayText ?? string.Empty;
         }
 
-        protected HtmlString GenerateDropDown(ModelMetadata metadata, string expression,
-            IEnumerable<SelectListItem> selectList, string optionLabel, object htmlAttributes)
+        protected HtmlString GenerateDropDown(
+            ModelMetadata metadata,
+            string expression,
+            IEnumerable<SelectListItem> selectList,
+            string optionLabel,
+            object htmlAttributes)
         {
             var tagBuilder = _htmlGenerator.GenerateSelect(
                 ViewContext,
                 metadata,
                 optionLabel,
-                name: expression,
+                expression: expression,
                 selectList: selectList,
                 allowMultiple: false,
                 htmlAttributes: htmlAttributes);
@@ -597,7 +632,10 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return tagBuilder.ToHtmlString(TagRenderMode.Normal);
         }
 
-        protected virtual HtmlString GenerateEditor(ModelMetadata metadata, string htmlFieldName, string templateName,
+        protected virtual HtmlString GenerateEditor(
+            ModelMetadata metadata,
+            string htmlFieldName,
+            string templateName,
             object additionalViewData)
         {
             var templateBuilder = new TemplateBuilder(
@@ -704,7 +742,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
         protected virtual HtmlString GenerateHidden(
             ModelMetadata metadata,
-            string name,
+            string expression,
             object value,
             bool useViewData,
             object htmlAttributes)
@@ -713,7 +751,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 _htmlGenerator.GenerateHidden(
                     ViewContext,
                     metadata,
-                    name,
+                    expression,
                     value,
                     useViewData,
                     htmlAttributes);
@@ -727,21 +765,22 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
         protected virtual string GenerateId(string expression)
         {
-            var fullName = DefaultHtmlGenerator.GetFullHtmlFieldName(ViewContext, name: expression);
+            var fullName = DefaultHtmlGenerator.GetFullHtmlFieldName(ViewContext, expression: expression);
             var id = TagBuilder.CreateSanitizedId(fullName, IdAttributeDotReplacement);
 
             return id;
         }
 
-        protected virtual HtmlString GenerateLabel([NotNull] ModelMetadata metadata,
-                                                    string htmlFieldName,
-                                                    string labelText,
-                                                    object htmlAttributes)
+        protected virtual HtmlString GenerateLabel(
+            [NotNull] ModelMetadata metadata,
+            string expression,
+            string labelText,
+            object htmlAttributes)
         {
             var tagBuilder = _htmlGenerator.GenerateLabel(
                 ViewContext,
                 metadata,
-                name: htmlFieldName,
+                expression: expression,
                 labelText: labelText,
                 htmlAttributes: htmlAttributes);
             if (tagBuilder == null)
@@ -754,7 +793,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
         protected HtmlString GenerateListBox(
             ModelMetadata metadata,
-            string name,
+            string expression,
             IEnumerable<SelectListItem> selectList,
             object htmlAttributes)
         {
@@ -762,7 +801,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 ViewContext,
                 metadata,
                 optionLabel: null,
-                name: name,
+                expression: expression,
                 selectList: selectList,
                 allowMultiple: true,
                 htmlAttributes: htmlAttributes);
@@ -774,19 +813,22 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return tagBuilder.ToHtmlString(TagRenderMode.Normal);
         }
 
-        protected virtual string GenerateName(string name)
+        protected virtual string GenerateName(string expression)
         {
-            var fullName = DefaultHtmlGenerator.GetFullHtmlFieldName(ViewContext, name);
+            var fullName = DefaultHtmlGenerator.GetFullHtmlFieldName(ViewContext, expression);
             return fullName;
         }
 
-        protected virtual HtmlString GeneratePassword(ModelMetadata metadata, string name, object value,
+        protected virtual HtmlString GeneratePassword(
+            ModelMetadata metadata,
+            string expression,
+            object value,
             object htmlAttributes)
         {
             var tagBuilder = _htmlGenerator.GeneratePassword(
                 ViewContext,
                 metadata,
-                name,
+                expression,
                 value,
                 htmlAttributes);
             if (tagBuilder == null)
@@ -797,13 +839,17 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return tagBuilder.ToHtmlString(TagRenderMode.SelfClosing);
         }
 
-        protected virtual HtmlString GenerateRadioButton(ModelMetadata metadata, string name, object value,
-            bool? isChecked, object htmlAttributes)
+        protected virtual HtmlString GenerateRadioButton(
+            ModelMetadata metadata,
+            string expression,
+            object value,
+            bool? isChecked,
+            object htmlAttributes)
         {
             var tagBuilder = _htmlGenerator.GenerateRadioButton(
                 ViewContext,
                 metadata,
-                name,
+                expression,
                 value,
                 isChecked,
                 htmlAttributes);
@@ -815,13 +861,17 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return tagBuilder.ToHtmlString(TagRenderMode.SelfClosing);
         }
 
-        protected virtual HtmlString GenerateTextArea(ModelMetadata metadata, string name,
-            int rows, int columns, object htmlAttributes)
+        protected virtual HtmlString GenerateTextArea(
+            ModelMetadata metadata,
+            string expression,
+            int rows,
+            int columns,
+            object htmlAttributes)
         {
             var tagBuilder = _htmlGenerator.GenerateTextArea(
                 ViewContext,
                 metadata,
-                name,
+                expression,
                 rows,
                 columns,
                 htmlAttributes);
@@ -833,13 +883,17 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return tagBuilder.ToHtmlString(TagRenderMode.Normal);
         }
 
-        protected virtual HtmlString GenerateTextBox(ModelMetadata metadata, string name, object value, string format,
+        protected virtual HtmlString GenerateTextBox(
+            ModelMetadata metadata,
+            string expression,
+            object value,
+            string format,
             object htmlAttributes)
         {
             var tagBuilder = _htmlGenerator.GenerateTextBox(
                 ViewContext,
                 metadata,
-                name,
+                expression,
                 value,
                 format,
                 htmlAttributes);
@@ -851,14 +905,15 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return tagBuilder.ToHtmlString(TagRenderMode.SelfClosing);
         }
 
-        protected virtual HtmlString GenerateValidationMessage(string expression,
+        protected virtual HtmlString GenerateValidationMessage(
+            string expression,
             string message,
             object htmlAttributes,
             string tag)
         {
             var tagBuilder = _htmlGenerator.GenerateValidationMessage(
                 ViewContext,
-                name: expression,
+                expression: expression,
                 message: message,
                 tag: tag,
                 htmlAttributes: htmlAttributes);
@@ -890,9 +945,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return tagBuilder.ToHtmlString(TagRenderMode.Normal);
         }
 
-        protected virtual string GenerateValue(string name, object value, string format, bool useViewData)
+        protected virtual string GenerateValue(string expression, object value, string format, bool useViewData)
         {
-            var fullName = DefaultHtmlGenerator.GetFullHtmlFieldName(ViewContext, name);
+            var fullName = DefaultHtmlGenerator.GetFullHtmlFieldName(ViewContext, expression);
             var attemptedValue =
                 (string)DefaultHtmlGenerator.GetModelStateValue(ViewContext, fullName, typeof(string));
 
@@ -904,7 +959,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             }
             else if (useViewData)
             {
-                if (string.IsNullOrEmpty(name))
+                if (string.IsNullOrEmpty(expression))
                 {
                     // case 2(a): format the value from ModelMetadata for the current model
                     var metadata = ViewData.ModelMetadata;
@@ -913,7 +968,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 else
                 {
                     // case 2(b): format the value from ViewData
-                    resolvedValue = DefaultHtmlGenerator.EvalString(ViewContext, name, format);
+                    resolvedValue = DefaultHtmlGenerator.EvalString(ViewContext, expression, format);
                 }
             }
             else
@@ -928,9 +983,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <inheritdoc />
         public IEnumerable<ModelClientValidationRule> GetClientValidationRules(
             ModelMetadata metadata,
-            string name)
+            string expression)
         {
-            return _htmlGenerator.GetClientValidationRules(ViewContext, metadata, name);
+            return _htmlGenerator.GetClientValidationRules(ViewContext, metadata, expression);
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/HtmlHelperOfT.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/HtmlHelperOfT.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 throw new ArgumentException(Resources.FormatPropertyOfTypeCannotBeNull(
                         "ViewData",
                         typeof(ViewContext)),
-                    "viewContext");
+                    nameof(viewContext));
             }
 
             ViewData = viewContext.ViewData as ViewDataDictionary<TModel>;
@@ -44,14 +44,15 @@ namespace Microsoft.AspNet.Mvc.Rendering
                         "ViewData",
                         viewContext.ViewData.GetType().FullName,
                         typeof(ViewDataDictionary<TModel>).FullName),
-                    "viewContext");
+                    nameof(viewContext));
             }
 
             base.Contextualize(viewContext);
         }
 
         /// <inheritdoc />
-        public HtmlString CheckBoxFor([NotNull] Expression<Func<TModel, bool>> expression,
+        public HtmlString CheckBoxFor(
+            [NotNull] Expression<Func<TModel, bool>> expression,
             object htmlAttributes)
         {
             var metadata = GetModelMetadata(expression);
@@ -60,8 +61,11 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <inheritdoc />
-        public HtmlString DropDownListFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression,
-            IEnumerable<SelectListItem> selectList, string optionLabel, object htmlAttributes)
+        public HtmlString DropDownListFor<TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            IEnumerable<SelectListItem> selectList,
+            string optionLabel,
+            object htmlAttributes)
         {
             var metadata = ExpressionMetadataProvider.FromLambdaExpression(expression, ViewData, MetadataProvider);
 
@@ -70,10 +74,11 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <inheritdoc />
-        public HtmlString DisplayFor<TValue>([NotNull] Expression<Func<TModel, TValue>> expression,
-                                             string templateName,
-                                             string htmlFieldName,
-                                             object additionalViewData)
+        public HtmlString DisplayFor<TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            string templateName,
+            string htmlFieldName,
+            object additionalViewData)
         {
             var metadata = ExpressionMetadataProvider.FromLambdaExpression(expression,
                                                                            ViewData,
@@ -86,17 +91,17 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <inheritdoc />
-        public string DisplayNameFor<TValue>([NotNull] Expression<Func<TModel, TValue>> expression)
+        public string DisplayNameFor<TResult>([NotNull] Expression<Func<TModel, TResult>> expression)
         {
             var metadata = GetModelMetadata(expression);
             return GenerateDisplayName(metadata, ExpressionHelper.GetExpressionText(expression));
         }
 
         /// <inheritdoc />
-        public string DisplayNameForInnerType<TModelItem, TValue>(
-            [NotNull] Expression<Func<TModelItem, TValue>> expression)
+        public string DisplayNameForInnerType<TModelItem, TResult>(
+            [NotNull] Expression<Func<TModelItem, TResult>> expression)
         {
-            var metadata = ExpressionMetadataProvider.FromLambdaExpression<TModelItem, TValue>(
+            var metadata = ExpressionMetadataProvider.FromLambdaExpression<TModelItem, TResult>(
                 expression,
                 new ViewDataDictionary<TModelItem>(ViewData, model: null),
                 MetadataProvider);
@@ -111,14 +116,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <inheritdoc />
-        public string DisplayTextFor<TValue>([NotNull] Expression<Func<TModel, TValue>> expression)
+        public string DisplayTextFor<TResult>([NotNull] Expression<Func<TModel, TResult>> expression)
         {
             return GenerateDisplayText(GetModelMetadata(expression));
         }
 
         /// <inheritdoc />
-        public HtmlString EditorFor<TValue>(
-            [NotNull] Expression<Func<TModel, TValue>> expression,
+        public HtmlString EditorFor<TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
             string templateName,
             string htmlFieldName,
             object additionalViewData)
@@ -133,7 +138,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <inheritdoc />
-        public HtmlString HiddenFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression,
+        public HtmlString HiddenFor<TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
             object htmlAttributes)
         {
             var metadata = GetModelMetadata(expression);
@@ -142,14 +148,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <inheritdoc />
-        public string IdFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression)
+        public string IdFor<TResult>([NotNull] Expression<Func<TModel, TResult>> expression)
         {
             return GenerateId(GetExpressionName(expression));
         }
 
         /// <inheritdoc />
-        public HtmlString LabelFor<TValue>(
-            [NotNull] Expression<Func<TModel, TValue>> expression,
+        public HtmlString LabelFor<TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
             string labelText,
             object htmlAttributes)
         {
@@ -158,8 +164,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <inheritdoc />
-        public HtmlString ListBoxFor<TProperty>(
-            [NotNull] Expression<Func<TModel, TProperty>> expression,
+        public HtmlString ListBoxFor<TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
             IEnumerable<SelectListItem> selectList,
             object htmlAttributes)
         {
@@ -170,14 +176,15 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <inheritdoc />
-        public string NameFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression)
+        public string NameFor<TResult>([NotNull] Expression<Func<TModel, TResult>> expression)
         {
             var expressionName = GetExpressionName(expression);
             return Name(expressionName);
         }
 
         /// <inheritdoc />
-        public HtmlString PasswordFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression,
+        public HtmlString PasswordFor<TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
             object htmlAttributes)
         {
             var metadata = GetModelMetadata(expression);
@@ -186,8 +193,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <inheritdoc />
-        public HtmlString RadioButtonFor<TProperty>(
-            [NotNull] Expression<Func<TModel, TProperty>> expression,
+        public HtmlString RadioButtonFor<TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
             [NotNull] object value,
             object htmlAttributes)
         {
@@ -197,27 +204,32 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <inheritdoc />
-        public HtmlString TextAreaFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression, int rows,
-            int columns, object htmlAttributes)
+        public HtmlString TextAreaFor<TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            int rows,
+            int columns,
+            object htmlAttributes)
         {
             var metadata = GetModelMetadata(expression);
             return GenerateTextArea(metadata, GetExpressionName(expression), rows, columns, htmlAttributes);
         }
 
         /// <inheritdoc />
-        public HtmlString TextBoxFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression,
-            string format, object htmlAttributes)
+        public HtmlString TextBoxFor<TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            string format,
+            object htmlAttributes)
         {
             var metadata = GetModelMetadata(expression);
             return GenerateTextBox(metadata, GetExpressionName(expression), metadata.Model, format, htmlAttributes);
         }
 
-        protected string GetExpressionName<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression)
+        protected string GetExpressionName<TResult>([NotNull] Expression<Func<TModel, TResult>> expression)
         {
             return ExpressionHelper.GetExpressionText(expression);
         }
 
-        protected ModelMetadata GetModelMetadata<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression)
+        protected ModelMetadata GetModelMetadata<TResult>([NotNull] Expression<Func<TModel, TResult>> expression)
         {
             var metadata = ExpressionMetadataProvider.FromLambdaExpression(expression, ViewData, MetadataProvider);
             if (metadata == null)
@@ -230,7 +242,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <inheritdoc />
-        public HtmlString ValidationMessageFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression,
+        public HtmlString ValidationMessageFor<TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
             string message,
             object htmlAttributes,
             string tag)
@@ -242,7 +255,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <inheritdoc />
-        public string ValueFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression, string format)
+        public string ValueFor<TResult>([NotNull] Expression<Func<TModel, TResult>> expression, string format)
         {
             var metadata = GetModelMetadata(expression);
             return GenerateValue(ExpressionHelper.GetExpressionText(expression), metadata.Model, format,

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/HtmlHelperOfT.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/HtmlHelperOfT.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             if (viewContext.ViewData == null)
             {
                 throw new ArgumentException(Resources.FormatPropertyOfTypeCannotBeNull(
-                        "ViewData",
+                        nameof(ViewContext.ViewData),
                         typeof(ViewContext)),
                     nameof(viewContext));
             }
@@ -41,7 +41,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             {
                 // viewContext may contain a base ViewDataDictionary instance. So complain about that type, not TModel.
                 throw new ArgumentException(Resources.FormatArgumentPropertyUnexpectedType(
-                        "ViewData",
+                        nameof(ViewContext.ViewData),
                         viewContext.ViewData.GetType().FullName,
                         typeof(ViewDataDictionary<TModel>).FullName),
                     nameof(viewContext));

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/IHtmlGenerator.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/IHtmlGenerator.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         TagBuilder GenerateCheckBox(
             [NotNull] ViewContext viewContext,
             ModelMetadata metadata,
-            string name,
+            string expression,
             bool? isChecked,
             object htmlAttributes);
 
@@ -46,7 +46,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         TagBuilder GenerateHiddenForCheckbox(
             [NotNull] ViewContext viewContext,
             ModelMetadata metadata,
-            string name);
+            string expression);
 
         /// <summary>
         /// Generate a &lt;form&gt; element. When the user submits the form, the action with name
@@ -107,7 +107,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         TagBuilder GenerateHidden(
             [NotNull] ViewContext viewContext,
             ModelMetadata metadata,
-            string name,
+            string expression,
             object value,
             bool useViewData,
             object htmlAttributes);
@@ -115,21 +115,21 @@ namespace Microsoft.AspNet.Mvc.Rendering
         TagBuilder GenerateLabel(
             [NotNull] ViewContext viewContext,
             [NotNull] ModelMetadata metadata,
-            string name,
+            string expression,
             string labelText,
             object htmlAttributes);
 
         TagBuilder GeneratePassword(
             [NotNull] ViewContext viewContext,
             ModelMetadata metadata,
-            string name,
+            string expression,
             object value,
             object htmlAttributes);
 
         TagBuilder GenerateRadioButton(
             [NotNull] ViewContext viewContext,
             ModelMetadata metadata,
-            string name,
+            string expression,
             object value,
             bool? isChecked,
             object htmlAttributes);
@@ -147,7 +147,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             [NotNull] ViewContext viewContext,
             ModelMetadata metadata,
             string optionLabel,
-            string name,
+            string expression,
             IEnumerable<SelectListItem> selectList,
             bool allowMultiple,
             object htmlAttributes);
@@ -156,7 +156,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             [NotNull] ViewContext viewContext,
             ModelMetadata metadata,
             string optionLabel,
-            string name,
+            string expression,
             IEnumerable<SelectListItem> selectList,
             bool allowMultiple,
             object htmlAttributes,
@@ -165,7 +165,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         TagBuilder GenerateTextArea(
             [NotNull] ViewContext viewContext,
             ModelMetadata metadata,
-            string name,
+            string expression,
             int rows,
             int columns,
             object htmlAttributes);
@@ -173,14 +173,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
         TagBuilder GenerateTextBox(
             [NotNull] ViewContext viewContext,
             ModelMetadata metadata,
-            string name,
+            string expression,
             object value,
             string format,
             object htmlAttributes);
 
         TagBuilder GenerateValidationMessage(
             [NotNull] ViewContext viewContext,
-            string name,
+            string expression,
             string message,
             string tag,
             object htmlAttributes);
@@ -193,11 +193,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
             object htmlAttributes);
 
         /// <remarks>
-        /// Not used directly in HtmlHelper. Exposed publicly for use in other IHtmlHelper implementations.
+        /// Not used directly in <see cref="HtmlHelper"/>. Exposed publicly for use in other <see cref="IHtmlHelper"/>
+        /// implementations.
         /// </remarks>
         IEnumerable<ModelClientValidationRule> GetClientValidationRules(
             [NotNull] ViewContext viewContext,
             ModelMetadata metadata,
-            string name);
+            string expression);
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperDisplayExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperDisplayExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// Returns HTML markup for the <paramref name="expression"/>, using a display template. The template is found
         /// using the <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">
         /// Expression name, relative to the current model. May identify a single property or an
         /// <see cref="object"/> that contains the properties to display.
@@ -35,9 +35,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString Display([NotNull] this IHtmlHelper html, string expression)
+        public static HtmlString Display([NotNull] this IHtmlHelper htmlHelper, string expression)
         {
-            return html.Display(expression, templateName: null, htmlFieldName: null, additionalViewData: null);
+            return htmlHelper.Display(expression, templateName: null, htmlFieldName: null, additionalViewData: null);
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// additional view data. The template is found using the <paramref name="expression"/>'s
         /// <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">
         /// Expression name, relative to the current model. May identify a single property or an
         /// <see cref="object"/> that contains the properties to display.
@@ -71,11 +71,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </para>
         /// </remarks>
         public static HtmlString Display(
-            [NotNull] this IHtmlHelper html,
+            [NotNull] this IHtmlHelper htmlHelper,
             string expression,
             object additionalViewData)
         {
-            return html.Display(expression, templateName: null, htmlFieldName: null,
+            return htmlHelper.Display(
+                expression,
+                templateName: null,
+                htmlFieldName: null,
                 additionalViewData: additionalViewData);
         }
 
@@ -84,7 +87,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// using the <paramref name="templateName"/> or the <paramref name="expression"/>'s
         /// <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">
         /// Expression name, relative to the current model. May identify a single property or an
         /// <see cref="object"/> that contains the properties to display.
@@ -106,11 +109,11 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </para>
         /// </remarks>
         public static HtmlString Display(
-            [NotNull] this IHtmlHelper html,
+            [NotNull] this IHtmlHelper htmlHelper,
             string expression,
             string templateName)
         {
-            return html.Display(expression, templateName, htmlFieldName: null, additionalViewData: null);
+            return htmlHelper.Display(expression, templateName, htmlFieldName: null, additionalViewData: null);
         }
 
         /// <summary>
@@ -118,7 +121,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// additional view data. The template is found using the <paramref name="templateName"/> or the
         /// <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">
         /// Expression name, relative to the current model. May identify a single property or an
         /// <see cref="object"/> that contains the properties to display.
@@ -145,12 +148,16 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </para>
         /// </remarks>
         public static HtmlString Display(
-            [NotNull] this IHtmlHelper html,
+            [NotNull] this IHtmlHelper htmlHelper,
             string expression,
             string templateName,
             object additionalViewData)
         {
-            return html.Display(expression, templateName, htmlFieldName: null, additionalViewData: additionalViewData);
+            return htmlHelper.Display(
+                expression,
+                templateName,
+                htmlFieldName: null,
+                additionalViewData: additionalViewData);
         }
 
         /// <summary>
@@ -158,7 +165,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// field name. The template is found using the <paramref name="templateName"/> or the
         /// <paramref name="expression"/>'s<see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">
         /// Expression name, relative to the current model. May identify a single property or an
         /// <see cref="object"/> that contains the properties to display.
@@ -184,22 +191,22 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </para>
         /// </remarks>
         public static HtmlString Display(
-            [NotNull] this IHtmlHelper html,
+            [NotNull] this IHtmlHelper htmlHelper,
             string expression,
             string templateName,
             string htmlFieldName)
         {
-            return html.Display(expression, templateName, htmlFieldName, additionalViewData: null);
+            return htmlHelper.Display(expression, templateName, htmlFieldName, additionalViewData: null);
         }
 
         /// <summary>
         /// Returns HTML markup for the <paramref name="expression"/>, using a display template. The template is found
         /// using the <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the created HTML.</returns>
         /// <remarks>
         /// <para>
@@ -211,10 +218,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString DisplayFor<TModel, TValue>([NotNull] this IHtmlHelper<TModel> html,
-                                                            [NotNull] Expression<Func<TModel, TValue>> expression)
+        public static HtmlString DisplayFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression)
         {
-            return html.DisplayFor<TValue>(expression, templateName: null, htmlFieldName: null,
+            return htmlHelper.DisplayFor<TResult>(
+                expression,
+                templateName: null,
+                htmlFieldName: null,
                 additionalViewData: null);
         }
 
@@ -223,7 +234,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// additional view data. The template is found using the <paramref name="expression"/>'s
         /// <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="additionalViewData">
         /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{string, object}"/>
@@ -231,7 +242,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// instance created for the template.
         /// </param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the created HTML.</returns>
         /// <remarks>
         /// <para>
@@ -243,11 +254,15 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString DisplayFor<TModel, TValue>([NotNull] this IHtmlHelper<TModel> html,
-                                                            [NotNull] Expression<Func<TModel, TValue>> expression,
-                                                            object additionalViewData)
+        public static HtmlString DisplayFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            object additionalViewData)
         {
-            return html.DisplayFor<TValue>(expression, templateName: null, htmlFieldName: null,
+            return htmlHelper.DisplayFor<TResult>(
+                expression,
+                templateName: null,
+                htmlFieldName: null,
                 additionalViewData: additionalViewData);
         }
 
@@ -256,11 +271,11 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// using the <paramref name="templateName"/> or the <paramref name="expression"/>'s
         /// <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="templateName">The name of the template used to create the HTML markup.</param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the created HTML.</returns>
         /// <remarks>
         /// <para>
@@ -272,11 +287,16 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString DisplayFor<TModel, TValue>([NotNull] this IHtmlHelper<TModel> html,
-                                                            [NotNull] Expression<Func<TModel, TValue>> expression,
-                                                            string templateName)
+        public static HtmlString DisplayFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            string templateName)
         {
-            return html.DisplayFor<TValue>(expression, templateName, htmlFieldName: null, additionalViewData: null);
+            return htmlHelper.DisplayFor<TResult>(
+                expression,
+                templateName,
+                htmlFieldName: null,
+                additionalViewData: null);
         }
 
         /// <summary>
@@ -284,7 +304,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// additional view data. The template is found using the <paramref name="templateName"/> or the
         /// <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="templateName">The name of the template used to create the HTML markup.</param>
         /// <param name="additionalViewData">
@@ -293,7 +313,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// instance created for the template.
         /// </param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the created HTML.</returns>
         /// <remarks>
         /// <para>
@@ -305,12 +325,16 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString DisplayFor<TModel, TValue>([NotNull] this IHtmlHelper<TModel> html,
-                                                            [NotNull] Expression<Func<TModel, TValue>> expression,
-                                                            string templateName,
-                                                            object additionalViewData)
+        public static HtmlString DisplayFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            string templateName,
+            object additionalViewData)
         {
-            return html.DisplayFor<TValue>(expression, templateName, htmlFieldName: null,
+            return htmlHelper.DisplayFor<TResult>(
+                expression,
+                templateName,
+                htmlFieldName: null,
                 additionalViewData: additionalViewData);
         }
 
@@ -319,7 +343,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// field name. The template is found using the <paramref name="templateName"/> or the
         /// <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="templateName">The name of the template used to create the HTML markup.</param>
         /// <param name="htmlFieldName">
@@ -327,7 +351,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// that have the same name.
         /// </param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the created HTML.</returns>
         /// <remarks>
         /// <para>
@@ -339,12 +363,16 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString DisplayFor<TModel, TValue>([NotNull] this IHtmlHelper<TModel> html,
-                                                            [NotNull] Expression<Func<TModel, TValue>> expression,
-                                                            string templateName,
-                                                            string htmlFieldName)
+        public static HtmlString DisplayFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            string templateName,
+            string htmlFieldName)
         {
-            return html.DisplayFor<TValue>(expression, templateName: templateName, htmlFieldName: htmlFieldName,
+            return htmlHelper.DisplayFor<TResult>(
+                expression,
+                templateName: templateName,
+                htmlFieldName: htmlFieldName,
                 additionalViewData: null);
         }
 
@@ -352,7 +380,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// Returns HTML markup for the current model, using a display template. The template is found using the
         /// model's <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <returns>A new <see cref="HtmlString"/> containing the created HTML.</returns>
         /// <remarks>
         /// <para>
@@ -364,16 +392,20 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString DisplayForModel([NotNull] this IHtmlHelper html)
+        public static HtmlString DisplayForModel([NotNull] this IHtmlHelper htmlHelper)
         {
-            return html.Display(expression: null, templateName: null, htmlFieldName: null, additionalViewData: null);
+            return htmlHelper.Display(
+                expression: null,
+                templateName: null,
+                htmlFieldName: null,
+                additionalViewData: null);
         }
 
         /// <summary>
         /// Returns HTML markup for the current model, using a display template and specified additional view data. The
         /// template is found using the model's <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="additionalViewData">
         /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{string, object}"/>
         /// that can contain additional view data that will be merged into the <see cref="ViewDataDictionary{TModel}"/>
@@ -390,9 +422,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString DisplayForModel([NotNull] this IHtmlHelper html, object additionalViewData)
+        public static HtmlString DisplayForModel([NotNull] this IHtmlHelper htmlHelper, object additionalViewData)
         {
-            return html.Display(expression: null, templateName: null, htmlFieldName: null,
+            return htmlHelper.Display(
+                expression: null,
+                templateName: null,
+                htmlFieldName: null,
                 additionalViewData: additionalViewData);
         }
 
@@ -400,7 +435,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// Returns HTML markup for the current model, using a display template. The template is found using the
         /// <paramref name="templateName"/> or the model's <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="templateName">The name of the template used to create the HTML markup.</param>
         /// <returns>A new <see cref="HtmlString"/> containing the created HTML.</returns>
         /// <remarks>
@@ -413,9 +448,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString DisplayForModel([NotNull] this IHtmlHelper html, string templateName)
+        public static HtmlString DisplayForModel([NotNull] this IHtmlHelper htmlHelper, string templateName)
         {
-            return html.Display(expression: null, templateName: templateName, htmlFieldName: null,
+            return htmlHelper.Display(
+                expression: null,
+                templateName: templateName,
+                htmlFieldName: null,
                 additionalViewData: null);
         }
 
@@ -424,7 +462,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// template is found using the <paramref name="templateName"/> or the model's
         /// <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="templateName">The name of the template used to create the HTML markup.</param>
         /// <param name="additionalViewData">
         /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{string, object}"/>
@@ -443,11 +481,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </para>
         /// </remarks>
         public static HtmlString DisplayForModel(
-            [NotNull] this IHtmlHelper html,
+            [NotNull] this IHtmlHelper htmlHelper,
             string templateName,
             object additionalViewData)
         {
-            return html.Display(expression: null, templateName: templateName, htmlFieldName: null,
+            return htmlHelper.Display(
+                expression: null,
+                templateName: templateName,
+                htmlFieldName: null,
                 additionalViewData: additionalViewData);
         }
 
@@ -456,7 +497,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// template is found using the <paramref name="templateName"/> or the model's
         /// <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="templateName">The name of the template used to create the HTML markup.</param>
         /// <param name="htmlFieldName">
         /// A <see cref="string"/> used to disambiguate the names of HTML elements that are created for
@@ -474,11 +515,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </para>
         /// </remarks>
         public static HtmlString DisplayForModel(
-            [NotNull] this IHtmlHelper html,
+            [NotNull] this IHtmlHelper htmlHelper,
             string templateName,
             string htmlFieldName)
         {
-            return html.Display(expression: null, templateName: templateName, htmlFieldName: htmlFieldName,
+            return htmlHelper.Display(
+                expression: null,
+                templateName: templateName,
+                htmlFieldName: htmlFieldName,
                 additionalViewData: null);
         }
 
@@ -487,7 +531,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// additional view data. The template is found using the <paramref name="templateName"/> or the model's
         /// <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="templateName">The name of the template used to create the HTML markup.</param>
         /// <param name="htmlFieldName">
         /// A <see cref="string"/> used to disambiguate the names of HTML elements that are created for
@@ -510,12 +554,15 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </para>
         /// </remarks>
         public static HtmlString DisplayForModel(
-            [NotNull] this IHtmlHelper html,
+            [NotNull] this IHtmlHelper htmlHelper,
             string templateName,
             string htmlFieldName,
             object additionalViewData)
         {
-            return html.Display(expression: null, templateName: templateName, htmlFieldName: htmlFieldName,
+            return htmlHelper.Display(
+                expression: null,
+                templateName: templateName,
+                htmlFieldName: htmlFieldName,
                 additionalViewData: additionalViewData);
         }
     }

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperDisplayNameExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperDisplayNameExtensions.cs
@@ -31,13 +31,13 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </param>
         /// <param name="expression">An expression to be evaluated against an item in the current model.</param>
         /// <typeparam name="TModelItem">The type of items in the model collection.</typeparam>
-        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A <see cref="string"/> containing the display name.</returns>
-        public static string DisplayNameFor<TModelItem, TValue>(
+        public static string DisplayNameFor<TModelItem, TResult>(
             [NotNull] this IHtmlHelper<IEnumerable<TModelItem>> htmlHelper,
-            [NotNull] Expression<Func<TModelItem, TValue>> expression)
+            [NotNull] Expression<Func<TModelItem, TResult>> expression)
         {
-            return htmlHelper.DisplayNameForInnerType<TModelItem, TValue>(expression);
+            return htmlHelper.DisplayNameForInnerType<TModelItem, TResult>(expression);
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperEditorExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperEditorExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// Returns HTML markup for the <paramref name="expression"/>, using an editor template. The template is found
         /// using the <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">
         /// Expression name, relative to the current model. May identify a single property or an
         /// <see cref="object"/> that contains the properties to edit.
@@ -35,9 +35,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString Editor([NotNull] this IHtmlHelper html, string expression)
+        public static HtmlString Editor([NotNull] this IHtmlHelper htmlHelper, string expression)
         {
-            return html.Editor(expression, templateName: null, htmlFieldName: null, additionalViewData: null);
+            return htmlHelper.Editor(expression, templateName: null, htmlFieldName: null, additionalViewData: null);
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// additional view data. The template is found using the <paramref name="expression"/>'s
         /// <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">
         /// Expression name, relative to the current model. May identify a single property or an
         /// <see cref="object"/> that contains the properties to edit.
@@ -70,9 +70,15 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString Editor([NotNull] this IHtmlHelper html, string expression, object additionalViewData)
+        public static HtmlString Editor(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string expression,
+            object additionalViewData)
         {
-            return html.Editor(expression, templateName: null, htmlFieldName: null,
+            return htmlHelper.Editor(
+                expression,
+                templateName: null,
+                htmlFieldName: null,
                 additionalViewData: additionalViewData);
         }
 
@@ -81,7 +87,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// using the <paramref name="templateName"/> or the <paramref name="expression"/>'s
         /// <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">
         /// Expression name, relative to the current model. May identify a single property or an
         /// <see cref="object"/> that contains the properties to edit.
@@ -102,9 +108,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString Editor([NotNull] this IHtmlHelper html, string expression, string templateName)
+        public static HtmlString Editor([NotNull] this IHtmlHelper htmlHelper, string expression, string templateName)
         {
-            return html.Editor(expression, templateName, htmlFieldName: null, additionalViewData: null);
+            return htmlHelper.Editor(expression, templateName, htmlFieldName: null, additionalViewData: null);
         }
 
         /// <summary>
@@ -112,7 +118,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// additional view data. The template is found using the <paramref name="templateName"/> or the
         /// <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">
         /// Expression name, relative to the current model. May identify a single property or an
         /// <see cref="object"/> that contains the properties to edit.
@@ -138,10 +144,17 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString Editor([NotNull] this IHtmlHelper html, string expression, string templateName,
+        public static HtmlString Editor(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string expression,
+            string templateName,
             object additionalViewData)
         {
-            return html.Editor(expression, templateName, htmlFieldName: null, additionalViewData: additionalViewData);
+            return htmlHelper.Editor(
+                expression,
+                templateName,
+                htmlFieldName: null,
+                additionalViewData: additionalViewData);
         }
 
         /// <summary>
@@ -149,7 +162,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// field name. The template is found using the <paramref name="templateName"/> or the
         /// <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">
         /// Expression name, relative to the current model. May identify a single property or an
         /// <see cref="object"/> that contains the properties to edit.
@@ -174,20 +187,23 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString Editor([NotNull] this IHtmlHelper html, string expression, string templateName,
+        public static HtmlString Editor(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string expression,
+            string templateName,
             string htmlFieldName)
         {
-            return html.Editor(expression, templateName, htmlFieldName, additionalViewData: null);
+            return htmlHelper.Editor(expression, templateName, htmlFieldName, additionalViewData: null);
         }
 
         /// <summary>
         /// Returns HTML markup for the <paramref name="expression"/>, using an editor template. The template is found
         /// using the <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element(s).</returns>
         /// <remarks>
         /// <para>
@@ -199,10 +215,11 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString EditorFor<TModel, TValue>([NotNull] this IHtmlHelper<TModel> html,
-            [NotNull] Expression<Func<TModel, TValue>> expression)
+        public static HtmlString EditorFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression)
         {
-            return html.EditorFor(expression, templateName: null, htmlFieldName: null, additionalViewData: null);
+            return htmlHelper.EditorFor(expression, templateName: null, htmlFieldName: null, additionalViewData: null);
         }
 
         /// <summary>
@@ -210,7 +227,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// additional view data. The template is found using the <paramref name="expression"/>'s
         /// <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="additionalViewData">
         /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{string, object}"/>
@@ -218,7 +235,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// instance created for the template.
         /// </param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element(s).</returns>
         /// <remarks>
         /// <para>
@@ -230,10 +247,15 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString EditorFor<TModel, TValue>([NotNull] this IHtmlHelper<TModel> html,
-            [NotNull] Expression<Func<TModel, TValue>> expression, object additionalViewData)
+        public static HtmlString EditorFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            object additionalViewData)
         {
-            return html.EditorFor(expression, templateName: null, htmlFieldName: null,
+            return htmlHelper.EditorFor(
+                expression,
+                templateName: null,
+                htmlFieldName: null,
                 additionalViewData: additionalViewData);
         }
 
@@ -242,11 +264,11 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// using the <paramref name="templateName"/> or the <paramref name="expression"/>'s
         /// <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="templateName">The name of the template that is used to create the HTML markup.</param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element(s).</returns>
         /// <remarks>
         /// <para>
@@ -258,10 +280,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString EditorFor<TModel, TValue>([NotNull] this IHtmlHelper<TModel> html,
-            [NotNull] Expression<Func<TModel, TValue>> expression, string templateName)
+        public static HtmlString EditorFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            string templateName)
         {
-            return html.EditorFor(expression, templateName, htmlFieldName: null, additionalViewData: null);
+            return htmlHelper.EditorFor(expression, templateName, htmlFieldName: null, additionalViewData: null);
         }
 
         /// <summary>
@@ -269,7 +293,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// additional view data. The template is found using the <paramref name="templateName"/> or the
         /// <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="templateName">The name of the template that is used to create the HTML markup.</param>
         /// <param name="additionalViewData">
@@ -278,7 +302,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// instance created for the template.
         /// </param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element(s).</returns>
         /// <remarks>
         /// <para>
@@ -290,10 +314,16 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString EditorFor<TModel, TValue>([NotNull] this IHtmlHelper<TModel> html,
-            [NotNull] Expression<Func<TModel, TValue>> expression, string templateName, object additionalViewData)
+        public static HtmlString EditorFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            string templateName,
+            object additionalViewData)
         {
-            return html.EditorFor(expression, templateName, htmlFieldName: null,
+            return htmlHelper.EditorFor(
+                expression,
+                templateName,
+                htmlFieldName: null,
                 additionalViewData: additionalViewData);
         }
 
@@ -302,7 +332,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// field name. The template is found using the <paramref name="templateName"/> or the
         /// <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="templateName">The name of the template that is used to create the HTML markup.</param>
         /// <param name="htmlFieldName">
@@ -310,7 +340,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// that have the same name.
         /// </param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element(s).</returns>
         /// <remarks>
         /// <para>
@@ -322,17 +352,20 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString EditorFor<TModel, TValue>([NotNull] this IHtmlHelper<TModel> html,
-            [NotNull] Expression<Func<TModel, TValue>> expression, string templateName, string htmlFieldName)
+        public static HtmlString EditorFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            string templateName,
+            string htmlFieldName)
         {
-            return html.EditorFor(expression, templateName, htmlFieldName, additionalViewData: null);
+            return htmlHelper.EditorFor(expression, templateName, htmlFieldName, additionalViewData: null);
         }
 
         /// <summary>
         /// Returns HTML markup for the current model, using an editor template. The template is found using the
         /// model's <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element(s).</returns>
         /// <remarks>
         /// <para>
@@ -344,16 +377,20 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString EditorForModel([NotNull] this IHtmlHelper html)
+        public static HtmlString EditorForModel([NotNull] this IHtmlHelper htmlHelper)
         {
-            return html.Editor(expression: null, templateName: null, htmlFieldName: null, additionalViewData: null);
+            return htmlHelper.Editor(
+                expression: null,
+                templateName: null,
+                htmlFieldName: null,
+                additionalViewData: null);
         }
 
         /// <summary>
         /// Returns HTML markup for the current model, using an editor template and specified additional view data. The
         /// template is found using the model's <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="additionalViewData">
         /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{string, object}"/>
         /// that can contain additional view data that will be merged into the <see cref="ViewDataDictionary{TModel}"/>
@@ -370,9 +407,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString EditorForModel([NotNull] this IHtmlHelper html, object additionalViewData)
+        public static HtmlString EditorForModel([NotNull] this IHtmlHelper htmlHelper, object additionalViewData)
         {
-            return html.Editor(expression: null, templateName: null, htmlFieldName: null,
+            return htmlHelper.Editor(
+                expression: null,
+                templateName: null,
+                htmlFieldName: null,
                 additionalViewData: additionalViewData);
         }
 
@@ -380,7 +420,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// Returns HTML markup for the current model, using an editor template. The template is found using the
         /// <paramref name="templateName"/> or the model's <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="templateName">The name of the template used to create the HTML markup.</param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element(s).</returns>
         /// <remarks>
@@ -393,9 +433,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString EditorForModel([NotNull] this IHtmlHelper html, string templateName)
+        public static HtmlString EditorForModel([NotNull] this IHtmlHelper htmlHelper, string templateName)
         {
-            return html.Editor(expression: null, templateName: templateName, htmlFieldName: null,
+            return htmlHelper.Editor(
+                expression: null,
+                templateName: templateName,
+                htmlFieldName: null,
                 additionalViewData: null);
         }
 
@@ -404,7 +447,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// template is found using the <paramref name="templateName"/> or the model's
         /// <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="templateName">The name of the template used to create the HTML markup.</param>
         /// <param name="additionalViewData">
         /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{string, object}"/>
@@ -422,10 +465,15 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString EditorForModel([NotNull] this IHtmlHelper html, string templateName,
+        public static HtmlString EditorForModel(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string templateName,
             object additionalViewData)
         {
-            return html.Editor(expression: null, templateName: templateName, htmlFieldName: null,
+            return htmlHelper.Editor(
+                expression: null,
+                templateName: templateName,
+                htmlFieldName: null,
                 additionalViewData: additionalViewData);
         }
 
@@ -434,7 +482,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// template is found using the <paramref name="templateName"/> or the model's
         /// <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="templateName">The name of the template used to create the HTML markup.</param>
         /// <param name="htmlFieldName">
         /// A <see cref="string"/> used to disambiguate the names of HTML elements that are created for
@@ -451,10 +499,15 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString EditorForModel([NotNull] this IHtmlHelper html, string templateName,
+        public static HtmlString EditorForModel(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string templateName,
             string htmlFieldName)
         {
-            return html.Editor(expression: null, templateName: templateName, htmlFieldName: htmlFieldName,
+            return htmlHelper.Editor(
+                expression: null,
+                templateName: templateName,
+                htmlFieldName: htmlFieldName,
                 additionalViewData: null);
         }
 
@@ -463,7 +516,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// additional view data. The template is found using the <paramref name="templateName"/> or the model's
         /// <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="templateName">The name of the template used to create the HTML markup.</param>
         /// <param name="htmlFieldName">
         /// A <see cref="string"/> used to disambiguate the names of HTML elements that are created for
@@ -485,10 +538,16 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// case-sensitive file systems.
         /// </para>
         /// </remarks>
-        public static HtmlString EditorForModel([NotNull] this IHtmlHelper html, string templateName,
-            string htmlFieldName, object additionalViewData)
+        public static HtmlString EditorForModel(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string templateName,
+            string htmlFieldName,
+            object additionalViewData)
         {
-            return html.Editor(expression: null, templateName: templateName, htmlFieldName: htmlFieldName,
+            return htmlHelper.Editor(
+                expression: null,
+                templateName: templateName,
+                htmlFieldName: htmlFieldName,
                 additionalViewData: additionalViewData);
         }
     }

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperInputExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperInputExtensions.cs
@@ -16,26 +16,27 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// "hidden" with value "false".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; elements.</returns>
         /// <remarks>
         /// <para>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set checkbox
-        /// element's "name" attribute. Sanitizes <paramref name="name"/> to set checkbox element's "id" attribute.
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set checkbox
+        /// element's "name" attribute. Sanitizes <paramref name="expression"/> to set checkbox element's "id"
+        /// attribute.
         /// </para>
         /// <para>Determines checkbox element's "checked" attribute based on the following precedence:</para>
         /// <list type="number">
         /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="name"/> (converted to a
+        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
         /// fully-qualified name) if entry exists and can be converted to a <see cref="bool"/>.
         /// </item>
         /// <item>
-        /// <see cref="ViewDataDictionary"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="bool"/>.
+        /// <see cref="ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
+        /// name) if entry exists and can be converted to a <see cref="bool"/>.
         /// </item>
         /// <item>
-        /// Linq expression based on <paramref name="name"/> (converted to a fully-qualified name) run against current
-        /// model if result is non-<c>null</c> and can be converted to a <see cref="bool"/>. For example
+        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
+        /// current model if result is non-<c>null</c> and can be converted to a <see cref="bool"/>. For example
         /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
         /// property.
         /// </item>
@@ -46,9 +47,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// value "checked" if the <see cref="bool"/> values is <c>true</c>; does not include the attribute otherwise.
         /// </para>
         /// </remarks>
-        public static HtmlString CheckBox([NotNull] this IHtmlHelper htmlHelper, string name)
+        public static HtmlString CheckBox([NotNull] this IHtmlHelper htmlHelper, string expression)
         {
-            return htmlHelper.CheckBox(name, isChecked: null, htmlAttributes: null);
+            return htmlHelper.CheckBox(expression, isChecked: null, htmlAttributes: null);
         }
 
         /// <summary>
@@ -56,28 +57,29 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// "hidden" with value "false".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="isChecked">If <c>true</c>, checkbox is initially checked.</param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; elements.</returns>
         /// <remarks>
         /// <para>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set checkbox
-        /// element's "name" attribute. Sanitizes <paramref name="name"/> to set checkbox element's "id" attribute.
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set checkbox
+        /// element's "name" attribute. Sanitizes <paramref name="expression"/> to set checkbox element's "id"
+        /// attribute.
         /// </para>
         /// <para>Determines checkbox element's "checked" attribute based on the following precedence:</para>
         /// <list type="number">
         /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="name"/> (converted to a
+        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
         /// fully-qualified name) if entry exists and can be converted to a <see cref="bool"/>.
         /// </item>
         /// <item><paramref name="isChecked"/> if non-<c>null</c>.</item>
         /// <item>
-        /// <see cref="ViewDataDictionary"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="bool"/>.
+        /// <see cref="ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
+        /// name) if entry exists and can be converted to a <see cref="bool"/>.
         /// </item>
         /// <item>
-        /// Linq expression based on <paramref name="name"/> (converted to a fully-qualified name) run against current
-        /// model if result is non-<c>null</c> and can be converted to a <see cref="bool"/>. For example
+        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
+        /// current model if result is non-<c>null</c> and can be converted to a <see cref="bool"/>. For example
         /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
         /// property.
         /// </item>
@@ -90,10 +92,10 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </remarks>
         public static HtmlString CheckBox(
             [NotNull] this IHtmlHelper htmlHelper,
-            string name,
+            string expression,
             bool isChecked)
         {
-            return htmlHelper.CheckBox(name, isChecked, htmlAttributes: null);
+            return htmlHelper.CheckBox(expression, isChecked, htmlAttributes: null);
         }
 
         /// <summary>
@@ -101,7 +103,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// "hidden" with value "false".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="htmlAttributes">
         /// An <see cref="object"/> that contains the HTML attributes for the checkbox element. Alternatively, an
         /// <see cref="System.Collections.Generic.IDictionary{string, object}"/> instance containing the HTML
@@ -110,22 +112,23 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; elements.</returns>
         /// <remarks>
         /// <para>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set checkbox
-        /// element's "name" attribute. Sanitizes <paramref name="name"/> to set checkbox element's "id" attribute.
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set checkbox
+        /// element's "name" attribute. Sanitizes <paramref name="expression"/> to set checkbox element's "id"
+        /// attribute.
         /// </para>
         /// <para>Determines checkbox element's "checked" attribute based on the following precedence:</para>
         /// <list type="number">
         /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="name"/> (converted to a
+        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
         /// fully-qualified name) if entry exists and can be converted to a <see cref="bool"/>.
         /// </item>
         /// <item>
-        /// <see cref="ViewDataDictionary"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="bool"/>.
+        /// <see cref="ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
+        /// name) if entry exists and can be converted to a <see cref="bool"/>.
         /// </item>
         /// <item>
-        /// Linq expression based on <paramref name="name"/> (converted to a fully-qualified name) run against current
-        /// model if result is non-<c>null</c> and can be converted to a <see cref="bool"/>. For example
+        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
+        /// current model if result is non-<c>null</c> and can be converted to a <see cref="bool"/>. For example
         /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
         /// property.
         /// </item>
@@ -139,10 +142,10 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </remarks>
         public static HtmlString CheckBox(
             [NotNull] this IHtmlHelper htmlHelper,
-            string name,
+            string expression,
             object htmlAttributes)
         {
-            return htmlHelper.CheckBox(name, isChecked: null, htmlAttributes: htmlAttributes);
+            return htmlHelper.CheckBox(expression, isChecked: null, htmlAttributes: htmlAttributes);
         }
 
         /// <summary>
@@ -175,75 +178,76 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// value "checked" if the <see cref="bool"/> values is <c>true</c>; does not include the attribute otherwise.
         /// </para>
         /// </remarks>
-        public static HtmlString CheckBoxFor<TModel>([NotNull] this IHtmlHelper<TModel> htmlHelper,
+        public static HtmlString CheckBoxFor<TModel>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
             [NotNull] Expression<Func<TModel, bool>> expression)
         {
             return htmlHelper.CheckBoxFor(expression, htmlAttributes: null);
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "hidden" for the specified expression <paramref name="name"/>.
+        /// Returns an &lt;input&gt; element of type "hidden" for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </para>
         /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
         /// <list type="number">
         /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="name"/> (converted to a
+        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
         /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
-        /// <see cref="ViewDataDictionary"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="string"/>.
+        /// <see cref="ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
+        /// name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
-        /// Linq expression based on <paramref name="name"/> (converted to a fully-qualified name) run against current
-        /// model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
+        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
+        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
         /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
         /// property.
         /// </item>
         /// <item>Otherwise, <c>string.Empty</c>.</item>
         /// </list>
         /// </remarks>
-        public static HtmlString Hidden([NotNull] this IHtmlHelper htmlHelper, string name)
+        public static HtmlString Hidden([NotNull] this IHtmlHelper htmlHelper, string expression)
         {
-            return htmlHelper.Hidden(name, value: null, htmlAttributes: null);
+            return htmlHelper.Hidden(expression, value: null, htmlAttributes: null);
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "hidden" for the specified expression <paramref name="name"/>.
+        /// Returns an &lt;input&gt; element of type "hidden" for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </para>
         /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
         /// <list type="number">
         /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="name"/> (converted to a
+        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
         /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item><paramref name="value"/> if non-<c>null</c>.</item>
         /// <item>
-        /// <see cref="ViewDataDictionary"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="string"/>.
+        /// <see cref="ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
+        /// name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
-        /// Linq expression based on <paramref name="name"/> (converted to a fully-qualified name) run against current
-        /// model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
+        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
+        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
         /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
         /// property.
         /// </item>
@@ -252,10 +256,10 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </remarks>
         public static HtmlString Hidden(
             [NotNull] this IHtmlHelper htmlHelper,
-            string name,
+            string expression,
             object value)
         {
-            return htmlHelper.Hidden(name, value, htmlAttributes: null);
+            return htmlHelper.Hidden(expression, value, htmlAttributes: null);
         }
 
         /// <summary>
@@ -264,7 +268,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
@@ -285,39 +289,40 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <item>Otherwise, <c>string.Empty</c>.</item>
         /// </list>
         /// </remarks>
-        public static HtmlString HiddenFor<TModel, TProperty>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            [NotNull] Expression<Func<TModel, TProperty>> expression)
+        public static HtmlString HiddenFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression)
         {
             return htmlHelper.HiddenFor(expression, htmlAttributes: null);
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "password" for the specified expression <paramref name="name"/>.
+        /// Returns an &lt;input&gt; element of type "password" for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute. Sets &lt;input&gt; element's "value" attribute to <c>string.Empty</c>.
         /// </remarks>
-        public static HtmlString Password([NotNull] this IHtmlHelper htmlHelper, string name)
+        public static HtmlString Password([NotNull] this IHtmlHelper htmlHelper, string expression)
         {
-            return htmlHelper.Password(name, value: null, htmlAttributes: null);
+            return htmlHelper.Password(expression, value: null, htmlAttributes: null);
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "password" for the specified expression <paramref name="name"/>.
+        /// Returns an &lt;input&gt; element of type "password" for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </para>
         /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
@@ -328,10 +333,10 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </remarks>
         public static HtmlString Password(
             [NotNull] this IHtmlHelper htmlHelper,
-            string name,
+            string expression,
             object value)
         {
-            return htmlHelper.Password(name, value, htmlAttributes: null);
+            return htmlHelper.Password(expression, value, htmlAttributes: null);
         }
 
         /// <summary>
@@ -340,7 +345,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
@@ -357,38 +362,39 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <item>Otherwise, <c>string.Empty</c>.</item>
         /// </list>
         /// </remarks>
-        public static HtmlString PasswordFor<TModel, TProperty>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            [NotNull] Expression<Func<TModel, TProperty>> expression)
+        public static HtmlString PasswordFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression)
         {
             return htmlHelper.PasswordFor(expression, htmlAttributes: null);
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "radio" for the specified expression <paramref name="name"/>.
+        /// Returns an &lt;input&gt; element of type "radio" for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">Value to include in the element. Must not be <c>null</c>.</param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute. Sets &lt;input&gt; element's "value" attribute to <paramref name="value"/>.
         /// </para>
         /// <para>Determines &lt;input&gt; element's "checked" attribute based on the following precedence:</para>
         /// <list type="number">
         /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="name"/> (converted to a
+        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
         /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
-        /// <see cref="ViewDataDictionary"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="string"/>.
+        /// <see cref="ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
+        /// name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
-        /// Linq expression based on <paramref name="name"/> (converted to a fully-qualified name) run against current
-        /// model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
+        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
+        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
         /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
         /// property.
         /// </item>
@@ -403,17 +409,17 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </remarks>
         public static HtmlString RadioButton(
             [NotNull] this IHtmlHelper htmlHelper,
-            string name,
+            string expression,
             object value)
         {
-            return htmlHelper.RadioButton(name, value, isChecked: null, htmlAttributes: null);
+            return htmlHelper.RadioButton(expression, value, isChecked: null, htmlAttributes: null);
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "radio" for the specified expression <paramref name="name"/>.
+        /// Returns an &lt;input&gt; element of type "radio" for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">
         /// If non-<c>null</c>, value to include in the element. Must not be <c>null</c> if no "checked" entry exists
         /// in <paramref name="htmlAttributes"/>.
@@ -426,8 +432,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </para>
         /// <para>Determines element's "value" attribute based on the following precedence:</para>
@@ -439,17 +445,17 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <para>Determines &lt;input&gt; element's "checked" attribute based on the following precedence:</para>
         /// <list type="number">
         /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="name"/> (converted to a
+        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
         /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>Existing "checked" entry in <paramref name="htmlAttributes"/> if any.</item>
         /// <item>
-        /// <see cref="ViewDataDictionary"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="string"/>.
+        /// <see cref="ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
+        /// name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
-        /// Linq expression based on <paramref name="name"/> (converted to a fully-qualified name) run against current
-        /// model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
+        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
+        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
         /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
         /// property.
         /// </item>
@@ -464,18 +470,18 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </remarks>
         public static HtmlString RadioButton(
             [NotNull] this IHtmlHelper htmlHelper,
-            string name,
+            string expression,
             object value,
             object htmlAttributes)
         {
-            return htmlHelper.RadioButton(name, value, isChecked: null, htmlAttributes: htmlAttributes);
+            return htmlHelper.RadioButton(expression, value, isChecked: null, htmlAttributes: htmlAttributes);
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "radio" for the specified expression <paramref name="name"/>.
+        /// Returns an &lt;input&gt; element of type "radio" for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">
         /// If non-<c>null</c>, value to include in the element. Must not be <c>null</c> if
         /// <paramref name="isChecked"/> is also <c>null</c>.
@@ -487,8 +493,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </para>
         /// <para>Determines element's "value" attribute based on the following precedence:</para>
@@ -499,18 +505,17 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <para>Determines &lt;input&gt; element's "checked" attribute based on the following precedence:</para>
         /// <list type="number">
         /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="name"/> (converted to a
+        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
         /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item><paramref name="isChecked"/> if non-<c>null</c>.</item>
         /// <item>
-        /// <see cref="ViewDataDictionary"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="string"/>.
-        /// otherwise.
+        /// <see cref="ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
+        /// name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
-        /// Linq expression based on <paramref name="name"/> (converted to a fully-qualified name) run against current
-        /// model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
+        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
+        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
         /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
         /// property.
         /// </item>
@@ -525,11 +530,11 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </remarks>
         public static HtmlString RadioButton(
             [NotNull] this IHtmlHelper htmlHelper,
-            string name,
+            string expression,
             object value,
             bool isChecked)
         {
-            return htmlHelper.RadioButton(name, value, isChecked, htmlAttributes: null);
+            return htmlHelper.RadioButton(expression, value, isChecked, htmlAttributes: null);
         }
 
         /// <summary>
@@ -539,7 +544,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="value">Value to include in the element. Must not be <c>null</c>.</param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
@@ -565,79 +570,79 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <paramref name="value"/>; does not include the attribute otherwise.
         /// </para>
         /// </remarks>
-        public static HtmlString RadioButtonFor<TModel, TProperty>(
+        public static HtmlString RadioButtonFor<TModel, TResult>(
             [NotNull] this IHtmlHelper<TModel> htmlHelper,
-            [NotNull] Expression<Func<TModel, TProperty>> expression,
+            [NotNull] Expression<Func<TModel, TResult>> expression,
             [NotNull] object value)
         {
             return htmlHelper.RadioButtonFor(expression, value, htmlAttributes: null);
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "text" for the specified expression <paramref name="name"/>.
+        /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </para>
         /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
         /// <list type="number">
         /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="name"/> (converted to a
+        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
         /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
-        /// <see cref="ViewDataDictionary"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="string"/>.
+        /// <see cref="ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
+        /// name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
-        /// Linq expression based on <paramref name="name"/> (converted to a fully-qualified name) run against current
-        /// model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
+        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
+        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
         /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
         /// property.
         /// </item>
         /// <item>Otherwise, <c>string.Empty</c>.</item>
         /// </list>
         /// </remarks>
-        public static HtmlString TextBox([NotNull] this IHtmlHelper htmlHelper, string name)
+        public static HtmlString TextBox([NotNull] this IHtmlHelper htmlHelper, string expression)
         {
-            return htmlHelper.TextBox(name, value: null, format: null, htmlAttributes: null);
+            return htmlHelper.TextBox(expression, value: null, format: null, htmlAttributes: null);
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "text" for the specified expression <paramref name="name"/>.
+        /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </para>
         /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
         /// <list type="number">
         /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="name"/> (converted to a
+        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
         /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
         /// <paramref name="value"/> if non-<c>null</c>.
         /// </item>
         /// <item>
-        /// <see cref="ViewDataDictionary"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="string"/>.
+        /// <see cref="ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
+        /// name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
-        /// Linq expression based on <paramref name="name"/> (converted to a fully-qualified name) run against current
-        /// model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
+        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
+        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
         /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
         /// property.
         /// </item>
@@ -646,17 +651,17 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </remarks>
         public static HtmlString TextBox(
             [NotNull] this IHtmlHelper htmlHelper,
-            string name,
+            string expression,
             object value)
         {
-            return htmlHelper.TextBox(name, value, format: null, htmlAttributes: null);
+            return htmlHelper.TextBox(expression, value, format: null, htmlAttributes: null);
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "text" for the specified expression <paramref name="name"/>.
+        /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
         /// <param name="format">
         /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx).
@@ -664,14 +669,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </para>
         /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
         /// <list type="number">
         /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="name"/> (converted to a
+        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
         /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
@@ -680,13 +685,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <paramref name="format"/> is <c>null</c> or empty.
         /// </item>
         /// <item>
-        /// <see cref="ViewDataDictionary"/> entry for <paramref name="name"/> (converted to a fully-qualified name) if
-        /// entry exists and can be converted to a <see cref="string"/>. Formats entry using <paramref name="format"/>
-        /// or converts entry to a <see cref="string"/> directly if <paramref name="format"/> is <c>null</c> or empty.
+        /// <see cref="ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
+        /// name) if entry exists and can be converted to a <see cref="string"/>. Formats entry using
+        /// <paramref name="format"/> or converts entry to a <see cref="string"/> directly if <paramref name="format"/>
+        /// is <c>null</c> or empty.
         /// </item>
         /// <item>
-        /// Linq expression based on <paramref name="name"/> (converted to a fully-qualified name) run against current
-        /// model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
+        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
+        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
         /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
         /// property. Formats result using <paramref name="format"/> or converts result to a <see cref="string"/>
         /// directly if <paramref name="format"/> is <c>null</c> or empty.
@@ -696,18 +702,18 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </remarks>
         public static HtmlString TextBox(
             [NotNull] this IHtmlHelper htmlHelper,
-            string name,
+            string expression,
             object value,
             string format)
         {
-            return htmlHelper.TextBox(name, value, format, htmlAttributes: null);
+            return htmlHelper.TextBox(expression, value, format, htmlAttributes: null);
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "text" for the specified expression <paramref name="name"/>.
+        /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
         /// <param name="htmlAttributes">
         /// An <see cref="object"/> that contains the HTML attributes for the element. Alternatively, an
@@ -717,26 +723,26 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </para>
         /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
         /// <list type="number">
         /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="name"/> (converted to a
+        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
         /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
         /// <paramref name="value"/> if non-<c>null</c>.
         /// </item>
         /// <item>
-        /// <see cref="ViewDataDictionary"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="string"/>.
+        /// <see cref="ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
+        /// name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
-        /// Linq expression based on <paramref name="name"/> (converted to a fully-qualified name) run against current
-        /// model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
+        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
+        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
         /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
         /// property.
         /// </item>
@@ -746,11 +752,11 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </remarks>
         public static HtmlString TextBox(
             [NotNull] this IHtmlHelper htmlHelper,
-            string name,
+            string expression,
             object value,
             object htmlAttributes)
         {
-            return htmlHelper.TextBox(name, value, format: null, htmlAttributes: htmlAttributes);
+            return htmlHelper.TextBox(expression, value, format: null, htmlAttributes: htmlAttributes);
         }
 
         /// <summary>
@@ -759,7 +765,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
@@ -779,8 +785,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <item>Otherwise, <c>string.Empty</c>.</item>
         /// </list>
         /// </remarks>
-        public static HtmlString TextBoxFor<TModel, TProperty>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            [NotNull] Expression<Func<TModel, TProperty>> expression)
+        public static HtmlString TextBoxFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression)
         {
             return htmlHelper.TextBoxFor(expression, format: null, htmlAttributes: null);
         }
@@ -794,7 +801,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx).
         /// </param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
@@ -816,8 +823,10 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <item>Otherwise, <c>string.Empty</c>.</item>
         /// </list>
         /// </remarks>
-        public static HtmlString TextBoxFor<TModel, TProperty>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            [NotNull] Expression<Func<TModel, TProperty>> expression, string format)
+        public static HtmlString TextBoxFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            string format)
         {
             return htmlHelper.TextBoxFor(expression, format, htmlAttributes: null);
         }
@@ -833,7 +842,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// attributes.
         /// </param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
@@ -854,54 +863,57 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <item>Otherwise, <c>string.Empty</c>.</item>
         /// </list>
         /// </remarks>
-        public static HtmlString TextBoxFor<TModel, TProperty>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            [NotNull] Expression<Func<TModel, TProperty>> expression, object htmlAttributes)
+        public static HtmlString TextBoxFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            object htmlAttributes)
         {
             return htmlHelper.TextBoxFor(expression, format: null, htmlAttributes: htmlAttributes);
         }
 
         /// <summary>
-        /// Returns a &lt;textarea&gt; element for the specified expression <paramref name="name"/>.
+        /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;textarea&gt; element.</returns>
         /// <remarks>
         /// <para>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;textarea&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;textarea&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </para>
         /// <para>Determines &lt;textarea&gt; element's content based on the following precedence:</para>
         /// <list type="number">
         /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="name"/> (converted to a
+        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
         /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
-        /// <see cref="ViewDataDictionary"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="string"/>.
+        /// <see cref="ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
+        /// name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
-        /// Linq expression based on <paramref name="name"/> (converted to a fully-qualified name) run against current
-        /// model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
+        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
+        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
         /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
         /// property.
         /// </item>
         /// <item>Otherwise, <c>string.Empty</c>.</item>
         /// </list>
         /// </remarks>
-        public static HtmlString TextArea([NotNull] this IHtmlHelper htmlHelper,
-            string name)
+        public static HtmlString TextArea(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string expression)
         {
-            return htmlHelper.TextArea(name, value: null, rows: 0, columns: 0, htmlAttributes: null);
+            return htmlHelper.TextArea(expression, value: null, rows: 0, columns: 0, htmlAttributes: null);
         }
 
         /// <summary>
-        /// Returns a &lt;textarea&gt; element for the specified expression <paramref name="name"/>.
+        /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="htmlAttributes">
         /// An <see cref="object"/> that contains the HTML attributes for the element. Alternatively, an
         /// <see cref="System.Collections.Generic.IDictionary{string, object}"/> instance containing the HTML
@@ -910,79 +922,83 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;textarea&gt; element.</returns>
         /// <remarks>
         /// <para>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;textarea&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;textarea&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </para>
         /// <para>Determines &lt;textarea&gt; element's content based on the following precedence:</para>
         /// <list type="number">
         /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="name"/> (converted to a
+        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
         /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
-        /// <see cref="ViewDataDictionary"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="string"/>.
+        /// <see cref="ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
+        /// name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
-        /// Linq expression based on <paramref name="name"/> (converted to a fully-qualified name) run against current
-        /// model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
+        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
+        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
         /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
         /// property.
         /// </item>
         /// <item>Otherwise, <c>string.Empty</c>.</item>
         /// </list>
         /// </remarks>
-        public static HtmlString TextArea([NotNull] this IHtmlHelper htmlHelper,
-            string name, object htmlAttributes)
+        public static HtmlString TextArea(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string expression,
+            object htmlAttributes)
         {
-            return htmlHelper.TextArea(name, value: null, rows: 0, columns: 0, htmlAttributes: htmlAttributes);
+            return htmlHelper.TextArea(expression, value: null, rows: 0, columns: 0, htmlAttributes: htmlAttributes);
         }
 
         /// <summary>
-        /// Returns a &lt;textarea&gt; element for the specified expression <paramref name="name"/>.
+        /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;textarea&gt; element.</returns>
         /// <remarks>
         /// <para>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;textarea&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;textarea&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </para>
         /// <para>Determines &lt;textarea&gt; element's content based on the following precedence:</para>
         /// <list type="number">
         /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="name"/> (converted to a
+        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
         /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item><paramref name="value"/> if non-<c>null</c>.</item>
         /// <item>
-        /// <see cref="ViewDataDictionary"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="string"/>.
+        /// <see cref="ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
+        /// name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
-        /// Linq expression based on <paramref name="name"/> (converted to a fully-qualified name) run against current
-        /// model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
+        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
+        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
         /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
         /// property.
         /// </item>
         /// <item>Otherwise, <c>string.Empty</c>.</item>
         /// </list>
         /// </remarks>
-        public static HtmlString TextArea([NotNull] this IHtmlHelper htmlHelper,
-            string name, string value)
+        public static HtmlString TextArea(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string expression,
+            string value)
         {
-            return htmlHelper.TextArea(name, value, rows: 0, columns: 0, htmlAttributes: null);
+            return htmlHelper.TextArea(expression, value, rows: 0, columns: 0, htmlAttributes: null);
         }
 
         /// <summary>
-        /// Returns a &lt;textarea&gt; element for the specified expression <paramref name="name"/>.
+        /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
         /// <param name="htmlAttributes">
         /// An <see cref="object"/> that contains the HTML attributes for the element. Alternatively, an
@@ -992,34 +1008,37 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;textarea&gt; element.</returns>
         /// <remarks>
         /// <para>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;textarea&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;textarea&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </para>
         /// <para>Determines &lt;textarea&gt; element's content based on the following precedence:</para>
         /// <list type="number">
         /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="name"/> (converted to a
+        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
         /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item><paramref name="value"/> if non-<c>null</c>.</item>
         /// <item>
-        /// <see cref="ViewDataDictionary"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="string"/>.
+        /// <see cref="ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
+        /// name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
-        /// Linq expression based on <paramref name="name"/> (converted to a fully-qualified name) run against current
-        /// model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
+        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
+        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
         /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
         /// property.
         /// </item>
         /// <item>Otherwise, <c>string.Empty</c>.</item>
         /// </list>
         /// </remarks>
-        public static HtmlString TextArea([NotNull] this IHtmlHelper htmlHelper,
-            string name, string value, object htmlAttributes)
+        public static HtmlString TextArea(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string expression,
+            string value,
+            object htmlAttributes)
         {
-            return htmlHelper.TextArea(name, value, rows: 0, columns: 0, htmlAttributes: htmlAttributes);
+            return htmlHelper.TextArea(expression, value, rows: 0, columns: 0, htmlAttributes: htmlAttributes);
         }
 
         /// <summary>
@@ -1028,7 +1047,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;textarea&gt; element.</returns>
         /// <remarks>
         /// <para>
@@ -1048,8 +1067,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <item>Otherwise, <c>string.Empty</c>.</item>
         /// </list>
         /// </remarks>
-        public static HtmlString TextAreaFor<TModel, TProperty>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            [NotNull] Expression<Func<TModel, TProperty>> expression)
+        public static HtmlString TextAreaFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression)
         {
             return htmlHelper.TextAreaFor(expression, rows: 0, columns: 0, htmlAttributes: null);
         }
@@ -1065,7 +1085,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// attributes.
         /// </param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;textarea&gt; element.</returns>
         /// <remarks>
         /// <para>
@@ -1085,8 +1105,10 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <item>Otherwise, <c>string.Empty</c>.</item>
         /// </list>
         /// </remarks>
-        public static HtmlString TextAreaFor<TModel, TProperty>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            [NotNull] Expression<Func<TModel, TProperty>> expression, object htmlAttributes)
+        public static HtmlString TextAreaFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            object htmlAttributes)
         {
             return htmlHelper.TextAreaFor(expression, rows: 0, columns: 0, htmlAttributes: htmlAttributes);
         }

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperLabelExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperLabelExtensions.cs
@@ -12,64 +12,64 @@ namespace Microsoft.AspNet.Mvc.Rendering
     public static class HtmlHelperLabelExtensions
     {
         /// <summary>
-        /// Returns a &lt;label&gt; element for the specified expression <paramref name="name"/>.
+        /// Returns a &lt;label&gt; element for the specified <paramref name="expression"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;label&gt; element.</returns>
-        public static HtmlString Label([NotNull] this IHtmlHelper html, string expression)
+        public static HtmlString Label([NotNull] this IHtmlHelper htmlHelper, string expression)
         {
-            return html.Label(expression,
-                             labelText: null,
-                             htmlAttributes: null);
+            return htmlHelper.Label(expression, labelText: null, htmlAttributes: null);
         }
 
         /// <summary>
-        /// Returns a &lt;label&gt; element for the specified expression <paramref name="name"/>.
+        /// Returns a &lt;label&gt; element for the specified <paramref name="expression"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="labelText">The inner text of the element.</param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;label&gt; element.</returns>
-        public static HtmlString Label([NotNull] this IHtmlHelper html, string expression, string labelText)
+        public static HtmlString Label([NotNull] this IHtmlHelper htmlHelper, string expression, string labelText)
         {
-            return html.Label(expression, labelText, htmlAttributes: null);
+            return htmlHelper.Label(expression, labelText, htmlAttributes: null);
         }
 
         /// <summary>
         /// Returns a &lt;label&gt; element for the specified <paramref name="expression"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;label&gt; element.</returns>
-        public static HtmlString LabelFor<TModel, TValue>([NotNull] this IHtmlHelper<TModel> html,
-                                                          [NotNull] Expression<Func<TModel, TValue>> expression)
+        public static HtmlString LabelFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression)
         {
-            return html.LabelFor<TValue>(expression, labelText: null, htmlAttributes: null);
+            return htmlHelper.LabelFor<TResult>(expression, labelText: null, htmlAttributes: null);
         }
 
         /// <summary>
         /// Returns a &lt;label&gt; element for the specified <paramref name="expression"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="labelText">The inner text of the element.</param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;label&gt; element.</returns>
-        public static HtmlString LabelFor<TModel, TValue>([NotNull] this IHtmlHelper<TModel> html,
-                                                          [NotNull] Expression<Func<TModel, TValue>> expression,
-                                                          string labelText)
+        public static HtmlString LabelFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            string labelText)
         {
-            return html.LabelFor<TValue>(expression, labelText, htmlAttributes: null);
+            return htmlHelper.LabelFor<TResult>(expression, labelText, htmlAttributes: null);
         }
 
         /// <summary>
         /// Returns a &lt;label&gt; element for the specified <paramref name="expression"/>.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="htmlAttributes">
         /// An <see cref="object"/> that contains the HTML attributes for the element. Alternatively, an
@@ -77,55 +77,56 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// attributes.
         /// </param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;label&gt; element.</returns>
-        public static HtmlString LabelFor<TModel, TValue>([NotNull] this IHtmlHelper<TModel> html,
-                                                          [NotNull] Expression<Func<TModel, TValue>> expression,
-                                                          object htmlAttributes)
+        public static HtmlString LabelFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            object htmlAttributes)
         {
-            return html.LabelFor<TValue>(expression, labelText: null, htmlAttributes: htmlAttributes);
+            return htmlHelper.LabelFor<TResult>(expression, labelText: null, htmlAttributes: htmlAttributes);
         }
 
         /// <summary>
         /// Returns a &lt;label&gt; element for the current model.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;label&gt; element.</returns>
-        public static HtmlString LabelForModel([NotNull] this IHtmlHelper html)
+        public static HtmlString LabelForModel([NotNull] this IHtmlHelper htmlHelper)
         {
-            return html.Label(expression: null, labelText: null, htmlAttributes: null);
+            return htmlHelper.Label(expression: null, labelText: null, htmlAttributes: null);
         }
 
         /// <summary>
         /// Returns a &lt;label&gt; element for the current model.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="labelText">The inner text of the element.</param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;label&gt; element.</returns>
-        public static HtmlString LabelForModel([NotNull] this IHtmlHelper html, string labelText)
+        public static HtmlString LabelForModel([NotNull] this IHtmlHelper htmlHelper, string labelText)
         {
-            return html.Label(expression: null, labelText: labelText, htmlAttributes: null);
+            return htmlHelper.Label(expression: null, labelText: labelText, htmlAttributes: null);
         }
 
         /// <summary>
         /// Returns a &lt;label&gt; element for the current model.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="htmlAttributes">
         /// An <see cref="object"/> that contains the HTML attributes for the element. Alternatively, an
         /// <see cref="System.Collections.Generic.IDictionary{string, object}"/> instance containing the HTML
         /// attributes.
         /// </param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;label&gt; element.</returns>
-        public static HtmlString LabelForModel([NotNull] this IHtmlHelper html, object htmlAttributes)
+        public static HtmlString LabelForModel([NotNull] this IHtmlHelper htmlHelper, object htmlAttributes)
         {
-            return html.Label(expression: null, labelText: null, htmlAttributes: htmlAttributes);
+            return htmlHelper.Label(expression: null, labelText: null, htmlAttributes: htmlAttributes);
         }
 
         /// <summary>
         /// Returns a &lt;label&gt; element for the current model.
         /// </summary>
-        /// <param name="html">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="labelText">The inner text of the element.</param>
         /// <param name="htmlAttributes">
         /// An <see cref="object"/> that contains the HTML attributes for the element. Alternatively, an
@@ -134,11 +135,11 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;label&gt; element.</returns>
         public static HtmlString LabelForModel(
-            [NotNull] this IHtmlHelper html,
+            [NotNull] this IHtmlHelper htmlHelper,
             string labelText,
             object htmlAttributes)
         {
-            return html.Label(expression: null, labelText: labelText, htmlAttributes: htmlAttributes);
+            return htmlHelper.Label(expression: null, labelText: labelText, htmlAttributes: htmlAttributes);
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperNameExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperNameExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <returns>A <see cref="string"/> containing the element name.</returns>
         public static string NameForModel([NotNull] this IHtmlHelper htmlHelper)
         {
-            return htmlHelper.Name(name: null);
+            return htmlHelper.Name(expression: null);
         }
 
         /// <summary>
@@ -25,7 +25,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <returns>A <see cref="string"/> containing the element Id.</returns>
         public static string IdForModel([NotNull] this IHtmlHelper htmlHelper)
         {
-            return htmlHelper.Id(name: null);
+            return htmlHelper.Id(expression: null);
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperSelectExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperSelectExtensions.cs
@@ -13,71 +13,78 @@ namespace Microsoft.AspNet.Mvc.Rendering
     public static class HtmlHelperSelectExtensions
     {
         /// <summary>
-        /// Returns a single-selection HTML &lt;select&gt; element for the expression <paramref name="name"/>.
+        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;select&gt; element.</returns>
         /// <remarks>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;select&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;select&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </remarks>
-        public static HtmlString DropDownList([NotNull] this IHtmlHelper htmlHelper, string name)
+        public static HtmlString DropDownList([NotNull] this IHtmlHelper htmlHelper, string expression)
         {
-            return htmlHelper.DropDownList(name, selectList: null, optionLabel: null, htmlAttributes: null);
+            return htmlHelper.DropDownList(expression, selectList: null, optionLabel: null, htmlAttributes: null);
         }
 
         /// <summary>
-        /// Returns a single-selection HTML &lt;select&gt; element for the expression <paramref name="name"/>,
-        /// using the option label.
+        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>, using the
+        /// option label.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="optionLabel">
         /// The text for a default empty item. Does not include such an item if argument is <c>null</c>.
         /// </param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;select&gt; element.</returns>
         /// <remarks>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;select&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;select&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </remarks>
-        public static HtmlString DropDownList([NotNull] this IHtmlHelper htmlHelper, string name, string optionLabel)
+        public static HtmlString DropDownList(
+            [NotNull] this IHtmlHelper htmlHelper,
+            string expression,
+            string optionLabel)
         {
-            return htmlHelper.DropDownList(name, selectList: null, optionLabel: optionLabel, htmlAttributes: null);
+            return htmlHelper.DropDownList(
+                expression,
+                selectList: null,
+                optionLabel: optionLabel,
+                htmlAttributes: null);
         }
 
         /// <summary>
-        /// Returns a single-selection HTML &lt;select&gt; element for the expression <paramref name="name"/>,
-        /// using the specified list items.
+        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>, using the
+        /// specified list items.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="selectList">
         /// A collection of <see cref="SelectListItem"/> objects used to populate the &lt;select&gt; element with
         /// &lt;optgroup&gt; and &lt;option&gt; elements.
         /// </param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;select&gt; element.</returns>
         /// <remarks>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;select&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;select&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </remarks>
         public static HtmlString DropDownList(
             [NotNull] this IHtmlHelper htmlHelper,
-            string name,
+            string expression,
             IEnumerable<SelectListItem> selectList)
         {
-            return htmlHelper.DropDownList(name, selectList, optionLabel: null, htmlAttributes: null);
+            return htmlHelper.DropDownList(expression, selectList, optionLabel: null, htmlAttributes: null);
         }
 
         /// <summary>
-        /// Returns a single-selection HTML &lt;select&gt; element for the expression <paramref name="name"/>,
-        /// using the specified list items and HTML attributes.
+        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>, using the
+        /// specified list items and HTML attributes.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="selectList">
         /// A collection of <see cref="SelectListItem"/> objects used to populate the &lt;select&gt; element with
         /// &lt;optgroup&gt; and &lt;option&gt; elements.
@@ -88,25 +95,25 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;select&gt; element.</returns>
         /// <remarks>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;select&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;select&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </remarks>
         public static HtmlString DropDownList(
             [NotNull] this IHtmlHelper htmlHelper,
-            string name,
+            string expression,
             IEnumerable<SelectListItem> selectList,
             object htmlAttributes)
         {
-            return htmlHelper.DropDownList(name, selectList, optionLabel: null, htmlAttributes: htmlAttributes);
+            return htmlHelper.DropDownList(expression, selectList, optionLabel: null, htmlAttributes: htmlAttributes);
         }
 
         /// <summary>
-        /// Returns a single-selection HTML &lt;select&gt; element for the expression <paramref name="name"/>,
-        /// using the specified list items and option label.
+        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>, using the
+        /// specified list items and option label.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="selectList">
         /// A collection of <see cref="SelectListItem"/> objects used to populate the &lt;select&gt; element with
         /// &lt;optgroup&gt; and &lt;option&gt; elements.
@@ -116,17 +123,17 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;select&gt; element.</returns>
         /// <remarks>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;select&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;select&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </remarks>
         public static HtmlString DropDownList(
             [NotNull] this IHtmlHelper htmlHelper,
-            string name,
+            string expression,
             IEnumerable<SelectListItem> selectList,
             string optionLabel)
         {
-            return htmlHelper.DropDownList(name, selectList, optionLabel, htmlAttributes: null);
+            return htmlHelper.DropDownList(expression, selectList, optionLabel, htmlAttributes: null);
         }
 
         /// <summary>
@@ -140,15 +147,17 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// &lt;optgroup&gt; and &lt;option&gt; elements.
         /// </param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;select&gt; element.</returns>
         /// <remarks>
         /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and the string representation of the
         /// <paramref name="expression"/> to set &lt;select&gt; element's "name" attribute. Sanitizes the string
         /// representation of the <paramref name="expression"/> to set element's "id" attribute.
         /// </remarks>
-        public static HtmlString DropDownListFor<TModel, TProperty>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            [NotNull] Expression<Func<TModel, TProperty>> expression, IEnumerable<SelectListItem> selectList)
+        public static HtmlString DropDownListFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            IEnumerable<SelectListItem> selectList)
         {
             return htmlHelper.DropDownListFor(expression, selectList, optionLabel: null, htmlAttributes: null);
         }
@@ -168,18 +177,23 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
         /// </param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;select&gt; element.</returns>
         /// <remarks>
         /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and the string representation of the
         /// <paramref name="expression"/> to set &lt;select&gt; element's "name" attribute. Sanitizes the string
         /// representation of the <paramref name="expression"/> to set element's "id" attribute.
         /// </remarks>
-        public static HtmlString DropDownListFor<TModel, TProperty>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            [NotNull] Expression<Func<TModel, TProperty>> expression, IEnumerable<SelectListItem> selectList,
+        public static HtmlString DropDownListFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            IEnumerable<SelectListItem> selectList,
             object htmlAttributes)
         {
-            return htmlHelper.DropDownListFor(expression, selectList, optionLabel: null,
+            return htmlHelper.DropDownListFor(
+                expression,
+                selectList,
+                optionLabel: null,
                 htmlAttributes: htmlAttributes);
         }
 
@@ -197,58 +211,60 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// The text for a default empty item. Does not include such an item if argument is <c>null</c>.
         /// </param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;select&gt; element.</returns>
         /// <remarks>
         /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and the string representation of the
         /// <paramref name="expression"/> to set &lt;select&gt; element's "name" attribute. Sanitizes the string
         /// representation of the <paramref name="expression"/> to set element's "id" attribute.
         /// </remarks>
-        public static HtmlString DropDownListFor<TModel, TProperty>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            [NotNull] Expression<Func<TModel, TProperty>> expression, IEnumerable<SelectListItem> selectList,
+        public static HtmlString DropDownListFor<TModel, TResult>([
+            NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            IEnumerable<SelectListItem> selectList,
             string optionLabel)
         {
             return htmlHelper.DropDownListFor(expression, selectList, optionLabel, htmlAttributes: null);
         }
 
         /// <summary>
-        /// Returns a multi-selection &lt;select&gt; element for the expression <paramref name="name"/>.
+        /// Returns a multi-selection &lt;select&gt; element for the <paramref name="expression"/>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;select&gt; element.</returns>
         /// <remarks>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;select&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;select&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </remarks>
-        public static HtmlString ListBox([NotNull] this IHtmlHelper htmlHelper, string name)
+        public static HtmlString ListBox([NotNull] this IHtmlHelper htmlHelper, string expression)
         {
-            return htmlHelper.ListBox(name, selectList: null, htmlAttributes: null);
+            return htmlHelper.ListBox(expression, selectList: null, htmlAttributes: null);
         }
 
         /// <summary>
-        /// Returns a multi-selection &lt;select&gt; element for the expression <paramref name="name"/>, using the
+        /// Returns a multi-selection &lt;select&gt; element for the <paramref name="expression"/>, using the
         /// specified list items.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="selectList">
         /// A collection of <see cref="SelectListItem"/> objects used to populate the &lt;select&gt; element with
         /// &lt;optgroup&gt; and &lt;option&gt; elements.
         /// </param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;select&gt; element.</returns>
         /// <remarks>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;select&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;select&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </remarks>
         public static HtmlString ListBox(
             [NotNull] this IHtmlHelper htmlHelper,
-            string name,
+            string expression,
             IEnumerable<SelectListItem> selectList)
         {
-            return htmlHelper.ListBox(name, selectList, htmlAttributes: null);
+            return htmlHelper.ListBox(expression, selectList, htmlAttributes: null);
         }
 
         /// <summary>
@@ -262,16 +278,16 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// &lt;optgroup&gt; and &lt;option&gt; elements.
         /// </param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;select&gt; element.</returns>
         /// <remarks>
         /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and the string representation of the
         /// <paramref name="expression"/> to set &lt;select&gt; element's "name" attribute. Sanitizes the string
         /// representation of the <paramref name="expression"/> to set element's "id" attribute.
         /// </remarks>
-        public static HtmlString ListBoxFor<TModel, TProperty>(
+        public static HtmlString ListBoxFor<TModel, TResult>(
             [NotNull] this IHtmlHelper<TModel> htmlHelper,
-            [NotNull] Expression<Func<TModel, TProperty>> expression,
+            [NotNull] Expression<Func<TModel, TResult>> expression,
             IEnumerable<SelectListItem> selectList)
         {
             return htmlHelper.ListBoxFor(expression, selectList, htmlAttributes: null);

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperValidationExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperValidationExtensions.cs
@@ -13,20 +13,20 @@ namespace Microsoft.AspNet.Mvc.Rendering
     {
         /// <summary>
         /// Returns the validation message if an error exists in the <see cref="ModelBinding.ModelStateDictionary"/>
-        /// object for the specified expression <paramref name="expression"/>.
+        /// object for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <returns>
         /// A new <see cref="HtmlString"/> containing a <see cref="ViewContext.ValidationMessageElement"/> element.
-        /// <c>null</c> if the expression <paramref name="expression"/> is valid and client-side validation is
-        /// disabled.
+        /// <c>null</c> if the <paramref name="expression"/> is valid and client-side validation is disabled.
         /// </returns>
         /// <remarks>
         /// Method extracts an error string from the <see cref="ModelBinding.ModelStateDictionary"/> object. Message
         /// will always be visible but client-side validation may update the associated CSS class.
         /// </remarks>
-        public static HtmlString ValidationMessage([NotNull] this IHtmlHelper htmlHelper,
+        public static HtmlString ValidationMessage(
+            [NotNull] this IHtmlHelper htmlHelper,
             string expression)
         {
             return htmlHelper.ValidationMessage(expression, message: null, htmlAttributes: null, tag: null);
@@ -34,7 +34,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
         /// <summary>
         /// Returns the validation message if an error exists in the <see cref="ModelBinding.ModelStateDictionary"/>
-        /// object for the specified expression <paramref name="expression"/>.
+        /// object for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
@@ -45,10 +45,10 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </param>
         /// <returns>
         /// A new <see cref="HtmlString"/> containing a <see cref="ViewContext.ValidationMessageElement"/> element.
-        /// <c>null</c> if the expression <paramref name="expression"/> is valid and client-side validation is
-        /// disabled.
+        /// <c>null</c> if the <paramref name="expression"/> is valid and client-side validation is disabled.
         /// </returns>
-        public static HtmlString ValidationMessage([NotNull] this IHtmlHelper htmlHelper,
+        public static HtmlString ValidationMessage(
+            [NotNull] this IHtmlHelper htmlHelper,
             string expression,
             string message)
         {
@@ -57,7 +57,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
         /// <summary>
         /// Returns the validation message if an error exists in the <see cref="ModelBinding.ModelStateDictionary"/>
-        /// object for the specified expression <paramref name="expression"/>.
+        /// object for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
@@ -69,14 +69,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </param>
         /// <returns>
         /// A new <see cref="HtmlString"/> containing a <see cref="ViewContext.ValidationMessageElement"/> element.
-        /// <c>null</c> if the expression <paramref name="expression"/> is valid and client-side validation is
-        /// disabled.
+        /// <c>null</c> if the <paramref name="expression"/> is valid and client-side validation is disabled.
         /// </returns>
         /// <remarks>
         /// Method extracts an error string from the <see cref="ModelBinding.ModelStateDictionary"/> object. Message
         /// will always be visible but client-side validation may update the associated CSS class.
         /// </remarks>
-        public static HtmlString ValidationMessage([NotNull] this IHtmlHelper htmlHelper,
+        public static HtmlString ValidationMessage(
+            [NotNull] this IHtmlHelper htmlHelper,
             string expression,
             object htmlAttributes)
         {
@@ -85,7 +85,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
         /// <summary>
         /// Returns the validation message if an error exists in the <see cref="ModelBinding.ModelStateDictionary"/>
-        /// object for the specified expression <paramref name="expression"/>.
+        /// object for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
@@ -100,9 +100,10 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </param>
         /// <returns>
         /// A new <see cref="HtmlString"/> containing a <paramref name="tag"/> element. <c>null</c> if the
-        /// expression <paramref name="expression"/> is valid and client-side validation is disabled.
+        /// <paramref name="expression"/> is valid and client-side validation is disabled.
         /// </returns>
-        public static HtmlString ValidationMessage([NotNull] this IHtmlHelper htmlHelper,
+        public static HtmlString ValidationMessage(
+            [NotNull] this IHtmlHelper htmlHelper,
             string expression,
             string message,
             string tag)
@@ -112,7 +113,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
         /// <summary>
         /// Returns the validation message if an error exists in the <see cref="ModelBinding.ModelStateDictionary"/>
-        /// object for the specified expression <paramref name="expression"/>.
+        /// object for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
@@ -129,10 +130,10 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </param>
         /// <returns>
         /// A new <see cref="HtmlString"/> containing a <see cref="ViewContext.ValidationMessageElement"/> element.
-        /// <c>null</c> if the expression <paramref name="expression"/> is valid and client-side validation is
-        /// disabled.
+        /// <c>null</c> if the <paramref name="expression"/> is valid and client-side validation is disabled.
         /// </returns>
-        public static HtmlString ValidationMessage([NotNull] this IHtmlHelper htmlHelper,
+        public static HtmlString ValidationMessage(
+            [NotNull] this IHtmlHelper htmlHelper,
             string expression,
             string message,
             object htmlAttributes)
@@ -147,18 +148,18 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>
         /// A new <see cref="HtmlString"/> containing a <see cref="ViewContext.ValidationMessageElement"/> element.
-        /// <c>null</c> if the expression <paramref name="expression"/> is valid and client-side validation is
-        /// disabled.
+        /// <c>null</c> if the <paramref name="expression"/> is valid and client-side validation is disabled.
         /// </returns>
         /// <remarks>
         /// Method extracts an error string from the <see cref="ModelBinding.ModelStateDictionary"/> object. Message
         /// will always be visible but client-side validation may update the associated CSS class.
         /// </remarks>
-        public static HtmlString ValidationMessageFor<TModel, TProperty>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            [NotNull] Expression<Func<TModel, TProperty>> expression)
+        public static HtmlString ValidationMessageFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression)
         {
             return htmlHelper.ValidationMessageFor(expression, message: null, htmlAttributes: null, tag: null);
         }
@@ -175,14 +176,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// validation may update the associated CSS class.
         /// </param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>
         /// A new <see cref="HtmlString"/> containing a <see cref="ViewContext.ValidationMessageElement"/> element.
-        /// <c>null</c> if the expression <paramref name="expression"/> is valid and client-side validation is
-        /// disabled.
+        /// <c>null</c> if the <paramref name="expression"/> is valid and client-side validation is disabled.
         /// </returns>
-        public static HtmlString ValidationMessageFor<TModel, TProperty>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            [NotNull] Expression<Func<TModel, TProperty>> expression,
+        public static HtmlString ValidationMessageFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression,
             string message)
         {
             return htmlHelper.ValidationMessageFor(expression, message, htmlAttributes: null, tag: null);
@@ -206,14 +207,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// attributes.
         /// </param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>
         /// A new <see cref="HtmlString"/> containing a <see cref="ViewContext.ValidationMessageElement"/> element.
-        /// <c>null</c> if the expression <paramref name="expression"/> is valid and client-side validation is
-        /// disabled.
+        /// <c>null</c> if the <paramref name="expression"/> is valid and client-side validation is disabled.
         /// </returns>
-        public static HtmlString ValidationMessageFor<TModel, TProperty>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            [NotNull] Expression<Func<TModel, TProperty>> expression,
+        public static HtmlString ValidationMessageFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression,
             string message,
             object htmlAttributes)
         {
@@ -236,13 +237,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <see cref="ViewContext.ValidationMessageElement"/>.
         /// </param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>
         /// A new <see cref="HtmlString"/> containing the <paramref name="tag"/> element. <c>null</c> if the
         /// <paramref name="expression"/> is valid and client-side validation is disabled.
         /// </returns>
-        public static HtmlString ValidationMessageFor<TModel, TProperty>([NotNull] this IHtmlHelper<TModel> htmlHelper,
-            [NotNull] Expression<Func<TModel, TProperty>> expression,
+        public static HtmlString ValidationMessageFor<TModel, TResult>(
+            [NotNull] this IHtmlHelper<TModel> htmlHelper,
+            [NotNull] Expression<Func<TModel, TResult>> expression,
             string message,
             string tag)
         {
@@ -260,7 +262,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </returns>
         public static HtmlString ValidationSummary([NotNull] this IHtmlHelper htmlHelper)
         {
-            return htmlHelper.ValidationSummary(excludePropertyErrors: false,
+            return htmlHelper.ValidationSummary(
+                excludePropertyErrors: false,
                 message: null,
                 htmlAttributes: null,
                 tag: null);
@@ -280,7 +283,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </returns>
         public static HtmlString ValidationSummary([NotNull] this IHtmlHelper htmlHelper, bool excludePropertyErrors)
         {
-            return htmlHelper.ValidationSummary(excludePropertyErrors,
+            return htmlHelper.ValidationSummary(
+                excludePropertyErrors,
                 message: null,
                 htmlAttributes: null,
                 tag: null);
@@ -300,7 +304,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </returns>
         public static HtmlString ValidationSummary([NotNull] this IHtmlHelper htmlHelper, string message)
         {
-            return htmlHelper.ValidationSummary(excludePropertyErrors: false,
+            return htmlHelper.ValidationSummary(
+                excludePropertyErrors: false,
                 message: message,
                 htmlAttributes: null,
                 tag: null);
@@ -323,7 +328,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </returns>
         public static HtmlString ValidationSummary([NotNull] this IHtmlHelper htmlHelper, string message, string tag)
         {
-            return htmlHelper.ValidationSummary(excludePropertyErrors: false,
+            return htmlHelper.ValidationSummary(
+                excludePropertyErrors: false,
                 message: message,
                 htmlAttributes: null,
                 tag: tag);
@@ -344,11 +350,13 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <paramref name="message"/>) and the &lt;ul&gt; element. <see cref="HtmlString.Empty"/> if the current model
         /// is valid and client-side validation is disabled).
         /// </returns>
-        public static HtmlString ValidationSummary([NotNull] this IHtmlHelper htmlHelper,
+        public static HtmlString ValidationSummary(
+            [NotNull] this IHtmlHelper htmlHelper,
             bool excludePropertyErrors,
             string message)
         {
-            return htmlHelper.ValidationSummary(excludePropertyErrors,
+            return htmlHelper.ValidationSummary(
+                excludePropertyErrors,
                 message,
                 htmlAttributes: null,
                 tag: null);
@@ -371,12 +379,16 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <paramref name="message"/>) and the &lt;ul&gt; element. <see cref="HtmlString.Empty"/> if the current model
         /// is valid and client-side validation is disabled).
         /// </returns>
-        public static HtmlString ValidationSummary([NotNull] this IHtmlHelper htmlHelper,
+        public static HtmlString ValidationSummary(
+            [NotNull] this IHtmlHelper htmlHelper,
             string message,
             object htmlAttributes)
         {
             return htmlHelper.ValidationSummary(
-                excludePropertyErrors: false, message: message, htmlAttributes: htmlAttributes, tag: null);
+                excludePropertyErrors: false,
+                message: message,
+                htmlAttributes: htmlAttributes,
+                tag: null);
         }
 
         /// <summary>
@@ -399,13 +411,17 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// and the &lt;ul&gt; element. <see cref="HtmlString.Empty"/> if the current model is valid and client-side
         /// validation is disabled).
         /// </returns>
-        public static HtmlString ValidationSummary([NotNull] this IHtmlHelper htmlHelper,
+        public static HtmlString ValidationSummary(
+            [NotNull] this IHtmlHelper htmlHelper,
             string message,
             object htmlAttributes,
             string tag)
         {
             return htmlHelper.ValidationSummary(
-                excludePropertyErrors: false, message: message, htmlAttributes: htmlAttributes, tag: tag);
+                excludePropertyErrors: false,
+                message: message,
+                htmlAttributes: htmlAttributes,
+                tag: tag);
         }
 
         /// <summary>
@@ -426,12 +442,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// and the &lt;ul&gt; element. <see cref="HtmlString.Empty"/> if the current model is valid and client-side
         /// validation is disabled).
         /// </returns>
-        public static HtmlString ValidationSummary([NotNull] this IHtmlHelper htmlHelper,
+        public static HtmlString ValidationSummary(
+            [NotNull] this IHtmlHelper htmlHelper,
             bool excludePropertyErrors,
             string message,
             string tag)
         {
-            return htmlHelper.ValidationSummary(excludePropertyErrors,
+            return htmlHelper.ValidationSummary(
+                excludePropertyErrors,
                 message,
                 htmlAttributes: null,
                 tag: tag);
@@ -457,7 +475,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <paramref name="message"/>) and the &lt;ul&gt; element. <see cref="HtmlString.Empty"/> if the current model
         /// is valid and client-side validation is disabled).
         /// </returns>
-        public static HtmlString ValidationSummary([NotNull] this IHtmlHelper htmlHelper,
+        public static HtmlString ValidationSummary(
+            [NotNull] this IHtmlHelper htmlHelper,
             bool excludePropertyErrors,
             string message,
             object htmlAttributes)

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperValueExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/HtmlHelperValueExtensions.cs
@@ -12,17 +12,17 @@ namespace Microsoft.AspNet.Mvc.Rendering
     public static class HtmlHelperValueExtensions
     {
         /// <summary>
-        /// Returns the formatted value for the specified expression <paramref name="name"/>.
+        /// Returns the formatted value for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <returns>A <see cref="string"/> containing the formatted value.</returns>
         /// <remarks>
         /// Converts the expression result to a <see cref="string"/> directly.
         /// </remarks>
-        public static string Value([NotNull] this IHtmlHelper htmlHelper, string name)
+        public static string Value([NotNull] this IHtmlHelper htmlHelper, string expression)
         {
-            return htmlHelper.Value(name, format: null);
+            return htmlHelper.Value(expression, format: null);
         }
 
         /// <summary>
@@ -31,14 +31,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A <see cref="string"/> containing the formatted value.</returns>
         /// <remarks>
         /// Converts the <paramref name="expression"/> result to a <see cref="string"/> directly.
         /// </remarks>
-        public static string ValueFor<TModel, TProperty>(
+        public static string ValueFor<TModel, TResult>(
             [NotNull] this IHtmlHelper<TModel> htmlHelper,
-            [NotNull] Expression<Func<TModel, TProperty>> expression)
+            [NotNull] Expression<Func<TModel, TResult>> expression)
         {
             return htmlHelper.ValueFor(expression, format: null);
         }
@@ -53,7 +53,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </remarks>
         public static string ValueForModel([NotNull] this IHtmlHelper htmlHelper)
         {
-            return htmlHelper.Value(name: null, format: null);
+            return htmlHelper.Value(expression: null, format: null);
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </remarks>
         public static string ValueForModel([NotNull] this IHtmlHelper htmlHelper, string format)
         {
-            return htmlHelper.Value(name: null, format: format);
+            return htmlHelper.Value(expression: null, format: format);
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/IHtmlHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/IHtmlHelper.cs
@@ -143,7 +143,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// Returns an &lt;input&gt; element of type "checkbox" with value "true" and an &lt;input&gt; element of type
         /// "hidden" with value "false".
         /// </summary>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="isChecked">If <c>true</c>, checkbox is initially checked.</param>
         /// <param name="htmlAttributes">
         /// An <see cref="object"/> that contains the HTML attributes for the checkbox element. Alternatively, an
@@ -152,23 +152,24 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; elements.</returns>
         /// <remarks>
         /// <para>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set checkbox
-        /// element's "name" attribute. Sanitizes <paramref name="name"/> to set checkbox element's "id" attribute.
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set checkbox
+        /// element's "name" attribute. Sanitizes <paramref name="expression"/> to set checkbox element's "id"
+        /// attribute.
         /// </para>
         /// <para>Determines checkbox element's "checked" attribute based on the following precedence:</para>
         /// <list type="number">
         /// <item>
-        /// <see cref="ModelStateDictionary"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="bool"/>.
+        /// <see cref="ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
+        /// name) if entry exists and can be converted to a <see cref="bool"/>.
         /// </item>
         /// <item><paramref name="isChecked"/> if non-<c>null</c>.</item>
         /// <item>
-        /// <see cref="ViewData"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
+        /// <see cref="ViewData"/> entry for <paramref name="expression"/> (converted to a fully-qualified name)
         /// if entry exists and can be converted to a <see cref="bool"/>.
         /// </item>
         /// <item>
-        /// Linq expression based on <paramref name="name"/> (converted to a fully-qualified name) run against current
-        /// model if result is non-<c>null</c> and can be converted to a <see cref="bool"/>. For example
+        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
+        /// current model if result is non-<c>null</c> and can be converted to a <see cref="bool"/>. For example
         /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
         /// property.
         /// </item>
@@ -180,7 +181,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// value "checked" if the <see cref="bool"/> values is <c>true</c>; does not include the attribute otherwise.
         /// </para>
         /// </remarks>
-        HtmlString CheckBox(string name, bool? isChecked, object htmlAttributes);
+        HtmlString CheckBox(string expression, bool? isChecked, object htmlAttributes);
 
         /// <summary>
         /// Returns HTML markup for the <paramref name="expression"/>, using a display template, specified HTML field
@@ -219,27 +220,27 @@ namespace Microsoft.AspNet.Mvc.Rendering
             object additionalViewData);
 
         /// <summary>
-        /// Returns the display name for the specified expression <paramref name="expression"/>.
+        /// Returns the display name for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <returns>A <see cref="string"/> containing the display name.</returns>
         string DisplayName(string expression);
 
         /// <summary>
-        /// Returns the simple display text for the specified expression <paramref name="name"/>.
+        /// Returns the simple display text for the specified <paramref name="expression"/>.
         /// </summary>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <returns>
         /// A <see cref="string"/> containing the simple display text.
         /// If the expression result is <c>null</c>, returns <see cref="ModelMetadata.NullDisplayText"/>.
         /// </returns>
-        string DisplayText(string name);
+        string DisplayText(string expression);
 
         /// <summary>
-        /// Returns a single-selection HTML &lt;select&gt; element for the expression <paramref name="name"/>,
+        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>,
         /// using the specified list items, option label, and HTML attributes.
         /// </summary>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="selectList">
         /// A collection of <see cref="SelectListItem"/> objects used to populate the &lt;select&gt; element with
         /// &lt;optgroup&gt; and &lt;option&gt; elements.
@@ -253,12 +254,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;select&gt; element.</returns>
         /// <remarks>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;select&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;select&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </remarks>
         HtmlString DropDownList(
-            string name,
+            string expression,
             IEnumerable<SelectListItem> selectList,
             string optionLabel,
             object htmlAttributes);
@@ -332,30 +333,30 @@ namespace Microsoft.AspNet.Mvc.Rendering
         string FormatValue(object value, string format);
 
         /// <summary>
-        /// Returns an HTML element Id for the specified expression <paramref name="name"/>.
+        /// Returns an HTML element Id for the specified expression <paramref name="fullName"/>.
         /// </summary>
-        /// <param name="name">
+        /// <param name="fullName">
         /// Fully-qualified expression name, ignoring the current model. Must not be <c>null</c>.
         /// </param>
         /// <returns>A <see cref="string"/> containing the element Id.</returns>
-        string GenerateIdFromName([NotNull] string name);
+        string GenerateIdFromName([NotNull] string fullName);
 
         /// <summary>
         /// Returns information about about client validation rules for the specified <paramref name="metadata"/> or
-        /// <paramref name="name"/>. Intended for use in <see cref="IHtmlHelper"/> extension methods.
+        /// <paramref name="expression"/>. Intended for use in <see cref="IHtmlHelper"/> extension methods.
         /// </summary>
         /// <param name="metadata">Metadata about the <see cref="object"/> of interest.</param>
-        /// <param name="name">
+        /// <param name="expression">
         /// Expression name, relative to the current model. Used to determine <see cref="ModelMetadata"/> when
         /// <paramref name="metadata"/> is <c>null</c>; ignored otherwise.
         /// </param>
         /// <returns>An <see cref="IEnumerable{ModelClientValidationRule}"/> containing the relevant rules.</returns>
-        IEnumerable<ModelClientValidationRule> GetClientValidationRules(ModelMetadata metadata, string name);
+        IEnumerable<ModelClientValidationRule> GetClientValidationRules(ModelMetadata metadata, string expression);
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "hidden" for the specified expression <paramref name="name"/>.
+        /// Returns an &lt;input&gt; element of type "hidden" for the specified <paramref name="expression"/>.
         /// </summary>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
         /// <param name="htmlAttributes">
         /// An <see cref="object"/> that contains the HTML attributes for the element. Alternatively, an
@@ -364,24 +365,24 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </para>
         /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
         /// <list type="number">
         /// <item>
-        /// <see cref="ModelStateDictionary"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="string"/>.
+        /// <see cref="ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
+        /// name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item><paramref name="value"/> if non-<c>null</c>.</item>
         /// <item>
-        /// <see cref="ViewData"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
+        /// <see cref="ViewData"/> entry for <paramref name="expression"/> (converted to a fully-qualified name)
         /// if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
-        /// Linq expression based on <paramref name="name"/> (converted to a fully-qualified name) run against current
-        /// model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
+        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
+        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
         /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
         /// property.
         /// </item>
@@ -389,17 +390,17 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <item>Otherwise, <c>string.Empty</c>.</item>
         /// </list>
         /// </remarks>
-        HtmlString Hidden(string name, object value, object htmlAttributes);
+        HtmlString Hidden(string expression, object value, object htmlAttributes);
 
         /// <summary>
-        /// Returns the HTML element Id for the specified expression <paramref name="name"/>.
+        /// Returns the HTML element Id for the specified <paramref name="expression"/>.
         /// </summary>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <returns>A <see cref="string"/> containing the element Id.</returns>
-        string Id(string name);
+        string Id(string expression);
 
         /// <summary>
-        /// Returns a &lt;label&gt; element for the specified expression <paramref name="name"/>.
+        /// Returns a &lt;label&gt; element for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="labelText">The inner text of the element.</param>
@@ -411,10 +412,10 @@ namespace Microsoft.AspNet.Mvc.Rendering
         HtmlString Label(string expression, string labelText, object htmlAttributes);
 
         /// <summary>
-        /// Returns a multi-selection &lt;select&gt; element for the expression <paramref name="name"/>, using the
+        /// Returns a multi-selection &lt;select&gt; element for the <paramref name="expression"/>, using the
         /// specified list items and HTML attributes.
         /// </summary>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="selectList">
         /// A collection of <see cref="SelectListItem"/> objects used to populate the &lt;select&gt; element with
         /// &lt;optgroup&gt; and &lt;option&gt; elements.
@@ -425,18 +426,18 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </param>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;select&gt; element.</returns>
         /// <remarks>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;select&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;select&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </remarks>
-        HtmlString ListBox(string name, IEnumerable<SelectListItem> selectList, object htmlAttributes);
+        HtmlString ListBox(string expression, IEnumerable<SelectListItem> selectList, object htmlAttributes);
 
         /// <summary>
-        /// Returns the full HTML element name for the specified expression <paramref name="name"/>.
+        /// Returns the full HTML element name for the specified <paramref name="expression"/>.
         /// </summary>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <returns>A <see cref="string"/> containing the element name.</returns>
-        string Name(string name);
+        string Name(string expression);
 
         /// <summary>
         /// Returns HTML markup for the specified partial view.
@@ -453,9 +454,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
         Task<HtmlString> PartialAsync([NotNull] string partialViewName, object model, ViewDataDictionary viewData);
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "password" for the specified expression <paramref name="name"/>.
+        /// Returns an &lt;input&gt; element of type "password" for the specified <paramref name="expression"/>.
         /// </summary>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
         /// <param name="htmlAttributes">
         /// An <see cref="object"/> that contains the HTML attributes for the element. Alternatively, an
@@ -464,8 +465,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </para>
         /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
@@ -475,12 +476,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <item>Otherwise, <c>string.Empty</c>.</item>
         /// </list>
         /// </remarks>
-        HtmlString Password(string name, object value, object htmlAttributes);
+        HtmlString Password(string expression, object value, object htmlAttributes);
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "radio" for the specified expression <paramref name="name"/>.
+        /// Returns an &lt;input&gt; element of type "radio" for the specified <paramref name="expression"/>.
         /// </summary>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">
         /// If non-<c>null</c>, value to include in the element. Must not be <c>null</c> if
         /// <paramref name="isChecked"/> is also <c>null</c> and no "checked" entry exists in
@@ -498,8 +499,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </para>
         /// <para>Determines element's "value" attribute based on the following precedence:</para>
@@ -511,18 +512,18 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <para>Determines &lt;input&gt; element's "checked" attribute based on the following precedence:</para>
         /// <list type="number">
         /// <item>
-        /// <see cref="ModelStateDictionary"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="string"/>.
+        /// <see cref="ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
+        /// name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item><paramref name="isChecked"/> if non-<c>null</c>.</item>
         /// <item>Existing "checked" entry in <paramref name="htmlAttributes"/> if any.</item>
         /// <item>
-        /// <see cref="ViewData"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
+        /// <see cref="ViewData"/> entry for <paramref name="expression"/> (converted to a fully-qualified name)
         /// if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
-        /// Linq expression based on <paramref name="name"/> (converted to a fully-qualified name) run against current
-        /// model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
+        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
+        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
         /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
         /// property.
         /// </item>
@@ -535,7 +536,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// the attribute otherwise.
         /// </para>
         /// </remarks>
-        HtmlString RadioButton(string name, object value, bool? isChecked, object htmlAttributes);
+        HtmlString RadioButton(string expression, object value, bool? isChecked, object htmlAttributes);
 
         /// <summary>
         /// Wraps HTML markup in an <see cref="HtmlString"/>, without HTML-encoding the specified
@@ -596,9 +597,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
             object htmlAttributes);
 
         /// <summary>
-        /// Returns a &lt;textarea&gt; element for the specified expression <paramref name="name"/>.
+        /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>.
         /// </summary>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
         /// <param name="rows">Number of rows in the textarea.</param>
         /// <param name="columns">Number of columns in the textarea.</param>
@@ -609,36 +610,36 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;textarea&gt; element.</returns>
         /// <remarks>
         /// <para>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;textarea&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
+        /// &lt;textarea&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
         /// </para>
         /// <para>Determines &lt;textarea&gt; element's content based on the following precedence:</para>
         /// <list type="number">
         /// <item>
-        /// <see cref="ModelStateDictionary"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="string"/>.
+        /// <see cref="ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
+        /// name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item><paramref name="value"/> if non-<c>null</c>.</item>
         /// <item>
-        /// <see cref="ViewData"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
+        /// <see cref="ViewData"/> entry for <paramref name="expression"/> (converted to a fully-qualified name)
         /// if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
-        /// Linq expression based on <paramref name="name"/> (converted to a fully-qualified name) run against current
-        /// model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
+        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
+        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
         /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
         /// property.
         /// </item>
         /// <item>Otherwise, <c>string.Empty</c>.</item>
         /// </list>
         /// </remarks>
-        HtmlString TextArea(string name, string value, int rows, int columns, object htmlAttributes);
+        HtmlString TextArea(string expression, string value, int rows, int columns, object htmlAttributes);
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "text" for the specified expression <paramref name="name"/>.
+        /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="current"/>.
         /// </summary>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="current">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
         /// <param name="format">
         /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx).
@@ -650,15 +651,15 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
-        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="name"/> to set
-        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="name"/> to set element's "id"
+        /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="current"/> to set
+        /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="current"/> to set element's "id"
         /// attribute.
         /// </para>
         /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
         /// <list type="number">
         /// <item>
-        /// <see cref="ModelStateDictionary"/> entry for <paramref name="name"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="string"/>.
+        /// <see cref="ModelStateDictionary"/> entry for <paramref name="current"/> (converted to a fully-qualified
+        /// name) if entry exists and can be converted to a <see cref="string"/>.
         /// </item>
         /// <item>
         /// <paramref name="value"/> if non-<c>null</c>. Formats <paramref name="value"/> using
@@ -666,13 +667,13 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <paramref name="format"/> is <c>null</c> or empty.
         /// </item>
         /// <item>
-        /// <see cref="ViewData"/> entry for <paramref name="name"/> (converted to a fully-qualified name) if entry
+        /// <see cref="ViewData"/> entry for <paramref name="current"/> (converted to a fully-qualified name) if entry
         /// exists and can be converted to a <see cref="string"/>. Formats entry using <paramref name="format"/> or
         /// converts entry to a <see cref="string"/> directly if <paramref name="format"/> is <c>null</c> or empty.
         /// </item>
         /// <item>
-        /// Linq expression based on <paramref name="name"/> (converted to a fully-qualified name) run against current
-        /// model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
+        /// Linq expression based on <paramref name="current"/> (converted to a fully-qualified name) run against
+        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
         /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
         /// property. Formats result using <paramref name="format"/> or converts result to a <see cref="string"/>
         /// directly if <paramref name="format"/> is <c>null</c> or empty.
@@ -681,13 +682,13 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <item>Otherwise, <c>string.Empty</c>.</item>
         /// </list>
         /// </remarks>
-        HtmlString TextBox(string name, object value, string format, object htmlAttributes);
+        HtmlString TextBox(string current, object value, string format, object htmlAttributes);
 
         /// <summary>
         /// Returns the validation message if an error exists in the <see cref="ModelStateDictionary"/> object
-        /// for the specified expression <paramref name="modelName"/>.
+        /// for the specified <paramref name="expression"/>.
         /// </summary>
-        /// <param name="modelName">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="message">
         /// The message to be displayed. If <c>null</c> or empty, method extracts an error string from the
         /// <see cref="ModelStateDictionary"/> object. Message will always be visible but client-side validation may
@@ -703,9 +704,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </param>
         /// <returns>
         /// A new <see cref="HtmlString"/> containing a <paramref name="tag"/> element. <c>null</c> if the
-        /// expression <paramref name="modelName"/> is valid and client-side validation is disabled.
+        /// <paramref name="expression"/> is valid and client-side validation is disabled.
         /// </returns>
-        HtmlString ValidationMessage(string modelName, string message, object htmlAttributes, string tag);
+        HtmlString ValidationMessage(string expression, string message, object htmlAttributes, string tag);
 
         /// <summary>
         /// Returns an unordered list (&lt;ul&gt; element) of validation messages that are in the
@@ -735,9 +736,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
             string tag);
 
         /// <summary>
-        /// Returns the formatted value for the specified expression <paramref name="name"/>.
+        /// Returns the formatted value for the specified <paramref name="expression"/>.
         /// </summary>
-        /// <param name="name">Expression name, relative to the current model.</param>
+        /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="format">
         /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx).
         /// </param>
@@ -746,6 +747,6 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// Converts the expression result to a <see cref="string"/> directly if
         /// <paramref name="format"/> is <c>null</c> or empty.
         /// </remarks>
-        string Value(string name, string format);
+        string Value(string expression, string format);
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/IHtmlHelperOfT.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/IHtmlHelperOfT.cs
@@ -70,24 +70,25 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// view data that will be merged into the <see cref="ViewDataDictionary{TModel}"/> instance created for the
         /// template.
         /// </param>
-        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the created HTML.</returns>
         /// <remarks>
         /// For example the default <see cref="object"/> display template includes markup for each property in the
         /// <paramref name="expression"/> result.
         /// </remarks>
-        HtmlString DisplayFor<TValue>([NotNull] Expression<Func<TModel, TValue>> expression,
-                                      string templateName,
-                                      string htmlFieldName,
-                                      object additionalViewData);
+        HtmlString DisplayFor<TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            string templateName,
+            string htmlFieldName,
+            object additionalViewData);
 
         /// <summary>
         /// Returns the display name for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
-        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A <see cref="string"/> containing the display name.</returns>
-        string DisplayNameFor<TValue>([NotNull] Expression<Func<TModel, TValue>> expression);
+        string DisplayNameFor<TResult>([NotNull] Expression<Func<TModel, TResult>> expression);
 
         /// <summary>
         /// Returns the display name for the specified <paramref name="expression"/>
@@ -95,22 +96,22 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </summary>
         /// <param name="expression">An expression to be evaluated against an item in the current model.</param>
         /// <typeparam name="TModelItem">The type of items in the model collection.</typeparam>
-        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A <see cref="string"/> containing the display name.</returns>
-        string DisplayNameForInnerType<TModelItem, TValue>(
-            [NotNull] Expression<Func<TModelItem, TValue>> expression);
+        string DisplayNameForInnerType<TModelItem, TResult>(
+            [NotNull] Expression<Func<TModelItem, TResult>> expression);
 
         /// <summary>
         /// Returns the simple display text for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
-        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>
         /// A <see cref="string"/> containing the simple display text.
         /// If the <paramref name="expression"/> result is <c>null</c>, returns
         /// <see cref="ModelBinding.ModelMetadata.NullDisplayText"/>.
         /// </returns>
-        string DisplayTextFor<TValue>([NotNull] Expression<Func<TModel, TValue>> expression);
+        string DisplayTextFor<TResult>([NotNull] Expression<Func<TModel, TResult>> expression);
 
         /// <summary>
         /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>, using the
@@ -128,15 +129,15 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// An <see cref="object"/> that contains the HTML attributes for the &lt;select&gt; element. Alternatively, an
         /// <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
         /// </param>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;select&gt; element.</returns>
         /// <remarks>
         /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and the string representation of the
         /// <paramref name="expression"/> to set &lt;select&gt; element's "name" attribute. Sanitizes the string
         /// representation of the <paramref name="expression"/> to set element's "id" attribute.
         /// </remarks>
-        HtmlString DropDownListFor<TProperty>(
-            [NotNull] Expression<Func<TModel, TProperty>> expression,
+        HtmlString DropDownListFor<TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
             IEnumerable<SelectListItem> selectList,
             string optionLabel,
             object htmlAttributes);
@@ -157,13 +158,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// view data that will be merged into the <see cref="ViewDataDictionary{TModel}"/> instance created for the
         /// template.
         /// </param>
-        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element(s).</returns>
         /// <remarks>
         /// For example the default <see cref="object"/> editor template includes &lt;label&gt; and &lt;input&gt;
         /// elements for each property in the <paramref name="expression"/> result.
         /// </remarks>
-        HtmlString EditorFor<TValue>([NotNull] Expression<Func<TModel, TValue>> expression,
+        HtmlString EditorFor<TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
             string templateName,
             string htmlFieldName,
             object additionalViewData);
@@ -176,7 +178,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// An <see cref="object"/> that contains the HTML attributes for the element. Alternatively, an
         /// <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
         /// </param>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
@@ -198,16 +200,17 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <item>Otherwise, <c>string.Empty</c>.</item>
         /// </list>
         /// </remarks>
-        HtmlString HiddenFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression,
+        HtmlString HiddenFor<TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
             object htmlAttributes);
 
         /// <summary>
         /// Returns the HTML element Id for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A <see cref="string"/> containing the element Id.</returns>
-        string IdFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression);
+        string IdFor<TResult>([NotNull] Expression<Func<TModel, TResult>> expression);
 
         /// <summary>
         /// Returns a &lt;label&gt; element for the specified <paramref name="expression"/>.
@@ -218,11 +221,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// An <see cref="object"/> that contains the HTML attributes for the element. Alternatively, an
         /// <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
         /// </param>
-        /// <typeparam name="TValue">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;label&gt; element.</returns>
-        HtmlString LabelFor<TValue>([NotNull] Expression<Func<TModel, TValue>> expression,
-                                    string labelText,
-                                    object htmlAttributes);
+        HtmlString LabelFor<TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            string labelText,
+            object htmlAttributes);
 
         /// <summary>
         /// Returns a multi-selection &lt;select&gt; element for the <paramref name="expression"/>, using the
@@ -237,15 +241,15 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// An <see cref="object"/> that contains the HTML attributes for the &lt;select&gt; element. Alternatively, an
         /// <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
         /// </param>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;select&gt; element.</returns>
         /// <remarks>
         /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and the string representation of the
         /// <paramref name="expression"/> to set &lt;select&gt; element's "name" attribute. Sanitizes the string
         /// representation of the <paramref name="expression"/> to set element's "id" attribute.
         /// </remarks>
-        HtmlString ListBoxFor<TProperty>(
-            [NotNull] Expression<Func<TModel, TProperty>> expression,
+        HtmlString ListBoxFor<TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
             IEnumerable<SelectListItem> selectList,
             object htmlAttributes);
 
@@ -253,9 +257,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// Returns the full HTML element name for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A <see cref="string"/> containing the element name.</returns>
-        string NameFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression);
+        string NameFor<TResult>([NotNull] Expression<Func<TModel, TResult>> expression);
 
         /// <summary>
         /// Returns an &lt;input&gt; element of type "password" for the specified <paramref name="expression"/>.
@@ -265,7 +269,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// An <see cref="object"/> that contains the HTML attributes for the element. Alternatively, an
         /// <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
         /// </param>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
@@ -283,7 +287,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <item>Otherwise, <c>string.Empty</c>.</item>
         /// </list>
         /// </remarks>
-        HtmlString PasswordFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression,
+        HtmlString PasswordFor<TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
             object htmlAttributes);
 
         /// <summary>
@@ -295,7 +300,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// An <see cref="object"/> that contains the HTML attributes for the element. Alternatively, an
         /// <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
         /// </param>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
@@ -322,8 +327,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <paramref name="value"/>; does not include the attribute otherwise.
         /// </para>
         /// </remarks>
-        HtmlString RadioButtonFor<TProperty>(
-            [NotNull] Expression<Func<TModel, TProperty>> expression,
+        HtmlString RadioButtonFor<TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
             [NotNull] object value,
             object htmlAttributes);
 
@@ -337,7 +342,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// An <see cref="object"/> that contains the HTML attributes for the element. Alternatively, an
         /// <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
         /// </param>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;textarea&gt; element.</returns>
         /// <remarks>
         /// <para>
@@ -357,8 +362,11 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <item>Otherwise, <c>string.Empty</c>.</item>
         /// </list>
         /// </remarks>
-        HtmlString TextAreaFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression,
-            int rows, int columns, object htmlAttributes);
+        HtmlString TextAreaFor<TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            int rows,
+            int columns,
+            object htmlAttributes);
 
         /// <summary>
         /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="expression"/>.
@@ -371,7 +379,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// An <see cref="object"/> that contains the HTML attributes for the element. Alternatively, an
         /// <see cref="IDictionary{string, object}"/> instance containing the HTML attributes.
         /// </param>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="HtmlString"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
         /// <para>
@@ -394,7 +402,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <item>Otherwise, <c>string.Empty</c>.</item>
         /// </list>
         /// </remarks>
-        HtmlString TextBoxFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression, string format,
+        HtmlString TextBoxFor<TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            string format,
             object htmlAttributes);
 
         /// <summary>
@@ -415,12 +425,13 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// The tag to wrap the <paramref name="message"/> in the generated HTML. Its default value is
         /// <see cref="ViewContext.ValidationMessageElement"/>.
         /// </param>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>
         /// A new <see cref="HtmlString"/> containing the <paramref name="tag"/> element. <c>null</c> if the
         /// <paramref name="expression"/> is valid and client-side validation is disabled.
         /// </returns>
-        HtmlString ValidationMessageFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression,
+        HtmlString ValidationMessageFor<TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
             string message,
             object htmlAttributes,
             string tag);
@@ -432,12 +443,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <param name="format">
         /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx).
         /// </param>
-        /// <typeparam name="TProperty">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A <see cref="string"/> containing the formatted value.</returns>
         /// <remarks>
         /// Converts the <paramref name="expression"/> result to a <see cref="string"/> directly if
         /// <paramref name="format"/> is <c>null</c> or empty.
         /// </remarks>
-        string ValueFor<TProperty>([NotNull] Expression<Func<TModel, TProperty>> expression, string format);
+        string ValueFor<TResult>(
+            [NotNull] Expression<Func<TModel, TResult>> expression,
+            string format);
     }
 }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/SelectTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/SelectTagHelper.cs
@@ -98,7 +98,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     ViewContext,
                     For.Metadata,
                     optionLabel: null,
-                    name: For.Name,
+                    expression: For.Name,
                     selectList: items,
                     allowMultiple: allowMultiple,
                     htmlAttributes: null,

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Rendering/HtmlHelperDisplayTextTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Rendering/HtmlHelperDisplayTextTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             var helper = DefaultTemplatesUtilities.GetHtmlHelper<OverriddenToStringModel>(model: null);
 
             // Act
-            var result = helper.DisplayText(name: string.Empty);
+            var result = helper.DisplayText(expression: string.Empty);
 
             // Assert
             Assert.Empty(result);
@@ -47,7 +47,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             helper.ViewData.ModelMetadata.NullDisplayText = "Null display Text";
 
             // Act
-            var result = helper.DisplayText(name: string.Empty);
+            var result = helper.DisplayText(expression: string.Empty);
 
             // Assert
             Assert.Equal("Null display Text", result);
@@ -75,8 +75,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
 
             // Act
-            var result = helper.DisplayText(name: string.Empty);
-            var nullResult = helper.DisplayText(name: null);    // null is another alias for current model
+            var result = helper.DisplayText(expression: string.Empty);
+            var nullResult = helper.DisplayText(expression: null);    // null is another alias for current model
 
             // Assert
             Assert.Equal("Model value", result);
@@ -120,7 +120,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             helper.ViewData.ModelMetadata.SimpleDisplayText = "Simple display text";
 
             // Act
-            var result = helper.DisplayText(name: string.Empty);
+            var result = helper.DisplayText(expression: string.Empty);
 
             // Assert
             Assert.Equal("Simple display text", result);

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Rendering/HtmlHelperHiddenTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Rendering/HtmlHelperHiddenTest.cs
@@ -290,7 +290,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
             // Act and Assert
             ExceptionAssert.ThrowsArgumentNullOrEmpty(() => helper.Hidden(string.Empty, string.Empty, attributes),
-                                                      "name");
+                                                      "expression");
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Rendering/HtmlHelperNameExtensionsTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Rendering/HtmlHelperNameExtensionsTest.cs
@@ -21,12 +21,12 @@ namespace Microsoft.AspNet.Mvc.Core
             var helper = DefaultTemplatesUtilities.GetHtmlHelper();
 
             // Act
-            var idResult = helper.Id(name: string.Empty);
-            var idNullResult = helper.Id(name: null);   // null is another alias for current model
+            var idResult = helper.Id(expression: string.Empty);
+            var idNullResult = helper.Id(expression: null);   // null is another alias for current model
             var idForResult = helper.IdFor(m => m);
             var idForModelResult = helper.IdForModel();
-            var nameResult = helper.Name(name: string.Empty);
-            var nameNullResult = helper.Name(name: null);
+            var nameResult = helper.Name(expression: string.Empty);
+            var nameNullResult = helper.Name(expression: null);
             var nameForResult = helper.NameFor(m => m);
             var nameForModelResult = helper.NameForModel();
 
@@ -54,10 +54,10 @@ namespace Microsoft.AspNet.Mvc.Core
             helper.ViewData.TemplateInfo.HtmlFieldPrefix = prefix;
 
             // Act
-            var idResult = helper.Id(name: string.Empty);
+            var idResult = helper.Id(expression: string.Empty);
             var idForResult = helper.IdFor(m => m);
             var idForModelResult = helper.IdForModel();
-            var nameResult = helper.Name(name: string.Empty);
+            var nameResult = helper.Name(expression: string.Empty);
             var nameForResult = helper.NameFor(m => m);
             var nameForModelResult = helper.NameForModel();
 
@@ -149,10 +149,10 @@ namespace Microsoft.AspNet.Mvc.Core
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(provider.Object);
 
             // Act (do not throw)
-            var idResult = helper.Id(name: string.Empty);
+            var idResult = helper.Id(expression: string.Empty);
             var idForResult = helper.IdFor(m => m);
             var idForModelResult = helper.IdForModel();
-            var nameResult = helper.Name(name: string.Empty);
+            var nameResult = helper.Name(expression: string.Empty);
             var nameForResult = helper.NameFor(m => m);
             var nameForModelResult = helper.NameForModel();
 

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Rendering/HtmlHelperPasswordTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Rendering/HtmlHelperPasswordTest.cs
@@ -130,7 +130,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
             // Act and Assert
             ExceptionAssert.ThrowsArgumentNullOrEmpty(() => helper.Password(name, value, htmlAttributes: null),
-                                                      "name");
+                                                      "expression");
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Rendering/HtmlHelperValueExtensionsTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Rendering/HtmlHelperValueExtensionsTest.cs
@@ -91,8 +91,8 @@ namespace Microsoft.AspNet.Mvc.Core
                 "{ StringProperty = ModelStringPropertyValue, ObjectProperty = 01/01/1900 00:00:00 }";
 
             // Act & Assert
-            Assert.Equal(expectedModelValue, helper.Value(name: string.Empty));
-            Assert.Equal(expectedModelValue, helper.Value(name: null)); // null is another alias for current model
+            Assert.Equal(expectedModelValue, helper.Value(expression: string.Empty));
+            Assert.Equal(expectedModelValue, helper.Value(expression: null)); // null is another alias for current model
             Assert.Equal(expectedModelValue, helper.ValueFor(m => m));
             Assert.Equal(expectedModelValue, helper.ValueForModel());
         }


### PR DESCRIPTION
- #944
- name `string` expression name and `Expression<Func<TModel, TResult>>`
  parameters "expression"
 - single special case is `GenerateIdFromName(string fullName)` since every
   other expression name is relative to the current
   `ViewData,TemplateInfo.HtmlFieldPrefix` value
 - applied from `IHtmlHelper` and `IHtmlGenerator` on up
- name `IHtmlHelper` and `IHtmlHelper<TModel>` parameters "htmlHelper"
- rename `TProperty` and `TValue` type parameters to `TResult`

nits:
- clean up abbreviated names in `CachedExpressionCompiler`
- change `ObjectToDictionary()`'s parameter name to `value`
- use `nameof` more to make renaming (and refactoring) easier in the future
- rewrap parameters and arguments to avoid long lines and orphans