### PR TITLE
Correct fallbacks to empty prefix in ModelBinding (#1865 and #2129)

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinders/BodyModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinders/BodyModelBinder.cs
@@ -6,8 +6,6 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc.Core;
-using Microsoft.AspNet.Mvc.ModelBinding;
-using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Mvc.ModelBinding
@@ -57,6 +55,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 var unsupportedContentType = Resources.FormatUnsupportedContentType(
                     bindingContext.OperationBindingContext.HttpContext.Request.ContentType);
                 bindingContext.ModelState.AddModelError(bindingContext.ModelName, unsupportedContentType);
+
+                // This model binder is the only handler for the Body binding source.
+                // Always tell the model binding system to skip other model binders i.e. return non-null.
                 return new ModelBindingResult(model: null, key: bindingContext.ModelName, isModelSet: false);
             }
 
@@ -69,9 +70,13 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             {
                 model = GetDefaultValueForType(bindingContext.ModelType);
                 bindingContext.ModelState.AddModelError(bindingContext.ModelName, ex);
+
+                // This model binder is the only handler for the Body binding source.
+                // Always tell the model binding system to skip other model binders i.e. return non-null.
                 return new ModelBindingResult(model: null, key: bindingContext.ModelName, isModelSet: false);
             }
 
+            // Success
             // key is empty to ensure that the model name is not used as a prefix for validation.
             return new ModelBindingResult(model, key: string.Empty, isModelSet: true);
         }

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinders/ServicesModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinders/ServicesModelBinder.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         {
             var requestServices = bindingContext.OperationBindingContext.HttpContext.RequestServices;
             var model = requestServices.GetRequiredService(bindingContext.ModelType);
-            return Task.FromResult(new ModelBindingResult(model, bindingContext.ModelName, true));
+            return Task.FromResult(new ModelBindingResult(model, bindingContext.ModelName, isModelSet: true));
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/BinderTypeBasedModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/BinderTypeBasedModelBinder.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var requestServices = bindingContext.OperationBindingContext.HttpContext.RequestServices;
             var createFactory = _typeActivatorCache.GetOrAdd(bindingContext.BinderType, _createFactory);
             var instance = createFactory(requestServices, arguments: null);
-            
+
             var modelBinder = instance as IModelBinder;
             if (modelBinder == null)
             {
@@ -54,12 +54,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             var result = await modelBinder.BindModelAsync(bindingContext);
 
-            var modelBindingResult = result != null ? 
+            var modelBindingResult = result != null ?
                 new ModelBindingResult(result.Model, result.Key, result.IsModelSet) :
-                new ModelBindingResult(null, bindingContext.ModelName, false);
+                new ModelBindingResult(model: null, key: bindingContext.ModelName, isModelSet: false);
 
-            // return a non null modelbinding result here, because this binder will handle all cases where the
-            //  model binder is specified by metadata.
+            // A model binder was specified by metadata and this binder handles all such cases.
+            // Always tell the model binding system to skip other model binders i.e. return non-null.
             return modelBindingResult;
         }
     }

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/BindingSourceModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/BindingSourceModelBinder.cs
@@ -59,6 +59,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// <returns>
         /// A <see cref="Task"/> which will complete when model binding has completed.
         /// </returns>
+        /// <remarks>
+        /// Other model binders will never run if this method is called. Return <c>null</c> to skip other model binders
+        /// but allow higher-level handling e.g. falling back to empty prefix.
+        /// </remarks>
         protected abstract Task<ModelBindingResult> BindModelCoreAsync([NotNull] ModelBindingContext bindingContext);
 
         /// <inheritdoc />
@@ -74,13 +78,13 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             var result = await BindModelCoreAsync(context);
 
-            var modelBindingResult = 
-                result != null ? 
+            var modelBindingResult =
+                result != null ?
                     new ModelBindingResult(result.Model, result.Key, result.IsModelSet) :
-                    new ModelBindingResult(null, context.ModelName, false);
+                    new ModelBindingResult(model: null, key: context.ModelName, isModelSet: false);
 
-            // Prevent other model binders from running because this model binder is the only handler for
-            // its binding source.
+            // This model binder is the only handler for its binding source.
+            // Always tell the model binding system to skip other model binders i.e. return non-null.
             return modelBindingResult;
         }
     }

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/ByteArrayModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/ByteArrayModelBinder.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Mvc.ModelBinding.Internal;
 using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Mvc.ModelBinding
@@ -40,13 +39,15 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             try
             {
                 var model = Convert.FromBase64String(value);
-                return new ModelBindingResult(model, bindingContext.ModelName, true);
+                return new ModelBindingResult(model, bindingContext.ModelName, isModelSet: true);
             }
             catch (Exception ex)
             {
                 bindingContext.ModelState.TryAddModelError(bindingContext.ModelName, ex);
             }
 
+            // Matched the type (byte[]) only this binder supports.
+            // Always tell the model binding system to skip other model binders i.e. return non-null.
             return new ModelBindingResult(model: null, key: bindingContext.ModelName, isModelSet: false);
         }
     }

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/CancellationTokenModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/CancellationTokenModelBinder.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             if (bindingContext.ModelType == typeof(CancellationToken))
             {
                 var model = bindingContext.OperationBindingContext.HttpContext.RequestAborted;
-                return Task.FromResult(new ModelBindingResult(model, bindingContext.ModelName, true));
+                return Task.FromResult(new ModelBindingResult(model, bindingContext.ModelName, isModelSet: true));
             }
 
             return Task.FromResult<ModelBindingResult>(null);

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/CollectionModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/CollectionModelBinder.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                     BindComplexCollection(bindingContext);
             var boundCollection = await bindCollectionTask;
             var model = GetModel(boundCollection);
-            return new ModelBindingResult(model, bindingContext.ModelName, true);
+            return new ModelBindingResult(model, bindingContext.ModelName, isModelSet: true);
         }
 
         // Used when the ValueProvider contains the collection to be bound as a single element, e.g. the raw value

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/ComplexModelDtoModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/ComplexModelDtoModelBinder.cs
@@ -15,27 +15,29 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 return null;
             }
 
-            ModelBindingHelper.ValidateBindingContext(bindingContext,
-                                                      typeof(ComplexModelDto),
-                                                      allowNullModel: false);
+            ModelBindingHelper.ValidateBindingContext(bindingContext, typeof(ComplexModelDto), allowNullModel: false);
 
             var dto = (ComplexModelDto)bindingContext.Model;
             foreach (var propertyMetadata in dto.PropertyMetadata)
             {
                 var propertyModelName = ModelBindingHelper.CreatePropertyModelName(
-                        bindingContext.ModelName,
-                        propertyMetadata.BinderModelName ?? propertyMetadata.PropertyName);
+                    bindingContext.ModelName,
+                    propertyMetadata.BinderModelName ?? propertyMetadata.PropertyName);
 
                 var propertyBindingContext = ModelBindingContext.GetChildModelBindingContext(
                     bindingContext,
                     propertyModelName,
                     propertyMetadata);
 
-                // bind and propagate the values
-                // If we can't bind then leave the result missing (don't add a null).
                 var modelBindingResult =
                     await bindingContext.OperationBindingContext.ModelBinder.BindModelAsync(propertyBindingContext);
-                if (modelBindingResult != null)
+                if (modelBindingResult == null)
+                {
+                    // Could not bind. Add a result so MutableObjectModelBinder will check for [DefaultValue].
+                    dto.Results[propertyMetadata] =
+                        new ModelBindingResult(model: null, key: propertyModelName, isModelSet: false);
+                }
+                else
                 {
                     dto.Results[propertyMetadata] = modelBindingResult;
                 }

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/CompositeModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/CompositeModelBinder.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Mvc.ModelBinding
@@ -34,14 +33,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
         public virtual async Task<ModelBindingResult> BindModelAsync([NotNull] ModelBindingContext bindingContext)
         {
-            var newBindingContext = CreateNewBindingContext(bindingContext,
-                                                            bindingContext.ModelName);
-
+            var newBindingContext = CreateNewBindingContext(bindingContext, bindingContext.ModelName);
             var modelBindingResult = await TryBind(newBindingContext);
-            if (modelBindingResult == null && !string.IsNullOrEmpty(bindingContext.ModelName)
-                && bindingContext.FallbackToEmptyPrefix)
+
+            if (modelBindingResult == null &&
+                bindingContext.FallbackToEmptyPrefix &&
+                !string.IsNullOrEmpty(bindingContext.ModelName))
             {
-                // fallback to empty prefix?
+                // Fall back to empty prefix.
                 newBindingContext = CreateNewBindingContext(bindingContext,
                                                             modelName: string.Empty);
                 modelBindingResult = await TryBind(newBindingContext);
@@ -75,13 +74,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                     // {
                     // }
                     //
-                    // In this case, for the model parameter the key would be SimpleType instead of model.SimpleType. 
+                    // In this case, for the model parameter the key would be SimpleType instead of model.SimpleType.
                     // (i.e here the prefix for the model key is empty).
                     // For the id parameter the key would be id.
                     return modelBindingResult;
                 }
             }
 
+            // Fall through to update the ModelBindingResult's key.
             return new ModelBindingResult(
                 modelBindingResult.Model,
                 bindingContext.ModelName,

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/FormCollectionModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/FormCollectionModelBinder.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 model = new FormCollection(new Dictionary<string, string[]>());
             }
 
-            return new ModelBindingResult(model, bindingContext.ModelName, true);
+            return new ModelBindingResult(model, bindingContext.ModelName, isModelSet: true);
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/FormFileModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/FormFileModelBinder.cs
@@ -25,14 +25,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             {
                 var postedFiles = await GetFormFilesAsync(bindingContext);
                 var value = postedFiles.FirstOrDefault();
-                return new ModelBindingResult(value, bindingContext.ModelName, value != null);
+                return new ModelBindingResult(value, bindingContext.ModelName, isModelSet: value != null);
             }
             else if (typeof(IEnumerable<IFormFile>).GetTypeInfo().IsAssignableFrom(
                     bindingContext.ModelType.GetTypeInfo()))
             {
                 var postedFiles = await GetFormFilesAsync(bindingContext);
                 var value = ModelBindingHelper.ConvertValuesToCollectionType(bindingContext.ModelType, postedFiles);
-                return new ModelBindingResult(value, bindingContext.ModelName, value != null);
+                return new ModelBindingResult(value, bindingContext.ModelName, isModelSet: value != null);
             }
 
             return null;

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/GenericModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/GenericModelBinder.cs
@@ -22,10 +22,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
                 var modelBindingResult = result != null ?
                     new ModelBindingResult(result.Model, result.Key, result.IsModelSet) :
-                    new ModelBindingResult(null, bindingContext.ModelName, false);
+                    new ModelBindingResult(model: null, key: bindingContext.ModelName, isModelSet: false);
 
-                // Was able to resolve a binder type, hence we should tell the model binding system to return
-                // true so that none of the other model binders participate.
+                // Were able to resolve a binder type.
+                // Always tell the model binding system to skip other model binders i.e. return non-null.
                 return modelBindingResult;
             }
 

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/HeaderModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/HeaderModelBinder.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 }
             }
 
-            return Task.FromResult(new ModelBindingResult(model, bindingContext.ModelName, model != null));
+            return Task.FromResult(new ModelBindingResult(model, bindingContext.ModelName, isModelSet: model != null));
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/MutableObjectModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/MutableObjectModelBinder.cs
@@ -328,6 +328,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             {
                 var propertyName = property.Name;
                 var propertyMetadata = bindingContext.ModelMetadata.Properties[propertyName];
+                if (propertyMetadata == null)
+                {
+                    // Skip indexer properties and others ModelMetadata ignores.
+                    continue;
+                }
+
                 var requiredValidator = bindingContext.OperationBindingContext
                                                       .ValidatorProvider
                                                       .GetValidators(propertyMetadata)

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/MutableObjectModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/MutableObjectModelBinder.cs
@@ -92,16 +92,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 return true;
             }
 
-            // 3. The model name is not prefixed and a value provider can directly provide a value for the model name.
-            //    The fact that it is not prefixed means that the containsPrefixAsync call checks for the exact
-            //    model name instead of doing a prefix match.
-            if (!bindingContext.ModelName.Contains(".") &&
-                await bindingContext.ValueProvider.ContainsPrefixAsync(bindingContext.ModelName))
-            {
-                return true;
-            }
-
-            // 4. Any of the model properties can be bound using a value provider.
+            // 3. Any of the model properties can be bound using a value provider.
             if (await CanValueBindAnyModelProperties(context))
             {
                 return true;

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/MutableObjectModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/MutableObjectModelBinder.cs
@@ -40,8 +40,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             // post-processing, e.g. property setters and hooking up validation
             ProcessDto(bindingContext, (ComplexModelDto)result.Model);
             return new ModelBindingResult(
-                bindingContext.Model, 
-                bindingContext.ModelName, 
+                bindingContext.Model,
+                bindingContext.ModelName,
                 isModelSet: true);
         }
 
@@ -53,6 +53,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         internal async Task<bool> CanCreateModel(MutableObjectBinderContext context)
         {
             var bindingContext = context.ModelBindingContext;
+
             var isTopLevelObject = bindingContext.ModelMetadata.ContainerType == null;
             var hasExplicitAlias = bindingContext.BinderModelName != null;
 
@@ -117,7 +118,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             // However, because a property might specify a custom binding source ([FromForm]), it's not correct
             // for us to just try bindingContext.ValueProvider.ContainsPrefixAsync(bindingContext.ModelName),
             // because that may include ALL value providers - that would lead us to mistakenly create the model
-            // when the data is coming from a source we should use (ex: value found in query string, but the 
+            // when the data is coming from a source we should use (ex: value found in query string, but the
             // model has [FromForm]).
             //
             // To do this we need to enumerate the properties, and see which of them provide a binding source
@@ -133,7 +134,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             //      If a property does not have a binding source, then it's fair game for any value provider.
             //
             // If any property meets the above conditions and has a value from valueproviders, then we'll
-            // create the model and try to bind it. OR if ALL properties of the model have a greedy source, 
+            // create the model and try to bind it. OR if ALL properties of the model have a greedy source,
             // then we go ahead and create it.
             //
             var isAnyPropertyEnabledForValueProviderBasedBinding = false;

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/MutableObjectModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/MutableObjectModelBinder.cs
@@ -410,7 +410,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 }
             }
 
-            // for each property that was bound, call the setter, recording exceptions as necessary
+            // For each property that ComplexModelDtoModelBinder attempted to bind, call the setter, recording
+            // exceptions as necessary.
             foreach (var entry in dto.Results)
             {
                 var dtoResult = entry.Value;

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/TypeConverterModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/TypeConverterModelBinder.cs
@@ -31,14 +31,16 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             {
                 newModel = valueProviderResult.ConvertTo(bindingContext.ModelType);
                 ModelBindingHelper.ReplaceEmptyStringWithNull(bindingContext.ModelMetadata, ref newModel);
-                return new ModelBindingResult(newModel, bindingContext.ModelName, true);
+                return new ModelBindingResult(newModel, bindingContext.ModelName, isModelSet: true);
             }
             catch (Exception ex)
             {
                 bindingContext.ModelState.TryAddModelError(bindingContext.ModelName, ex);
             }
 
-            return new ModelBindingResult(null, bindingContext.ModelName, false);
+            // Were able to find a converter for the type but conversion failed.
+            // Tell the model binding system to skip other model binders i.e. return non-null.
+            return new ModelBindingResult(model: null, key: bindingContext.ModelName, isModelSet: false);
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/TypeMatchModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/TypeMatchModelBinder.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             bindingContext.ModelState.SetModelValue(bindingContext.ModelName, valueProviderResult);
             var model = valueProviderResult.RawValue;
             ModelBindingHelper.ReplaceEmptyStringWithNull(bindingContext.ModelMetadata, ref model);
-            return new ModelBindingResult(model, bindingContext.ModelName, true);
+            return new ModelBindingResult(model, bindingContext.ModelName, isModelSet: true);
         }
 
         internal static async Task<ValueProviderResult> GetCompatibleValueProviderResult(ModelBindingContext context)

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/ModelBindingResult.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/ModelBindingResult.cs
@@ -23,22 +23,28 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         }
 
         /// <summary>
-        /// Gets or sets the model associated with this context.
+        /// Gets the model associated with this context.
         /// </summary>
         public object Model { get; }
 
         /// <summary>
-        /// Gets or sets the model name which was used to bind the model.
-        /// 
+        /// <para>
+        /// Gets the model name which was used to bind the model.
+        /// </para>
+        /// <para>
         /// This property can be used during validation to add model state for a bound model.
+        /// </para>
         /// </summary>
         public string Key { get; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether or not the <see cref="Model"/> value has been set.
-        /// 
+        /// <para>
+        /// Gets a value indicating whether or not the <see cref="Model"/> value has been set.
+        /// </para>
+        /// <para>
         /// This property can be used to distinguish between a model binder which does not find a value and
         /// the case where a model binder sets the <c>null</c> value.
+        /// </para>
         /// </summary>
         public bool IsModelSet { get; }
     }

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/HttpRequestMessage/HttpRequestMessageModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/HttpRequestMessage/HttpRequestMessageModelBinder.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShim
             if (bindingContext.ModelType == typeof(HttpRequestMessage))
             {
                 var model = bindingContext.OperationBindingContext.HttpContext.GetHttpRequestMessage();
-                return Task.FromResult(new ModelBindingResult(model, bindingContext.ModelName, true));
+                return Task.FromResult(new ModelBindingResult(model, bindingContext.ModelName, isModelSet: true));
             }
 
             return Task.FromResult<ModelBindingResult>(null);

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Binders/CompositeModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Binders/CompositeModelBinderTest.cs
@@ -112,10 +112,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         }
 
         [Fact]
-        public async Task ModelBinder_ReturnsTrue_WithoutSettingValue()
+        public async Task ModelBinder_ReturnsNull_IfBinderMatchesButDoesNotSetModel()
         {
             // Arrange
-
             var bindingContext = new ModelBindingContext
             {
                 FallbackToEmptyPrefix = true,
@@ -135,7 +134,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var modelBinder = new Mock<IModelBinder>();
             modelBinder
                 .Setup(mb => mb.BindModelAsync(It.IsAny<ModelBindingContext>()))
-                .Returns(Task.FromResult(new ModelBindingResult(null, "someName", false)));
+                .Returns(Task.FromResult(new ModelBindingResult(model: null, key: "someName", isModelSet: false)));
 
             var composite = CreateCompositeBinder(modelBinder.Object);
 
@@ -143,10 +142,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await composite.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
-            Assert.False(result.IsModelSet);
-            Assert.Equal("someName", result.Key);
-            Assert.Null(result.Model);
+            Assert.Null(result);
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Binders/KeyValuePairModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Binders/KeyValuePairModelBinderTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
     public class KeyValuePairModelBinderTest
     {
         [Fact]
-        public async Task BindModel_MissingKey_ReturnsTrue_AndAddsModelValidationError()
+        public async Task BindModel_MissingKey_ReturnsResult_AndAddsModelValidationError()
         {
             // Arrange
             var valueProvider = new SimpleHttpValueProvider();
@@ -36,7 +36,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         }
 
         [Fact]
-        public async Task BindModel_MissingValue_ReturnsTrue_AndAddsModelValidationError()
+        public async Task BindModel_MissingValue_ReturnsResult_AndAddsModelValidationError()
         {
             // Arrange
             var valueProvider = new SimpleHttpValueProvider();

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Binders/KeyValuePairModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Binders/KeyValuePairModelBinderTest.cs
@@ -4,7 +4,6 @@
 #if DNX451
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
 using Moq;
@@ -25,11 +24,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var binder = new KeyValuePairModelBinder<int, string>();
 
             // Act
-            var retVal = await binder.BindModelAsync(bindingContext);
+            var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(retVal);
-            Assert.Null(retVal.Model);
+            Assert.NotNull(result);
+            Assert.Null(result.Model);
             Assert.False(bindingContext.ModelState.IsValid);
             Assert.Equal("someName", bindingContext.ModelName);
             var error = Assert.Single(bindingContext.ModelState["someName.Key"].Errors);
@@ -47,11 +46,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var binder = new KeyValuePairModelBinder<int, string>();
 
             // Act
-            var retVal = await binder.BindModelAsync(bindingContext);
+            var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(retVal);
-            Assert.Null(retVal.Model);
+            Assert.NotNull(result);
+            Assert.Null(result.Model);
             Assert.False(bindingContext.ModelState.IsValid);
             Assert.Equal("someName", bindingContext.ModelName);
             Assert.Equal(bindingContext.ModelState["someName.Value"].Errors.First().ErrorMessage, "A value is required.");
@@ -73,10 +72,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var binder = new KeyValuePairModelBinder<int, string>();
 
             // Act
-            var retVal = await binder.BindModelAsync(bindingContext);
+            var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.Null(retVal);
+            Assert.Null(result);
             Assert.True(bindingContext.ModelState.IsValid);
             Assert.Equal(0, bindingContext.ModelState.ErrorCount);
         }
@@ -92,11 +91,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var binder = new KeyValuePairModelBinder<int, string>();
 
             // Act
-            var retVal = await binder.BindModelAsync(bindingContext);
+            var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(retVal);
-            Assert.Equal(new KeyValuePair<int, string>(42, "some-value"), retVal.Model);
+            Assert.NotNull(result);
+            Assert.Equal(new KeyValuePair<int, string>(42, "some-value"), result.Model);
         }
 
         [Fact]
@@ -107,11 +106,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var binder = new KeyValuePairModelBinder<int, string>();
 
             // Act
-            var retVal = await binder.TryBindStrongModel<int>(bindingContext, "key");
+            var result = await binder.TryBindStrongModel<int>(bindingContext, "key");
 
             // Assert
-            Assert.True(retVal.IsModelSet);
-            Assert.Equal(42, retVal.Model);
+            Assert.True(result.IsModelSet);
+            Assert.Equal(42, result.Model);
             Assert.Empty(bindingContext.ModelState);
         }
 
@@ -133,11 +132,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var binder = new KeyValuePairModelBinder<int, string>();
 
             // Act
-            var retVal = await binder.TryBindStrongModel<int>(bindingContext, "key");
+            var result = await binder.TryBindStrongModel<int>(bindingContext, "key");
 
             // Assert
-            Assert.True(retVal.IsModelSet);
-            Assert.Null(retVal.Model);
+            Assert.True(result.IsModelSet);
+            Assert.Null(result.Model);
             Assert.Empty(bindingContext.ModelState);
         }
 

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Binders/MutableObjectModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Binders/MutableObjectModelBinderTest.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Http.Core;
 using Microsoft.AspNet.Testing;
@@ -106,17 +105,15 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         [Fact]
         public async Task CanCreateModel_ReturnsFalse_ForNonTopLevelModel_IfModelIsMarkedWithBinderMetadata()
         {
+            // Get the property metadata so that it is not a top level object.
             var modelMetadata = GetMetadataForType(typeof(Document))
-                                        .Properties
-                                        .First(metadata => metadata.PropertyName == nameof(Document.SubDocument));
+                .Properties
+                .First(metadata => metadata.PropertyName == nameof(Document.SubDocument));
             var bindingContext = new MutableObjectBinderContext
             {
                 ModelBindingContext = new ModelBindingContext
                 {
-                    // Get the property metadata so that it is not a top level object.
-                    ModelMetadata = GetMetadataForType(typeof(Document))
-                                        .Properties
-                                        .First(metadata => metadata.PropertyName == nameof(Document.SubDocument)),
+                    ModelMetadata = modelMetadata,
                     OperationBindingContext = new OperationBindingContext
                     {
                         ValidatorProvider = Mock.Of<IModelValidatorProvider>(),
@@ -381,7 +378,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 .Verifiable();
             testableBinder
                 .Setup(o => o.GetMetadataForProperties(bindingContext))
-                              .Returns(new ModelMetadata[0]);
+                .Returns(new ModelMetadata[0]);
 
             // Act
             var retValue = await testableBinder.Object.BindModelAsync(bindingContext);
@@ -389,8 +386,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             // Assert
             Assert.NotNull(retValue);
             Assert.True(retValue.IsModelSet);
-            Assert.Same(model, retValue.Model);
-            Assert.IsType<Person>(retValue.Model);
+            var returnedPerson = Assert.IsType<Person>(retValue.Model);
+            Assert.Same(model, returnedPerson);
             testableBinder.Verify();
         }
 
@@ -442,8 +439,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             // Assert
             Assert.NotNull(retValue);
             Assert.True(retValue.IsModelSet);
-            Assert.Same(model, retValue.Model);
-            Assert.IsType<Person>(retValue.Model);
+            var returnedPerson = Assert.IsType<Person>(retValue.Model);
+            Assert.Same(model, returnedPerson);
             testableBinder.Verify();
         }
 

--- a/test/WebSites/FiltersWebSite/Controllers/ActionFilterController.cs
+++ b/test/WebSites/FiltersWebSite/Controllers/ActionFilterController.cs
@@ -37,6 +37,7 @@ namespace FiltersWebSite
             {
                 filters = (List<ContentResult>)obj;
             }
+            else
             {
                 filters = new List<ContentResult>();
                 context.ActionArguments.Add("fromGlobalActionFilter", filters);

--- a/test/WebSites/ModelBindingWebSite/Controllers/HomeController.cs
+++ b/test/WebSites/ModelBindingWebSite/Controllers/HomeController.cs
@@ -18,6 +18,18 @@ namespace ModelBindingWebSite.Controllers
             return Content(System.Text.Encoding.UTF8.GetString(byteValues));
         }
 
+        [HttpPost("/integers")]
+        public IActionResult CollectionToJson(int[] model)
+        {
+            return Json(model);
+        }
+
+        [HttpPost("/cities")]
+        public IActionResult PocoCollectionToJson(List<City> model)
+        {
+            return Json(model);
+        }
+
         public object ModelWithTooManyValidationErrors(LargeModelWithValidation model)
         {
             return CreateValidationDictionary();

--- a/test/WebSites/ModelBindingWebSite/Models/LargeModelWithValidation.cs
+++ b/test/WebSites/ModelBindingWebSite/Models/LargeModelWithValidation.cs
@@ -18,5 +18,17 @@ namespace ModelBindingWebSite.Models
 
         [Required]
         public ModelWithValidation Field4 { get; set; }
+
+        [Required]
+        public ModelWithValidation Field5 { get; set; }
+
+        [Required]
+        public ModelWithValidation Field6 { get; set; }
+
+        [Required]
+        public ModelWithValidation Field7 { get; set; }
+
+        [Required]
+        public ModelWithValidation Field8 { get; set; }
     }
 }


### PR DESCRIPTION
this PR is mostly complete but lacks unit and functional tests covering the specific fallback scenarios mentioned in #1865 and #2129.  i.e. I didn't have to update as many tests as I'd hoped.

the first three commits are cleanup I did as I was working out what the model binding system was doing.  might be easier to look at them individually or at least review all the commit descriptions before looking at the files.