### PR TITLE
Avoid exception in `MvcTagHelper` JavaScript

### DIFF
--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Script.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Script.html
@@ -13,12 +13,12 @@
     <script src="/blank.js" data-foo="foo-data2">
         // TagHelper script with comment in body, and extra properties.
     </script>
-<script>(blank.wooptido||document.write("<script src=\"/fallback.js\" data-foo=\"foo-data2\"><\/script>"));</script>
+<script>(false||document.write("<script src=\"/fallback.js\" data-foo=\"foo-data2\"><\/script>"));</script>
 
     <script data-foo="foo-data3">
         // Valid TagHelper (although no src is provided) script with comment in body, and extra properties.
     </script>
-<script>(blank.wooptido||document.write("<script src=\"/fallback.js\" data-foo=\"foo-data3\"><\/script>"));</script>
+<script>(false||document.write("<script src=\"/fallback.js\" data-foo=\"foo-data3\"><\/script>"));</script>
 
     <script src="/blank.js">
         // Invalid TagHelper script with comment in body.

--- a/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/Script.cshtml
+++ b/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/Script.cshtml
@@ -15,11 +15,11 @@
         // Regular script with comment in body, and extra properties.
     </script>
 
-    <script src="~/blank.js" asp-fallback-src="~/fallback.js" asp-fallback-test="blank.wooptido" data-foo="foo-data2">
+    <script src="~/blank.js" asp-fallback-src="~/fallback.js" asp-fallback-test="false" data-foo="foo-data2">
         // TagHelper script with comment in body, and extra properties.
     </script>
 
-    <script asp-fallback-src="~/fallback.js" asp-fallback-test="blank.wooptido" data-foo="foo-data3">
+    <script asp-fallback-src="~/fallback.js" asp-fallback-test="false" data-foo="foo-data3">
         // Valid TagHelper (although no src is provided) script with comment in body, and extra properties.
     </script>
 


### PR DESCRIPTION
- `blank` is undefined so `blank.wooptido` threw