### PR TITLE
ModelMetadataIdentity cleanup

### DIFF
--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/DefaultModelMetadataProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/DefaultModelMetadataProvider.cs
@@ -167,10 +167,52 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
 
         private class TypeCache : ConcurrentDictionary<ModelMetadataIdentity, DefaultMetadataDetailsCache>
         {
+            public TypeCache()
+                : base(ModelMetadataIdentityComparer.Instance)
+            {
+            }
         }
 
         private class PropertiesCache : ConcurrentDictionary<ModelMetadataIdentity, DefaultMetadataDetailsCache[]>
         {
+            public PropertiesCache()
+                : base(ModelMetadataIdentityComparer.Instance)
+            {
+            }
+        }
+
+        private class ModelMetadataIdentityComparer : IEqualityComparer<ModelMetadataIdentity>
+        {
+            public static readonly ModelMetadataIdentityComparer Instance = new ModelMetadataIdentityComparer();
+
+            public bool Equals(ModelMetadataIdentity x, ModelMetadataIdentity y)
+            {
+                return
+                    x.ContainerType == y.ContainerType &&
+                    x.ModelType == y.ModelType &&
+                    x.Name == y.Name;
+            }
+
+            public int GetHashCode(ModelMetadataIdentity obj)
+            {
+                unchecked
+                {
+                    var hash = 17;
+                    hash = hash * 23 + obj.ModelType.GetHashCode();
+
+                    if (obj.ContainerType != null)
+                    {
+                        hash = hash * 23 + obj.ContainerType.GetHashCode();
+                    }
+
+                    if (obj.Name != null)
+                    {
+                        hash = hash * 23 + obj.Name.GetHashCode();
+                    }
+
+                    return hash;
+                }
+            }
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/ModelMetadataIdentity.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/ModelMetadataIdentity.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Reflection;
 using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
@@ -22,21 +21,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
             return new ModelMetadataIdentity()
             {
                 ModelType = modelType,
-            };
-        }
-
-        /// <summary>
-        /// Creates a <see cref="ModelMetadataIdentity"/> for the provided <see cref="ParameterInfo"/>.
-        /// </summary>
-        /// <param name="parameterInfo">The model parameter.</param>
-        /// <returns>A <see cref="ModelMetadataIdentity"/>.</returns>
-        public static ModelMetadataIdentity ForParameter([NotNull] ParameterInfo parameterInfo)
-        {
-            return new ModelMetadataIdentity()
-            {
-                ParameterInfo = parameterInfo,
-                Name = parameterInfo.Name,
-                ModelType = parameterInfo.ParameterType,
             };
         }
 
@@ -70,12 +54,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         /// instance, or <c>null</c> if the current instance does not represent a property.
         /// </summary>
         public Type ContainerType { get; private set; }
-
-        /// <summary>
-        /// Gets the <see cref="ParameterInfo"/> represented by the current instance, or <c>null</c>
-        /// if the current instance does not represent a parameter.
-        /// </summary>
-        public ParameterInfo ParameterInfo { get; private set; }
 
         /// <summary>
         /// Gets the <see cref="Type"/> represented by the current instance.

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/DefaultModelMetadataTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/DefaultModelMetadataTest.cs
@@ -106,30 +106,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
             Assert.Equal(typeof(Exception), metadata.ContainerType);
         }
 
-        [Fact]
-        public void CreateMetadataForParameter()
-        {
-            // Arrange
-            var provider = new EmptyModelMetadataProvider();
-            var detailsProvider = new EmptyCompositeMetadataDetailsProvider();
-
-            var methodInfo = GetType().GetMethod(
-                "ActionMethod",
-                BindingFlags.Instance | BindingFlags.NonPublic);
-
-            var parameterInfo = methodInfo.GetParameters().Where(p => p.Name == "input").Single();
-
-            var key = ModelMetadataIdentity.ForParameter(parameterInfo);
-            var cache = new DefaultMetadataDetailsCache(key, new object[0]);
-
-            // Act
-            var metadata = new DefaultModelMetadata(provider, detailsProvider, cache);
-
-            Assert.Equal(typeof(string), metadata.ModelType);
-            Assert.Equal("input", metadata.PropertyName);
-            Assert.Null(metadata.ContainerType);
-        }
-
         [Theory]
         [InlineData(typeof(string))]
         [InlineData(typeof(IDisposable))]


### PR DESCRIPTION
Adding Equals and GetHashCode implementations - the lack of these results
in a lot of boxing.

Removing dead code, not possible to create a model metadata for a
parameter anymore.