### PR TITLE
Reduce use of TypeActivation for ModelBinders

### DIFF
--- a/src/Microsoft.AspNet.Mvc/MvcOptionsSetup.cs
+++ b/src/Microsoft.AspNet.Mvc/MvcOptionsSetup.cs
@@ -29,8 +29,8 @@ namespace Microsoft.AspNet.Mvc
             options.ViewEngines.Add(typeof(RazorViewEngine));
 
             // Set up ModelBinding
-            options.ModelBinders.Add(typeof(BinderTypeBasedModelBinder));
-            options.ModelBinders.Add(typeof(ServicesModelBinder));
+            options.ModelBinders.Add(new BinderTypeBasedModelBinder());
+            options.ModelBinders.Add(new ServicesModelBinder());
             options.ModelBinders.Add(typeof(BodyModelBinder));
             options.ModelBinders.Add(new HeaderModelBinder());
             options.ModelBinders.Add(new TypeConverterModelBinder());
@@ -39,7 +39,7 @@ namespace Microsoft.AspNet.Mvc
             options.ModelBinders.Add(new ByteArrayModelBinder());
             options.ModelBinders.Add(new FormFileModelBinder());
             options.ModelBinders.Add(new FormCollectionModelBinder());
-            options.ModelBinders.Add(typeof(GenericModelBinder));
+            options.ModelBinders.Add(new GenericModelBinder());
             options.ModelBinders.Add(new MutableObjectModelBinder());
             options.ModelBinders.Add(new ComplexModelDtoModelBinder());
 


### PR DESCRIPTION
These model binders don't have any per-request state so there is no need
for them to be type activated. In one case the model binder actually does
its own caching which is being defeated by the fact that we register it as
type activated.

More changes to come in this area.