### PR TITLE
Part 1 of a fix for #1712 - ModelBinding and validation should not use

### DIFF
--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/BindingMetadata.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/BindingMetadata.cs
@@ -29,6 +29,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         public Type BinderType { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating if the model is allowed for model binding. Will be ignored
+        /// if the model metadata being created is not a property.
+        /// </summary>
+        public bool CanBeBound { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets a value indicating whether or not the model is read-only. Will be ignored
         /// if the model metadata being created is not a property. If <c>null</c> then
         /// <see cref="ModelMetadata.IsReadOnly"/> will be  computed based on the accessibility

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/DataAnnotationsMetadataProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/DataAnnotationsMetadataProvider.cs
@@ -22,7 +22,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         /// <inheritdoc />
         public void GetBindingMetadata([NotNull] BindingMetadataProviderContext context)
         {
-            context.BindingMetadata.IsRequired = context.Attributes.OfType<RequiredAttribute>().Any();
+            var requiredAttribute = context.Attributes.OfType<RequiredAttribute>().FirstOrDefault();
+            if (requiredAttribute != null)
+            {
+                context.BindingMetadata.IsRequired = true;
+            }
 
             var editableAttribute = context.Attributes.OfType<EditableAttribute>().FirstOrDefault();
             if (editableAttribute != null)

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/DefaultModelMetadata.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/DefaultModelMetadata.cs
@@ -20,7 +20,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
 
         private ReadOnlyDictionary<object, object> _additionalValues;
         private bool? _isReadOnly;
-        private bool? _isRequired;
         private ModelPropertyCollection _properties;
         private ReadOnlyCollection<object> _validatorMetadata;
 
@@ -153,6 +152,15 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
             get
             {
                 return BindingMetadata.BinderType;
+            }
+        }
+
+        /// <inheritdoc />
+        public override bool CanBeBound
+        {
+            get
+            {
+                return BindingMetadata.CanBeBound;
             }
         }
 
@@ -299,19 +307,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         {
             get
             {
-                if (!_isRequired.HasValue)
-                {
-                    if (BindingMetadata.IsRequired.HasValue)
-                    {
-                        _isRequired = BindingMetadata.IsRequired;
-                    }
-                    else
-                    {
-                        _isRequired = !ModelType.AllowsNullValue();
-                    }
-                }
-
-                return _isRequired.Value;
+                return BindingMetadata.IsRequired ?? false;
             }
         }
 

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/ModelMetadata.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/ModelMetadata.cs
@@ -86,6 +86,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         public abstract BindingSource BindingSource { get; }
 
         /// <summary>
+        /// Gets a value indicating whether or not the model value is allowed to be model-bound. This is only
+        /// applicable when the current instance represents a property.
+        /// </summary>
+        public abstract bool CanBeBound { get; }
+
+        /// <summary>
         /// Gets a value indicating whether or not to convert an empty string value to <c>null</c> when
         /// representing a model as text.
         /// </summary>

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Binders/MutableObjectModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Binders/MutableObjectModelBinderTest.cs
@@ -742,15 +742,15 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             };
 
             // Act
-            var validationInfo = MutableObjectModelBinder.GetPropertyValidationInfo(bindingContext);
+            var bindingInfo = MutableObjectModelBinder.GetPropertyBindingInfo(bindingContext);
 
             // Assert
-            Assert.Equal(new[] { "Required" }, validationInfo.RequiredProperties);
-            Assert.Equal(new[] { "Never" }, validationInfo.SkipProperties);
+            Assert.Equal(new[] { "Required" }, bindingInfo.RequiredProperties);
+            Assert.Equal(new[] { "Never" }, bindingInfo.SkipProperties);
         }
 
         [Fact]
-        public void GetPropertyValidationInfo_WithIndexerProperties_Succeeds()
+        public void GetPropertyBindingInfo_WithIndexerProperties_Succeeds()
         {
             // Arrange
             var bindingContext = new ModelBindingContext
@@ -764,11 +764,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             };
 
             // Act
-            var validationInfo = MutableObjectModelBinder.GetPropertyValidationInfo(bindingContext);
+            var bindingInfo = MutableObjectModelBinder.GetPropertyBindingInfo(bindingContext);
 
             // Assert
-            Assert.Equal(Enumerable.Empty<string>(), validationInfo.RequiredProperties);
-            Assert.Equal(Enumerable.Empty<string>(), validationInfo.SkipProperties);
+            Assert.Equal(Enumerable.Empty<string>(), bindingInfo.RequiredProperties);
+            Assert.Equal(Enumerable.Empty<string>(), bindingInfo.SkipProperties);
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/DataMemberBindingMetadataProviderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/DataMemberBindingMetadataProviderTest.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         private class ClassWithDataMemberIsRequiredFalse
         {
             [DataMember(IsRequired = false)]
-            public int TheProperty { get; set; }
+            public string TheProperty { get; set; }
         }
 
         [Fact]
@@ -90,7 +90,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         private class ClassWithDataMemberIsRequiredTrueWithoutDataContract
         {
             [DataMember(IsRequired = true)]
-            public int TheProperty { get; set; }
+            public string TheProperty { get; set; }
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/DefaultBindingMetadataProviderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/DefaultBindingMetadataProviderTest.cs
@@ -147,5 +147,267 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
             // Assert
             Assert.Equal(BindingSource.Body, context.BindingMetadata.BindingSource);
         }
+
+        [Fact]
+        public void GetBindingMetadata_BindingBehavior_Defaults()
+        {
+            // Arrange
+            var key = ModelMetadataIdentity.ForProperty(
+                typeof(string),
+                nameof(BindingBehaviorOnProperties.Defaults),
+                typeof(BindingBehaviorOnProperties));
+
+            var context = new BindingMetadataProviderContext(
+                key,
+                attributes: new object[0]);
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.True(context.BindingMetadata.CanBeBound);
+            Assert.Null(context.BindingMetadata.IsRequired);
+        }
+
+        [Fact]
+        public void GetBindingMetadata_BindingBehaviorRequired()
+        {
+            // Arrange
+            var key = ModelMetadataIdentity.ForProperty(
+                typeof(string),
+                nameof(BindingBehaviorOnProperties.BindingBehaviorRequired),
+                typeof(BindingBehaviorOnProperties));
+
+            var context = new BindingMetadataProviderContext(
+                key,
+                attributes: new object[0]);
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.True(context.BindingMetadata.CanBeBound);
+            Assert.True(context.BindingMetadata.IsRequired);
+        }
+
+        [Fact]
+        public void GetBindingMetadata_BindingBehaviorNever()
+        {
+            // Arrange
+            var key = ModelMetadataIdentity.ForProperty(
+                typeof(string),
+                nameof(BindingBehaviorOnProperties.BindingBehaviorNever),
+                typeof(BindingBehaviorOnProperties));
+
+            var context = new BindingMetadataProviderContext(
+                key,
+                attributes: new object[0]);
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.False(context.BindingMetadata.CanBeBound);
+            Assert.Null(context.BindingMetadata.IsRequired);
+        }
+
+        // BindingBehavior.Optional leaves both settings with their defaults.
+        [Fact]
+        public void GetBindingMetadata_FindsBindingBehavior_Optional()
+        {
+            // Arrange
+            var key = ModelMetadataIdentity.ForProperty(
+                typeof(string),
+                nameof(BindingBehaviorOnProperties.BindingBehaviorOptional),
+                typeof(BindingBehaviorOnProperties));
+
+            var context = new BindingMetadataProviderContext(
+                key,
+                attributes: new object[0]);
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.True(context.BindingMetadata.CanBeBound);
+            Assert.Null(context.BindingMetadata.IsRequired);
+        }
+
+        [Fact]
+        public void GetBindingMetadata_BindRequired()
+        {
+            // Arrange
+            var key = ModelMetadataIdentity.ForProperty(
+                typeof(string),
+                nameof(BindingBehaviorOnProperties.BindRequired),
+                typeof(BindingBehaviorOnProperties));
+
+            var context = new BindingMetadataProviderContext(
+                key,
+                attributes: new object[0]);
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.True(context.BindingMetadata.CanBeBound);
+            Assert.True(context.BindingMetadata.IsRequired);
+        }
+
+        [Fact]
+        public void GetBindingMetadata_BindNever()
+        {
+            // Arrange
+            var key = ModelMetadataIdentity.ForProperty(
+                typeof(string),
+                nameof(BindingBehaviorOnProperties.BindNever),
+                typeof(BindingBehaviorOnProperties));
+
+            var context = new BindingMetadataProviderContext(
+                key,
+                attributes: new object[0]);
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.False(context.BindingMetadata.CanBeBound);
+            Assert.Null(context.BindingMetadata.IsRequired);
+        }
+
+        // We only look at BindingBehaviorAttribute for a model property
+        [Fact]
+        public void GetBindingMetadata_IgnoresBindingBehavior_ForType()
+        {
+            // Arrange
+            var context = new BindingMetadataProviderContext(
+                ModelMetadataIdentity.ForType(typeof(BindingBehaviorFallbackToContainer)),
+                attributes: new object[0]);
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.True(context.BindingMetadata.CanBeBound);
+            Assert.Null(context.BindingMetadata.IsRequired);
+        }
+
+        [Fact]
+        public void GetBindingMetadata_IgnoresAttributesOnModelType()
+        {
+            // Arrange
+            var key = ModelMetadataIdentity.ForProperty(
+                typeof(BindingBehaviorFallbackToContainer),
+                nameof(BindingBehaviorOnProperties.IgnoresModelType),
+                typeof(BindingBehaviorOnProperties));
+
+            var context = new BindingMetadataProviderContext(
+                key,
+                attributes: new object[0]);
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.True(context.BindingMetadata.CanBeBound);
+            Assert.Null(context.BindingMetadata.IsRequired);
+        }
+
+        // BindingBehaviorAttribute is peculiar in that we fallback to the container
+        // type not the model type.
+        [Fact]
+        public void GetBindingMetadata_BindingBehavior_FallbackToContainer()
+        {
+            // Arrange
+            var key = ModelMetadataIdentity.ForProperty(
+                typeof(string),
+                nameof(BindingBehaviorFallbackToContainer.FallbackToContainer),
+                typeof(BindingBehaviorFallbackToContainer));
+
+            var context = new BindingMetadataProviderContext(
+                key,
+                attributes: new object[0]);
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.True(context.BindingMetadata.CanBeBound);
+            Assert.True(context.BindingMetadata.IsRequired);
+        }
+
+        // BindingBehaviorAttribute is peculiar in that we fallback to the container
+        // type not the model type.
+        [Fact]
+        public void GetBindingMetadata_BindingBehavior_Overridden()
+        {
+            // Arrange
+            var key = ModelMetadataIdentity.ForProperty(
+                typeof(string),
+                nameof(BindingBehaviorFallbackToContainer.Overridden),
+                typeof(BindingBehaviorFallbackToContainer));
+
+            var context = new BindingMetadataProviderContext(
+                key,
+                attributes: new object[0]);
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.False(context.BindingMetadata.CanBeBound);
+            Assert.Null(context.BindingMetadata.IsRequired);
+        }
+
+        [BindingBehavior(BindingBehavior.Required)]
+        private class BindingBehaviorFallbackToContainer
+        {
+            public string FallbackToContainer { get; set; }
+
+            [BindingBehavior(BindingBehavior.Never)]
+            public string Overridden { get; set; }
+        }
+
+        private class BindingBehaviorOnProperties
+        {
+            public string Defaults { get; set; }
+
+            [BindingBehavior(BindingBehavior.Never)]
+            public string BindingBehaviorNever { get; set; }
+
+            [BindingBehavior(BindingBehavior.Optional)]
+            public string BindingBehaviorOptional { get; set; }
+
+            [BindingBehavior(BindingBehavior.Required)]
+            public string BindingBehaviorRequired { get; set; }
+
+            [BindNever]
+            public string BindNever { get; set; }
+
+            [BindRequired]
+            public string BindRequired { get; set;}
+
+            public BindingBehaviorFallbackToContainer IgnoresModelType { get; set; }
+        }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/DefaultModelMetadataTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/DefaultModelMetadataTest.cs
@@ -33,6 +33,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
             Assert.Empty(metadata.AdditionalValues);
             Assert.Equal(typeof(string), metadata.ModelType);
 
+            Assert.True(metadata.CanBeBound);
             Assert.True(metadata.ConvertEmptyStringToNull);
             Assert.False(metadata.HasNonDefaultEditFormat);
             Assert.False(metadata.HideSurroundingHtml);
@@ -128,49 +129,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
             Assert.Equal(typeof(string), metadata.ModelType);
             Assert.Equal("input", metadata.PropertyName);
             Assert.Null(metadata.ContainerType);
-        }
-
-        [Theory]
-        [InlineData(typeof(string))]
-        [InlineData(typeof(IDisposable))]
-        [InlineData(typeof(Nullable<int>))]
-        public void IsRequired_ReturnsFalse_ForNullableTypes(Type modelType)
-        {
-            // Arrange
-            var provider = new EmptyModelMetadataProvider();
-            var detailsProvider = new EmptyCompositeMetadataDetailsProvider();
-
-            var key = ModelMetadataIdentity.ForType(modelType);
-            var cache = new DefaultMetadataDetailsCache(key, new object[0]);
-
-            var metadata = new DefaultModelMetadata(provider, detailsProvider, cache);
-
-            // Act
-            var isRequired = metadata.IsRequired;
-
-            // Assert
-            Assert.False(isRequired);
-        }
-
-        [Theory]
-        [InlineData(typeof(int))]
-        [InlineData(typeof(DayOfWeek))]
-        public void IsRequired_ReturnsTrue_ForNonNullableTypes(Type modelType)
-        {
-            // Arrange
-            var provider = new EmptyModelMetadataProvider();
-            var detailsProvider = new EmptyCompositeMetadataDetailsProvider();
-
-            var key = ModelMetadataIdentity.ForType(modelType);
-            var cache = new DefaultMetadataDetailsCache(key, new object[0]);
-
-            var metadata = new DefaultModelMetadata(provider, detailsProvider, cache);
-
-            // Act
-            var isRequired = metadata.IsRequired;
-
-            // Assert
-            Assert.True(isRequired);
         }
 
 #if !DNXCORE50

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/ModelMetadataTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/ModelMetadataTest.cs
@@ -216,6 +216,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 }
             }
 
+            public override bool CanBeBound
+            {
+                get
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
             public override bool ConvertEmptyStringToNull
             {
                 get


### PR DESCRIPTION
reflection.

This change moves the logic to process BindingBehaviorAttribute into the
model metadata system, and exposes it via that CanBeBound and IsRequired
properties.

This removes the need in the MutableObjectModelBinder to reflect over
properties and look at for this attribute.