### PR TITLE
Need `[NotNull]` for all `TextWriter parameters in `RazorPage`

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
@@ -186,7 +186,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         /// All writes to the <see cref="Output"/> or <see cref="ViewContext.Writer"/> after calling this method will
         /// be buffered until <see cref="EndTagHelperWritingScope"/> is called.
         /// </remarks>
-        public void StartTagHelperWritingScope(TextWriter writer)
+        public void StartTagHelperWritingScope([NotNull] TextWriter writer)
         {
             // If there isn't a base writer take the ViewContext.Writer
             if (_originalWriter == null)
@@ -264,7 +264,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         /// <param name="writer">The <see cref="TextWriter"/> to which the
         /// <paramref name="copyableTextWriter"/> is written.</param>
         /// <param name="copyableTextWriter">Contains the data to be written.</param>
-        public void WriteTo(TextWriter writer, ITextWriterCopyable copyableTextWriter)
+        public void WriteTo([NotNull] TextWriter writer, ITextWriterCopyable copyableTextWriter)
         {
             if (copyableTextWriter != null)
             {
@@ -292,7 +292,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         /// For all other types, the encoded result of <see cref="object.ToString"/> is written to the
         /// <paramref name="writer"/>.
         /// </remarks>
-        public virtual void WriteTo(TextWriter writer, object value)
+        public virtual void WriteTo([NotNull] TextWriter writer, object value)
         {
             if (value != null && value != HtmlString.Empty)
             {
@@ -334,7 +334,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         /// </summary>
         /// <param name="writer">The <see cref="TextWriter"/> instance to write to.</param>
         /// <param name="value">The <see cref="string"/> to write.</param>
-        public virtual void WriteTo(TextWriter writer, string value)
+        public virtual void WriteTo([NotNull] TextWriter writer, string value)
         {
             if (!string.IsNullOrEmpty(value))
             {
@@ -356,7 +356,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         /// </summary>
         /// <param name="writer">The <see cref="TextWriter"/> instance to write to.</param>
         /// <param name="value">The <see cref="object"/> to write.</param>
-        public virtual void WriteLiteralTo(TextWriter writer, object value)
+        public virtual void WriteLiteralTo([NotNull] TextWriter writer, object value)
         {
             if (value != null)
             {
@@ -368,7 +368,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         /// Writes the specified <paramref name="value"/> without HTML encoding to <see cref="Output"/>.
         /// </summary>
         /// <param name="value">The <see cref="string"/> to write.</param>
-        public virtual void WriteLiteralTo(TextWriter writer, string value)
+        public virtual void WriteLiteralTo([NotNull] TextWriter writer, string value)
         {
             if (!string.IsNullOrEmpty(value))
             {
@@ -376,19 +376,21 @@ namespace Microsoft.AspNet.Mvc.Razor
             }
         }
 
-        public virtual void WriteAttribute(string name,
-                                           PositionTagged<string> prefix,
-                                           PositionTagged<string> suffix,
-                                           params AttributeValue[] values)
+        public virtual void WriteAttribute(
+            string name,
+            [NotNull] PositionTagged<string> prefix,
+            [NotNull] PositionTagged<string> suffix,
+            params AttributeValue[] values)
         {
             WriteAttributeTo(Output, name, prefix, suffix, values);
         }
 
-        public virtual void WriteAttributeTo(TextWriter writer,
-                                             string name,
-                                             PositionTagged<string> prefix,
-                                             PositionTagged<string> suffix,
-                                             params AttributeValue[] values)
+        public virtual void WriteAttributeTo(
+            [NotNull] TextWriter writer,
+            string name,
+            [NotNull] PositionTagged<string> prefix,
+            [NotNull] PositionTagged<string> suffix,
+            params AttributeValue[] values)
         {
             var first = true;
             var wroteSomething = false;
@@ -452,7 +454,7 @@ namespace Microsoft.AspNet.Mvc.Razor
                     var sourceLength = next.Position - attrVal.Value.Position;
 
                     BeginContext(attrVal.Value.Position, sourceLength, isLiteral: attrVal.Literal);
-                    // The extra branching here is to ensure that we call the Write*To(string) overload whe
+                    // The extra branching here is to ensure that we call the Write*To(string) overload where
                     // possible.
                     if (attrVal.Literal && stringValue != null)
                     {
@@ -521,7 +523,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         /// </summary>
         /// <param name="name">The name of the section to create.</param>
         /// <param name="section">The <see cref="RenderAsyncDelegate"/> to execute when rendering the section.</param>
-        public void DefineSection(string name, RenderAsyncDelegate section)
+        public void DefineSection([NotNull] string name, [NotNull] RenderAsyncDelegate section)
         {
             if (SectionWriters.ContainsKey(name))
             {


### PR DESCRIPTION
- #2102
- `PositionTagged<string>` and `RenderAsyncDelegate` parameters too
- and a few `string` parameters dereferenced or used as `Dictionary` keys