### PR TITLE
Reacting to Razor changes for removing Generate*() methods.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor.Host/MvcRazorHost.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/MvcRazorHost.cs
@@ -92,15 +92,10 @@ namespace Microsoft.AspNet.Mvc.Razor
                     ScopeManagerBeginMethodName = nameof(TagHelperScopeManager.Begin),
                     ScopeManagerEndMethodName = nameof(TagHelperScopeManager.End),
 
-                    OutputGenerateStartTagMethodName = nameof(TagHelperOutput.GenerateStartTag),
-                    OutputGenerateContentMethodName = nameof(TagHelperOutput.GenerateContent),
-                    OutputGenerateEndTagMethodName = nameof(TagHelperOutput.GenerateEndTag),
-
                     // Can't use nameof because RazorPage is not accessible here.
                     CreateTagHelperMethodName = "CreateTagHelper",
                     StartTagHelperWritingScopeMethodName = "StartTagHelperWritingScope",
                     EndTagHelperWritingScopeMethodName = "EndTagHelperWritingScope",
-                    HtmlEncoderPropertyName = "HtmlEncoder",
                 })
             {
                 ResolveUrlMethodName = "Href",

--- a/src/Microsoft.AspNet.Mvc.Razor.Host/MvcRazorHost.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/MvcRazorHost.cs
@@ -96,6 +96,9 @@ namespace Microsoft.AspNet.Mvc.Razor
                     CreateTagHelperMethodName = "CreateTagHelper",
                     StartTagHelperWritingScopeMethodName = "StartTagHelperWritingScope",
                     EndTagHelperWritingScopeMethodName = "EndTagHelperWritingScope",
+
+                    WriteTagHelperAsyncMethodName = "WriteTagHelperAsync",
+                    WriteTagHelperToAsyncMethodName = "WriteTagHelperToAsync",
                 })
             {
                 ResolveUrlMethodName = "Href",

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
@@ -250,12 +250,23 @@ namespace Microsoft.AspNet.Mvc.Razor
             return tagHelperContentWrapperTextWriter.Content;
         }
 
-        public void WriteTagHelper(TagHelperExecutionContext tagHelperExecutionContext)
+        /// <summary>
+        /// Writes the output of a specified <see cref="TagHelperExecutionContext"/>.
+        /// </summary>
+        /// <param name="tagHelperExecutionContext">The execution context containing the output.</param>
+        public async Task WriteTagHelperAsync([NotNull] TagHelperExecutionContext tagHelperExecutionContext)
         {
-            WriteTagHelperTo(Output, tagHelperExecutionContext);
+            await WriteTagHelperToAsync(Output, tagHelperExecutionContext);
         }
 
-        public void WriteTagHelperTo([NotNull] TextWriter writer, TagHelperExecutionContext tagHelperExecutionContext)
+        /// <summary>
+        /// Wrutes the output of a specified <see cref="TagHelperExecutionContext"/> to the specified
+        /// <paramref name="writer"/>.
+        /// </summary>
+        /// <param name="writer">The <see cref="TextWriter"/> instance to write to.</param>
+        /// <param name="tagHelperExecutionContext">The execution context containing the output.</param>
+        public async Task WriteTagHelperToAsync(
+            [NotNull] TextWriter writer, [NotNull] TagHelperExecutionContext tagHelperExecutionContext)
         {
             var tagHelperOutput = tagHelperExecutionContext.Output;
             var isTagNameNullOrWhitespace = string.IsNullOrWhiteSpace(tagHelperOutput.TagName);
@@ -292,21 +303,20 @@ namespace Microsoft.AspNet.Mvc.Razor
                 }
                 else if (tagHelperExecutionContext.ChildContentRetrieved)
                 {
-                    WriteTagHelperContentTo(writer, tagHelperExecutionContext.GetChildContentAsync().Result);
+                    WriteTagHelperContentTo(writer, await tagHelperExecutionContext.GetChildContentAsync());
                 }
                 else
                 {
-                    tagHelperExecutionContext.ExecuteChildContentAsync().Wait();
+                    await tagHelperExecutionContext.ExecuteChildContentAsync();
                 }
 
                 WriteTagHelperContentTo(writer, tagHelperOutput.PostContent);
             }
 
-            if (!tagHelperOutput.SelfClosing && !isTagNameNullOrWhitespace)
+            if (!isTagNameNullOrWhitespace && !tagHelperOutput.SelfClosing)
             {
                 writer.Write(string.Format(CultureInfo.InvariantCulture, "</{0}>", tagHelperOutput.TagName));
             }
-
         }
 
         private void WriteTagHelperContentTo(TextWriter writer, TagHelperContent content)

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
@@ -251,22 +251,30 @@ namespace Microsoft.AspNet.Mvc.Razor
         }
 
         /// <summary>
-        /// Writes the output of a specified <see cref="TagHelperExecutionContext"/>.
+        /// Writes the content of a specified <paramref name="tagHelperExecutionContext"/>.
         /// </summary>
         /// <param name="tagHelperExecutionContext">The execution context containing the output.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that on completion writes the <paramref name="tagHelperExecutionContext"/> content.
+        /// </returns>
         public async Task WriteTagHelperAsync([NotNull] TagHelperExecutionContext tagHelperExecutionContext)
         {
             await WriteTagHelperToAsync(Output, tagHelperExecutionContext);
         }
 
         /// <summary>
-        /// Wrutes the output of a specified <see cref="TagHelperExecutionContext"/> to the specified
+        /// Writes the content of a specified <paramref name="tagHelperExecutionContext"/> to the specified
         /// <paramref name="writer"/>.
         /// </summary>
         /// <param name="writer">The <see cref="TextWriter"/> instance to write to.</param>
         /// <param name="tagHelperExecutionContext">The execution context containing the output.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that on completion writes the <paramref name="tagHelperExecutionContext"/> content
+        /// to the <paramref name="writer"/>.
+        /// </returns>
         public async Task WriteTagHelperToAsync(
-            [NotNull] TextWriter writer, [NotNull] TagHelperExecutionContext tagHelperExecutionContext)
+            [NotNull] TextWriter writer,
+            [NotNull] TagHelperExecutionContext tagHelperExecutionContext)
         {
             var tagHelperOutput = tagHelperExecutionContext.Output;
             var isTagNameNullOrWhitespace = string.IsNullOrWhiteSpace(tagHelperOutput.TagName);
@@ -303,7 +311,8 @@ namespace Microsoft.AspNet.Mvc.Razor
                 }
                 else if (tagHelperExecutionContext.ChildContentRetrieved)
                 {
-                    WriteTagHelperContentTo(writer, await tagHelperExecutionContext.GetChildContentAsync());
+                    var childContent = await tagHelperExecutionContext.GetChildContentAsync();
+                    WriteTagHelperContentTo(writer, childContent);
                 }
                 else
                 {

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/OptionTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/OptionTagHelper.cs
@@ -85,7 +85,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
                     // Select this <option/> element if value attribute or content matches a selected value. Callers
                     // encode values as-needed while executing child content. But TagHelperOutput itself
-                    // encodes attribute values later, when GenerateStartTag() is called.
+                    // encodes attribute values later, when start tag is generated.
                     bool selected;
                     if (Value != null)
                     {

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/ModelExpressionTagHelper.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/ModelExpressionTagHelper.cs
@@ -42,7 +42,7 @@ namespace Asp
         #pragma warning disable 1998
         public override async Task ExecuteAsync()
         {
-            __tagHelperRunner = __tagHelperRunner ?? new Microsoft.AspNet.Razor.Runtime.TagHelpers.TagHelperRunner(HtmlEncoder);
+            __tagHelperRunner = __tagHelperRunner ?? new Microsoft.AspNet.Razor.Runtime.TagHelpers.TagHelperRunner();
             BeginContext(120, 2, true);
             WriteLiteral("\r\n");
             EndContext();
@@ -58,22 +58,7 @@ __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For = CreateModelExpression(__mo
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("for", __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For);
             __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
-            WriteLiteral(__tagHelperExecutionContext.Output.GenerateStartTag());
-            Write(__tagHelperExecutionContext.Output.GeneratePreContent());
-            if (__tagHelperExecutionContext.Output.IsContentModified)
-            {
-                Write(__tagHelperExecutionContext.Output.GenerateContent());
-            }
-            else if (__tagHelperExecutionContext.ChildContentRetrieved)
-            {
-                Write(__tagHelperExecutionContext.GetChildContentAsync().Result);
-            }
-            else
-            {
-                __tagHelperExecutionContext.ExecuteChildContentAsync().Wait();
-            }
-            Write(__tagHelperExecutionContext.Output.GeneratePostContent());
-            WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
+            WriteTagHelper(__tagHelperExecutionContext);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
             BeginContext(146, 2, true);
             WriteLiteral("\r\n");
@@ -90,22 +75,7 @@ __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For = CreateModelExpression(__mo
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("for", __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For);
             __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
-            WriteLiteral(__tagHelperExecutionContext.Output.GenerateStartTag());
-            Write(__tagHelperExecutionContext.Output.GeneratePreContent());
-            if (__tagHelperExecutionContext.Output.IsContentModified)
-            {
-                Write(__tagHelperExecutionContext.Output.GenerateContent());
-            }
-            else if (__tagHelperExecutionContext.ChildContentRetrieved)
-            {
-                Write(__tagHelperExecutionContext.GetChildContentAsync().Result);
-            }
-            else
-            {
-                __tagHelperExecutionContext.ExecuteChildContentAsync().Wait();
-            }
-            Write(__tagHelperExecutionContext.Output.GeneratePostContent());
-            WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
+            WriteTagHelper(__tagHelperExecutionContext);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/ModelExpressionTagHelper.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/ModelExpressionTagHelper.cs
@@ -58,7 +58,7 @@ __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For = CreateModelExpression(__mo
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("for", __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For);
             __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
-            WriteTagHelper(__tagHelperExecutionContext);
+            WriteTagHelperAsync(__tagHelperExecutionContext).Wait();
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
             BeginContext(146, 2, true);
             WriteLiteral("\r\n");
@@ -75,7 +75,7 @@ __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For = CreateModelExpression(__mo
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("for", __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For);
             __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
-            WriteTagHelper(__tagHelperExecutionContext);
+            WriteTagHelperAsync(__tagHelperExecutionContext).Wait();
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/RazorPageTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/RazorPageTest.cs
@@ -696,8 +696,8 @@ namespace Microsoft.AspNet.Mvc.Razor
                 {
                     {
                         // parameters: TagName, Attributes, SelfClosing, PreContent, Content, PostContent
-                        GetTagHelperOutput("p", new Dictionary<string, string>(), false, null, "Hello World!", null),
-                        "<p>Hello World!</p>"
+                        GetTagHelperOutput("div", new Dictionary<string, string>(), false, null, "Hello World!", null),
+                        "<div>Hello World!</div>"
                     },
                     {
                         GetTagHelperOutput(null, new Dictionary<string, string>(), false, null, "Hello World!", null),
@@ -766,6 +766,14 @@ namespace Microsoft.AspNet.Mvc.Razor
                     {
                         GetTagHelperOutput("p", new Dictionary<string, string>(), true, "Hello", "Test", "World!"),
                         "<p />"
+                    },
+                    {
+                        GetTagHelperOutput("custom", new Dictionary<string, string>(), false, "Hello", "Test", "World!"),
+                        "<custom>HelloTestWorld!</custom>"
+                    },
+                    {
+                        GetTagHelperOutput("random", new Dictionary<string, string>(), true, "Hello", "Test", "World!"),
+                        "<random />"
                     }
                 };
             }
@@ -778,13 +786,14 @@ namespace Microsoft.AspNet.Mvc.Razor
             // Arrange
             var writer = new StringCollectionTextWriter(Encoding.UTF8);
             var context = CreateViewContext(writer);
-            var tagHelperExecutionContext = new TagHelperExecutionContext(tagName: output.TagName,
-                   selfClosing: output.SelfClosing,
-                   items: new Dictionary<object, object>(),
-                   uniqueId: string.Empty,
-                   executeChildContentAsync: () => Task.FromResult(result: true),
-                   startTagHelperWritingScope: () => { },
-                   endTagHelperWritingScope: () => new DefaultTagHelperContent());
+            var tagHelperExecutionContext = new TagHelperExecutionContext(
+                tagName: output.TagName,
+                selfClosing: output.SelfClosing,
+                items: new Dictionary<object, object>(),
+                uniqueId: string.Empty,
+                executeChildContentAsync: () => Task.FromResult(result: true),
+                startTagHelperWritingScope: () => { },
+                endTagHelperWritingScope: () => new DefaultTagHelperContent());
             tagHelperExecutionContext.Output = output;
 
             // Act
@@ -811,16 +820,17 @@ namespace Microsoft.AspNet.Mvc.Razor
             var defaultTagHelperContent = new DefaultTagHelperContent();
             var writer = new StringCollectionTextWriter(Encoding.UTF8);
             var context = CreateViewContext(writer);
-            var tagHelperExecutionContext = new TagHelperExecutionContext(tagName: "p",
-                   selfClosing: false,
-                   items: new Dictionary<object, object>(),
-                   uniqueId: string.Empty,
-                   executeChildContentAsync: () => {
-                       defaultTagHelperContent.SetContent(input);
-                       return Task.FromResult(result: true);
-                   },
-                   startTagHelperWritingScope: () => { },
-                   endTagHelperWritingScope: () => defaultTagHelperContent);
+            var tagHelperExecutionContext = new TagHelperExecutionContext(
+                tagName: "p",
+                selfClosing: false,
+                items: new Dictionary<object, object>(),
+                uniqueId: string.Empty,
+                executeChildContentAsync: () => {
+                    defaultTagHelperContent.SetContent(input);
+                    return Task.FromResult(result: true);
+                },
+                startTagHelperWritingScope: () => { },
+                endTagHelperWritingScope: () => defaultTagHelperContent);
             tagHelperExecutionContext.Output =
                 new TagHelperOutput("p", new Dictionary<string, string>());
             if (childContentRetrieved)
@@ -846,15 +856,17 @@ namespace Microsoft.AspNet.Mvc.Razor
             // Arrange
             var writer = new StringCollectionTextWriter(Encoding.UTF8);
             var context = CreateViewContext(new StringWriter());
-            var tagHelperExecutionContext = new TagHelperExecutionContext(tagName: "p",
-                   selfClosing: false,
-                   items: new Dictionary<object, object>(),
-                   uniqueId: string.Empty,
-                   executeChildContentAsync: () => { return Task.FromResult(result: true); },
-                   startTagHelperWritingScope: () => { },
-                   endTagHelperWritingScope: () => new DefaultTagHelperContent());
+            var tagHelperExecutionContext = new TagHelperExecutionContext(
+                tagName: "p",
+                selfClosing: false,
+                items: new Dictionary<object, object>(),
+                uniqueId: string.Empty,
+                executeChildContentAsync: () => { return Task.FromResult(result: true); },
+                startTagHelperWritingScope: () => { },
+                endTagHelperWritingScope: () => new DefaultTagHelperContent());
             tagHelperExecutionContext.Output =
                 new TagHelperOutput("p", new Dictionary<string, string>());
+            tagHelperExecutionContext.Output.Content.SetContent("Hello World!");
 
             // Act
             var page = CreatePage(p =>
@@ -864,7 +876,7 @@ namespace Microsoft.AspNet.Mvc.Razor
             await page.ExecuteAsync();
 
             // Assert
-            Assert.Equal("Hello World!", writer.ToString());
+            Assert.Equal("<p>Hello World!</p>", writer.ToString());
         }
 
         [Theory]
@@ -874,13 +886,14 @@ namespace Microsoft.AspNet.Mvc.Razor
             // Arrange
             var writer = new StringCollectionTextWriter(Encoding.UTF8);
             var context = CreateViewContext(new StringWriter());
-            var tagHelperExecutionContext = new TagHelperExecutionContext(tagName: output.TagName,
-                   selfClosing: output.SelfClosing,
-                   items: new Dictionary<object, object>(),
-                   uniqueId: string.Empty,
-                   executeChildContentAsync: () => Task.FromResult(result: true),
-                   startTagHelperWritingScope: () => { },
-                   endTagHelperWritingScope: () => new DefaultTagHelperContent());
+            var tagHelperExecutionContext = new TagHelperExecutionContext(
+                tagName: output.TagName,
+                selfClosing: output.SelfClosing,
+                items: new Dictionary<object, object>(),
+                uniqueId: string.Empty,
+                executeChildContentAsync: () => Task.FromResult(result: true),
+                startTagHelperWritingScope: () => { },
+                endTagHelperWritingScope: () => new DefaultTagHelperContent());
             tagHelperExecutionContext.Output = output;
 
             // Act

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/AnchorTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/AnchorTagHelperTest.cs
@@ -47,8 +47,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 {
                     { "id", "myanchor" },
                     { "asp-route-foo", "bar" },
-                },
-                htmlEncoder: new HtmlEncoder());
+                });
             output.Content.SetContent("Something");
 
             var urlHelper = new Mock<IUrlHelper>();
@@ -98,8 +97,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 });
             var output = new TagHelperOutput(
                 "a",
-                attributes: new Dictionary<string, string>(),
-                htmlEncoder: new HtmlEncoder());
+                attributes: new Dictionary<string, string>());
             output.Content.SetContent(string.Empty);
 
             var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
@@ -141,8 +139,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 });
             var output = new TagHelperOutput(
                 "a",
-                attributes: new Dictionary<string, string>(),
-                htmlEncoder: new HtmlEncoder());
+                attributes: new Dictionary<string, string>());
             output.Content.SetContent(string.Empty);
 
             var generator = new Mock<IHtmlGenerator>();
@@ -186,8 +183,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 attributes: new Dictionary<string, string>()
                 {
                     { "href", "http://www.contoso.com" }
-                },
-                htmlEncoder: new HtmlEncoder());
+                });
             if (propertyName == "asp-route-")
             {
                 output.Attributes.Add("asp-route-foo", "bar");
@@ -222,8 +218,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             typeof(AnchorTagHelper).GetProperty(propertyName).SetValue(anchorTagHelper, "Home");
             var output = new TagHelperOutput(
                 "a",
-                attributes: new Dictionary<string, string>(),
-                htmlEncoder: new HtmlEncoder());
+                attributes: new Dictionary<string, string>());
             var expectedErrorMessage = "Cannot determine an 'href' attribute for <a>. An <a> with a specified " +
                 "'asp-route' must not have an 'asp-action' or 'asp-controller' attribute.";
 

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/CacheTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/CacheTagHelperTest.cs
@@ -245,7 +245,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var childContent = "original-child-content";
             var cache = new MemoryCache(new MemoryCacheOptions());
             var tagHelperContext1 = GetTagHelperContext(id, childContent);
-            var tagHelperOutput1 = new TagHelperOutput("cache", new Dictionary<string, string>(), new HtmlEncoder());
+            var tagHelperOutput1 = new TagHelperOutput("cache", new Dictionary<string, string>());
             var cacheTagHelper1 = new CacheTagHelper
             {
                 VaryByQuery = "key1,key2",
@@ -266,7 +266,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             // Arrange - 2
             var tagHelperContext2 = GetTagHelperContext(id, "different-content");
-            var tagHelperOutput2 = new TagHelperOutput("cache", new Dictionary<string, string>(), new HtmlEncoder());
+            var tagHelperOutput2 = new TagHelperOutput("cache", new Dictionary<string, string>());
             var cacheTagHelper2 = new CacheTagHelper
             {
                 VaryByQuery = "key1,key2",
@@ -295,8 +295,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var cache = new MemoryCache(new MemoryCacheOptions());
             var tagHelperContext1 = GetTagHelperContext(id, childContent1);
             var tagHelperOutput1 = new TagHelperOutput("cache",
-                                                       new Dictionary<string, string> { { "attr", "value" } },
-                                                       new HtmlEncoder());
+                                                       new Dictionary<string, string> { { "attr", "value" } });
             tagHelperOutput1.PreContent.Append("<cache>");
             tagHelperOutput1.PostContent.SetContent("</cache>");
             var cacheTagHelper1 = new CacheTagHelper
@@ -321,8 +320,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var tagHelperContext2 = GetTagHelperContext(id, childContent2);
             var tagHelperOutput2 = new TagHelperOutput(
                 "cache",
-                new Dictionary<string, string> { { "attr", "value" } },
-                new HtmlEncoder());
+                new Dictionary<string, string> { { "attr", "value" } });
             tagHelperOutput2.PreContent.SetContent("<cache>");
             tagHelperOutput2.PostContent.SetContent("</cache>");
             var cacheTagHelper2 = new CacheTagHelper
@@ -532,8 +530,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var cache = new MemoryCache(new MemoryCacheOptions { Clock = clock.Object });
             var tagHelperContext1 = GetTagHelperContext(id, childContent1);
             var tagHelperOutput1 = new TagHelperOutput("cache",
-                                                       new Dictionary<string, string> { { "attr", "value" } },
-                                                       new HtmlEncoder());
+                                                       new Dictionary<string, string> { { "attr", "value" } });
             tagHelperOutput1.PreContent.SetContent("<cache>");
             tagHelperOutput1.PostContent.SetContent("</cache>");
             var cacheTagHelper1 = new CacheTagHelper
@@ -556,8 +553,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var childContent2 = "different-content";
             var tagHelperContext2 = GetTagHelperContext(id, childContent2);
             var tagHelperOutput2 = new TagHelperOutput("cache",
-                                                       new Dictionary<string, string> { { "attr", "value" } },
-                                                       new HtmlEncoder());
+                                                       new Dictionary<string, string> { { "attr", "value" } });
             tagHelperOutput2.PreContent.SetContent("<cache>");
             tagHelperOutput2.PostContent.SetContent("</cache>");
             var cacheTagHelper2 = new CacheTagHelper
@@ -591,8 +587,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var cache = new MemoryCache(new MemoryCacheOptions { Clock = clock.Object });
             var tagHelperContext1 = GetTagHelperContext(id, childContent1);
             var tagHelperOutput1 = new TagHelperOutput("cache",
-                                                       new Dictionary<string, string> { { "attr", "value" } },
-                                                       new HtmlEncoder());
+                                                       new Dictionary<string, string> { { "attr", "value" } });
             tagHelperOutput1.PreContent.SetContent("<cache>");
             tagHelperOutput1.PostContent.SetContent("</cache>");
             var cacheTagHelper1 = new CacheTagHelper
@@ -616,8 +611,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var childContent2 = "different-content";
             var tagHelperContext2 = GetTagHelperContext(id, childContent2);
             var tagHelperOutput2 = new TagHelperOutput("cache",
-                                                       new Dictionary<string, string> { { "attr", "value" } },
-                                                       new HtmlEncoder());
+                                                       new Dictionary<string, string> { { "attr", "value" } });
             tagHelperOutput2.PreContent.SetContent("<cache>");
             tagHelperOutput2.PostContent.SetContent("</cache>");
             var cacheTagHelper2 = new CacheTagHelper
@@ -650,8 +644,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var cache = new MemoryCache(new MemoryCacheOptions { Clock = clock.Object });
             var tagHelperContext1 = GetTagHelperContext(id, childContent1);
             var tagHelperOutput1 = new TagHelperOutput("cache",
-                                                       new Dictionary<string, string> { { "attr", "value" } },
-                                                       new HtmlEncoder());
+                                                       new Dictionary<string, string> { { "attr", "value" } });
             tagHelperOutput1.PreContent.SetContent("<cache>");
             tagHelperOutput1.PostContent.SetContent("</cache>");
             var cacheTagHelper1 = new CacheTagHelper
@@ -675,8 +668,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var childContent2 = "different-content";
             var tagHelperContext2 = GetTagHelperContext(id, childContent2);
             var tagHelperOutput2 = new TagHelperOutput("cache",
-                                                       new Dictionary<string, string> { { "attr", "value" } },
-                                                       new HtmlEncoder());
+                                                       new Dictionary<string, string> { { "attr", "value" } });
             tagHelperOutput2.PreContent.SetContent("<cache>");
             tagHelperOutput2.PostContent.SetContent("</cache>");
             var cacheTagHelper2 = new CacheTagHelper
@@ -720,8 +712,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     return Task.FromResult<TagHelperContent>(expectedContent);
                 });
             var tagHelperOutput = new TagHelperOutput("cache",
-                                                       new Dictionary<string, string> { { "attr", "value" } },
-                                                       new HtmlEncoder());
+                                                       new Dictionary<string, string> { { "attr", "value" } });
             tagHelperOutput.PreContent.SetContent("<cache>");
             tagHelperOutput.PostContent.SetContent("</cache>");
             var cacheTagHelper = new CacheTagHelper

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/EnvironmentTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/EnvironmentTagHelperTest.cs
@@ -151,7 +151,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Test
         {
             attributes = attributes ?? new Dictionary<string, string>();
 
-            return new TagHelperOutput(tagName, attributes, new HtmlEncoder());
+            return new TagHelperOutput(tagName, attributes);
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/FormTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/FormTagHelperTest.cs
@@ -49,8 +49,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 {
                     { "id", "myform" },
                     { "asp-route-foo", "bar" },
-                },
-                htmlEncoder: new HtmlEncoder());
+                });
             output.PostContent.SetContent("Something");
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper
@@ -111,8 +110,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 });
             var output = new TagHelperOutput(
                 "form",
-                attributes: new Dictionary<string, string>(),
-                htmlEncoder: new HtmlEncoder());
+                attributes: new Dictionary<string, string>());
             var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
             generator
                 .Setup(mock => mock.GenerateForm(
@@ -168,8 +166,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 {
                     { "asp-route-val", "hello" },
                     { "asp-roUte--Foo", "bar" }
-                },
-                htmlEncoder: new HtmlEncoder());
+                });
             output.Attributes.Add(expectedAttribute);
 
             var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
@@ -235,8 +232,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 });
             var output = new TagHelperOutput(
                 "form",
-                attributes: new Dictionary<string, string>(),
-                htmlEncoder: new HtmlEncoder());
+                attributes: new Dictionary<string, string>());
             var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
             generator
                 .Setup(mock => mock.GenerateForm(viewContext, "Index", "Home", null, "POST", null))
@@ -279,8 +275,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                                              attributes: new Dictionary<string, string>
                                              {
                                                  { "aCTiON", htmlAction },
-                                             },
-                                             htmlEncoder: new HtmlEncoder());
+                                             });
 
             var context = new TagHelperContext(
                 allAttributes: new Dictionary<string, object>()
@@ -336,8 +331,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                                              attributes: new Dictionary<string, string>
                                              {
                                                  { "aCTiON", "my-action" },
-                                             },
-                                             htmlEncoder: new HtmlEncoder());
+                                             });
             var context = new TagHelperContext(
                 allAttributes: new Dictionary<string, object>(),
                 items: new Dictionary<object, object>(),
@@ -379,8 +373,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 attributes: new Dictionary<string, string>
                 {
                     { "action", "my-action" },
-                },
-                htmlEncoder: new HtmlEncoder());
+                });
             if (propertyName == "asp-route-")
             {
                 tagHelperOutput.Attributes.Add("asp-route-foo", "bar");

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/InputTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/InputTagHelperTest.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, new HtmlEncoder())
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
                 SelfClosing = false,
             };
@@ -170,7 +170,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(originalTagName, originalAttributes, new HtmlEncoder())
+            var output = new TagHelperOutput(originalTagName, originalAttributes)
             {
                 SelfClosing = true,
             };
@@ -266,7 +266,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, new HtmlEncoder())
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
                 SelfClosing = false,
             };
@@ -365,7 +365,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, new HtmlEncoder())
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
                 SelfClosing = false,
             };
@@ -461,7 +461,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, new HtmlEncoder())
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
                 SelfClosing = false,
             };
@@ -566,7 +566,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, new HtmlEncoder())
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
                 SelfClosing = false,
             };
@@ -643,7 +643,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
 
-            var output = new TagHelperOutput(expectedTagName, expectedAttributes, new HtmlEncoder())
+            var output = new TagHelperOutput(expectedTagName, expectedAttributes)
             {
                 SelfClosing = false,
             };
@@ -709,7 +709,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, new HtmlEncoder());
+            var output = new TagHelperOutput(expectedTagName, originalAttributes);
             var tagHelper = new InputTagHelper
             {
                 Format = "{0}",

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LabelTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LabelTagHelperTest.cs
@@ -200,7 +200,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(expectedTagName, htmlAttributes, new HtmlEncoder());
+            var output = new TagHelperOutput(expectedTagName, htmlAttributes);
             output.PreContent.SetContent(expectedPreContent);
             output.PostContent.SetContent(expectedPostContent);
 
@@ -259,7 +259,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-            var output = new TagHelperOutput(expectedTagName, expectedAttributes, new HtmlEncoder());
+            var output = new TagHelperOutput(expectedTagName, expectedAttributes);
             output.PreContent.SetContent(expectedPreContent);
             output.Content.SetContent(expectedContent);
             output.PostContent.SetContent(expectedPostContent);

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LinkTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LinkTagHelperTest.cs
@@ -403,7 +403,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             attributes = attributes ?? new Dictionary<string, string>();
 
-            return new TagHelperOutput(tagName, attributes, new HtmlEncoder());
+            return new TagHelperOutput(tagName, attributes);
         }
 
         private static IHostingEnvironment MakeHostingEnvironment()

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/OptionTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/OptionTagHelperTest.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc.ModelBinding;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
-using Microsoft.Framework.WebEncoders;
 using Xunit;
 
 namespace Microsoft.AspNet.Mvc.TagHelpers
@@ -15,79 +14,141 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     {
         // Original content, selected attribute, value attribute, selected values (to place in FormContext.FormData)
         // and expected output (concatenation of TagHelperOutput generations).
-        public static TheoryData<string, string, string, ICollection<string>, string> GeneratesExpectedDataSet
+        public static TheoryData<string, string, string, ICollection<string>, TagHelperOutput> GeneratesExpectedDataSet
         {
             get
             {
-                return new TheoryData<string, string, string, ICollection<string>, string>
+                return new TheoryData<string, string, string, ICollection<string>, TagHelperOutput>
                 {
-                    { null, null, null, null,
-                        "<not-option label=\"my-label\"></not-option>" },
-                    { null, string.Empty, "value", null,
-                        "<not-option label=\"my-label\" value=\"value\" selected=\"\"></not-option>" },
-                    { null, "selected", "value", null,
-                        "<not-option label=\"my-label\" value=\"value\" selected=\"selected\"></not-option>" },
-                    { null, null, "value", new string[0],
-                        "<not-option label=\"my-label\" value=\"value\"></not-option>" },
+                    // original content, selected, value, selected values,
+                    // expected tag helper output - attributes, content
+                    {
+                        null, null, null, null,
+                        GetTagHelperOutput(
+                            "not-option", new Dictionary<string, string> { { "label", "my-label" } }, "")
+                    },
+                    {
+                        null, string.Empty, "value", null,
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string> {
+                                { "label", "my-label" }, { "value", "value" }, { "selected", "" } },
+                            "")
+                    },
+                    {
+                        null, "selected", "value", null,
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string> {
+                                { "label", "my-label" }, { "value", "value" }, { "selected", "selected" } },
+                            "")
+                    },
+                    {
+                        null, null, "value", new string[0],
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string> {{ "label", "my-label" }, { "value", "value" } },
+                            "")
+                    },
                     { null, null, "value", new [] { string.Empty, },
-                        "<not-option label=\"my-label\" value=\"value\"></not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" }, { "value", "value" } }, "") },
                     { null, string.Empty, "value", new [] { string.Empty, },
-                        "<not-option label=\"my-label\" value=\"value\" selected=\"\"></not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" }, { "value", "value" }, { "selected", "" } }, "") },
                     { null, null, "value", new [] { "value", },
-                        "<not-option label=\"my-label\" value=\"value\" selected=\"selected\"></not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" }, { "value", "value" }, { "selected", "selected" } }, "") },
                     { null, null, "value", new [] { string.Empty, "value", },
-                        "<not-option label=\"my-label\" value=\"value\" selected=\"selected\"></not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" }, { "value", "value" }, { "selected", "selected" } }, "") },
 
-                    { string.Empty, null, null, null,
-                        "<not-option label=\"my-label\"></not-option>" },
+                    {
+                        string.Empty, null, null, null,
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string> {{ "label", "my-label" } },
+                        "")
+                    },
                     { string.Empty, string.Empty, null, null,
-                        "<not-option label=\"my-label\" selected=\"\"></not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" }, { "selected", "" } }, "") },
                     { string.Empty, "selected", null, null,
-                        "<not-option label=\"my-label\" selected=\"selected\"></not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" }, { "selected", "selected" } }, "") },
                     { string.Empty, null, null, new string[0],
-                        "<not-option label=\"my-label\"></not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" } }, "") },
                     { string.Empty, null, null, new [] { string.Empty, },
-                        "<not-option label=\"my-label\" selected=\"selected\"></not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" }, { "selected", "selected" } }, "") },
                     { string.Empty, string.Empty, null, new [] { string.Empty, },
-                        "<not-option label=\"my-label\" selected=\"\"></not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" }, { "selected", "" } }, "") },
                     { string.Empty, null, null, new [] { "text", },
-                        "<not-option label=\"my-label\"></not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" } }, "") },
                     { string.Empty, null, null, new [] { string.Empty, "text", },
-                        "<not-option label=\"my-label\" selected=\"selected\"></not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" }, { "selected", "selected" } }, "") },
 
-                    { "text", null, null, null,
-                        "<not-option label=\"my-label\">text</not-option>" },
+                    { "text", null, null, null, GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" } }, "text") },
                     { "text", string.Empty, null, null,
-                        "<not-option label=\"my-label\" selected=\"\">text</not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" }, { "selected", "" } }, "text") },
                     { "text", "selected", null, null,
-                        "<not-option label=\"my-label\" selected=\"selected\">text</not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" }, { "selected", "selected" } }, "text") },
                     { "text", null, null, new string[0],
-                        "<not-option label=\"my-label\">text</not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" } }, "text") },
                     { "text", null, null, new [] { string.Empty, },
-                        "<not-option label=\"my-label\">text</not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" } }, "text") },
                     { "text", null, null, new [] { "text", },
-                        "<not-option label=\"my-label\" selected=\"selected\">text</not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" }, { "selected", "selected" } }, "text") },
                     { "text", string.Empty, null, new [] { "text", },
-                        "<not-option label=\"my-label\" selected=\"\">text</not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" }, { "selected", "" } }, "text") },
                     { "text", null, null, new [] { string.Empty, "text", },
-                        "<not-option label=\"my-label\" selected=\"selected\">text</not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" }, { "selected", "selected" } }, "text") },
 
-                    { "text", string.Empty, "value", null,
-                        "<not-option label=\"my-label\" value=\"value\" selected=\"\">text</not-option>" },
-                    { "text", "selected", "value", null,
-                        "<not-option label=\"my-label\" value=\"value\" selected=\"selected\">text</not-option>" },
+                    {
+                        "text", string.Empty, "value", null,
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string> {
+                                { "label", "my-label" }, { "value", "value" }, { "selected", "" } },
+                            "text") },
+                    {
+                        "text", "selected", "value", null,
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string> {
+                                { "label", "my-label" }, { "value", "value" }, { "selected", "selected" } },
+                            "text")
+                    },
                     { "text", null, "value", new string[0],
-                        "<not-option label=\"my-label\" value=\"value\">text</not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" }, { "value", "value" } }, "text") },
                     { "text", null, "value", new [] { string.Empty, },
-                        "<not-option label=\"my-label\" value=\"value\">text</not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" }, { "value", "value" } }, "text") },
                     { "text", string.Empty, "value", new [] { string.Empty, },
-                        "<not-option label=\"my-label\" value=\"value\" selected=\"\">text</not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" }, { "value", "value" }, { "selected", "" } }, "text") },
                     { "text", null, "value", new [] { "text", },
-                        "<not-option label=\"my-label\" value=\"value\">text</not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" }, { "value", "value" } }, "text") },
                     { "text", null, "value", new [] { "value", },
-                        "<not-option label=\"my-label\" value=\"value\" selected=\"selected\">text</not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" }, { "value", "value" }, { "selected", "selected" } }, "text") },
                     { "text", null, "value", new [] { string.Empty, "value", },
-                        "<not-option label=\"my-label\" value=\"value\" selected=\"selected\">text</not-option>" },
+                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
+                        { "label", "my-label" }, { "value", "value" }, { "selected", "selected" } }, "text") }
                 };
             }
         }
@@ -122,14 +183,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             string selected,
             string value,
             ICollection<string> selectedValues,
-            string expectedOutput)
+            TagHelperOutput expectedTagHelperOutput)
         {
             // Arrange
             var originalAttributes = new Dictionary<string, string>
             {
                 { "label", "my-label" },
             };
-            var expectedTagName = "not-option";
 
             var contextAttributes = new Dictionary<string, object>
             {
@@ -147,7 +207,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     tagHelperContent.SetContent(originalContent);
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, new HtmlEncoder())
+            var output = new TagHelperOutput(expectedTagHelperOutput.TagName, originalAttributes)
             {
                 SelfClosing = false,
             };
@@ -172,11 +232,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             await tagHelper.ProcessAsync(tagHelperContext, output);
 
             // Assert
-            Assert.Equal(
-                expectedOutput,
-                output.GenerateStartTag() +
-                (output.GenerateContent() as TagHelperContent).GetContent() +
-                output.GenerateEndTag());
+            Assert.Equal(expectedTagHelperOutput.TagName, output.TagName);
+            Assert.Equal(expectedTagHelperOutput.Content.GetContent(), output.Content.GetContent());
+            Assert.Equal(expectedTagHelperOutput.Attributes.Count, output.Attributes.Count);
+            Assert.True(expectedTagHelperOutput.Attributes.All(e => output.Attributes.Contains(e)));
         }
 
         [Theory]
@@ -186,7 +245,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             string selected,
             string value,
             ICollection<string> selectedValues,
-            string ignored)
+            TagHelperOutput ignored)
         {
             // Arrange
             var originalAttributes = new Dictionary<string, string>
@@ -213,7 +272,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     tagHelperContent.SetContent(originalContent);
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-            var output = new TagHelperOutput(originalTagName, originalAttributes, new HtmlEncoder())
+            var output = new TagHelperOutput(originalTagName, originalAttributes)
             {
                 SelfClosing = false,
             };
@@ -247,7 +306,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             string selected,
             string value,
             ICollection<string> ignoredValues,
-            string ignoredOutput)
+            TagHelperOutput ignoredOutput)
         {
             // Arrange
             var originalAttributes = new Dictionary<string, string>
@@ -274,7 +333,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     tagHelperContent.SetContent(originalContent);
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-            var output = new TagHelperOutput(originalTagName, originalAttributes, new HtmlEncoder())
+            var output = new TagHelperOutput(originalTagName, originalAttributes)
             {
                 SelfClosing = false,
             };
@@ -291,6 +350,14 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Act & Assert (does not throw)
             // Tag helper would throw an NRE if it used ViewContext or Generator values.
             await tagHelper.ProcessAsync(tagHelperContext, output);
+        }
+
+        private static TagHelperOutput GetTagHelperOutput(string tagName, IDictionary<string, string> attributes, string content)
+        {
+            var tagHelperOutput = new TagHelperOutput(tagName, attributes);
+            tagHelperOutput.Content.SetContent(content);
+
+            return tagHelperOutput;
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/OptionTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/OptionTagHelperTest.cs
@@ -25,130 +25,325 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     {
                         null, null, null, null,
                         GetTagHelperOutput(
-                            "not-option", new Dictionary<string, string> { { "label", "my-label" } }, "")
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }
+                            },
+                            "")
                     },
                     {
                         null, string.Empty, "value", null,
                         GetTagHelperOutput(
                             "not-option",
-                            new Dictionary<string, string> {
-                                { "label", "my-label" }, { "value", "value" }, { "selected", "" } },
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "value", "value" }, { "selected", "" }
+                            },
                             "")
                     },
                     {
                         null, "selected", "value", null,
                         GetTagHelperOutput(
                             "not-option",
-                            new Dictionary<string, string> {
-                                { "label", "my-label" }, { "value", "value" }, { "selected", "selected" } },
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "value", "value" }, { "selected", "selected" }
+                            },
                             "")
                     },
                     {
                         null, null, "value", new string[0],
                         GetTagHelperOutput(
                             "not-option",
-                            new Dictionary<string, string> {{ "label", "my-label" }, { "value", "value" } },
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "value", "value" }
+                            },
                             "")
                     },
-                    { null, null, "value", new [] { string.Empty, },
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" }, { "value", "value" } }, "") },
-                    { null, string.Empty, "value", new [] { string.Empty, },
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" }, { "value", "value" }, { "selected", "" } }, "") },
-                    { null, null, "value", new [] { "value", },
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" }, { "value", "value" }, { "selected", "selected" } }, "") },
-                    { null, null, "value", new [] { string.Empty, "value", },
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" }, { "value", "value" }, { "selected", "selected" } }, "") },
-
+                    {
+                        null, null, "value", new [] { string.Empty, },
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "value", "value" }
+                            },
+                            "")
+                    },
+                    {
+                        null, string.Empty, "value", new [] { string.Empty, },
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "value", "value" }, { "selected", "" }
+                            },
+                            "")
+                    },
+                    {
+                        null, null, "value", new [] { "value", },
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "value", "value" }, { "selected", "selected" }
+                            },
+                            "")
+                    },
+                    {
+                        null, null, "value", new [] { string.Empty, "value", },
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "value", "value" }, { "selected", "selected" }
+                            },
+                            "")
+                    },
                     {
                         string.Empty, null, null, null,
                         GetTagHelperOutput(
                             "not-option",
-                            new Dictionary<string, string> {{ "label", "my-label" } },
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }
+                            },
                         "")
                     },
-                    { string.Empty, string.Empty, null, null,
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" }, { "selected", "" } }, "") },
-                    { string.Empty, "selected", null, null,
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" }, { "selected", "selected" } }, "") },
-                    { string.Empty, null, null, new string[0],
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" } }, "") },
-                    { string.Empty, null, null, new [] { string.Empty, },
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" }, { "selected", "selected" } }, "") },
-                    { string.Empty, string.Empty, null, new [] { string.Empty, },
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" }, { "selected", "" } }, "") },
-                    { string.Empty, null, null, new [] { "text", },
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" } }, "") },
-                    { string.Empty, null, null, new [] { string.Empty, "text", },
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" }, { "selected", "selected" } }, "") },
+                    {
+                        string.Empty, string.Empty, null, null,
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "selected", "" }
+                            },
+                            "")
+                    },
+                    {
+                        string.Empty, "selected", null, null,
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "selected", "selected" }
+                            },
+                            "")
+                    },
+                    {
+                        string.Empty, null, null, new string[0],
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }
+                            },
+                            "")
+                    },
+                    {
+                        string.Empty, null, null, new [] { string.Empty, },
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "selected", "selected" }
+                            },
+                            "")
+                    },
+                    {
+                        string.Empty, string.Empty, null, new [] { string.Empty, },
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "selected", "" }
+                            },
+                            "")
+                    },
+                    {
+                        string.Empty, null, null, new [] { "text", },
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }
+                            },
+                            "")
+                    },
+                    {
+                        string.Empty, null, null, new [] { string.Empty, "text", },
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "selected", "selected" }
+                            },
+                            "")
+                    },
 
-                    { "text", null, null, null, GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" } }, "text") },
-                    { "text", string.Empty, null, null,
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" }, { "selected", "" } }, "text") },
-                    { "text", "selected", null, null,
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" }, { "selected", "selected" } }, "text") },
-                    { "text", null, null, new string[0],
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" } }, "text") },
-                    { "text", null, null, new [] { string.Empty, },
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" } }, "text") },
-                    { "text", null, null, new [] { "text", },
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" }, { "selected", "selected" } }, "text") },
-                    { "text", string.Empty, null, new [] { "text", },
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" }, { "selected", "" } }, "text") },
-                    { "text", null, null, new [] { string.Empty, "text", },
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" }, { "selected", "selected" } }, "text") },
+                    {
+                        "text", null, null, null,
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }
+                            },
+                            "text")
+                    },
+                    {
+                        "text", string.Empty, null, null,
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "selected", "" }
+                            },
+                            "text")
+                    },
+                    {
+                        "text", "selected", null, null,
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "selected", "selected" }
+                            },
+                            "text")
+                    },
+                    {
+                        "text", null, null, new string[0],
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }
+                            },
+                            "text")
+                    },
+                    {
+                        "text", null, null, new [] { string.Empty, },
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }
+                            },
+                            "text")
+                    },
+                    {
+                        "text", null, null, new [] { "text", },
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "selected", "selected" }
+                            },
+                            "text")
+                    },
+                    {
+                        "text", string.Empty, null, new [] { "text", },
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "selected", "" }
+                            },
+                            "text")
+                    },
+                    {
+                        "text", null, null, new [] { string.Empty, "text", },
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "selected", "selected" }
+                            },
+                            "text")
+                    },
 
                     {
                         "text", string.Empty, "value", null,
                         GetTagHelperOutput(
                             "not-option",
-                            new Dictionary<string, string> {
-                                { "label", "my-label" }, { "value", "value" }, { "selected", "" } },
-                            "text") },
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "value", "value" }, { "selected", "" }
+                            },
+                            "text")
+                    },
                     {
                         "text", "selected", "value", null,
                         GetTagHelperOutput(
                             "not-option",
-                            new Dictionary<string, string> {
-                                { "label", "my-label" }, { "value", "value" }, { "selected", "selected" } },
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "value", "value" }, { "selected", "selected" }
+                            },
                             "text")
                     },
-                    { "text", null, "value", new string[0],
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" }, { "value", "value" } }, "text") },
-                    { "text", null, "value", new [] { string.Empty, },
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" }, { "value", "value" } }, "text") },
-                    { "text", string.Empty, "value", new [] { string.Empty, },
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" }, { "value", "value" }, { "selected", "" } }, "text") },
-                    { "text", null, "value", new [] { "text", },
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" }, { "value", "value" } }, "text") },
-                    { "text", null, "value", new [] { "value", },
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" }, { "value", "value" }, { "selected", "selected" } }, "text") },
-                    { "text", null, "value", new [] { string.Empty, "value", },
-                        GetTagHelperOutput("not-option", new Dictionary<string, string> {
-                        { "label", "my-label" }, { "value", "value" }, { "selected", "selected" } }, "text") }
+                    {
+                        "text", null, "value", new string[0],
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "value", "value" }
+                            },
+                            "text")
+                    },
+                    {
+                        "text", null, "value", new [] { string.Empty, },
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "value", "value" }
+                            },
+                            "text")
+                    },
+                    {
+                        "text", string.Empty, "value", new [] { string.Empty, },
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "value", "value" }, { "selected", "" }
+                            },
+                            "text")
+                    },
+                    {
+                        "text", null, "value", new [] { "text", },
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "value", "value" }
+                            },
+                            "text")
+                    },
+                    {
+                        "text", null, "value", new [] { "value", },
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "value", "value" }, { "selected", "selected" }
+                            },
+                            "text")
+                    },
+                    {
+                        "text", null, "value", new [] { string.Empty, "value", },
+                        GetTagHelperOutput(
+                            "not-option",
+                            new Dictionary<string, string>
+                            {
+                                { "label", "my-label" }, { "value", "value" }, { "selected", "selected" }
+                            },
+                            "text")
+                    }
                 };
             }
         }
@@ -352,7 +547,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             await tagHelper.ProcessAsync(tagHelperContext, output);
         }
 
-        private static TagHelperOutput GetTagHelperOutput(string tagName, IDictionary<string, string> attributes, string content)
+        private static TagHelperOutput GetTagHelperOutput(
+            string tagName, IDictionary<string, string> attributes, string content)
         {
             var tagHelperOutput = new TagHelperOutput(tagName, attributes);
             tagHelperOutput.Content.SetContent(content);

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/OptionTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/OptionTagHelperTest.cs
@@ -14,11 +14,11 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     {
         // Original content, selected attribute, value attribute, selected values (to place in FormContext.FormData)
         // and expected output (concatenation of TagHelperOutput generations).
-        public static TheoryData<string, string, string, ICollection<string>, TagHelperOutput> GeneratesExpectedDataSet
+        public static TheoryData<string, string, string, IEnumerable<string>, TagHelperOutput> GeneratesExpectedDataSet
         {
             get
             {
-                return new TheoryData<string, string, string, ICollection<string>, TagHelperOutput>
+                return new TheoryData<string, string, string, IEnumerable<string>, TagHelperOutput>
                 {
                     // original content, selected, value, selected values,
                     // expected tag helper output - attributes, content
@@ -53,7 +53,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                             "")
                     },
                     {
-                        null, null, "value", new string[0],
+                        null, null, "value", Enumerable.Empty<string>(),
                         GetTagHelperOutput(
                             "not-option",
                             new Dictionary<string, string>
@@ -133,7 +133,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                             "")
                     },
                     {
-                        string.Empty, null, null, new string[0],
+                        string.Empty, null, null, Enumerable.Empty<string>(),
                         GetTagHelperOutput(
                             "not-option",
                             new Dictionary<string, string>
@@ -214,7 +214,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                             "text")
                     },
                     {
-                        "text", null, null, new string[0],
+                        "text", null, null, Enumerable.Empty<string>(),
                         GetTagHelperOutput(
                             "not-option",
                             new Dictionary<string, string>
@@ -285,7 +285,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                             "text")
                     },
                     {
-                        "text", null, "value", new string[0],
+                        "text", null, "value", Enumerable.Empty<string>(),
                         GetTagHelperOutput(
                             "not-option",
                             new Dictionary<string, string>
@@ -377,7 +377,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             string originalContent,
             string selected,
             string value,
-            ICollection<string> selectedValues,
+            IEnumerable<string> selectedValues,
             TagHelperOutput expectedTagHelperOutput)
         {
             // Arrange
@@ -430,7 +430,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal(expectedTagHelperOutput.TagName, output.TagName);
             Assert.Equal(expectedTagHelperOutput.Content.GetContent(), output.Content.GetContent());
             Assert.Equal(expectedTagHelperOutput.Attributes.Count, output.Attributes.Count);
-            Assert.True(expectedTagHelperOutput.Attributes.All(e => output.Attributes.Contains(e)));
+            foreach (var attribute in output.Attributes)
+            {
+                Assert.Contains(attribute, expectedTagHelperOutput.Attributes);
+            }
         }
 
         [Theory]
@@ -439,7 +442,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             string originalContent,
             string selected,
             string value,
-            ICollection<string> selectedValues,
+            IEnumerable<string> selectedValues,
             TagHelperOutput ignored)
         {
             // Arrange
@@ -500,7 +503,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             string originalContent,
             string selected,
             string value,
-            ICollection<string> ignoredValues,
+            IEnumerable<string> ignoredValues,
             TagHelperOutput ignoredOutput)
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ScriptTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ScriptTagHelperTest.cs
@@ -476,7 +476,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             attributes = attributes ?? new Dictionary<string, string>();
 
-            return new TagHelperOutput(tagName, attributes, new HtmlEncoder());
+            return new TagHelperOutput(tagName, attributes);
         }
 
         private TagHelperLogger<ScriptTagHelper> CreateLogger()

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/SelectTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/SelectTagHelperTest.cs
@@ -208,7 +208,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, new HtmlEncoder())
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
                 SelfClosing = true,
             };
@@ -298,7 +298,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, new HtmlEncoder())
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
                 SelfClosing = true,
             };
@@ -402,7 +402,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, new HtmlEncoder())
+            var output = new TagHelperOutput(expectedTagName, originalAttributes)
             {
                 SelfClosing = true
             };
@@ -492,7 +492,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
 
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, new HtmlEncoder());
+            var output = new TagHelperOutput(expectedTagName, originalAttributes);
             var metadataProvider = new EmptyModelMetadataProvider();
             string model = null;
             var modelExplorer = metadataProvider.GetModelExplorerForType(typeof(string), model);
@@ -562,7 +562,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-            var output = new TagHelperOutput(tagName, originalAttributes, new HtmlEncoder());
+            var output = new TagHelperOutput(tagName, originalAttributes);
             var metadataProvider = new EmptyModelMetadataProvider();
             var modelExplorer = metadataProvider.GetModelExplorerForType(modelType, model);
             var modelExpression = new ModelExpression(propertyName, modelExplorer);
@@ -622,7 +622,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-            var output = new TagHelperOutput(expectedTagName, originalAttributes, new HtmlEncoder());
+            var output = new TagHelperOutput(expectedTagName, originalAttributes);
             var tagHelper = new SelectTagHelper
             {
                 Items = Enumerable.Empty<SelectListItem>(),

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TagHelperOutputExtensionsTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TagHelperOutputExtensionsTest.cs
@@ -21,8 +21,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                htmlEncoder: new HtmlEncoder());
+                attributes: new Dictionary<string, string>());
             var tagHelperContext = new TagHelperContext(
                 allAttributes: new Dictionary<string, object>(StringComparer.Ordinal)
                 {
@@ -56,8 +55,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 attributes: new Dictionary<string, string>()
                 {
                     { attributeName, "world2" }
-                },
-                htmlEncoder: new HtmlEncoder());
+                });
             var expectedAttribute = new KeyValuePair<string, string>(attributeName, "world2");
             var tagHelperContext = new TagHelperContext(
                 allAttributes: new Dictionary<string, object>(StringComparer.Ordinal)
@@ -91,8 +89,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 {
                     { "route-Hello", "World" },
                     { "Route-I", "Am" }
-                },
-                htmlEncoder: new HtmlEncoder());
+                });
             var expectedAttribute = new KeyValuePair<string, string>("type", "btn");
             tagHelperOutput.Attributes.Add(expectedAttribute);
             var attributes = tagHelperOutput.FindPrefixedAttributes("route-");
@@ -115,8 +112,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 {
                     { "routeHello", "World" },
                     { "Routee-I", "Am" }
-                },
-                htmlEncoder: new HtmlEncoder());
+                });
 
             // Act
             var attributes = tagHelperOutput.FindPrefixedAttributes("route-");
@@ -135,8 +131,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                htmlEncoder: new HtmlEncoder());
+                attributes: new Dictionary<string, string>());
             var expectedAttribute = new KeyValuePair<string, string>("type", "btn");
             tagHelperOutput.Attributes.Add(expectedAttribute);
 
@@ -157,8 +152,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                htmlEncoder: new HtmlEncoder());
+                attributes: new Dictionary<string, string>());
             tagHelperOutput.Attributes.Add("class", "Hello");
 
             var tagBuilder = new TagBuilder("p", new HtmlEncoder());
@@ -184,8 +178,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                htmlEncoder: new HtmlEncoder());
+                attributes: new Dictionary<string, string>());
             tagHelperOutput.Attributes.Add(originalName, "Hello");
 
             var tagBuilder = new TagBuilder("p", new HtmlEncoder());
@@ -205,8 +198,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                htmlEncoder: new HtmlEncoder());
+                attributes: new Dictionary<string, string>());
 
             var tagBuilder = new TagBuilder("p", new HtmlEncoder());
             var expectedAttribute = new KeyValuePair<string, string>("visible", "val < 3");
@@ -226,8 +218,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                htmlEncoder: new HtmlEncoder());
+                attributes: new Dictionary<string, string>());
 
             var tagBuilder = new TagBuilder("p", new HtmlEncoder());
             var expectedAttribute1 = new KeyValuePair<string, string>("class", "btn");
@@ -252,8 +243,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                htmlEncoder: new HtmlEncoder());
+                attributes: new Dictionary<string, string>());
             var expectedAttribute = new KeyValuePair<string, string>("class", "btn");
             tagHelperOutput.Attributes.Add(expectedAttribute);
 
@@ -273,8 +263,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new Dictionary<string, string>(),
-                htmlEncoder: new HtmlEncoder());
+                attributes: new Dictionary<string, string>());
             var expectedOutputAttribute = new KeyValuePair<string, string>("class", "btn");
             tagHelperOutput.Attributes.Add(expectedOutputAttribute);
 

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TextAreaTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TextAreaTagHelperTest.cs
@@ -127,7 +127,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 { "class", "form-control" },
             };
-            var output = new TagHelperOutput(expectedTagName, htmlAttributes, new HtmlEncoder())
+            var output = new TagHelperOutput(expectedTagName, htmlAttributes)
             {
                 SelfClosing = true,
             };
@@ -185,7 +185,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-            var output = new TagHelperOutput(expectedTagName, expectedAttributes, new HtmlEncoder())
+            var output = new TagHelperOutput(expectedTagName, expectedAttributes)
             {
                 SelfClosing = true,
             };

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ValidationMessageTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ValidationMessageTagHelperTest.cs
@@ -52,8 +52,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 attributes: new Dictionary<string, string>
                 {
                     { "id", "myvalidationmessage" }
-                },
-                htmlEncoder: new HtmlEncoder());
+                });
             output.PreContent.SetContent(expectedPreContent);
             output.Content.SetContent(expectedContent);
             output.PostContent.SetContent(expectedPostContent);
@@ -106,8 +105,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 });
             var output = new TagHelperOutput(
                 "span",
-                attributes: new Dictionary<string, string>(),
-                htmlEncoder: new HtmlEncoder());
+                attributes: new Dictionary<string, string>());
             output.PreContent.SetContent(expectedPreContent);
             output.Content.SetContent(expectedContent);
             output.PostContent.SetContent(expectedPostContent);
@@ -147,8 +145,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             };
             var output = new TagHelperOutput(
                 "span",
-                attributes: new Dictionary<string, string>(),
-                htmlEncoder: new HtmlEncoder());
+                attributes: new Dictionary<string, string>());
             output.Content.SetContent(outputContent);
 
             var context = new TagHelperContext(
@@ -207,8 +204,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             };
             var output = new TagHelperOutput(
                 "span",
-                attributes: new Dictionary<string, string>(),
-                htmlEncoder: new HtmlEncoder());
+                attributes: new Dictionary<string, string>());
 
             var context = new TagHelperContext(
                 allAttributes: new Dictionary<string, object>(),
@@ -263,8 +259,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var expectedPostContent = "original post-content";
             var output = new TagHelperOutput(
                 "span",
-                attributes: new Dictionary<string, string>(),
-                htmlEncoder: new HtmlEncoder());
+                attributes: new Dictionary<string, string>());
             output.PreContent.SetContent(expectedPreContent);
             output.Content.SetContent(expectedContent);
             output.PostContent.SetContent(expectedPostContent);

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ValidationSummaryTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ValidationSummaryTagHelperTest.cs
@@ -58,8 +58,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 attributes: new Dictionary<string, string>
                 {
                     { "class", "form-control" }
-                },
-                htmlEncoder: new HtmlEncoder());
+                });
             output.PreContent.SetContent(expectedPreContent);
             output.Content.SetContent(expectedContent);
             output.PostContent.SetContent("Custom Content");
@@ -103,8 +102,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var expectedPostContent = "original post-content";
             var output = new TagHelperOutput(
                 "div",
-                attributes: new Dictionary<string, string>(),
-                htmlEncoder: new HtmlEncoder());
+                attributes: new Dictionary<string, string>());
             output.PreContent.SetContent(expectedPreContent);
             output.Content.SetContent(expectedContent);
             output.PostContent.SetContent(expectedPostContent);
@@ -146,8 +144,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var expectedContent = "original content";
             var output = new TagHelperOutput(
                 "div",
-                attributes: new Dictionary<string, string>(),
-                htmlEncoder: new HtmlEncoder());
+                attributes: new Dictionary<string, string>());
             output.PreContent.SetContent(expectedPreContent);
             output.Content.SetContent(expectedContent);
             output.PostContent.SetContent("Content of validation summary");
@@ -204,8 +201,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var expectedPostContent = "original post-content";
             var output = new TagHelperOutput(
                 "div",
-                attributes: new Dictionary<string, string>(),
-                htmlEncoder: new HtmlEncoder());
+                attributes: new Dictionary<string, string>());
             output.PreContent.SetContent(expectedPreContent);
             output.Content.SetContent(expectedContent);
             output.PostContent.SetContent(expectedPostContent);
@@ -240,8 +236,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var expectedContent = "original content";
             var output = new TagHelperOutput(
                 "div",
-                attributes: new Dictionary<string, string>(),
-                htmlEncoder: new HtmlEncoder());
+                attributes: new Dictionary<string, string>());
             output.PreContent.SetContent(expectedPreContent);
             output.Content.SetContent(expectedContent);
             output.PostContent.SetContent("Content of validation message");


### PR DESCRIPTION
1. Removed HtmlEncoder dependency for TagHelperOutput.
2. Removed ITextWriterCopyable dependency.
3. Removed Write/WriteTo for TagHelperContent.
4. Added WriteTagHelper/WriteTagHelperTo methods.
5. Updated tests for the same.