### PR TITLE
Api cleanup (remove List and Dictionary in favor of IList and IDictionar...

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ActionDescriptor.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionDescriptor.cs
@@ -17,20 +17,20 @@ namespace Microsoft.AspNet.Mvc
 
         public virtual string Name { get; set; }
 
-        public List<RouteDataActionConstraint> RouteConstraints { get; set; }
+        public IList<RouteDataActionConstraint> RouteConstraints { get; set; }
 
         public AttributeRouteInfo AttributeRouteInfo { get; set; }
 
-        public Dictionary<string, object> RouteValueDefaults { get; private set; }
+        public IDictionary<string, object> RouteValueDefaults { get; }
 
         /// <summary>
         /// The set of constraints for this action. Must all be satisfied for the action to be selected.
         /// </summary>
-        public List<IActionConstraintMetadata> ActionConstraints { get; set; }
+        public IList<IActionConstraintMetadata> ActionConstraints { get; set; }
 
-        public List<ParameterDescriptor> Parameters { get; set; }
+        public IList<ParameterDescriptor> Parameters { get; set; }
 
-        public List<FilterDescriptor> FilterDescriptors { get; set; }
+        public IList<FilterDescriptor> FilterDescriptors { get; set; }
 
         /// <summary>
         /// A friendly name for this action.
@@ -40,6 +40,6 @@ namespace Microsoft.AspNet.Mvc
         /// <summary>
         /// Stores arbitrary metadata properties associated with the <see cref="ActionDescriptor"/>.
         /// </summary>
-        public IDictionary<object, object> Properties { get; private set; }
+        public IDictionary<object, object> Properties { get; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ActionDescriptorProviderContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionDescriptorProviderContext.cs
@@ -12,6 +12,6 @@ namespace Microsoft.AspNet.Mvc
             Results = new List<ActionDescriptor>();
         }
 
-        public List<ActionDescriptor> Results { get; private set; }
+        public IList<ActionDescriptor> Results { get; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ApplicationModelConventionExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ApplicationModelConventionExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNet.Mvc
         /// <param name="controllerModelConvention">The <see cref="IControllerModelConvention"/> which needs to be
         /// added.</param>
         public static void Add(
-            [NotNull] this List<IApplicationModelConvention> conventions,
+            [NotNull] this IList<IApplicationModelConvention> conventions,
             [NotNull] IControllerModelConvention controllerModelConvention)
         {
             conventions.Add(new ControllerApplicationModelConvention(controllerModelConvention));
@@ -33,7 +33,7 @@ namespace Microsoft.AspNet.Mvc
         /// <param name="actionModelConvention">The <see cref="IActionModelConvention"/> which needs to be
         /// added.</param>
         public static void Add(
-            this List<IApplicationModelConvention> conventions,
+            this IList<IApplicationModelConvention> conventions,
             IActionModelConvention actionModelConvention)
         {
             conventions.Add(new ActionApplicationModelConvention(actionModelConvention));

--- a/src/Microsoft.AspNet.Mvc.Core/ControllerActionDescriptorBuilder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ControllerActionDescriptorBuilder.cs
@@ -495,7 +495,7 @@ namespace Microsoft.AspNet.Mvc
             }
         }
 
-        private static bool HasConstraint(List<RouteDataActionConstraint> constraints, string routeKey)
+        private static bool HasConstraint(IList<RouteDataActionConstraint> constraints, string routeKey)
         {
             return constraints.Any(
                 rc => string.Equals(rc.RouteKey, routeKey, StringComparison.OrdinalIgnoreCase));

--- a/src/Microsoft.AspNet.Mvc.Core/ControllerActionDescriptorProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ControllerActionDescriptorProvider.cs
@@ -39,7 +39,11 @@ namespace Microsoft.AspNet.Mvc
 
         public void Invoke(ActionDescriptorProviderContext context, Action callNext)
         {
-            context.Results.AddRange(GetDescriptors());
+            foreach (var descriptor in GetDescriptors())
+            {
+                context.Results.Add(descriptor);
+            }
+
             callNext();
         }
 

--- a/src/Microsoft.AspNet.Mvc.Core/DefaultActionDescriptorsCollectionProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/DefaultActionDescriptorsCollectionProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.ObjectModel;
 using Microsoft.AspNet.Mvc.Logging;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.Logging;
@@ -60,7 +61,8 @@ namespace Microsoft.AspNet.Mvc
                 }
             }
 
-            return new ActionDescriptorsCollection(actionDescriptorProviderContext.Results, 0);
+            return new ActionDescriptorsCollection(
+                new ReadOnlyCollection<ActionDescriptor>(actionDescriptorProviderContext.Results), 0);
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/Description/ApiDescription.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Description/ApiDescription.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNet.Mvc.Description
         /// <summary>
         /// The list of <see cref="ApiParameterDescription"/> for this api.
         /// </summary>
-        public List<ApiParameterDescription> ParameterDescriptions { get; private set; }
+        public IList<ApiParameterDescription> ParameterDescriptions { get; private set; }
 
         /// <summary>
         /// Stores arbitrary metadata properties associated with the <see cref="ApiDescription"/>.

--- a/src/Microsoft.AspNet.Mvc.Core/Description/ApiDescriptionProviderContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Description/ApiDescriptionProviderContext.cs
@@ -29,6 +29,6 @@ namespace Microsoft.AspNet.Mvc.Description
         /// <summary>
         /// The list of resulting <see cref="ApiDescription"/>.
         /// </summary>
-        public List<ApiDescription> Results { get; private set; }
+        public IList<ApiDescription> Results { get; private set; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/Description/DefaultApiDescriptionProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Description/DefaultApiDescriptionProvider.cs
@@ -81,7 +81,11 @@ namespace Microsoft.AspNet.Mvc.Description
             var templateParameters = parsedTemplate?.Parameters?.ToList() ?? new List<TemplatePart>();
 
             var parameterContext = new ApiParameterContext(_modelMetadataProvider, action, templateParameters);
-            apiDescription.ParameterDescriptions.AddRange(GetParameters(parameterContext));
+
+            foreach (var parameter in GetParameters(parameterContext))
+            {
+                apiDescription.ParameterDescriptions.Add(parameter);
+            }
 
             var responseMetadataAttributes = GetResponseMetadataAttributes(action);
 

--- a/src/Microsoft.AspNet.Mvc.Core/Filters/FilterProviderContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Filters/FilterProviderContext.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNet.Mvc
 {
     public class FilterProviderContext
     {
-        public FilterProviderContext([NotNull] ActionContext actionContext, [NotNull] List<FilterItem> items)
+        public FilterProviderContext([NotNull] ActionContext actionContext, [NotNull] IList<FilterItem> items)
         {
             ActionContext = actionContext;
             Results = items;
@@ -17,6 +17,6 @@ namespace Microsoft.AspNet.Mvc
         public ActionContext ActionContext { get; set; }
 
         // Results
-        public List<FilterItem> Results { get; set; }
+        public IList<FilterItem> Results { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/FormatterMappings.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/FormatterMappings.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNet.Mvc
         {
             ValidateContentType(contentType);
             format = RemovePeriodIfPresent(format);
-            _map[format] = contentType;
+            _map[format] = MediaTypeHeaderValue.Parse(contentType.ToString());
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace Microsoft.AspNet.Mvc
 
             MediaTypeHeaderValue value = null;
             _map.TryGetValue(format, out value);
-            
+
             return value;
         }
 
@@ -77,10 +77,10 @@ namespace Microsoft.AspNet.Mvc
                     throw new ArgumentException(string.Format(Resources.Format_NotValid, format));
                 }
 
-                format = format.Substring(1);                
-            }            
+                format = format.Substring(1);
+            }
 
             return format;
-        }        
+        }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/Internal/DecisionTree/DecisionTreeNode.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Internal/DecisionTree/DecisionTreeNode.cs
@@ -11,10 +11,10 @@ namespace Microsoft.AspNet.Mvc.Internal.DecisionTree
     {
         // The list of matches for the current node. This represents a set of items that have had all
         // of their criteria matched if control gets to this point in the tree.
-        public List<TItem> Matches { get; set; }
+        public IList<TItem> Matches { get; set; }
 
         // Additional criteria that further branch out from this node. Walk these to fine more items
         // matching the input data.
-        public List<DecisionCriterion<TItem>> Criteria { get; set; }
+        public IList<DecisionCriterion<TItem>> Criteria { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/Internal/Routing/LinkGenerationDecisionTree.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Internal/Routing/LinkGenerationDecisionTree.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNet.Mvc.Internal.Routing
                 new AttributeRouteLinkGenerationEntryClassifier());
         }
 
-        public List<LinkGenerationMatch> GetMatches(VirtualPathContext context)
+        public IList<LinkGenerationMatch> GetMatches(VirtualPathContext context)
         {
             var results = new List<LinkGenerationMatch>();
             Walk(results, context, _root, isFallbackPath: false);

--- a/src/Microsoft.AspNet.Mvc.Core/Logging/ActionDescriptorValues.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Logging/ActionDescriptorValues.cs
@@ -51,19 +51,19 @@ namespace Microsoft.AspNet.Mvc.Logging
         /// The parameters of the action as <see cref="ParameterDescriptorValues"/>.
         /// See <see cref="ActionDescriptor.Parameters"/>.
         /// </summary>
-        public List<ParameterDescriptorValues> Parameters { get; }
+        public IList<ParameterDescriptorValues> Parameters { get; }
 
         /// <summary>
         /// The filters of the action as <see cref="FilterDescriptorValues"/>.
         /// See <see cref="ActionDescriptor.FilterDescriptors"/>.
         /// </summary>
-        public List<FilterDescriptorValues> FilterDescriptors { get; }
+        public IList<FilterDescriptorValues> FilterDescriptors { get; }
 
         /// <summary>
         /// The route constraints of the action as <see cref="RouteDataActionConstraintValues"/>.
         /// See <see cref="ActionDescriptor.RouteConstraints"/>
         /// </summary>
-        public List<RouteDataActionConstraintValues> RouteConstraints { get; }
+        public IList<RouteDataActionConstraintValues> RouteConstraints { get; }
 
         /// <summary>
         /// The attribute route info of the action as <see cref="AttributeRouteInfoValues"/>.
@@ -74,23 +74,23 @@ namespace Microsoft.AspNet.Mvc.Logging
         /// <summary>
         /// See <see cref="ActionDescriptor.RouteValueDefaults"/>.
         /// </summary>
-        public Dictionary<string, string> RouteValueDefaults { get; }
+        public IDictionary<string, string> RouteValueDefaults { get; }
 
         /// <summary>
         /// The action constraints of the action as <see cref="ActionConstraintValues"/>.
         /// See <see cref="ActionDescriptor.ActionConstraints"/>.
         /// </summary>
-        public List<ActionConstraintValues> ActionConstraints { get; }
+        public IList<ActionConstraintValues> ActionConstraints { get; }
 
         /// <summary>
         /// The http methods this action supports.
         /// </summary>
-        public List<string> HttpMethods { get; }
+        public IList<string> HttpMethods { get; }
 
         /// <summary>
         /// See <see cref="ActionDescriptor.Properties"/>.
         /// </summary>
-        public Dictionary<string, Type> Properties { get; }
+        public IDictionary<string, Type> Properties { get; }
 
         /// <summary>
         /// The method info of the action if this is a <see cref="ControllerActionDescriptor"/>.

--- a/src/Microsoft.AspNet.Mvc.Core/Logging/ControllerModelValues.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Logging/ControllerModelValues.cs
@@ -52,37 +52,37 @@ namespace Microsoft.AspNet.Mvc.Logging
         /// The actions of the controller as <see cref="ActionModelValues"/>.
         /// See <see cref="ControllerModel.Actions"/>.
         /// </summary>
-        public List<ActionModelValues> Actions { get; }
+        public IList<ActionModelValues> Actions { get; }
 
         /// <summary>
         /// The <see cref="Type"/>s of the controller's attributes. 
         /// See <see cref="ControllerModel.Attributes"/>.
         /// </summary>
-        public List<Type> Attributes { get; }
+        public IList<Type> Attributes { get; }
 
         /// <summary>
         /// The filters on the controller as <see cref="FilterValues"/>.
         /// See <see cref="ControllerModel.Filters"/>.
         /// </summary>
-        public List<FilterValues> Filters { get; }
+        public IList<FilterValues> Filters { get; }
 
         /// <summary>
         /// The action constraints on the controller as <see cref="ActionConstraintValues"/>.
         /// See <see cref="ControllerModel.ActionConstraints"/>.
         /// </summary>
-        public List<ActionConstraintValues> ActionConstraints { get; }
+        public IList<ActionConstraintValues> ActionConstraints { get; }
 
         /// <summary>
         /// The route constraints on the controller as <see cref="RouteConstraintProviderValues"/>.
         /// See <see cref="ControllerModel.RouteConstraints"/>.
         /// </summary>
-        public List<RouteConstraintProviderValues> RouteConstraints { get; set; }
+        public IList<RouteConstraintProviderValues> RouteConstraints { get; set; }
 
         /// <summary>
         /// The attribute routes on the controller as <see cref="AttributeRouteModelValues"/>.
         /// See <see cref="ControllerModel.AttributeRoutes"/>.
         /// </summary>
-        public List<AttributeRouteModelValues> AttributeRoutes { get; set; }
+        public IList<AttributeRouteModelValues> AttributeRoutes { get; set; }
 
         /// <summary>
         /// Gets the set of properties associated with the controller <see cref="ControllerModel.Properties"/>.

--- a/src/Microsoft.AspNet.Mvc.Core/Logging/FilterValues.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Logging/FilterValues.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNet.Mvc.Logging
         /// <summary>
         /// A list of interfaces the <see cref="IFilter"/> implements.
         /// </summary>
-        public List<Type> FilterInterfaces { get; }
+        public IList<Type> FilterInterfaces { get; }
 
         public override string Format()
         {

--- a/src/Microsoft.AspNet.Mvc.Core/MvcOptions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/MvcOptions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.AspNet.Mvc.ApplicationModels;
 using Microsoft.AspNet.Mvc.Core;
 using Microsoft.AspNet.Mvc.OptionDescriptors;
@@ -30,6 +29,9 @@ namespace Microsoft.AspNet.Mvc
             InputFormatters = new List<InputFormatterDescriptor>();
             Filters = new List<IFilter>();
             FormatterMappings = new FormatterMappings();
+            ValidationExcludeFilters = new List<ExcludeValidationDescriptor>();
+            ModelValidatorProviders = new List<ModelValidatorProviderDescriptor>();
+            CacheProfiles = new Dictionary<string, CacheProfile>(StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -70,21 +72,20 @@ namespace Microsoft.AspNet.Mvc
         /// Gets a list of the <see cref="OutputFormatterDescriptor" /> which are used to construct
         /// a list of <see cref="IOutputFormatter"/> by <see cref="IOutputFormattersProvider"/>.
         /// </summary>
-        public List<OutputFormatterDescriptor> OutputFormatters { get; private set; }
+        public IList<OutputFormatterDescriptor> OutputFormatters { get; }
 
         /// <summary>
         /// Gets a list of the <see cref="InputFormatterDescriptor" /> which are used to construct
         /// a list of <see cref="IInputFormatter"/> by <see cref="IInputFormattersProvider"/>.
         /// </summary>
-        public List<InputFormatterDescriptor> InputFormatters { get; private set; }
+        public IList<InputFormatterDescriptor> InputFormatters { get; }
 
         /// <summary>
         /// Gets a list of <see cref="ExcludeValidationDescriptor"/> which are used to construct a list
         /// of exclude filters by <see cref="IValidationExcludeFiltersProvider"/>.
         /// </summary>
-        public List<ExcludeValidationDescriptor> ValidationExcludeFilters { get; }
-            = new List<ExcludeValidationDescriptor>();
-        
+        public IList<ExcludeValidationDescriptor> ValidationExcludeFilters { get; }
+
         /// <summary>
         /// Gets or sets the maximum number of validation errors that are allowed by this application before further
         /// errors are ignored.
@@ -108,44 +109,42 @@ namespace Microsoft.AspNet.Mvc
         /// Gets a list of the <see cref="ModelBinderDescriptor" /> used by the
         /// <see cref="ModelBinding.CompositeModelBinder" />.
         /// </summary>
-        public List<ModelBinderDescriptor> ModelBinders { get; private set; }
+        public IList<ModelBinderDescriptor> ModelBinders { get; }
 
         /// <summary>
         /// Gets a list of the <see cref="ModelValidatorProviderDescriptor" />s used by
         /// <see cref="ModelBinding.CompositeModelValidatorProvider"/>.
         /// </summary>
-        public List<ModelValidatorProviderDescriptor> ModelValidatorProviders { get; }
-            = new List<ModelValidatorProviderDescriptor>();
+        public IList<ModelValidatorProviderDescriptor> ModelValidatorProviders { get; }
 
         /// <summary>
         /// Gets a list of descriptors that represent <see cref="Rendering.IViewEngine"/> used
         /// by this application.
         /// </summary>
-        public List<ViewEngineDescriptor> ViewEngines { get; private set; }
+        public IList<ViewEngineDescriptor> ViewEngines { get; }
 
         /// <summary>
         /// Gets a list of descriptors that represent
         /// <see cref="ModelBinding.IValueProviderFactory"/> used by this application.
         /// </summary>
-        public List<ValueProviderFactoryDescriptor> ValueProviderFactories { get; private set; }
+        public IList<ValueProviderFactoryDescriptor> ValueProviderFactories { get; }
 
         /// <summary>
         /// Gets a list of <see cref="IApplicationModelConvention"/> instances that will be applied to
         /// the <see cref="ApplicationModel"/> when discovering actions.
         /// </summary>
-        public List<IApplicationModelConvention> Conventions { get; private set; }
+        public IList<IApplicationModelConvention> Conventions { get; }
 
         /// <summary>
         /// Gets or sets the flag which causes content negotiation to ignore Accept header 
         /// when it contains the media type */*. <see langword="false"/> by default.
         /// </summary>
-        public bool RespectBrowserAcceptHeader { get; set; } = false;
-        
+        public bool RespectBrowserAcceptHeader { get; set; }
+
         /// <summary>
         /// Gets a Dictionary of CacheProfile Names, <see cref="CacheProfile"/> which are pre-defined settings for
         /// <see cref="ResponseCacheFilter"/>.
         /// </summary>
-        public Dictionary<string, CacheProfile> CacheProfiles { get; }
-            = new Dictionary<string, CacheProfile>(StringComparer.OrdinalIgnoreCase);
+        public IDictionary<string, CacheProfile> CacheProfiles { get; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Razor.Host/InjectChunkVisitor.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/InjectChunkVisitor.cs
@@ -9,7 +9,6 @@ namespace Microsoft.AspNet.Mvc.Razor
 {
     public class InjectChunkVisitor : MvcCSharpCodeVisitor
     {
-        private readonly List<InjectChunk> _injectChunks = new List<InjectChunk>();
         private readonly string _activateAttribute;
 
         public InjectChunkVisitor([NotNull] CSharpCodeWriter writer,
@@ -20,10 +19,7 @@ namespace Microsoft.AspNet.Mvc.Razor
             _activateAttribute = "[" + activateAttributeName + "]";
         }
 
-        public List<InjectChunk> InjectChunks
-        {
-            get { return _injectChunks; }
-        }
+        public IList<InjectChunk> InjectChunks { get; } = new List<InjectChunk>();
 
         protected override void Visit([NotNull] InjectChunk chunk)
         {
@@ -53,7 +49,8 @@ namespace Microsoft.AspNet.Mvc.Razor
                       .Write(chunk.MemberName)
                       .WriteLine(" { get; private set; }");
             }
-            _injectChunks.Add(chunk);
+
+            InjectChunks.Add(chunk);
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Razor/IRazorPage.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/IRazorPage.cs
@@ -58,12 +58,12 @@ namespace Microsoft.AspNet.Mvc.Razor
         /// <summary>
         /// Gets or sets the sections that can be rendered by this page.
         /// </summary>
-        Dictionary<string, RenderAsyncDelegate> PreviousSectionWriters { get; set; }
+        IDictionary<string, RenderAsyncDelegate> PreviousSectionWriters { get; set; }
 
         /// <summary>
         /// Gets the sections that are defined by this page.
         /// </summary>
-        Dictionary<string, RenderAsyncDelegate> SectionWriters { get; }
+        IDictionary<string, RenderAsyncDelegate> SectionWriters { get; }
 
         /// <summary>
         /// Renders the page and writes the output to the <see cref="ViewContext.Writer"/>.

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
@@ -108,10 +108,10 @@ namespace Microsoft.AspNet.Mvc.Razor
         public bool IsLayoutBeingRendered { get; set; }
 
         /// <inheritdoc />
-        public Dictionary<string, RenderAsyncDelegate> PreviousSectionWriters { get; set; }
+        public IDictionary<string, RenderAsyncDelegate> PreviousSectionWriters { get; set; }
 
         /// <inheritdoc />
-        public Dictionary<string, RenderAsyncDelegate> SectionWriters { get; private set; }
+        public IDictionary<string, RenderAsyncDelegate> SectionWriters { get; private set; }
 
         /// <inheritdoc />
         public abstract Task ExecuteAsync();

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ControllerActionInvokerTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ControllerActionInvokerTest.cs
@@ -1979,8 +1979,14 @@ namespace Microsoft.AspNet.Mvc
             var filterProvider = new Mock<INestedProviderManager<FilterProviderContext>>(MockBehavior.Strict);
             filterProvider
                 .Setup(fp => fp.Invoke(It.IsAny<FilterProviderContext>()))
-                .Callback<FilterProviderContext>(
-                    context => context.Results.AddRange(filters.Select(f => new FilterItem(null, f))));
+                .Callback<FilterProviderContext>(context =>
+                    {
+                        foreach (var filter in filters.Select(f => new FilterItem(null, f)))
+                        {
+                            context.Results.Add(filter);
+                        }
+                    });
+
             var inputFormattersProvider = new Mock<IInputFormattersProvider>();
             inputFormattersProvider.SetupGet(o => o.InputFormatters)
                                             .Returns(new List<IInputFormatter>());

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Description/DefaultApiDescriptionProviderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Description/DefaultApiDescriptionProviderTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -925,7 +926,7 @@ namespace Microsoft.AspNet.Mvc.Description
                 modelMetadataProvider);
 
             provider.Invoke(context, () => { });
-            return context.Results;
+            return new ReadOnlyCollection<ApiDescription>(context.Results);
         }
 
         private List<MockFormatter> CreateFormatters()

--- a/test/WebSites/ApplicationModelWebSite/Conventions/ControllerLicenseConvention.cs
+++ b/test/WebSites/ApplicationModelWebSite/Conventions/ControllerLicenseConvention.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNet.Mvc.ApplicationModels;
 
 namespace ApplicationModelWebSite
 {
-    public class ControllerLisenceConvention : IControllerModelConvention
+    public class ControllerLicenseConvention : IControllerModelConvention
     {
         public void Apply(ControllerModel controller)
         {

--- a/test/WebSites/ApplicationModelWebSite/Startup.cs
+++ b/test/WebSites/ApplicationModelWebSite/Startup.cs
@@ -20,7 +20,7 @@ namespace ApplicationModelWebSite
                 services.Configure<MvcOptions>(options =>
                 {
                     options.Conventions.Add(new ApplicationDescription("Common Application Description"));
-                    options.Conventions.Add(new ControllerLisenceConvention());
+                    options.Conventions.Add(new ControllerLicenseConvention());
                     options.Conventions.Add(new FromHeaderConvention());
                 });
             });


### PR DESCRIPTION
Api cleanup (remove List and Dictionary in favor of IList and IDictionary)
from the public surface copy header values on registration.

Make a copy of the mediatypeheader value in FormatterMappings so it's
really immutable.