### PR TITLE
Add test to validate tooling path normalization.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor.Host/Directives/ChunkInheritanceUtility.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/Directives/ChunkInheritanceUtility.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNet.Mvc.Razor.Directives
         /// <param name="pagePath">The path of the page to locate inherited chunks for.</param>
         /// <returns>A <see cref="IReadOnlyList{CodeTree}"/> of parsed <c>_GlobalImport</c>
         /// <see cref="CodeTree"/>s.</returns>
-        public IReadOnlyList<CodeTree> GetInheritedCodeTrees([NotNull] string pagePath)
+        public virtual IReadOnlyList<CodeTree> GetInheritedCodeTrees([NotNull] string pagePath)
         {
             var inheritedCodeTrees = new List<CodeTree>();
             var templateEngine = new RazorTemplateEngine(_razorHost);

--- a/src/Microsoft.AspNet.Mvc.Razor.Host/Internal/DesignTimeRazorPathNormalizer.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/Internal/DesignTimeRazorPathNormalizer.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.Framework.Internal;
+
+namespace Microsoft.AspNet.Mvc.Razor.Internal
+{
+    public class DesignTimeRazorPathNormalizer : RazorPathNormalizer
+    {
+        private readonly string _applicationRoot;
+
+        public DesignTimeRazorPathNormalizer([NotNull] string applicationRoot)
+        {
+            _applicationRoot = applicationRoot;
+        }
+
+        public override string NormalizePath([NotNull] string path)
+        {
+            // Need to convert path to application relative (rooted paths are passed in during design time).
+            if (Path.IsPathRooted(path) && path.StartsWith(_applicationRoot, StringComparison.Ordinal))
+            {
+                path = path.Substring(_applicationRoot.Length);
+            }
+
+            return path;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Razor.Host/Internal/RazorPathNormalizer.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/Internal/RazorPathNormalizer.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Framework.Internal;
+
+namespace Microsoft.AspNet.Mvc.Razor.Internal
+{
+    public class RazorPathNormalizer
+    {
+        public virtual string NormalizePath([NotNull] string path)
+        {
+            return path;
+        }
+    }
+}


### PR DESCRIPTION
- Tooling passes in rooted paths when asking for a RazorParser for a file. This was problematic when resolving inherited code trees and ultimately this commit tests that.

#2213