### PR TITLE
Normalize paths for MvcRazorHost DecorateCodeBuilder's ChunkInheritanceU...

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor.Host/MvcRazorHost.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/MvcRazorHost.cs
@@ -105,7 +105,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         // Razor page that is loaded. Consequently, each loaded page has its own copy of
         // the CodeTreeCache, but this ok - having a shared CodeTreeCache per application in tooling
         // is problematic to manage.
-        public MvcRazorHost(string root) 
+        public MvcRazorHost(string root)
             : this(new DefaultCodeTreeCache(new PhysicalFileProvider(root)), new DesignTimeRazorPathNormalizer(root))
         {
         }
@@ -214,7 +214,10 @@ namespace Microsoft.AspNet.Mvc.Razor
         public override CodeBuilder DecorateCodeBuilder([NotNull] CodeBuilder incomingBuilder,
                                                         [NotNull] CodeBuilderContext context)
         {
-            var inheritedChunks = ChunkInheritanceUtility.GetInheritedCodeTrees(context.SourceFile);
+            // Need the normalized path to resolve inherited chunks only. Full paths are needed for generated Razor 
+            // files checksum and line pragmas to enable DesignTime debugging.
+            var normalizedPath = _pathNormalizer.NormalizePath(context.SourceFile);
+            var inheritedChunks = ChunkInheritanceUtility.GetInheritedCodeTrees(normalizedPath);
 
             ChunkInheritanceUtility.MergeInheritedCodeTrees(context.CodeTreeBuilder.CodeTree,
                                                          inheritedChunks,

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/MvcRazorHostTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/MvcRazorHostTest.cs
@@ -47,6 +47,39 @@ namespace Microsoft.AspNet.Mvc.Razor
             Assert.Equal("src/file.cshtml", chunkInheritanceUtility.InheritedCodeTreePagePath, StringComparer.Ordinal);
         }
 
+        [Theory]
+        [InlineData("//")]
+        [InlineData("C:/")]
+        [InlineData(@"\\")]
+        [InlineData(@"C:\")]
+        public void DecorateCodeBuilder_DesignTimeRazorPathNormalizer_NormalizesChunkInheritanceUtilityPaths(
+            string rootPrefix)
+        {
+            // Arrange
+            var rootedAppPath = $"{rootPrefix}SomeComputer/Location/Project/";
+            var rootedFilePath = $"{rootPrefix}SomeComputer/Location/Project/src/file.cshtml";
+            var host = new MvcRazorHost(
+                codeTreeCache: null,
+                pathNormalizer: new DesignTimeRazorPathNormalizer(rootedAppPath));
+            var chunkInheritanceUtility = new PathValidatingChunkInheritanceUtility(host);
+            var codeBuilderContext = new CodeBuilderContext(
+                new CodeGeneratorContext(
+                    host,
+                    host.DefaultClassName,
+                    host.DefaultNamespace,
+                    rootedFilePath,
+                    shouldGenerateLinePragmas: true),
+                new ParserErrorSink());
+            var codeBuilder = new CSharpCodeBuilder(codeBuilderContext);
+            host.ChunkInheritanceUtility = chunkInheritanceUtility;
+
+            // Act
+            host.DecorateCodeBuilder(codeBuilder, codeBuilderContext);
+
+            // Assert
+            Assert.Equal("src/file.cshtml", chunkInheritanceUtility.InheritedCodeTreePagePath, StringComparer.Ordinal);
+        }
+
         [Fact]
         public void MvcRazorHost_EnablesInstrumentationByDefault()
         {


### PR DESCRIPTION
...tility call.

- This solves tooling trying to resolve ChunkInheritanceUtility bits for chunks: Aka can't inherit `@using`, `@inject` etc. from _GlobalImport.cshtml
- Added test to validate paths are normalized for DecorateCodeBuilder.

#2271