### PR TITLE
React to HtmlElementName rename to TargetElement.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.TagHelpers/AnchorTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/AnchorTagHelper.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     /// <summary>
     /// <see cref="ITagHelper"/> implementation targeting &lt;a&gt; elements.
     /// </summary>
-    [HtmlElementName("a")]
+    [TargetElement("a")]
     public class AnchorTagHelper : TagHelper
     {
         private const string ActionAttributeName = "asp-action";

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/TextAreaTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/TextAreaTagHelper.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     /// <summary>
     /// <see cref="ITagHelper"/> implementation targeting &lt;textarea&gt; elements with an <c>asp-for</c> attribute.
     /// </summary>
-    [HtmlElementName("textarea")]
+    [TargetElement("textarea")]
     public class TextAreaTagHelper : TagHelper
     {
         private const string ForAttributeName = "asp-for";

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationMessageTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationMessageTagHelper.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     /// <see cref="ITagHelper"/> implementation targeting &lt;span&gt; elements with an <c>asp-validation-for</c>
     /// attribute.
     /// </summary>
-    [HtmlElementName("span")]
+    [TargetElement("span")]
     public class ValidationMessageTagHelper : TagHelper
     {
         private const string ValidationForAttributeName = "asp-validation-for";

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationSummaryTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationSummaryTagHelper.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     /// <see cref="ITagHelper"/> implementation targeting &lt;div&gt; elements with an <c>asp-validation-summary</c>
     /// attribute.
     /// </summary>
-    [HtmlElementName("div")]
+    [TargetElement("div")]
     public class ValidationSummaryTagHelper : TagHelper
     {
         private const string ValidationSummaryAttributeName = "asp-validation-summary";

--- a/test/WebSites/ActivatorWebSite/TagHelpers/FooterTagHelper.cs
+++ b/test/WebSites/ActivatorWebSite/TagHelpers/FooterTagHelper.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 
 namespace ActivatorWebSite.TagHelpers
 {
-    [HtmlElementName("body")]
+    [TargetElement("body")]
     public class FooterTagHelper : TagHelper
     {
         [Activate]

--- a/test/WebSites/ActivatorWebSite/TagHelpers/HiddenTagHelper.cs
+++ b/test/WebSites/ActivatorWebSite/TagHelpers/HiddenTagHelper.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 
 namespace ActivatorWebSite.TagHelpers
 {
-    [HtmlElementName("span")]
+    [TargetElement("span")]
     public class HiddenTagHelper : TagHelper
     {
         public string Name { get; set; }

--- a/test/WebSites/ActivatorWebSite/TagHelpers/RepeatContentTagHelper.cs
+++ b/test/WebSites/ActivatorWebSite/TagHelpers/RepeatContentTagHelper.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 
 namespace ActivatorWebSite.TagHelpers
 {
-    [HtmlElementName("div")]
+    [TargetElement("div")]
     public class RepeatContentTagHelper : TagHelper
     {
         public int RepeatContent { get; set; }

--- a/test/WebSites/ActivatorWebSite/TagHelpers/TitleTagHelper.cs
+++ b/test/WebSites/ActivatorWebSite/TagHelpers/TitleTagHelper.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNet.Razor.TagHelpers;
 
 namespace ActivatorWebSite.TagHelpers
 {
-    [HtmlElementName("body")]
+    [TargetElement("body")]
     public class TitleTagHelper : TagHelper
     {
         [Activate]

--- a/test/WebSites/PrecompilationWebSite/TagHelpers/RootViewStartTagHelper.cs
+++ b/test/WebSites/PrecompilationWebSite/TagHelpers/RootViewStartTagHelper.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 
 namespace PrecompilationWebSite.TagHelpers
 {
-    [HtmlElementName("root")]
+    [TargetElement("root")]
     public class RootViewStartTagHelper : TagHelper
     {
         public override void Process(TagHelperContext context, TagHelperOutput output)

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/AutoLinkerTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/AutoLinkerTagHelper.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 
 namespace TagHelpersWebSite.TagHelpers
 {
-    [HtmlElementName("p")]
+    [TargetElement("p")]
     public class AutoLinkerTagHelper : TagHelper
     {
         public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/ConditionTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/ConditionTagHelper.cs
@@ -6,7 +6,9 @@ using Microsoft.AspNet.Razor.TagHelpers;
 
 namespace TagHelpersWebSite.TagHelpers
 {
-    [HtmlElementName("div", "style", "p")]
+    [TargetElement("div")]
+    [TargetElement("style")]
+    [TargetElement("p")]
     public class ConditionTagHelper : TagHelper
     {
         public bool? Condition { get; set; }

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/NestedGlobalImportTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/NestedGlobalImportTagHelper.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNet.Razor.TagHelpers;
 
 namespace TagHelpersWebSite.TagHelpers
 {
-    [HtmlElementName("nested")]
+    [TargetElement("nested")]
     public class NestedGlobalImportTagHelper : TagHelper
     {
         public override void Process(TagHelperContext context, TagHelperOutput output)

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/PrettyTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/PrettyTagHelper.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 
 namespace TagHelpersWebSite.TagHelpers
 {
-    [HtmlElementName("*")]
+    [TargetElement("*")]
     public class PrettyTagHelper : TagHelper
     {
         private static readonly Dictionary<string, string> PrettyTagStyles =

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/RootViewStartTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/RootViewStartTagHelper.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNet.Razor.TagHelpers;
 
 namespace TagHelpersWebSite.TagHelpers
 {
-    [HtmlElementName("root")]
+    [TargetElement("root")]
     public class RootViewStartTagHelper : TagHelper
     {
         public override void Process(TagHelperContext context, TagHelperOutput output)

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/TagCloudViewComponentTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/TagCloudViewComponentTagHelper.cs
@@ -11,7 +11,7 @@ using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 
 namespace MvcSample.Web.Components
 {
-    [HtmlElementName("tag-cloud")]
+    [TargetElement("tag-cloud")]
     [ViewComponent(Name = "Tags")]
     public class TagCloudViewComponentTagHelper : ITagHelper
     {


### PR DESCRIPTION
aspnet/Razor#311

The transition to fully utilizing the `TargetElement`s attribute targeting in our MVC `TagHelper`s is a larger task detailed by https://github.com/aspnet/Mvc/issues/2195. This PR does not change the existing functionality of the MVC `TagHelper`s.

Auto-closing this. 