### PR TITLE
[Fixes #2190] Remove GetSupportedContentTypes method from IOutputFormatt...

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ActionResults/ObjectResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResults/ObjectResult.cs
@@ -170,12 +170,7 @@ namespace Microsoft.AspNet.Mvc
         {
             foreach (var formatter in formatters)
             {
-                var supportedContentTypes = formatter.GetSupportedContentTypes(
-                                                             formatterContext.DeclaredType,
-                                                             formatterContext.Object?.GetType(),
-                                                             contentType: null);
-
-                if (formatter.CanWriteResult(formatterContext, supportedContentTypes?.FirstOrDefault()))
+                if (formatter.CanWriteResult(formatterContext, contentType: null))
                 {
                     return formatter;
                 }

--- a/src/Microsoft.AspNet.Mvc.Core/Description/DefaultApiDescriptionProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Description/DefaultApiDescriptionProvider.cs
@@ -296,16 +296,24 @@ namespace Microsoft.AspNet.Mvc.Description
             {
                 foreach (var formatter in formatters)
                 {
-                    var supportedTypes = formatter.GetSupportedContentTypes(declaredType, runtimeType, contentType);
-                    if (supportedTypes != null)
+                    var responseFormatMetadataProvider = formatter as IApiResponseFormatMetadataProvider;
+                    if (responseFormatMetadataProvider != null)
                     {
-                        foreach (var supportedType in supportedTypes)
+                        var supportedTypes = responseFormatMetadataProvider.GetSupportedContentTypes(
+                            declaredType, 
+                            runtimeType, 
+                            contentType);
+
+                        if (supportedTypes != null)
                         {
-                            results.Add(new ApiResponseFormat()
+                            foreach (var supportedType in supportedTypes)
                             {
-                                Formatter = formatter,
-                                MediaType = supportedType,
-                            });
+                                results.Add(new ApiResponseFormat()
+                                {
+                                    Formatter = formatter,
+                                    MediaType = supportedType,
+                                });
+                            }
                         }
                     }
                 }

--- a/src/Microsoft.AspNet.Mvc.Core/Description/IApiResponseFormatMetadataProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Description/IApiResponseFormatMetadataProvider.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Net.Http.Headers;
+
+namespace Microsoft.AspNet.Mvc.Description
+{
+    /// <summary>
+    /// Provides metadata information about the response format to an <see cref="IApiDescriptionProvider"/>.
+    /// </summary>
+    /// <remarks>
+    /// An <see cref="IOutputFormatter"/> should implement this interface to expose metadata information
+    /// to an <see cref="IApiDescriptionProvider"/>.
+    /// </remarks>
+    public interface IApiResponseFormatMetadataProvider
+    {
+        /// <summary>
+        /// Gets a filtered list of content types which are supported by the <see cref="IOutputFormatter"/> 
+        /// for the <paramref name="declaredType"/> and <paramref name="contentType"/>.
+        /// </summary>
+        /// <param name="declaredType">The declared type for which the supported content types are desired.</param>
+        /// <param name="runtimeType">The runtime type for which the supported content types are desired.</param>
+        /// <param name="contentType">
+        /// The content type for which the supported content types are desired, or <c>null</c> if any content
+        /// type can be used.
+        /// </param>
+        /// <returns>Content types which are supported by the <see cref="IOutputFormatter"/>.</returns>
+        IReadOnlyList<MediaTypeHeaderValue> GetSupportedContentTypes(
+            Type declaredType,
+            Type runtimeType,
+            MediaTypeHeaderValue contentType);
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/Formatters/HttpNoContentOutputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Formatters/HttpNoContentOutputFormatter.cs
@@ -33,14 +33,6 @@ namespace Microsoft.AspNet.Mvc
             return TreatNullValueAsNoContent && context.Object == null;
         }
 
-        public IReadOnlyList<MediaTypeHeaderValue> GetSupportedContentTypes(
-            Type declaredType,
-            Type runtimeType,
-            MediaTypeHeaderValue contentType)
-        {
-            return null;
-        }
-
         public Task WriteAsync(OutputFormatterContext context)
         {
             var response = context.ActionContext.HttpContext.Response;

--- a/src/Microsoft.AspNet.Mvc.Core/Formatters/HttpNotAcceptableOutputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Formatters/HttpNotAcceptableOutputFormatter.cs
@@ -21,14 +21,6 @@ namespace Microsoft.AspNet.Mvc
         }
 
         /// <inheritdoc />
-        public IReadOnlyList<MediaTypeHeaderValue> GetSupportedContentTypes(Type declaredType,
-                                                                            Type runtimeType,
-                                                                            MediaTypeHeaderValue contentType)
-        {
-            return null;
-        }
-
-        /// <inheritdoc />
         public Task WriteAsync(OutputFormatterContext context)
         {
             var response = context.ActionContext.HttpContext.Response;

--- a/src/Microsoft.AspNet.Mvc.Core/Formatters/IOutputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Formatters/IOutputFormatter.cs
@@ -14,31 +14,6 @@ namespace Microsoft.AspNet.Mvc
     public interface IOutputFormatter
     {
         /// <summary>
-        /// Gets a filtered list of content types which are supported by this formatter
-        /// for the <paramref name="declaredType"/> and <paramref name="contentType"/>.
-        /// </summary>
-        /// <param name="declaredType">The declared type for which the supported content types are desired.</param>
-        /// <param name="runtimeType">The runtime type for which the supported content types are desired.</param>
-        /// <param name="contentType">
-        /// The content type for which the supported content types are desired, or <c>null</c> if any content
-        /// type can be used.
-        /// </param>
-        /// <returns>Content types which are supported by this formatter.</returns>
-        /// <remarks>
-        /// If the value of <paramref name="contentType"/> is <c>null</c>, then the formatter should return a list
-        /// of all content types that it can produce for the given data type. This may occur during content
-        /// negotiation when the HTTP Accept header is not specified, or when no match for the value in the Accept
-        /// header can be found.
-        ///
-        /// If the value of <paramref name="contentType"/> is not <c>null</c>, then the formatter should return
-        /// a list of all content types that it can produce which match the given data type and content type.
-        /// </remarks>
-        IReadOnlyList<MediaTypeHeaderValue> GetSupportedContentTypes(
-            Type declaredType,
-            Type runtimeType,
-            MediaTypeHeaderValue contentType);
-
-        /// <summary>
         /// Determines whether this <see cref="IOutputFormatter"/> can serialize
         /// an object of the specified type.
         /// </summary>

--- a/src/Microsoft.AspNet.Mvc.Core/Formatters/OutputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Formatters/OutputFormatter.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Mvc.Core;
+using Microsoft.AspNet.Mvc.Description;
 using Microsoft.Framework.Internal;
 using Microsoft.Net.Http.Headers;
 
@@ -16,7 +17,7 @@ namespace Microsoft.AspNet.Mvc
     /// <summary>
     /// Writes an object to the output stream.
     /// </summary>
-    public abstract class OutputFormatter : IOutputFormatter
+    public abstract class OutputFormatter : IOutputFormatter, IApiResponseFormatMetadataProvider
     {
         // using a field so we can return it as both IList and IReadOnlyList
         private readonly List<MediaTypeHeaderValue> _supportedMediaTypes;

--- a/src/Microsoft.AspNet.Mvc.Core/Formatters/StreamOutputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Formatters/StreamOutputFormatter.cs
@@ -15,32 +15,6 @@ namespace Microsoft.AspNet.Mvc
     /// </summary>
     public class StreamOutputFormatter : IOutputFormatter
     {
-        /// <summary>
-        /// Echos the <paramref name="contentType"/> if the <paramref name="runtimeType"/> implements 
-        /// <see cref="Stream"/> and <paramref name="contentType"/> is not <c>null</c>.
-        /// </summary>
-        /// <param name="declaredType">The declared type for which the supported content types are desired.</param>
-        /// <param name="runtimeType">The runtime type for which the supported content types are desired.</param>
-        /// <param name="contentType">
-        /// The content type for which the supported content types are desired, or <c>null</c> if any content
-        /// type can be used.
-        /// </param>
-        /// <returns>Content types which are supported by this formatter.</returns>
-        public IReadOnlyList<MediaTypeHeaderValue> GetSupportedContentTypes(
-            Type declaredType,
-            Type runtimeType,
-            MediaTypeHeaderValue contentType)
-        {
-            if (contentType != null &&
-                runtimeType != null &&
-                typeof(Stream).IsAssignableFrom(runtimeType))
-            {
-                return new[] { contentType };
-            }
-
-            return null;
-        }
-
         /// <inheritdoc />
         public bool CanWriteResult([NotNull] OutputFormatterContext context, MediaTypeHeaderValue contentType)
         {

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/Formatters/HttpResponseMessageOutputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/Formatters/HttpResponseMessageOutputFormatter.cs
@@ -18,14 +18,6 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShim
             return context.Object is HttpResponseMessage;
         }
 
-        public IReadOnlyList<MediaTypeHeaderValue> GetSupportedContentTypes(
-            Type declaredType,
-            Type runtimeType,
-            MediaTypeHeaderValue contentType)
-        {
-            return null;
-        }
-
         public async Task WriteAsync(OutputFormatterContext context)
         {
             var response = context.ActionContext.HttpContext.Response;

--- a/test/Microsoft.AspNet.Mvc.Core.Test/OptionDescriptors/OutputFormatterDescriptorTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/OptionDescriptors/OutputFormatterDescriptorTest.cs
@@ -61,13 +61,6 @@ namespace Microsoft.AspNet.Mvc.Core
                 throw new NotImplementedException();
             }
 
-            public IReadOnlyList<MediaTypeHeaderValue> GetSupportedContentTypes(Type declaredType,
-                                                                                Type runtimeType,
-                                                                                MediaTypeHeaderValue contentType)
-            {
-                return null;
-            }
-
             public Task WriteAsync(OutputFormatterContext context)
             {
                 throw new NotImplementedException();


### PR DESCRIPTION
...er and move to a separate metadata interface

@rynowak 