### PR TITLE
Quick fix: Correct invalid HTML in some of our tag helper-related views

### DIFF
--- a/samples/TagHelperSample.Web/Views/Home/Create.cshtml
+++ b/samples/TagHelperSample.Web/Views/Home/Create.cshtml
@@ -31,14 +31,14 @@
 
         <div class="form-group">
             @* no special-case for the "asp-for" attribute; now distinct from HTML "for" attribute. *@
-            <label asp-for="Name" class="control-label col-md-2" style="color:blue" />
+            <label asp-for="Name" class="control-label col-md-2" style="color:blue"></label>
             <div class="col-md-10">
                 <input type="text" asp-for="Name" style="color:blue" />
-                <span asp-validation-for="Name" style="color:blue" />
+                <span asp-validation-for="Name" style="color:blue"></span>
             </div>
         </div>
         <div class="form-group">
-            <label asp-for="DateOfBirth" class="control-label col-md-2" />
+            <label asp-for="DateOfBirth" class="control-label col-md-2"></label>
             <div class="col-md-10">
                 @* will automatically infer type="date" (reused HTML attribute) and asp-format="{0:yyyy-MM-dd}" (optional bound attribute) *@
                 <input asp-for="DateOfBirth" />
@@ -46,7 +46,7 @@
             </div>
         </div>
         <div class="form-group">
-            <label asp-for="YearsEmployeed" class="control-label col-md-2" />
+            <label asp-for="YearsEmployeed" class="control-label col-md-2"></label>
             <div class="col-md-10">
                 @* <select/> items render after static options *@
                 @{ var @object = "multiple"; }
@@ -69,14 +69,14 @@
 
                 @* targets only <span/> in Beta; does not support equivalent of Html.ValidationMessageFor()'s tag parameter *@
                 @* - may eventually either support additional tags e.g. <p/> and <div/> or all tags /> *@
-                <span asp-validation-for="YearsEmployeed" />
+                <span asp-validation-for="YearsEmployeed"></span>
             </div>
         </div>
         <div class="form-group">
-            <label asp-for="Blurb" class="control-label col-md-2" />
+            <label asp-for="Blurb" class="control-label col-md-2"></label>
             <div class="col-md-10">
                 <textarea rows="4" asp-for="Blurb"></textarea>
-                <span asp-validation-for="Blurb" />
+                <span asp-validation-for="Blurb"></span>
             </div>
         </div>
 

--- a/samples/TagHelperSample.Web/Views/Home/Edit.cshtml
+++ b/samples/TagHelperSample.Web/Views/Home/Edit.cshtml
@@ -6,25 +6,25 @@
 
 <form>
     <div class="form-horizontal">
-        <div asp-validation-summary="ValidationSummary.All" />
+        <div asp-validation-summary="ValidationSummary.All"></div>
         <input type="hidden" asp-for="Id" />
 
         <div class="form-group">
-            <label asp-for="Name" class="control-label col-md-2" />
+            <label asp-for="Name" class="control-label col-md-2"></label>
             <div class="col-md-10">
                 <input type="text" asp-for="Name" />
-                <span validation-for="Name" />
+                <span validation-for="Name"></span>
             </div>
         </div>
         <div class="form-group">
-            <label asp-for="DateOfBirth" class="control-label col-md-2" />
+            <label asp-for="DateOfBirth" class="control-label col-md-2"></label>
             <div class="col-md-10">
                 <input type="date" asp-for="DateOfBirth" asp-format="{0:yyyy-MM-dd}" />
-                <span asp-validation-for="DateOfBirth" />
+                <span asp-validation-for="DateOfBirth"></span>
             </div>
         </div>
         <div class="form-group">
-            <label asp-for="YearsEmployeed" class="control-label col-md-2" />
+            <label asp-for="YearsEmployeed" class="control-label col-md-2"></label>
             <div class="col-md-10">
                 <select asp-for="YearsEmployeed" asp-items="(IEnumerable<SelectListItem>)ViewBag.Items" size="2" class="form-control">
                     <optgroup label="Newby">
@@ -37,14 +37,14 @@
                     <option value="5">5</option>
                     <option value="6">6</option>
                 </select>
-                <span asp-validation-for="YearsEmployeed" />
+                <span asp-validation-for="YearsEmployeed"></span>
             </div>
         </div>
         <div class="form-group">
-            <label asp-for="Blurb" class="control-label col-md-2" />
+            <label asp-for="Blurb" class="control-label col-md-2"></label>
             <div class="col-md-10">
                 <textarea rows="4" asp-for="Blurb"></textarea>
-                <span asp-validation-for="Blurb" />
+                <span asp-validation-for="Blurb"></span>
             </div>
         </div>
 

--- a/samples/TagHelperSample.Web/Views/Home/Index.cshtml
+++ b/samples/TagHelperSample.Web/Views/Home/Index.cshtml
@@ -30,20 +30,20 @@
         @for (var index = 0; index < Model.Count(); ++index)
         {
             <div class="form-group">
-                <label asp-for="@Model[index].Name" />
+                <label asp-for="@Model[index].Name"></label>
                 <input type="text" asp-for="@Model[index].Name" disabled="disabled" readonly="readonly" />
             </div>
             <div class="form-group">
-                <label asp-for="@Model[index].DateOfBirth" />
+                <label asp-for="@Model[index].DateOfBirth"></label>
                 <input type="date" asp-for="@Model[index].DateOfBirth" asp-format="{0:yyyy-MM-dd}" disabled="disabled" readonly="readonly" />
             </div>
             <div class="form-group">
-                <label asp-for="@Model[index].YearsEmployeed" />
+                <label asp-for="@Model[index].YearsEmployeed"></label>
                 <input type="number" asp-for="@Model[index].YearsEmployeed" disabled="disabled" readonly="readonly" />
             </div>
             <div class="form-group">
-                <label asp-for="@Model[index].Blurb" />
-                <textarea rows="4" asp-for="@Model[index].Blurb" disabled="disabled" readonly="readonly" />
+                <label asp-for="@Model[index].Blurb"></label>
+                <textarea rows="4" asp-for="@Model[index].Blurb" disabled="disabled" readonly="readonly"></textarea>
             </div>
 
             <p>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Customer.Index.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Customer.Index.html
@@ -38,7 +38,7 @@
 </ul></div>
         <div class="order validation-summary-errors"><ul><li style="display:none"></li>
 </ul></div>
-        <input type="submit"></input>
+        <input type="submit"/>
     <input name="__RequestVerificationToken" type="hidden" value="{0}" /></form>
 </body>
 </html>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Customer.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Customer.html
@@ -36,7 +36,7 @@
         <div class="order validation-summary-valid" data-valmsg-summary="true"><ul><li style="display:none"></li>
 </ul></div>
         <div class="order"></div>
-        <input type="submit"></input>
+        <input type="submit"/>
     <input name="__RequestVerificationToken" type="hidden" value="{0}" /></form>
 </body>
 </html>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.OrderUsingHtmlHelpers.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/Compiler/Resources/MvcTagHelpersWebSite.MvcTagHelper_Home.OrderUsingHtmlHelpers.html
@@ -78,7 +78,7 @@
         <div class="validation-summary-valid order" data-valmsg-summary="true"><ul><li style="display:none"></li>
 </ul></div>
         <input id="Customer_Key" name="Customer.Key" type="hidden" value="KeyA" />
-        <input type="submit"></input>
+        <input type="submit"/>
     <input name="__RequestVerificationToken" type="hidden" value="{0}" /></form>
 </body>
 </html>

--- a/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/OrderUsingHtmlHelpers.cshtml
+++ b/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/OrderUsingHtmlHelpers.cshtml
@@ -74,7 +74,7 @@ Html.BeginForm(actionName: "Submit", controllerName: "MvcTagHelper_Order"))
         </div><text>
         </text>@Html.ValidationSummary(message: null, htmlAttributes: new { @class = "order" })<text>
         </text>@Html.HiddenFor(m => m.Customer.Key)<text></text>
-        <input type="submit"></input><text>
+        <input type="submit"/><text>
     </text>@Html.AntiForgeryToken();
     }@**@
 </body>

--- a/test/WebSites/MvcTagHelpersWebSite/Views/Shared/Customer.cshtml
+++ b/test/WebSites/MvcTagHelpersWebSite/Views/Shared/Customer.cshtml
@@ -40,7 +40,7 @@
         </div>
         <div asp-validation-summary="ValidationSummary.All" class="order"></div>
         <div asp-validation-summary="ValidationSummary.ModelOnly" class="order"></div>
-        <input type="submit"></input>
+        <input type="submit"/>
     </form>
 </body>
 </html>


### PR DESCRIPTION
- few end tags for void elements e.g. `</input>`
- fair number of self-closing flow elements e.g. `<label .../>`
- most-visible change is correction of `<textarea>` in tag helper sample
- no product code changes