### PR TITLE
Quick fixes: Clean up test code

### DIFF
--- a/src/Microsoft.AspNet.Mvc/RazorPreCompileModule.cs
+++ b/src/Microsoft.AspNet.Mvc/RazorPreCompileModule.cs
@@ -77,7 +77,6 @@ namespace Microsoft.AspNet.Mvc
         {
         }
 
-        // REVIEW: Welcome back to life delegating SP!!!
         private class WrappingServiceProvider : IServiceProvider
         {
             private readonly IServiceProvider _fallback;

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/TestHelper.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/TestHelper.cs
@@ -28,13 +28,40 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             string applicationWebSiteName,
             string applicationPath)
         {
-            return CreateServer(builder, applicationWebSiteName, applicationPath, configureServices: null);
+            return CreateServer(
+                builder,
+                applicationWebSiteName,
+                applicationPath,
+                configureServices: (Action<IServiceCollection>)null);
         }
 
         public static TestServer CreateServer(
             Action<IApplicationBuilder> builder,
             string applicationWebSiteName,
             Action<IServiceCollection> configureServices)
+        {
+            return CreateServer(
+                builder,
+                applicationWebSiteName,
+                applicationPath: null,
+                configureServices: configureServices);
+        }
+
+        public static TestServer CreateServer(
+            Action<IApplicationBuilder> builder,
+            string applicationWebSiteName,
+            string applicationPath,
+            Action<IServiceCollection> configureServices)
+        {
+            return TestServer.Create(
+                builder,
+                services => AddTestServices(services, applicationWebSiteName, applicationPath, configureServices));
+        }
+
+        public static TestServer CreateServer(
+            Action<IApplicationBuilder> builder,
+            string applicationWebSiteName,
+            Func<IServiceCollection, IServiceProvider> configureServices)
         {
             return CreateServer(
                 builder,
@@ -57,32 +84,6 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
                     AddTestServices(services, applicationWebSiteName, applicationPath, configureServices: null);
                     return (configureServices != null) ? configureServices(services) : services.BuildServiceProvider();
                 });
-        }
-
-        public static TestServer CreateServer(
-            Action<IApplicationBuilder> builder,
-            string applicationWebSiteName,
-            Func<IServiceCollection, IServiceProvider> configureServices)
-        {
-            return TestServer.Create(
-                CallContextServiceLocator.Locator.ServiceProvider,
-                builder,
-                services =>
-                {
-                    AddTestServices(services, applicationWebSiteName, applicationPath: null, configureServices: null);
-                    return configureServices(services);
-                });
-        }
-
-        public static TestServer CreateServer(
-            Action<IApplicationBuilder> builder,
-            string applicationWebSiteName,
-            string applicationPath,
-            Action<IServiceCollection> configureServices)
-        {
-            return TestServer.Create(
-                builder,
-                services => AddTestServices(services, applicationWebSiteName, applicationPath, configureServices));
         }
 
         private static void AddTestServices(

--- a/test/Microsoft.AspNet.Mvc.Test/MvcServiceCollectionExtensionsTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Test/MvcServiceCollectionExtensionsTest.cs
@@ -52,12 +52,10 @@ namespace Microsoft.AspNet.Mvc
             // Arrange
             var collection = new ServiceCollection();
             var assemblies = new[] { GetType().Assembly };
-            var configuration = new Configuration();
             var controllerTypes = new[] { typeof(ControllerTypeA), typeof(TypeBController) };
 
             // Act
-            MvcServiceCollectionExtensions.WithControllersAsServices(collection,
-                                                                     assemblies);
+            MvcServiceCollectionExtensions.WithControllersAsServices(collection, assemblies);
 
             // Assert
             var services = collection.ToList();

--- a/test/WebSites/ActionConstraintsWebSite/Startup.cs
+++ b/test/WebSites/ActionConstraintsWebSite/Startup.cs
@@ -21,7 +21,7 @@ namespace ActionConstraintsWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseErrorReporter();
 

--- a/test/WebSites/ActionConstraintsWebSite/Startup.cs
+++ b/test/WebSites/ActionConstraintsWebSite/Startup.cs
@@ -21,7 +21,7 @@ namespace ActionConstraintsWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseErrorReporter();
 

--- a/test/WebSites/ActionResultsWebSite/Startup.cs
+++ b/test/WebSites/ActionResultsWebSite/Startup.cs
@@ -23,7 +23,7 @@ namespace ActionResultsWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/ActionResultsWebSite/Startup.cs
+++ b/test/WebSites/ActionResultsWebSite/Startup.cs
@@ -23,7 +23,7 @@ namespace ActionResultsWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/ActivatorWebSite/Startup.cs
+++ b/test/WebSites/ActivatorWebSite/Startup.cs
@@ -19,7 +19,7 @@ namespace ActivatorWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             // Used to report exceptions that MVC doesn't handle
             app.UseErrorReporter();

--- a/test/WebSites/ActivatorWebSite/Startup.cs
+++ b/test/WebSites/ActivatorWebSite/Startup.cs
@@ -19,7 +19,7 @@ namespace ActivatorWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             // Used to report exceptions that MVC doesn't handle
             app.UseErrorReporter();

--- a/test/WebSites/AddServicesWebSite/Startup.cs
+++ b/test/WebSites/AddServicesWebSite/Startup.cs
@@ -9,7 +9,7 @@ namespace AddServicesWebSite
     {
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             // Not calling AddMvc() here.
             // The purpose of the Website is to demonstrate that it throws

--- a/test/WebSites/AddServicesWebSite/Startup.cs
+++ b/test/WebSites/AddServicesWebSite/Startup.cs
@@ -9,7 +9,7 @@ namespace AddServicesWebSite
     {
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             // Not calling AddMvc() here.
             // The purpose of the Website is to demonstrate that it throws

--- a/test/WebSites/AntiForgeryWebSite/Startup.cs
+++ b/test/WebSites/AntiForgeryWebSite/Startup.cs
@@ -16,7 +16,7 @@ namespace AntiForgeryWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseErrorReporter();
 

--- a/test/WebSites/AntiForgeryWebSite/Startup.cs
+++ b/test/WebSites/AntiForgeryWebSite/Startup.cs
@@ -16,7 +16,7 @@ namespace AntiForgeryWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseErrorReporter();
 

--- a/test/WebSites/ApiExplorerWebSite/Startup.cs
+++ b/test/WebSites/ApiExplorerWebSite/Startup.cs
@@ -33,7 +33,7 @@ namespace ApiExplorerWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/ApiExplorerWebSite/Startup.cs
+++ b/test/WebSites/ApiExplorerWebSite/Startup.cs
@@ -33,7 +33,7 @@ namespace ApiExplorerWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/ApplicationModelWebSite/Startup.cs
+++ b/test/WebSites/ApplicationModelWebSite/Startup.cs
@@ -24,7 +24,7 @@ namespace ApplicationModelWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/ApplicationModelWebSite/Startup.cs
+++ b/test/WebSites/ApplicationModelWebSite/Startup.cs
@@ -24,7 +24,7 @@ namespace ApplicationModelWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/AutofacWebSite/Startup.cs
+++ b/test/WebSites/AutofacWebSite/Startup.cs
@@ -28,7 +28,7 @@ namespace AutofacWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/AutofacWebSite/Startup.cs
+++ b/test/WebSites/AutofacWebSite/Startup.cs
@@ -28,7 +28,7 @@ namespace AutofacWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/BasicWebSite/Startup.cs
+++ b/test/WebSites/BasicWebSite/Startup.cs
@@ -26,7 +26,7 @@ namespace BasicWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             // Add MVC to the request pipeline
             app.UseMvc(routes =>

--- a/test/WebSites/BasicWebSite/Startup.cs
+++ b/test/WebSites/BasicWebSite/Startup.cs
@@ -26,7 +26,7 @@ namespace BasicWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             // Add MVC to the request pipeline
             app.UseMvc(routes =>

--- a/test/WebSites/BestEffortLinkGenerationWebSite/Startup.cs
+++ b/test/WebSites/BestEffortLinkGenerationWebSite/Startup.cs
@@ -22,7 +22,7 @@ namespace BestEffortLinkGenerationWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/BestEffortLinkGenerationWebSite/Startup.cs
+++ b/test/WebSites/BestEffortLinkGenerationWebSite/Startup.cs
@@ -22,7 +22,7 @@ namespace BestEffortLinkGenerationWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/CompositeViewEngineWebSite/Startup.cs
+++ b/test/WebSites/CompositeViewEngineWebSite/Startup.cs
@@ -22,7 +22,7 @@ namespace CompositeViewEngineWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             // Add MVC to the request pipeline
             app.UseMvc(routes =>

--- a/test/WebSites/CompositeViewEngineWebSite/Startup.cs
+++ b/test/WebSites/CompositeViewEngineWebSite/Startup.cs
@@ -22,7 +22,7 @@ namespace CompositeViewEngineWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             // Add MVC to the request pipeline
             app.UseMvc(routes =>

--- a/test/WebSites/ContentNegotiationWebSite/Startup.cs
+++ b/test/WebSites/ContentNegotiationWebSite/Startup.cs
@@ -22,7 +22,7 @@ namespace ContentNegotiationWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseErrorReporter();
 

--- a/test/WebSites/ContentNegotiationWebSite/Startup.cs
+++ b/test/WebSites/ContentNegotiationWebSite/Startup.cs
@@ -22,7 +22,7 @@ namespace ContentNegotiationWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseErrorReporter();
 

--- a/test/WebSites/ControllerDiscoveryConventionsWebSite/Startup.cs
+++ b/test/WebSites/ControllerDiscoveryConventionsWebSite/Startup.cs
@@ -16,7 +16,7 @@ namespace ControllerDiscoveryConventionsWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/ControllerDiscoveryConventionsWebSite/Startup.cs
+++ b/test/WebSites/ControllerDiscoveryConventionsWebSite/Startup.cs
@@ -16,7 +16,7 @@ namespace ControllerDiscoveryConventionsWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/ControllersFromServicesWebSite/Startup.cs
+++ b/test/WebSites/ControllersFromServicesWebSite/Startup.cs
@@ -46,7 +46,7 @@ namespace ControllersFromServicesWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/ControllersFromServicesWebSite/Startup.cs
+++ b/test/WebSites/ControllersFromServicesWebSite/Startup.cs
@@ -46,7 +46,7 @@ namespace ControllersFromServicesWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/CorsMiddlewareWebSite/Startup.cs
+++ b/test/WebSites/CorsMiddlewareWebSite/Startup.cs
@@ -15,7 +15,7 @@ namespace CorsMiddlewareWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseCors(policy => policy.WithOrigins("http://example.com"));
             app.UseMvc();

--- a/test/WebSites/CorsMiddlewareWebSite/Startup.cs
+++ b/test/WebSites/CorsMiddlewareWebSite/Startup.cs
@@ -15,7 +15,7 @@ namespace CorsMiddlewareWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseCors(policy => policy.WithOrigins("http://example.com"));
             app.UseMvc();

--- a/test/WebSites/CorsWebSite/Startup.cs
+++ b/test/WebSites/CorsWebSite/Startup.cs
@@ -51,7 +51,7 @@ namespace CorsWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseMvc();
         }

--- a/test/WebSites/CorsWebSite/Startup.cs
+++ b/test/WebSites/CorsWebSite/Startup.cs
@@ -51,7 +51,7 @@ namespace CorsWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseMvc();
         }

--- a/test/WebSites/CustomRouteWebSite/Startup.cs
+++ b/test/WebSites/CustomRouteWebSite/Startup.cs
@@ -16,7 +16,7 @@ namespace CustomRouteWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/CustomRouteWebSite/Startup.cs
+++ b/test/WebSites/CustomRouteWebSite/Startup.cs
@@ -16,7 +16,7 @@ namespace CustomRouteWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/ErrorPageMiddlewareWebSite/Startup.cs
+++ b/test/WebSites/ErrorPageMiddlewareWebSite/Startup.cs
@@ -16,7 +16,7 @@ namespace ErrorPageMiddlewareWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseErrorPage();
             app.UseMvc();

--- a/test/WebSites/ErrorPageMiddlewareWebSite/Startup.cs
+++ b/test/WebSites/ErrorPageMiddlewareWebSite/Startup.cs
@@ -16,7 +16,7 @@ namespace ErrorPageMiddlewareWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseErrorPage();
             app.UseMvc();

--- a/test/WebSites/FilesWebSite/Startup.cs
+++ b/test/WebSites/FilesWebSite/Startup.cs
@@ -16,7 +16,7 @@ namespace FilesWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseMiddleware<SendFileMiddleware>();
 

--- a/test/WebSites/FilesWebSite/Startup.cs
+++ b/test/WebSites/FilesWebSite/Startup.cs
@@ -16,7 +16,7 @@ namespace FilesWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseMiddleware<SendFileMiddleware>();
 

--- a/test/WebSites/FiltersWebSite/Startup.cs
+++ b/test/WebSites/FiltersWebSite/Startup.cs
@@ -54,7 +54,7 @@ namespace FiltersWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseErrorReporter();
 

--- a/test/WebSites/FiltersWebSite/Startup.cs
+++ b/test/WebSites/FiltersWebSite/Startup.cs
@@ -54,7 +54,7 @@ namespace FiltersWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseErrorReporter();
 

--- a/test/WebSites/FormatFilterWebSite/Startup.cs
+++ b/test/WebSites/FormatFilterWebSite/Startup.cs
@@ -32,7 +32,7 @@ namespace FormatFilterWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/FormatFilterWebSite/Startup.cs
+++ b/test/WebSites/FormatFilterWebSite/Startup.cs
@@ -32,7 +32,7 @@ namespace FormatFilterWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/FormatterWebSite/Startup.cs
+++ b/test/WebSites/FormatterWebSite/Startup.cs
@@ -28,7 +28,7 @@ namespace FormatterWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             // Add MVC to the request pipeline
             app.UseMvc(routes =>

--- a/test/WebSites/FormatterWebSite/Startup.cs
+++ b/test/WebSites/FormatterWebSite/Startup.cs
@@ -28,7 +28,7 @@ namespace FormatterWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             // Add MVC to the request pipeline
             app.UseMvc(routes =>

--- a/test/WebSites/InlineConstraintsWebSite/Startup.cs
+++ b/test/WebSites/InlineConstraintsWebSite/Startup.cs
@@ -18,7 +18,7 @@ namespace InlineConstraints
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseErrorReporter();
 

--- a/test/WebSites/InlineConstraintsWebSite/Startup.cs
+++ b/test/WebSites/InlineConstraintsWebSite/Startup.cs
@@ -18,7 +18,7 @@ namespace InlineConstraints
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseErrorReporter();
 

--- a/test/WebSites/LoggingWebSite/Startup.cs
+++ b/test/WebSites/LoggingWebSite/Startup.cs
@@ -22,7 +22,7 @@ namespace LoggingWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.Map("/logs", (appBuilder) =>
             {

--- a/test/WebSites/LoggingWebSite/Startup.cs
+++ b/test/WebSites/LoggingWebSite/Startup.cs
@@ -22,7 +22,7 @@ namespace LoggingWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.Map("/logs", (appBuilder) =>
             {

--- a/test/WebSites/LowercaseUrlsWebSite/Startup.cs
+++ b/test/WebSites/LowercaseUrlsWebSite/Startup.cs
@@ -19,7 +19,7 @@ namespace LowercaseUrlsWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/LowercaseUrlsWebSite/Startup.cs
+++ b/test/WebSites/LowercaseUrlsWebSite/Startup.cs
@@ -19,7 +19,7 @@ namespace LowercaseUrlsWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/Microsoft.AspNet.Mvc.TestConfiguration/BuilderExtensions.cs
+++ b/test/WebSites/Microsoft.AspNet.Mvc.TestConfiguration/BuilderExtensions.cs
@@ -7,9 +7,9 @@ namespace Microsoft.AspNet.Builder
 {
     public static class BuilderExtensions
     {
-        public static IApplicationBuilder GetTestConfiguration(this IApplicationBuilder app)
+        // Should be added to the pipeline as early as possible.
+        public static IApplicationBuilder UseCultureReplacer(this IApplicationBuilder app)
         {
-            // Unconditionally place CultureReplacerMiddleware as early as possible in the pipeline.
             return app.UseMiddleware<CultureReplacerMiddleware>();
         }
 

--- a/test/WebSites/Microsoft.AspNet.Mvc.TestConfiguration/BuilderExtensions.cs
+++ b/test/WebSites/Microsoft.AspNet.Mvc.TestConfiguration/BuilderExtensions.cs
@@ -2,22 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNet.Mvc.TestConfiguration;
-using Microsoft.Framework.ConfigurationModel;
-using Microsoft.Framework.DependencyInjection;
 
 namespace Microsoft.AspNet.Builder
 {
     public static class BuilderExtensions
     {
-        public static IConfiguration GetTestConfiguration(this IApplicationBuilder app)
+        public static IApplicationBuilder GetTestConfiguration(this IApplicationBuilder app)
         {
             // Unconditionally place CultureReplacerMiddleware as early as possible in the pipeline.
-            app.UseMiddleware<CultureReplacerMiddleware>();
-
-            // Until we update all references, return a useful configuration.
-            var configuration = app.ApplicationServices.GetService<IConfiguration>() ?? new Configuration();
-
-            return configuration;
+            return app.UseMiddleware<CultureReplacerMiddleware>();
         }
 
         public static IApplicationBuilder UseErrorReporter(this IApplicationBuilder app)

--- a/test/WebSites/ModelBindingWebSite/Startup.cs
+++ b/test/WebSites/ModelBindingWebSite/Startup.cs
@@ -37,7 +37,7 @@ namespace ModelBindingWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseErrorReporter();
 

--- a/test/WebSites/ModelBindingWebSite/Startup.cs
+++ b/test/WebSites/ModelBindingWebSite/Startup.cs
@@ -37,7 +37,7 @@ namespace ModelBindingWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseErrorReporter();
 

--- a/test/WebSites/MvcTagHelpersWebSite/Startup.cs
+++ b/test/WebSites/MvcTagHelpersWebSite/Startup.cs
@@ -18,7 +18,7 @@ namespace MvcTagHelpersWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/MvcTagHelpersWebSite/Startup.cs
+++ b/test/WebSites/MvcTagHelpersWebSite/Startup.cs
@@ -18,7 +18,7 @@ namespace MvcTagHelpersWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/PrecompilationWebSite/Startup.cs
+++ b/test/WebSites/PrecompilationWebSite/Startup.cs
@@ -17,7 +17,7 @@ namespace PrecompilationWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/PrecompilationWebSite/Startup.cs
+++ b/test/WebSites/PrecompilationWebSite/Startup.cs
@@ -17,7 +17,7 @@ namespace PrecompilationWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/RazorCompilerCacheWebSite/Startup.cs
+++ b/test/WebSites/RazorCompilerCacheWebSite/Startup.cs
@@ -20,7 +20,7 @@ namespace RazorCompilerCacheWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseMvc();
         }

--- a/test/WebSites/RazorCompilerCacheWebSite/Startup.cs
+++ b/test/WebSites/RazorCompilerCacheWebSite/Startup.cs
@@ -20,7 +20,7 @@ namespace RazorCompilerCacheWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseMvc();
         }

--- a/test/WebSites/RazorEmbeddedViewsWebSite/Startup.cs
+++ b/test/WebSites/RazorEmbeddedViewsWebSite/Startup.cs
@@ -25,7 +25,7 @@ namespace RazorEmbeddedViewsWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/RazorEmbeddedViewsWebSite/Startup.cs
+++ b/test/WebSites/RazorEmbeddedViewsWebSite/Startup.cs
@@ -25,7 +25,7 @@ namespace RazorEmbeddedViewsWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/RazorPageExecutionInstrumentationWebSite/Startup.cs
+++ b/test/WebSites/RazorPageExecutionInstrumentationWebSite/Startup.cs
@@ -21,7 +21,7 @@ namespace RazorPageExecutionInstrumentationWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.Use(async (HttpContext context, Func<Task> next) =>
             {

--- a/test/WebSites/RazorPageExecutionInstrumentationWebSite/Startup.cs
+++ b/test/WebSites/RazorPageExecutionInstrumentationWebSite/Startup.cs
@@ -21,7 +21,7 @@ namespace RazorPageExecutionInstrumentationWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.Use(async (HttpContext context, Func<Task> next) =>
             {

--- a/test/WebSites/RazorWebSite/Startup.cs
+++ b/test/WebSites/RazorWebSite/Startup.cs
@@ -29,7 +29,7 @@ namespace RazorWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             // Add MVC to the request pipeline
             app.UseMvc(routes =>

--- a/test/WebSites/RazorWebSite/Startup.cs
+++ b/test/WebSites/RazorWebSite/Startup.cs
@@ -29,7 +29,7 @@ namespace RazorWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             // Add MVC to the request pipeline
             app.UseMvc(routes =>

--- a/test/WebSites/RequestServicesWebSite/Startup.cs
+++ b/test/WebSites/RequestServicesWebSite/Startup.cs
@@ -18,7 +18,7 @@ namespace RequestServicesWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             // Initializes the RequestId service for each request
             app.UseMiddleware<RequestIdMiddleware>();

--- a/test/WebSites/RequestServicesWebSite/Startup.cs
+++ b/test/WebSites/RequestServicesWebSite/Startup.cs
@@ -18,7 +18,7 @@ namespace RequestServicesWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             // Initializes the RequestId service for each request
             app.UseMiddleware<RequestIdMiddleware>();

--- a/test/WebSites/ResponseCacheWebSite/Startup.cs
+++ b/test/WebSites/ResponseCacheWebSite/Startup.cs
@@ -41,7 +41,7 @@ namespace ResponseCacheWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
             app.UseMvc(routes =>
             {
                 routes.MapRoute(

--- a/test/WebSites/ResponseCacheWebSite/Startup.cs
+++ b/test/WebSites/ResponseCacheWebSite/Startup.cs
@@ -41,7 +41,7 @@ namespace ResponseCacheWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
             app.UseMvc(routes =>
             {
                 routes.MapRoute(

--- a/test/WebSites/RoutingWebSite/Startup.cs
+++ b/test/WebSites/RoutingWebSite/Startup.cs
@@ -18,7 +18,7 @@ namespace RoutingWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseErrorReporter();
 

--- a/test/WebSites/RoutingWebSite/Startup.cs
+++ b/test/WebSites/RoutingWebSite/Startup.cs
@@ -18,7 +18,7 @@ namespace RoutingWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseErrorReporter();
 

--- a/test/WebSites/TagHelpersWebSite/Startup.cs
+++ b/test/WebSites/TagHelpersWebSite/Startup.cs
@@ -16,7 +16,7 @@ namespace TagHelpersWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/TagHelpersWebSite/Startup.cs
+++ b/test/WebSites/TagHelpersWebSite/Startup.cs
@@ -16,7 +16,7 @@ namespace TagHelpersWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/TempDataWebSite/Startup.cs
+++ b/test/WebSites/TempDataWebSite/Startup.cs
@@ -18,7 +18,7 @@ namespace TempDataWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseInMemorySession();
             app.UseMvc(routes =>

--- a/test/WebSites/TempDataWebSite/Startup.cs
+++ b/test/WebSites/TempDataWebSite/Startup.cs
@@ -18,7 +18,7 @@ namespace TempDataWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseInMemorySession();
             app.UseMvc(routes =>

--- a/test/WebSites/UrlHelperWebSite/Startup.cs
+++ b/test/WebSites/UrlHelperWebSite/Startup.cs
@@ -27,7 +27,7 @@ namespace UrlHelperWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
 
             // Add MVC to the request pipeline

--- a/test/WebSites/UrlHelperWebSite/Startup.cs
+++ b/test/WebSites/UrlHelperWebSite/Startup.cs
@@ -27,7 +27,7 @@ namespace UrlHelperWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
 
             // Add MVC to the request pipeline

--- a/test/WebSites/ValidationWebSite/Startup.cs
+++ b/test/WebSites/ValidationWebSite/Startup.cs
@@ -17,7 +17,7 @@ namespace ValidationWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             // Set up file serving for JavaScript files.
             app.UseFileServer();

--- a/test/WebSites/ValidationWebSite/Startup.cs
+++ b/test/WebSites/ValidationWebSite/Startup.cs
@@ -17,7 +17,7 @@ namespace ValidationWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             // Set up file serving for JavaScript files.
             app.UseFileServer();

--- a/test/WebSites/ValueProvidersWebSite/Startup.cs
+++ b/test/WebSites/ValueProvidersWebSite/Startup.cs
@@ -21,7 +21,7 @@ namespace ValueProvidersWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             // Add MVC to the request pipeline
             app.UseMvc(routes =>

--- a/test/WebSites/ValueProvidersWebSite/Startup.cs
+++ b/test/WebSites/ValueProvidersWebSite/Startup.cs
@@ -21,7 +21,7 @@ namespace ValueProvidersWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             // Add MVC to the request pipeline
             app.UseMvc(routes =>

--- a/test/WebSites/VersioningWebSite/Startup.cs
+++ b/test/WebSites/VersioningWebSite/Startup.cs
@@ -18,7 +18,7 @@ namespace VersioningWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/VersioningWebSite/Startup.cs
+++ b/test/WebSites/VersioningWebSite/Startup.cs
@@ -18,7 +18,7 @@ namespace VersioningWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/ViewComponentWebSite/Startup.cs
+++ b/test/WebSites/ViewComponentWebSite/Startup.cs
@@ -16,7 +16,7 @@ namespace ViewComponentWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/ViewComponentWebSite/Startup.cs
+++ b/test/WebSites/ViewComponentWebSite/Startup.cs
@@ -16,7 +16,7 @@ namespace ViewComponentWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseMvc(routes =>
             {

--- a/test/WebSites/WebApiCompatShimWebSite/Startup.cs
+++ b/test/WebSites/WebApiCompatShimWebSite/Startup.cs
@@ -18,7 +18,7 @@ namespace WebApiCompatShimWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseErrorReporter();
 

--- a/test/WebSites/WebApiCompatShimWebSite/Startup.cs
+++ b/test/WebSites/WebApiCompatShimWebSite/Startup.cs
@@ -18,7 +18,7 @@ namespace WebApiCompatShimWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseErrorReporter();
 

--- a/test/WebSites/XmlFormattersWebSite/Startup.cs
+++ b/test/WebSites/XmlFormattersWebSite/Startup.cs
@@ -67,7 +67,7 @@ namespace XmlFormattersWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            var configuration = app.GetTestConfiguration();
+            app.GetTestConfiguration();
 
             app.UseErrorReporter();
 

--- a/test/WebSites/XmlFormattersWebSite/Startup.cs
+++ b/test/WebSites/XmlFormattersWebSite/Startup.cs
@@ -67,7 +67,7 @@ namespace XmlFormattersWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.GetTestConfiguration();
+            app.UseCultureReplacer();
 
             app.UseErrorReporter();
 


### PR DESCRIPTION
- remove useless `configuration` variables and `Configuration` instances
- remove "Review" code comment (the only product code change)
- reduce repeated code in `TestHelper` for functional tests