### PR TITLE
Unrendered sections does not throw when redefined and rendered in nested

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/IRazorPage.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/IRazorPage.cs
@@ -72,14 +72,11 @@ namespace Microsoft.AspNet.Mvc.Razor
         Task ExecuteAsync();
 
         /// <summary>
-        /// Verifies that RenderBody is called for the page that is
-        /// part of view execution hierarchy.
+        /// Verifies that all sections defined in <see cref="PreviousSectionWriters"/> were rendered, or
+        /// the body was rendered if no sections were defined.
         /// </summary>
-        void EnsureBodyWasRendered();
-
-        /// <summary>
-        /// Gets the sections that are rendered in the page.
-        /// </summary>
-        IEnumerable<string> RenderedSections { get; }
+        /// <exception cref="InvalidOperationException">if one or more sections were not rendered or if no sections were
+        /// defined and the body was not rendered.</exception>
+        void EnsureRenderedBodyOrSections();
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Razor/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Properties/Resources.Designer.cs
@@ -219,7 +219,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         }
 
         /// <summary>
-        /// {0} must be called from a layout page.
+        /// {0} has not been called for the page '{1}'.
         /// </summary>
         internal static string RenderBodyNotCalled
         {
@@ -227,11 +227,11 @@ namespace Microsoft.AspNet.Mvc.Razor
         }
 
         /// <summary>
-        /// {0} must be called from a layout page.
+        /// {0} has not been called for the page '{1}'.
         /// </summary>
-        internal static string FormatRenderBodyNotCalled(object p0)
+        internal static string FormatRenderBodyNotCalled(object p0, object p1)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("RenderBodyNotCalled"), p0);
+            return string.Format(CultureInfo.CurrentCulture, GetString("RenderBodyNotCalled"), p0, p1);
         }
 
         /// <summary>
@@ -283,7 +283,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         }
 
         /// <summary>
-        /// The following sections have been defined but have not been rendered: '{0}'.
+        /// The following sections have been defined but have not been rendered for the page '{0}': '{1}'.
         /// </summary>
         internal static string SectionsNotRendered
         {
@@ -291,11 +291,11 @@ namespace Microsoft.AspNet.Mvc.Razor
         }
 
         /// <summary>
-        /// The following sections have been defined but have not been rendered: '{0}'.
+        /// The following sections have been defined but have not been rendered for the page '{0}': '{1}'.
         /// </summary>
-        internal static string FormatSectionsNotRendered(object p0)
+        internal static string FormatSectionsNotRendered(object p0, object p1)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("SectionsNotRendered"), p0);
+            return string.Format(CultureInfo.CurrentCulture, GetString("SectionsNotRendered"), p0, p1);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Mvc.Razor/Resources.resx
+++ b/src/Microsoft.AspNet.Mvc.Razor/Resources.resx
@@ -157,7 +157,7 @@
     <value>{0} can only be called from a layout page.</value>
   </data>
   <data name="RenderBodyNotCalled" xml:space="preserve">
-    <value>{0} must be called from a layout page.</value>
+    <value>{0} has not been called for the page at '{1}'.</value>
   </data>
   <data name="SectionAlreadyDefined" xml:space="preserve">
     <value>Section '{0}' is already defined.</value>
@@ -169,7 +169,7 @@
     <value>Section '{0}' is not defined.</value>
   </data>
   <data name="SectionsNotRendered" xml:space="preserve">
-    <value>The following sections have been defined but have not been rendered: '{0}'.</value>
+    <value>The following sections have been defined but have not been rendered by the page at '{0}': '{1}'.</value>
   </data>
   <data name="ViewCannotBeActivated" xml:space="preserve">
     <value>View of type '{0}' cannot be activated by '{1}'.</value>


### PR DESCRIPTION
layout.

Fixes #2252