### PR TITLE
Follow up to `ModelExplorer` creation

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/HtmlHelperOfT.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/HtmlHelperOfT.cs
@@ -143,8 +143,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
             [NotNull] Expression<Func<TModel, TResult>> expression,
             object htmlAttributes)
         {
-            var metadata = GetModelExplorer(expression);
-            return GenerateHidden(metadata, GetExpressionName(expression), metadata.Model, useViewData: false,
+            var modelExplorer = GetModelExplorer(expression);
+            return GenerateHidden(
+                modelExplorer,
+                GetExpressionName(expression),
+                modelExplorer.Model,
+                useViewData: false,
                 htmlAttributes: htmlAttributes);
         }
 
@@ -160,8 +164,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
             string labelText,
             object htmlAttributes)
         {
-            var metadata = GetModelExplorer(expression);
-            return GenerateLabel(metadata, ExpressionHelper.GetExpressionText(expression), labelText, htmlAttributes);
+            var modelExplorer = GetModelExplorer(expression);
+            return GenerateLabel(
+                modelExplorer,
+                ExpressionHelper.GetExpressionText(expression),
+                labelText,
+                htmlAttributes);
         }
 
         /// <inheritdoc />
@@ -170,10 +178,10 @@ namespace Microsoft.AspNet.Mvc.Rendering
             IEnumerable<SelectListItem> selectList,
             object htmlAttributes)
         {
-            var metadata = GetModelExplorer(expression);
+            var modelExplorer = GetModelExplorer(expression);
             var name = ExpressionHelper.GetExpressionText(expression);
 
-            return GenerateListBox(metadata, name, selectList, htmlAttributes);
+            return GenerateListBox(modelExplorer, name, selectList, htmlAttributes);
         }
 
         /// <inheritdoc />
@@ -188,8 +196,11 @@ namespace Microsoft.AspNet.Mvc.Rendering
             [NotNull] Expression<Func<TModel, TResult>> expression,
             object htmlAttributes)
         {
-            var metadata = GetModelExplorer(expression);
-            return GeneratePassword(metadata, GetExpressionName(expression), value: null,
+            var modelExplorer = GetModelExplorer(expression);
+            return GeneratePassword(
+                modelExplorer,
+                GetExpressionName(expression),
+                value: null,
                 htmlAttributes: htmlAttributes);
         }
 
@@ -199,8 +210,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
             [NotNull] object value,
             object htmlAttributes)
         {
-            var metadata = GetModelExplorer(expression);
-            return GenerateRadioButton(metadata, GetExpressionName(expression), value, isChecked: null,
+            var modelExplorer = GetModelExplorer(expression);
+            return GenerateRadioButton(
+                modelExplorer,
+                GetExpressionName(expression),
+                value,
+                isChecked: null,
                 htmlAttributes: htmlAttributes);
         }
 
@@ -211,8 +226,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
             int columns,
             object htmlAttributes)
         {
-            var metadata = GetModelExplorer(expression);
-            return GenerateTextArea(metadata, GetExpressionName(expression), rows, columns, htmlAttributes);
+            var modelExplorer = GetModelExplorer(expression);
+            return GenerateTextArea(modelExplorer, GetExpressionName(expression), rows, columns, htmlAttributes);
         }
 
         /// <inheritdoc />
@@ -221,8 +236,13 @@ namespace Microsoft.AspNet.Mvc.Rendering
             string format,
             object htmlAttributes)
         {
-            var metadata = GetModelExplorer(expression);
-            return GenerateTextBox(metadata, GetExpressionName(expression), metadata.Model, format, htmlAttributes);
+            var modelExplorer = GetModelExplorer(expression);
+            return GenerateTextBox(
+                modelExplorer,
+                GetExpressionName(expression),
+                modelExplorer.Model,
+                format,
+                htmlAttributes);
         }
 
         protected string GetExpressionName<TResult>([NotNull] Expression<Func<TModel, TResult>> expression)
@@ -258,8 +278,11 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <inheritdoc />
         public string ValueFor<TResult>([NotNull] Expression<Func<TModel, TResult>> expression, string format)
         {
-            var metadata = GetModelExplorer(expression);
-            return GenerateValue(ExpressionHelper.GetExpressionText(expression), metadata.Model, format,
+            var modelExplorer = GetModelExplorer(expression);
+            return GenerateValue(
+                ExpressionHelper.GetExpressionText(expression),
+                modelExplorer.Model,
+                format,
                 useViewData: false);
         }
     }

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Validation/DataAnnotationsModelValidatorTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Validation/DataAnnotationsModelValidatorTest.cs
@@ -180,7 +180,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             // Arrange
             const string errorMessage = "A different error message";
 
-            var metadata = _metadataProvider.GetModelExplorerForType(typeof(object), new object());
+            var modelExplorer = _metadataProvider.GetModelExplorerForType(typeof(object), new object());
 
             var attribute = new Mock<ValidationAttribute> { CallBase = true };
             attribute.Protected()
@@ -188,7 +188,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                      .Returns(new ValidationResult(errorMessage, new[] { "FirstName" }));
 
             var validator = new DataAnnotationsModelValidator(attribute.Object);
-            var validationContext = CreateValidationContext(metadata);
+            var validationContext = CreateValidationContext(modelExplorer);
 
             // Act
             var results = validator.Validate(validationContext);
@@ -203,7 +203,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         public void ValidateReturnsMemberNameIfItIsDifferentFromDisplayName()
         {
             // Arrange
-            var metadata = _metadataProvider.GetModelExplorerForType(typeof(SampleModel), new SampleModel());
+            var modelExplorer = _metadataProvider.GetModelExplorerForType(typeof(SampleModel), new SampleModel());
 
             var attribute = new Mock<ValidationAttribute> { CallBase = true };
             attribute.Protected()
@@ -211,7 +211,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                      .Returns(new ValidationResult("Name error", new[] { "Name" }));
 
             var validator = new DataAnnotationsModelValidator(attribute.Object);
-            var validationContext = CreateValidationContext(metadata);
+            var validationContext = CreateValidationContext(modelExplorer);
 
             // Act
             var results = validator.Validate(validationContext);

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LabelTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LabelTagHelperTest.cs
@@ -175,7 +175,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var containerExplorer = metadataProvider.GetModelExplorerForType(containerType, model);
 
             var propertyMetadata = metadataProvider.GetMetadataForProperty(containerType, "Text");
-            var modelExplorer = containerExplorer.GetExplorerForExpression(propertyMetadata, modelAccessor);
+            var modelExplorer = containerExplorer.GetExplorerForExpression(propertyMetadata, modelAccessor());
 
             var modelExpression = new ModelExpression(propertyPath, modelExplorer);
             var tagHelper = new LabelTagHelper

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/SelectTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/SelectTagHelperTest.cs
@@ -193,7 +193,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var containerExplorer = metadataProvider.GetModelExplorerForType(containerType, model);
 
             var propertyMetadata = metadataProvider.GetMetadataForProperty(containerType, "Text");
-            var modelExplorer = containerExplorer.GetExplorerForExpression(propertyMetadata, modelAccessor);
+            var modelExplorer = containerExplorer.GetExplorerForExpression(propertyMetadata, modelAccessor());
 
             var modelExpression = new ModelExpression(nameAndId.Name, modelExplorer);
 
@@ -278,7 +278,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var containerExplorer = metadataProvider.GetModelExplorerForType(containerType, model);
 
             var propertyMetadata = metadataProvider.GetMetadataForProperty(containerType, "Text");
-            var modelExplorer = containerExplorer.GetExplorerForExpression(propertyMetadata, modelAccessor);
+            var modelExplorer = containerExplorer.GetExplorerForExpression(propertyMetadata, modelAccessor());
 
             var modelExpression = new ModelExpression(nameAndId.Name, modelExplorer);
 
@@ -374,20 +374,20 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             var metadataProvider = new EmptyModelMetadataProvider();
             string model = null;
-            var metadata = metadataProvider.GetModelExplorerForType(typeof(string), model);
+            var modelExplorer = metadataProvider.GetModelExplorerForType(typeof(string), model);
 
             var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
             var viewContext = TestableHtmlGenerator.GetViewContext(model, htmlGenerator.Object, metadataProvider);
 
             // Simulate a (model => model) scenario. E.g. the calling helper may appear in a low-level template.
-            var modelExpression = new ModelExpression(string.Empty, metadata);
+            var modelExpression = new ModelExpression(string.Empty, modelExplorer);
             viewContext.ViewData.TemplateInfo.HtmlFieldPrefix = propertyName;
 
             ICollection<string> selectedValues = new string[0];
             htmlGenerator
                 .Setup(real => real.GenerateSelect(
                     viewContext,
-                    metadata,
+                    modelExplorer,
                     null,         // optionLabel
                     string.Empty, // name
                     expectedItems,


### PR DESCRIPTION
- see commit 9d5364c
- never correct to pass a `Func<object>` to `GetExplorerForExpression()`
- `<label/>` tests succeeded because that tag helper doesn't use expression result
- `<select/>` tests succeeded because that tag helper gets result from `ViewData`
 - does not use `ModelExplorer` due to #1468

nit: update variable names `metadata` -> `modelExplorer`