### PR TITLE
Enabling generation of lower case URLs by default

### DIFF
--- a/src/Microsoft.AspNet.Mvc/MvcServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc/MvcServiceCollectionExtensions.cs
@@ -133,9 +133,12 @@ namespace Microsoft.Framework.DependencyInjection
             services.AddRouting(configuration);
             services.AddAuthorization(configuration);
             services.Configure<RouteOptions>(routeOptions =>
-                                                    routeOptions.ConstraintMap
-                                                         .Add("exists",
-                                                              typeof(KnownRouteValueConstraint)));
+            {
+                routeOptions.ConstraintMap
+                     .Add("exists",
+                          typeof(KnownRouteValueConstraint));
+                routeOptions.LowercaseUrls = true;
+            });
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ActionResultTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ActionResultTests.cs
@@ -141,7 +141,9 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 
             // Assert
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-            Assert.Equal("http://localhost/ActionResultsVerification/GetDummy/1", response.Headers.Location.OriginalString);
+            Assert.Equal(
+                "http://localhost/ActionResultsVerification/GetDummy/1".NormalizeExpectedUrl(), 
+                response.Headers.Location.OriginalString);
             Assert.Equal("{\"SampleInt\":10,\"SampleString\":\"Foo\"}", await response.Content.ReadAsStringAsync());
         }
 
@@ -161,7 +163,9 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 
             // Assert
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-            Assert.Equal("http://localhost/ActionResultsVerification/GetDummy/1", response.Headers.Location.OriginalString);
+            Assert.Equal(
+                "http://localhost/ActionResultsVerification/GetDummy/1".NormalizeExpectedUrl(), 
+                response.Headers.Location.OriginalString);
             Assert.Equal("{\"SampleInt\":10,\"SampleString\":\"Foo\"}", await response.Content.ReadAsStringAsync());
         }
 
@@ -181,7 +185,9 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 
             // Assert
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-            Assert.Equal("http://localhost/foo/ActionResultsVerification/GetDummy/1", response.Headers.Location.OriginalString);
+            Assert.Equal(
+                "http://localhost/foo/ActionResultsVerification/GetDummy/1".NormalizeExpectedUrl(), 
+                response.Headers.Location.OriginalString);
             Assert.Equal("{\"SampleInt\":10,\"SampleString\":\"Foo\"}", await response.Content.ReadAsStringAsync());
         }
 

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ActivatorTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ActivatorTests.cs
@@ -72,7 +72,8 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             // Arrange
             var server = TestServer.Create(_provider, _app);
             var client = server.CreateClient();
-            var expected = @"<label for=""Hello"">Hello</label> world! /View/ConsumeServicesFromBaseType";
+            var expected = @"<label for=""Hello"">Hello</label> world! " + 
+                "/View/ConsumeServicesFromBaseType".NormalizeExpectedUrl();
 
             // Act
             var body = await client.GetStringAsync("http://localhost/View/ConsumeDefaultProperties");

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/BestEffortLinkGenerationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/BestEffortLinkGenerationTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 
         private const string ExpectedOutput = @"<html>
 <body>
-<a href=""/Home/About"">About Us</a>
+<a href=""/home/about"">About Us</a>
 </body>
 </html>";
 

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/BasicWebSite.Home.ActionLinkView.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/BasicWebSite.Home.ActionLinkView.html
@@ -4,6 +4,6 @@
     <title>Action Link with non unicode host</title>
 </head>
 <body>
-    <a href="http://ping&#252;ino/Home/ActionLinkView">Ping&#252;ino</a>
+    <a href="http://ping&#252;ino/home/actionlinkview">Ping&#252;ino</a>
 </body>
 </html>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Customer.Index.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Customer.Index.html
@@ -3,7 +3,7 @@
 
 <html>
 <body>
-    <form action="/Customer/MvcTagHelper_Customer" method="post">
+    <form action="/customer/mvctaghelper_customer" method="post">
         <div>
             <label class="order" for="Number">Number</label>
             <input class="form-control input-validation-error" type="number" data-val="true" data-val-range="The field Number must be between 1 and 100." data-val-range-max="100" data-val-range-min="1" id="Number" name="Number" value="" />

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.CreateWarehouse.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.CreateWarehouse.html
@@ -3,7 +3,7 @@
 
 <html>
 <body>
-<form action="/MvcTagHelper_Home/CreateWarehouse" method="post">        <div>
+<form action="/mvctaghelper_home/createwarehouse" method="post">        <div>
             <label class="warehouse" for="City">City</label>
             <input size="50" type="text" data-val="true" data-val-minlength="The field City must be a string or array type with a minimum length of &#39;2&#39;." data-val-minlength-min="2" id="City" name="City" value="" />
             <span class="field-validation-valid" data-valmsg-for="City" data-valmsg-replace="true"></span>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Customer.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Customer.html
@@ -3,7 +3,7 @@
 
 <html>
 <body>
-    <form action="/Customer/MvcTagHelper_Customer" method="post">
+    <form action="/customer/mvctaghelper_customer" method="post">
         <div>
             <label class="order" for="Number">Number</label>
             <input class="form-control" type="number" data-val="true" data-val-range="The field Number must be between 1 and 100." data-val-range-max="100" data-val-range-min="1" id="Number" name="Number" value="" />

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.EditWarehouse.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.EditWarehouse.html
@@ -3,7 +3,7 @@
 
 <html>
 <body>
-    <form action="/MvcTagHelper_Home/EditWarehouse" method="post">
+    <form action="/mvctaghelper_home/editwarehouse" method="post">
         <div>
             City_1
             <input type="text" data-val="true" data-val-minlength="The field City must be a string or array type with a minimum length of &#39;2&#39;." data-val-minlength-min="2" id="City" name="City" value="City_1" />

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.EmployeeList.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.EmployeeList.html
@@ -3,7 +3,7 @@
 
 <html>
 <body>
-<form action="/MvcTagHelper_Home/EmployeeList" method="post">
+<form action="/mvctaghelper_home/employeelist" method="post">
 <div>
     <label for="z0__Number">Number</label>
     <input data-val="true" data-val-range="The field Number must be between 1 and 100." data-val-range-max="100" data-val-range-min="1" disabled="disabled" id="z0__Number" name="[0].Number" readonly="readonly" type="text" value="0" />

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Order.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Order.html
@@ -7,7 +7,7 @@
     <title></title>
 </head>
 <body>
-    <form action="/MvcTagHelper_Order/Submit" method="post">
+    <form action="/mvctaghelper_order/submit" method="post">
         <div>
             <label class="order" for="Shipping">Shipping</label>
             <input size="50" type="text" id="Shipping" name="Shipping" value="Your shipping method is UPSP" />

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.OrderUsingHtmlHelpers.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.OrderUsingHtmlHelpers.html
@@ -7,7 +7,7 @@
     <title></title>
 </head>
 <body>
-    <form action="/MvcTagHelper_Order/Submit" method="post">
+    <form action="/mvctaghelper_order/submit" method="post">
         <div>
             <label class="order" for="Shipping">Shipping</label>
             <input id="Shipping" name="Shipping" size="50" type="text" value="Your shipping method is UPSP" />

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Product.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Product.html
@@ -7,7 +7,7 @@
     <title></title>
 </head>
 <body>
-    <form action="/MvcTagHelper_Home/ProductSubmit" method="get">
+    <form action="/mvctaghelper_home/productsubmit" method="get">
         <div>
             <label class="product" for="HomePage">HomePage</label>
             <input size="50" type="url" id="HomePage" name="HomePage" value="http://www.contoso.com/" />

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.ProductList.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.ProductList.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<form action="/MvcTagHelper_Product" method="post">            <div>
+<form action="/mvctaghelper_product" method="post">            <div>
                 <label class="product" for="z0__HomePage">HomePage</label>
                 <input size="50" disabled="disabled" readonly="readonly" type="url" id="z0__HomePage" name="[0].HomePage" value="http://www.contoso.com/" />
             </div>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/TagHelpersWebSite.Employee.Create.Invalid.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/TagHelpersWebSite.Employee.Create.Invalid.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 
-    <form action="/Employee/Create" method="post">
+    <form action="/employee/create" method="post">
 
         <div class="form-horizontal">
             <h4>Employee</h4>
@@ -76,7 +76,7 @@
     </form>
 
     <div>
-        <a href="/Employee">Back to List</a>
+        <a href="/employee">Back to List</a>
     </div>
 </body>
 </html>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/TagHelpersWebSite.Employee.Create.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/TagHelpersWebSite.Employee.Create.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 
-    <form action="/Employee/Create" method="post">
+    <form action="/employee/create" method="post">
 
         <div class="form-horizontal">
             <h4>Employee</h4>
@@ -74,7 +74,7 @@
     </form>
 
     <div>
-        <a href="/Employee">Back to List</a>
+        <a href="/employee">Back to List</a>
     </div>
 </body>
 </html>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/TagHelpersWebSite.Employee.Details.AfterCreate.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/TagHelpersWebSite.Employee.Details.AfterCreate.html
@@ -54,7 +54,7 @@
     </dl>
 </div>
 <p>
-        <a href="/Employee">Back to List</a>
+        <a href="/employee">Back to List</a>
 </p>
 </body>
 </html>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/ValidationWebSite.Aria.RemoteAttribute_Home.Create.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/ValidationWebSite.Aria.RemoteAttribute_Home.Create.html
@@ -15,7 +15,7 @@
             <div>
                 <ul>
                     <li><a href="/">Home</a></li>
-                    <li><a href="/Aria">Aria Home</a></li>
+                    <li><a href="/aria">Aria Home</a></li>
                 </ul>
             </div>
         </div>
@@ -41,7 +41,7 @@
         <div class="form-group">
             <label class="control-label col-md-2" for="UserId1">UserId1</label>
             <div class="col-md-10">
-                <input class="form-control text-box single-line" data-val="true" data-val-remote="&#39;UserId1&#39; is invalid." data-val-remote-additionalfields="*.UserId1" data-val-remote-url="/Aria/RemoteAttribute_Verify/IsIdAvailable" id="UserId1" name="UserId1" type="text" value="" />
+                <input class="form-control text-box single-line" data-val="true" data-val-remote="&#39;UserId1&#39; is invalid." data-val-remote-additionalfields="*.UserId1" data-val-remote-url="/aria/remoteattribute_verify/isidavailable" id="UserId1" name="UserId1" type="text" value="" />
                 <span class="field-validation-valid text-danger" data-valmsg-for="UserId1" data-valmsg-replace="true"></span>
             </div>
         </div>
@@ -49,7 +49,7 @@
         <div class="form-group">
             <label class="control-label col-md-2" for="UserId2">UserId2</label>
             <div class="col-md-10">
-                <input class="form-control text-box single-line" data-val="true" data-val-remote="&#39;UserId2&#39; is invalid." data-val-remote-additionalfields="*.UserId2" data-val-remote-type="Post" data-val-remote-url="/RemoteAttribute_Verify/IsIdAvailable" id="UserId2" name="UserId2" type="text" value="" />
+                <input class="form-control text-box single-line" data-val="true" data-val-remote="&#39;UserId2&#39; is invalid." data-val-remote-additionalfields="*.UserId2" data-val-remote-type="Post" data-val-remote-url="/remoteattribute_verify/isidavailable" id="UserId2" name="UserId2" type="text" value="" />
                 <span class="field-validation-valid text-danger" data-valmsg-for="UserId2" data-valmsg-replace="true"></span>
             </div>
         </div>
@@ -57,7 +57,7 @@
         <div class="form-group">
             <label class="control-label col-md-2" for="UserId3">UserId3</label>
             <div class="col-md-10">
-                <input class="form-control text-box single-line" data-val="true" data-val-remote="/Aria/RemoteAttribute_Verify/IsIdAvailable rejects you." data-val-remote-additionalfields="*.UserId3" data-val-remote-url="/Aria/RemoteAttribute_Verify/IsIdAvailable" id="UserId3" name="UserId3" type="text" value="" />
+                <input class="form-control text-box single-line" data-val="true" data-val-remote="/Aria/RemoteAttribute_Verify/IsIdAvailable rejects you." data-val-remote-additionalfields="*.UserId3" data-val-remote-url="/aria/remoteattribute_verify/isidavailable" id="UserId3" name="UserId3" type="text" value="" />
                 <span class="field-validation-valid text-danger" data-valmsg-for="UserId3" data-valmsg-replace="true"></span>
             </div>
         </div>
@@ -65,7 +65,7 @@
         <div class="form-group">
             <label class="control-label col-md-2" for="UserId4">UserId4</label>
             <div class="col-md-10">
-                <input class="form-control text-box single-line" data-val="true" data-val-remote="&#39;UserId4&#39; is invalid." data-val-remote-additionalfields="*.UserId4,*.UserId1,*.UserId2,*.UserId3" data-val-remote-url="/AnotherAria/RemoteAttribute_Verify/IsIdAvailable" id="UserId4" name="UserId4" type="text" value="" />
+                <input class="form-control text-box single-line" data-val="true" data-val-remote="&#39;UserId4&#39; is invalid." data-val-remote-additionalfields="*.UserId4,*.UserId1,*.UserId2,*.UserId3" data-val-remote-url="/anotheraria/remoteattribute_verify/isidavailable" id="UserId4" name="UserId4" type="text" value="" />
                 <span class="field-validation-valid text-danger" data-valmsg-for="UserId4" data-valmsg-replace="true"></span>
             </div>
         </div>
@@ -78,7 +78,7 @@
     </div>
 </form>
 <div>
-    <a href="/Aria">Go back to home</a>
+    <a href="/aria">Go back to home</a>
 </div>
 
 

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/ValidationWebSite.Root.RemoteAttribute_Home.Create.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/ValidationWebSite.Root.RemoteAttribute_Home.Create.html
@@ -15,7 +15,7 @@
             <div>
                 <ul>
                     <li><a href="/">Home</a></li>
-                    <li><a href="/Aria">Aria Home</a></li>
+                    <li><a href="/aria">Aria Home</a></li>
                 </ul>
             </div>
         </div>
@@ -41,7 +41,7 @@
         <div class="form-group">
             <label class="control-label col-md-2" for="UserId1">UserId1</label>
             <div class="col-md-10">
-                <input class="form-control text-box single-line" data-val="true" data-val-remote="&#39;UserId1&#39; is invalid." data-val-remote-additionalfields="*.UserId1" data-val-remote-url="/RemoteAttribute_Verify/IsIdAvailable" id="UserId1" name="UserId1" type="text" value="" />
+                <input class="form-control text-box single-line" data-val="true" data-val-remote="&#39;UserId1&#39; is invalid." data-val-remote-additionalfields="*.UserId1" data-val-remote-url="/remoteattribute_verify/isidavailable" id="UserId1" name="UserId1" type="text" value="" />
                 <span class="field-validation-valid text-danger" data-valmsg-for="UserId1" data-valmsg-replace="true"></span>
             </div>
         </div>
@@ -49,7 +49,7 @@
         <div class="form-group">
             <label class="control-label col-md-2" for="UserId2">UserId2</label>
             <div class="col-md-10">
-                <input class="form-control text-box single-line" data-val="true" data-val-remote="&#39;UserId2&#39; is invalid." data-val-remote-additionalfields="*.UserId2" data-val-remote-type="Post" data-val-remote-url="/RemoteAttribute_Verify/IsIdAvailable" id="UserId2" name="UserId2" type="text" value="" />
+                <input class="form-control text-box single-line" data-val="true" data-val-remote="&#39;UserId2&#39; is invalid." data-val-remote-additionalfields="*.UserId2" data-val-remote-type="Post" data-val-remote-url="/remoteattribute_verify/isidavailable" id="UserId2" name="UserId2" type="text" value="" />
                 <span class="field-validation-valid text-danger" data-valmsg-for="UserId2" data-valmsg-replace="true"></span>
             </div>
         </div>
@@ -57,7 +57,7 @@
         <div class="form-group">
             <label class="control-label col-md-2" for="UserId3">UserId3</label>
             <div class="col-md-10">
-                <input class="form-control text-box single-line" data-val="true" data-val-remote="/Aria/RemoteAttribute_Verify/IsIdAvailable rejects you." data-val-remote-additionalfields="*.UserId3" data-val-remote-url="/Aria/RemoteAttribute_Verify/IsIdAvailable" id="UserId3" name="UserId3" type="text" value="" />
+                <input class="form-control text-box single-line" data-val="true" data-val-remote="/Aria/RemoteAttribute_Verify/IsIdAvailable rejects you." data-val-remote-additionalfields="*.UserId3" data-val-remote-url="/aria/remoteattribute_verify/isidavailable" id="UserId3" name="UserId3" type="text" value="" />
                 <span class="field-validation-valid text-danger" data-valmsg-for="UserId3" data-valmsg-replace="true"></span>
             </div>
         </div>
@@ -65,7 +65,7 @@
         <div class="form-group">
             <label class="control-label col-md-2" for="UserId4">UserId4</label>
             <div class="col-md-10">
-                <input class="form-control text-box single-line" data-val="true" data-val-remote="&#39;UserId4&#39; is invalid." data-val-remote-additionalfields="*.UserId4,*.UserId1,*.UserId2,*.UserId3" data-val-remote-url="/AnotherAria/RemoteAttribute_Verify/IsIdAvailable" id="UserId4" name="UserId4" type="text" value="" />
+                <input class="form-control text-box single-line" data-val="true" data-val-remote="&#39;UserId4&#39; is invalid." data-val-remote-additionalfields="*.UserId4,*.UserId1,*.UserId2,*.UserId3" data-val-remote-url="/anotheraria/remoteattribute_verify/isidavailable" id="UserId4" name="UserId4" type="text" value="" />
                 <span class="field-validation-valid text-danger" data-valmsg-for="UserId4" data-valmsg-replace="true"></span>
             </div>
         </div>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/InlineConstraintTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/InlineConstraintTests.cs
@@ -653,7 +653,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 
             // Assert            
             var body = await response.Content.ReadAsStringAsync();
-            Assert.Equal(expectedLink, body);
+            Assert.Equal(expectedLink.NormalizeExpectedUrl(), body);
         }
 
         private async Task<IDictionary<string, object>> GetResponseValues(HttpResponseMessage response)

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/LinkGenerationTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/LinkGenerationTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
 
-            Assert.Equal("/Home/ActionReturningTask", response.Headers.Location.ToString());
+            Assert.Equal("/Home/ActionReturningTask".NormalizeExpectedUrl(), response.Headers.Location.ToString());
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/MvcTagHelpersTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/MvcTagHelpersTest.cs
@@ -26,23 +26,28 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         // Test ability to generate nearly identical HTML with MVC tag and HTML helpers.
         // Only attribute order should differ.
         [InlineData("Order", "/MvcTagHelper_Order/Submit")]
-        [InlineData("OrderUsingHtmlHelpers", "/MvcTagHelper_Order/Submit")]
-        [InlineData("Product", null)]
-        [InlineData("Customer", "/Customer/MvcTagHelper_Customer")]
-        // Testing InputTagHelpers invoked in the partial views
-        [InlineData("ProductList", null)]
-        // Testing MvcTagHelpers invoked in the editor templates with the HTML helpers
-        [InlineData("EmployeeList", null)]
-        // Testing SelectTagHelper with Html.BeginForm
-        [InlineData("CreateWarehouse", null)]
-        // Testing the HTML helpers with FormTagHelper
-        [InlineData("EditWarehouse", null)]
         // Testing the EnvironmentTagHelper
         [InlineData("Environment", null)]
         // Testing the LinkTagHelper
         [InlineData("Link", null)]
         // Testing the ScriptTagHelper
         [InlineData("Script", null)]
+
+
+        // Test ability to generate nearly identical HTML with MVC tag and HTML helpers.
+        // Only attribute order should differ.
+        [InlineData("Order", "/MvcTagHelper_Order/Submit")]
+        [InlineData("Product", null)]
+        // Testing SelectTagHelper with Html.BeginForm
+        [InlineData("CreateWarehouse", null)]
+        // Testing the HTML helpers with FormTagHelper
+        [InlineData("EditWarehouse", null)]
+        [InlineData("Customer", "/Customer/MvcTagHelper_Customer")]
+        [InlineData("OrderUsingHtmlHelpers", "/MvcTagHelper_Order/Submit")]
+        // Testing InputTagHelpers invoked in the partial views
+        [InlineData("ProductList", null)]
+        // Testing MvcTagHelpers invoked in the editor templates with the HTML helpers
+        [InlineData("EmployeeList", null)]
         public async Task MvcTagHelpers_GeneratesExpectedResults(string action, string antiForgeryPath)
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/RazorViewEngineOptionsTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/RazorViewEngineOptionsTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         public async Task RazorViewEngine_UsesFileProviderOnViewEngineOptionsToLocateViews()
         {
             // Arrange
-            var expectedMessage = "Hello test-user, this is /RazorViewEngineOptions_Home";
+            var expectedMessage = "Hello test-user, this is " + "/RazorViewEngineOptions_Home".NormalizeExpectedUrl();
             var server = TestServer.Create(_services, _app);
             var client = server.CreateClient();
 
@@ -34,7 +34,8 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         public async Task RazorViewEngine_UsesFileProviderOnViewEngineOptionsToLocateAreaViews()
         {
             // Arrange
-            var expectedMessage = "Hello admin-user, this is /Restricted/RazorViewEngineOptions_Admin/Login";
+            var expectedMessage = "Hello admin-user, this is " + 
+                ("/Restricted/RazorViewEngineOptions_Admin/Login").NormalizeExpectedUrl();
             var server = TestServer.Create(_services, _app);
             var client = server.CreateClient();
             var target = "http://localhost/Restricted/RazorViewEngineOptions_Admin/Login?AdminUser=admin-user";

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/RoutingTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/RoutingTests.cs
@@ -185,9 +185,9 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 
             Assert.Equal(new string[]
             {
-                    "/api/v2/Maps",
-                    "/api/v1/Maps",
-                    "/api/v2/Maps"
+                    "/api/v2/Maps".NormalizeExpectedUrl(),
+                    "/api/v1/Maps".NormalizeExpectedUrl(),
+                    "/api/v2/Maps".NormalizeExpectedUrl()
             },
             result.ExpectedUrls);
         }
@@ -196,7 +196,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         public async Task AttributeRoutedAction_MultipleRouteAttributes_WorksWithOverrideRoutes()
         {
             // Arrange
-            var url = "http://localhost/api/v2/Maps";
+            var url = "http://localhost/api/v2/Maps".NormalizeExpectedUrl();
             var server = TestServer.Create(_services, _app);
             var client = server.CreateClient();
 
@@ -214,8 +214,8 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 
             Assert.Equal(new string[]
             {
-                    "/api/v2/Maps",
-                    "/api/v2/Maps"
+                    "/api/v2/Maps".NormalizeExpectedUrl(),
+                    "/api/v2/Maps".NormalizeExpectedUrl()
             },
             result.ExpectedUrls);
         }
@@ -262,8 +262,8 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 
             Assert.Equal(new string[]
             {
-                    "/api/v2/Maps/PartialUpdate/5",
-                    "/api/v2/Maps/PartialUpdate/5"
+                    "/api/v2/Maps/PartialUpdate/5".NormalizeExpectedUrl(),
+                    "/api/v2/Maps/PartialUpdate/5".NormalizeExpectedUrl()
             },
             result.ExpectedUrls);
         }
@@ -292,8 +292,8 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 
             Assert.Equal(new string[]
             {
-                    "/Bank/Get/5",
-                    "/Bank/Get/5"
+                    "/Bank/Get/5".NormalizeExpectedUrl(),
+                    "/Bank/Get/5".NormalizeExpectedUrl()
             },
             result.ExpectedUrls);
         }
@@ -562,7 +562,9 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var body = await response.Content.ReadAsStringAsync();
             var result = JsonConvert.DeserializeObject<RoutingResult>(body);
 
-            Assert.Equal(new string[] { expectedUrl, expectedUrl }, result.ExpectedUrls);
+            Assert.Equal(
+                new string[] { expectedUrl.NormalizeExpectedUrl(), expectedUrl.NormalizeExpectedUrl() }, 
+                result.ExpectedUrls);
             Assert.Equal("Banks", result.Controller);
             Assert.Equal("UpdateBank", result.Action);
         }
@@ -702,7 +704,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 
             // Assert
             Assert.NotNull(response);
-            Assert.Equal("/Club/5", response);
+            Assert.Equal("/Club/5".NormalizeExpectedUrl(), response);
         }
 
         [Fact]
@@ -717,7 +719,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 
             // Assert
             Assert.NotNull(response);
-            Assert.Equal("/Teams/AllOrganizations", response);
+            Assert.Equal("/Teams/AllOrganizations".NormalizeExpectedUrl(), response);
         }
 
         [Fact]
@@ -740,7 +742,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("Employee", result.Controller);
             Assert.Equal("List", result.Action);
 
-            Assert.Equal("/api/Employee", result.Link);
+            Assert.Equal("/api/Employee".NormalizeExpectedUrl(), result.Link);
         }
 
         [Fact]
@@ -763,7 +765,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("Employee", result.Controller);
             Assert.Equal("List", result.Action);
 
-            Assert.Equal("/api/Employee/5", result.Link);
+            Assert.Equal("/api/Employee/5".NormalizeExpectedUrl(), result.Link);
         }
 
         [Fact]
@@ -787,7 +789,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("Employee", result.Controller);
             Assert.Equal("List", result.Action);
 
-            Assert.Equal("/Blog/ShowPosts", result.Link);
+            Assert.Equal("/Blog/ShowPosts".NormalizeExpectedUrl(), result.Link);
         }
 
         [Fact]
@@ -835,7 +837,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("Company", result.Controller);
             Assert.Equal(actionName, result.Action);
 
-            Assert.Equal("/api/Company/5", result.ExpectedUrls.Single());
+            Assert.Equal("/api/Company/5".NormalizeExpectedUrl(), result.ExpectedUrls.Single());
             Assert.Equal("Company", result.RouteName);
         }
 
@@ -858,7 +860,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("Company", result.Controller);
             Assert.Equal("Delete", result.Action);
 
-            Assert.Equal("/api/Company/5", result.ExpectedUrls.Single());
+            Assert.Equal("/api/Company/5".NormalizeExpectedUrl(), result.ExpectedUrls.Single());
             Assert.Equal("RemoveCompany", result.RouteName);
         }
 
@@ -884,7 +886,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("Company", result.Controller);
             Assert.Equal("GetEmployees", result.Action);
 
-            Assert.Equal("/api/Company/5/Employees", result.ExpectedUrls.Single());
+            Assert.Equal("/api/Company/5/Employees".NormalizeExpectedUrl(), result.ExpectedUrls.Single());
             Assert.Equal(null, result.RouteName);
         }
 
@@ -907,7 +909,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("Company", result.Controller);
             Assert.Equal("GetDepartments", result.Action);
 
-            Assert.Equal("/api/Company/5/Departments", result.ExpectedUrls.Single());
+            Assert.Equal("/api/Company/5/Departments".NormalizeExpectedUrl(), result.ExpectedUrls.Single());
             Assert.Equal("Departments", result.RouteName);
         }
 
@@ -953,7 +955,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("Home", result.Controller);
             Assert.Equal("Index", result.Action);
 
-            Assert.Equal("/Travel/Flight/BuyTickets", result.Link);
+            Assert.Equal("/Travel/Flight/BuyTickets".NormalizeExpectedUrl(), result.Link);
         }
 
         [Fact]
@@ -976,7 +978,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("Flight", result.Controller);
             Assert.Equal("Index", result.Action);
 
-            Assert.Equal("/Travel/Flight/BuyTickets", result.Link);
+            Assert.Equal("/Travel/Flight/BuyTickets".NormalizeExpectedUrl(), result.Link);
         }
 
         [Fact]
@@ -1022,7 +1024,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("Flight", result.Controller);
             Assert.Equal("Index", result.Action);
 
-            Assert.Equal("/Home/Contact", result.Link);
+            Assert.Equal("/Home/Contact".NormalizeExpectedUrl(), result.Link);
         }
 
         [Fact]
@@ -1046,7 +1048,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("Employee", result.Controller);
             Assert.Equal("List", result.Action);
 
-            Assert.Equal("/ContosoCorp/Trains/CheckSchedule", result.Link);
+            Assert.Equal("/ContosoCorp/Trains/CheckSchedule".NormalizeExpectedUrl(), result.Link);
         }
 
         [Fact]
@@ -1069,7 +1071,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("Rail", result.Controller);
             Assert.Equal("Schedule", result.Action);
 
-            Assert.Equal("/ContosoCorp/Trains", result.Link);
+            Assert.Equal("/ContosoCorp/Trains".NormalizeExpectedUrl(), result.Link);
         }
 
         [Fact]
@@ -1117,7 +1119,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("Rail", result.Controller);
             Assert.Equal("Index", result.Action);
 
-            Assert.Equal("/Home/Contact", result.Link);
+            Assert.Equal("/Home/Contact".NormalizeExpectedUrl(), result.Link);
         }
 
         [Fact]
@@ -1142,7 +1144,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("Rail", result.Controller);
             Assert.Equal("Index", result.Action);
 
-            Assert.Equal("/Travel/Flight", result.Link);
+            Assert.Equal("/Travel/Flight".NormalizeExpectedUrl(), result.Link);
         }
 
         [Fact]
@@ -1167,7 +1169,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("Flight", result.Controller);
             Assert.Equal("Index", result.Action);
 
-            Assert.Equal("/ContosoCorp/Trains", result.Link);
+            Assert.Equal("/ContosoCorp/Trains".NormalizeExpectedUrl(), result.Link);
         }
 
         [Fact]
@@ -1192,7 +1194,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("Flight", result.Controller);
             Assert.Equal("Index", result.Action);
 
-            Assert.Equal("/Admin/Users/All", result.Link);
+            Assert.Equal("/Admin/Users/All".NormalizeExpectedUrl(), result.Link);
         }
 
         [Fact]
@@ -1217,7 +1219,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("Rail", result.Controller);
             Assert.Equal("Index", result.Action);
 
-            Assert.Equal("/Admin/Users/All", result.Link);
+            Assert.Equal("/Admin/Users/All".NormalizeExpectedUrl(), result.Link);
         }
 
         [Fact]
@@ -1281,7 +1283,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var result = JsonConvert.DeserializeObject<RoutingResult>(body);
 
             // Assert
-            Assert.Equal("/api/Products/US/GetProducts", result.Link);
+            Assert.Equal("/api/Products/US/GetProducts".NormalizeExpectedUrl(), result.Link);
         }
 
         [Fact]
@@ -1301,7 +1303,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var result = JsonConvert.DeserializeObject<RoutingResult>(body);
 
             // Assert
-            Assert.Equal("/api/Products/CA/GetProducts", result.Link);
+            Assert.Equal("/api/Products/CA/GetProducts".NormalizeExpectedUrl(), result.Link);
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/TestHelper.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/TestHelper.cs
@@ -131,6 +131,26 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             return sc.BuildServiceProvider();
         }
 
+        public static string NormalizeExpectedUrl(this string url)
+        {
+            if (string.IsNullOrEmpty(url)) return url;
+                var indexOfSeparator = url.IndexOfAny(new char[] { '?', '#' });
+
+            // No query string, lowercase the url
+            if (indexOfSeparator == -1)
+            {
+                return url.ToLowerInvariant();
+            }
+            else
+            {
+                var lowercaseUrl = url.Substring(0, indexOfSeparator).ToLowerInvariant();
+                var queryString = url.Substring(indexOfSeparator);
+
+                // queryString will contain the delimiter ? or # as the first character, so it's safe to append.
+                return lowercaseUrl + queryString;
+            }
+        }
+
         private class ServiceManifest : IServiceManifest
         {
             public ServiceManifest(IEnumerable<Type> services, IServiceManifest fallback = null)

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/VersioningTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/VersioningTests.cs
@@ -588,7 +588,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("GetVouchersMultipleVersions", result.Action);
 
             var actualUrl = Assert.Single(result.ExpectedUrls);
-            Assert.Equal(path, actualUrl);
+            Assert.Equal(path.NormalizeExpectedUrl(), actualUrl);
         }
 
         // See TestResponseGenerator in RoutingWebSite for the code that generates this data.

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ViewEngineTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ViewEngineTests.cs
@@ -43,8 +43,8 @@ ViewWithFullPath-content
                     "ViewWithNestedLayout",
 @"<layout>
 
-<nested-layout>
-/ViewEngine/ViewWithNestedLayout
+<nested-layout>" + @"
+/ViewEngine/ViewWithNestedLayout".NormalizeExpectedUrl() + @"
 
 ViewWithNestedLayout-Content
 </nested-layout>
@@ -194,8 +194,9 @@ ViewWithFullPath-content
                     "ViewWithNestedLayout",
 @"<layout>
 
-<nested-layout>
-/PartialViewEngine/ViewWithNestedLayout
+<nested-layout>" +
+@"
+/PartialViewEngine/ViewWithNestedLayout".NormalizeExpectedUrl() + @"
 
 ViewWithNestedLayout-Content
 </nested-layout>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/WebApiCompatShimActionResultTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/WebApiCompatShimActionResultTest.cs
@@ -175,7 +175,9 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             // Assert
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
             Assert.Equal("{\"Name\":\"Test User\"}", content);
-            Assert.Equal("http://localhost/api/Blog/ActionResult/GetUser/5", response.Headers.Location.OriginalString);
+            Assert.Equal(
+                "http://localhost/api/Blog/ActionResult/GetUser/5".NormalizeExpectedUrl(), 
+                response.Headers.Location.OriginalString);
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/WebApiCompatShimBasicTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/WebApiCompatShimBasicTest.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal(
-                "Visited: /api/Blog/BasicApi/GenerateUrl",
+                "Visited: " + "/api/Blog/BasicApi/GenerateUrl".NormalizeExpectedUrl(),
                 content);
         }
 


### PR DESCRIPTION
This is the first part of the fix. It sets the lowercase URL generation behavior to true by default. Fixes the test cases broken by it. Particular test cases to test the feature will come in next PR. 