### PR TITLE
Correct `grunt-bower-task` operation

### DIFF
--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/ValidationWebSite.Aria.RemoteAttribute_Home.Create.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/ValidationWebSite.Aria.RemoteAttribute_Home.Create.html
@@ -84,7 +84,7 @@
 
     </div>
 
-    <script src="/lib/jquery/js/jquery.js"></script>
+    <script src="/lib/jquery/jquery.js"></script>
     
     
     

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/ValidationWebSite.Root.RemoteAttribute_Home.Create.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/ValidationWebSite.Root.RemoteAttribute_Home.Create.html
@@ -84,7 +84,7 @@
 
     </div>
 
-    <script src="/lib/jquery/js/jquery.js"></script>
+    <script src="/lib/jquery/jquery.js"></script>
     
     
     

--- a/test/WebSites/ValidationWebSite/Views/Shared/_Layout.cshtml
+++ b/test/WebSites/ValidationWebSite/Views/Shared/_Layout.cshtml
@@ -25,7 +25,7 @@
         @RenderBody()
     </div>
 
-    <script src="~/lib/jquery/js/jquery.js"></script>
+    <script src="~/lib/jquery/jquery.js"></script>
     @RenderSection("scripts", required: false)
 </body>
 </html>

--- a/test/WebSites/ValidationWebSite/bower.json
+++ b/test/WebSites/ValidationWebSite/bower.json
@@ -9,10 +9,10 @@
     },
     "exportsOverride": {
         "jquery": {
-            "js": "jquery.{js,min.js,min.map}"
+            "": "dist/jquery.{js,min.js,min.map}"
         },
         "jquery-validation": {
-            "": "jquery.validate.js"
+            "": "dist/jquery.validate.{js,min.js}"
         },
         "jquery-validation-unobtrusive": {
             "": "jquery.validate.unobtrusive.{js,min.js}"


### PR DESCRIPTION
- jQuery and jQuery-validation files were not being copied
- update to match more-recent VS templates

nit: simplify wwwroot/lib directory tree slightly