### PR TITLE
Enabled coreclr for functional tests and reverted back previous change t...

### DIFF
--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/InputObjectValidationTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/InputObjectValidationTests.cs
@@ -44,6 +44,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             }
         }
 
+#if !DNXCORE50
         [Fact]
         public async Task CheckIfObjectIsDeserializedWithoutErrors()
         {
@@ -70,6 +71,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("User has been registerd : " + sampleName,
                 await response.Content.ReadAsStringAsync());
         }
+#endif
 
         [Fact]
         public async Task CheckIfObjectIsDeserialized_WithErrors()

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/SerializableErrorTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/SerializableErrorTests.cs
@@ -21,9 +21,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         private readonly Action<IServiceCollection> _configureServices = new XmlFormattersWebSite.Startup().ConfigureServices;
 
         [Theory]
-#if !DNXCORE50
         [InlineData("application/xml-xmlser")]
-#endif
         [InlineData("application/xml-dcs")]
         public async Task ModelStateErrors_AreSerialized(string acceptHeader)
         {
@@ -46,9 +44,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         }
 
         [Theory]
-#if !DNXCORE50
         [InlineData("application/xml-xmlser")]
-#endif
         [InlineData("application/xml-dcs")]
         public async Task PostedSerializableError_IsBound(string acceptHeader)
         {

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/XmlSerializerFormattersWrappingTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/XmlSerializerFormattersWrappingTest.cs
@@ -178,7 +178,6 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
                 result);
         }
 
-#if !DNXCORE50
         [Fact]
         public async Task CanWrite_IEnumerableOf_SerializableErrors()
         {
@@ -200,6 +199,5 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
                 "<key4>key2-error</key4></SerializableErrorWrapper></ArrayOfSerializableErrorWrapper>",
                 result);
         }
-#endif
     }
 }

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/project.json
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/project.json
@@ -68,6 +68,8 @@
             "dependencies": {
                 "AutofacWebSite": "1.0.0"
             }
+        },
+        "dnxcore50": {
         }
     }
 }


### PR DESCRIPTION
...o skipped tests.

- skipped a new test. This is a known issue that I have reported to the respective team.
- This also fixes #1987 : Investigate xml serializer test failures in Core CLR

@rynowak 