### PR TITLE
Change inject directive to format correctly after newline during design time.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor.Host/MvcRazorCodeParser.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/MvcRazorCodeParser.cs
@@ -133,7 +133,7 @@ namespace Microsoft.AspNet.Mvc.Razor
 
             // Output the span and finish the block
             CompleteBlock();
-            Output(SpanKind.Code);
+            Output(SpanKind.Code, AcceptedCharacters.AnyExceptNewline);
         }
 
         private SpanCodeGenerator CreateModelCodeGenerator(string model)

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/Directives/ChunkInheritanceUtilityTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/Directives/ChunkInheritanceUtilityTest.cs
@@ -48,7 +48,7 @@ namespace Microsoft.AspNet.Mvc.Razor.Directives
             Assert.IsType<LiteralChunk>(viewStartChunks[2]);
 
             viewStartChunks = codeTrees[1].Chunks;
-            Assert.Equal(5, viewStartChunks.Count);
+            Assert.Equal(7, viewStartChunks.Count);
 
             Assert.IsType<LiteralChunk>(viewStartChunks[0]);
 
@@ -56,11 +56,15 @@ namespace Microsoft.AspNet.Mvc.Razor.Directives
             Assert.Equal("MyHelper<TModel>", injectChunk.TypeName);
             Assert.Equal("Helper", injectChunk.MemberName);
 
-            var setBaseTypeChunk = Assert.IsType<SetBaseTypeChunk>(viewStartChunks[2]);
+            Assert.IsType<LiteralChunk>(viewStartChunks[2]);
+
+            var setBaseTypeChunk = Assert.IsType<SetBaseTypeChunk>(viewStartChunks[3]);
             Assert.Equal("MyBaseType", setBaseTypeChunk.TypeName);
 
-            Assert.IsType<StatementChunk>(viewStartChunks[3]);
             Assert.IsType<LiteralChunk>(viewStartChunks[4]);
+
+            Assert.IsType<StatementChunk>(viewStartChunks[5]);
+            Assert.IsType<LiteralChunk>(viewStartChunks[6]);
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/MvcCSharpRazorCodeParserTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/MvcCSharpRazorCodeParserTest.cs
@@ -47,6 +47,8 @@ namespace Microsoft.AspNet.Mvc.Razor
                     .Accepts(AcceptedCharacters.None),
                 factory.Code("   Foo")
                     .As(new ModelCodeGenerator("RazorView", "Foo"))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
+                factory.EmptyHtml()
             };
 
             // Act
@@ -76,7 +78,8 @@ namespace Microsoft.AspNet.Mvc.Razor
                 factory.MetaCode("model ")
                     .Accepts(AcceptedCharacters.None),
                 factory.Code(modelName + "\r\n")
-                    .As(new ModelCodeGenerator("RazorView", expectedModel)),
+                    .As(new ModelCodeGenerator("RazorView", expectedModel))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
                 factory.Markup("Bar")
                     .With(new MarkupCodeGenerator())
             };
@@ -107,7 +110,9 @@ namespace Microsoft.AspNet.Mvc.Razor
                 factory.MetaCode("model ")
                     .Accepts(AcceptedCharacters.None),
                 factory.Code("  ")
-                    .As(new ModelCodeGenerator("RazorView", string.Empty)),
+                    .As(new ModelCodeGenerator("RazorView", string.Empty))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
+                factory.EmptyHtml(),
             };
             var expectedErrors = new[]
             {
@@ -136,13 +141,17 @@ namespace Microsoft.AspNet.Mvc.Razor
                 factory.MetaCode("model ")
                     .Accepts(AcceptedCharacters.None),
                 factory.Code("Foo\r\n")
-                    .As(new ModelCodeGenerator("RazorView", "Foo")),
+                    .As(new ModelCodeGenerator("RazorView", "Foo"))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
+                factory.EmptyHtml(),
                 factory.CodeTransition(SyntaxConstants.TransitionString)
                     .Accepts(AcceptedCharacters.None),
                 factory.MetaCode("model ")
                     .Accepts(AcceptedCharacters.None),
                 factory.Code("Bar")
                     .As(new ModelCodeGenerator("RazorView", "Bar"))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
+                factory.EmptyHtml()
             };
 
             var expectedErrors = new[]
@@ -177,13 +186,17 @@ namespace Microsoft.AspNet.Mvc.Razor
                 factory.MetaCode("model ")
                     .Accepts(AcceptedCharacters.None),
                 factory.Code("Foo\r\n")
-                    .As(new ModelCodeGenerator("RazorView", "Foo")),
+                    .As(new ModelCodeGenerator("RazorView", "Foo"))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
+                factory.EmptyHtml(),
                 factory.CodeTransition(SyntaxConstants.TransitionString)
                     .Accepts(AcceptedCharacters.None),
                 factory.MetaCode("inherits ")
                     .Accepts(AcceptedCharacters.None),
                 factory.Code("Bar")
                     .As(new SetBaseTypeCodeGenerator("Bar"))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
+                factory.EmptyHtml()
             };
 
             var expectedErrors = new[]
@@ -218,13 +231,17 @@ namespace Microsoft.AspNet.Mvc.Razor
                 factory.MetaCode("inherits ")
                     .Accepts(AcceptedCharacters.None),
                 factory.Code("Bar" + Environment.NewLine)
-                    .As(new SetBaseTypeCodeGenerator("Bar")),
+                    .As(new SetBaseTypeCodeGenerator("Bar"))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
+                factory.EmptyHtml(),
                 factory.CodeTransition(SyntaxConstants.TransitionString)
                     .Accepts(AcceptedCharacters.None),
                 factory.MetaCode("model ")
                     .Accepts(AcceptedCharacters.None),
                 factory.Code("Foo")
                     .As(new ModelCodeGenerator("RazorView", "Foo"))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
+                factory.EmptyHtml()
             };
 
             var expectedErrors = new[]
@@ -263,6 +280,8 @@ namespace Microsoft.AspNet.Mvc.Razor
                     .Accepts(AcceptedCharacters.None),
                 factory.Code(injectStatement)
                     .As(new InjectParameterGenerator(expectedService, expectedPropertyName))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
+                factory.EmptyHtml()
             };
 
             // Act
@@ -307,6 +326,8 @@ namespace Microsoft.AspNet.Mvc.Razor
                     .Accepts(AcceptedCharacters.None),
                 factory.Code(injectStatement)
                     .As(new InjectParameterGenerator(expectedService, expectedPropertyName))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
+                factory.EmptyHtml()
             };
 
             // Act
@@ -336,7 +357,8 @@ namespace Microsoft.AspNet.Mvc.Razor
                 factory.MetaCode("inject ")
                     .Accepts(AcceptedCharacters.None),
                 factory.Code(injectStatement + "\r\n")
-                    .As(new InjectParameterGenerator(expectedService, expectedPropertyName)),
+                    .As(new InjectParameterGenerator(expectedService, expectedPropertyName))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
                 factory.Markup("Bar")
                     .With(new MarkupCodeGenerator())
             };
@@ -364,7 +386,8 @@ namespace Microsoft.AspNet.Mvc.Razor
                 factory.MetaCode("inject ")
                     .Accepts(AcceptedCharacters.None),
                 factory.Code("   \r\n")
-                    .As(new InjectParameterGenerator(string.Empty, string.Empty)),
+                    .As(new InjectParameterGenerator(string.Empty, string.Empty))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
                 factory.Markup("Bar")
                     .With(new MarkupCodeGenerator())
             };
@@ -397,7 +420,9 @@ namespace Microsoft.AspNet.Mvc.Razor
                 factory.MetaCode("inject ")
                     .Accepts(AcceptedCharacters.None),
                 factory.Code("   ")
-                    .As(new InjectParameterGenerator(string.Empty, string.Empty)),
+                    .As(new InjectParameterGenerator(string.Empty, string.Empty))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
+                factory.EmptyHtml()
             };
             var expectedErrors = new[]
             {
@@ -428,7 +453,8 @@ namespace Microsoft.AspNet.Mvc.Razor
                 factory.MetaCode("inject ")
                     .Accepts(AcceptedCharacters.None),
                 factory.Code("  IMyService  \r\n")
-                    .As(new InjectParameterGenerator("IMyService", string.Empty)),
+                    .As(new InjectParameterGenerator("IMyService", string.Empty))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
                 factory.Markup("Bar")
                     .With(new MarkupCodeGenerator())
             };
@@ -462,7 +488,9 @@ namespace Microsoft.AspNet.Mvc.Razor
                 factory.MetaCode("inject ")
                     .Accepts(AcceptedCharacters.None),
                 factory.Code("   IMyServi")
-                    .As(new InjectParameterGenerator("IMyServi", string.Empty)),
+                    .As(new InjectParameterGenerator("IMyServi", string.Empty))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
+                factory.EmptyHtml()
             };
             var expectedErrors = new[]
             {

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/MvcRazorCodeParserTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/MvcRazorCodeParserTest.cs
@@ -43,6 +43,8 @@ namespace Microsoft.AspNet.Mvc.Razor.Host.Test
                     .Accepts(AcceptedCharacters.None),
                 factory.Code("   Foo")
                     .As(new ModelCodeGenerator(DefaultBaseType, "Foo"))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
+                factory.EmptyHtml()
             };
             Assert.Equal(expectedSpans, spans.ToArray());
         }
@@ -64,7 +66,8 @@ namespace Microsoft.AspNet.Mvc.Razor.Host.Test
                 factory.MetaCode("model ")
                     .Accepts(AcceptedCharacters.None),
                 factory.Code("Foo?\r\n")
-                    .As(new ModelCodeGenerator(DefaultBaseType, "Foo?")),
+                    .As(new ModelCodeGenerator(DefaultBaseType, "Foo?"))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
                 factory.Markup("Bar")
                     .With(new MarkupCodeGenerator())
             };
@@ -88,7 +91,8 @@ namespace Microsoft.AspNet.Mvc.Razor.Host.Test
                 factory.MetaCode("model ")
                     .Accepts(AcceptedCharacters.None),
                 factory.Code("Foo[[]][]\r\n")
-                    .As(new ModelCodeGenerator(DefaultBaseType, "Foo[[]][]")),
+                    .As(new ModelCodeGenerator(DefaultBaseType, "Foo[[]][]"))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
                 factory.Markup("Bar")
                     .With(new MarkupCodeGenerator())
             };
@@ -113,6 +117,8 @@ namespace Microsoft.AspNet.Mvc.Razor.Host.Test
                     .Accepts(AcceptedCharacters.None),
                 factory.Code("$rootnamespace$.MyModel")
                     .As(new ModelCodeGenerator(DefaultBaseType, "$rootnamespace$.MyModel"))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
+                factory.EmptyHtml()
             };
             Assert.Equal(expectedSpans, spans.ToArray());
         }
@@ -135,7 +141,9 @@ namespace Microsoft.AspNet.Mvc.Razor.Host.Test
                 factory.MetaCode("model ")
                     .Accepts(AcceptedCharacters.None),
                 factory.Code("  ")
-                    .As(new ModelCodeGenerator(DefaultBaseType, string.Empty)),
+                    .As(new ModelCodeGenerator(DefaultBaseType, string.Empty))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
+                factory.EmptyHtml()
             };
             var expectedErrors = new[]
             {
@@ -165,13 +173,17 @@ namespace Microsoft.AspNet.Mvc.Razor.Host.Test
                 factory.MetaCode("model ")
                     .Accepts(AcceptedCharacters.None),
                 factory.Code("Foo\r\n")
-                    .As(new ModelCodeGenerator(DefaultBaseType, "Foo")),
+                    .As(new ModelCodeGenerator(DefaultBaseType, "Foo"))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
+                factory.EmptyHtml(),
                 factory.CodeTransition(SyntaxConstants.TransitionString)
                     .Accepts(AcceptedCharacters.None),
                 factory.MetaCode("model ")
                     .Accepts(AcceptedCharacters.None),
                 factory.Code("Bar")
                     .As(new ModelCodeGenerator(DefaultBaseType, "Bar"))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
+                factory.EmptyHtml()
             };
 
             var expectedErrors = new[]
@@ -203,13 +215,17 @@ namespace Microsoft.AspNet.Mvc.Razor.Host.Test
                 factory.MetaCode("model ")
                     .Accepts(AcceptedCharacters.None),
                 factory.Code("Foo\r\n")
-                    .As(new ModelCodeGenerator(DefaultBaseType, "Foo")),
+                    .As(new ModelCodeGenerator(DefaultBaseType, "Foo"))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
+                factory.EmptyHtml(),
                 factory.CodeTransition(SyntaxConstants.TransitionString)
                     .Accepts(AcceptedCharacters.None),
                 factory.MetaCode("inherits ")
                     .Accepts(AcceptedCharacters.None),
                 factory.Code("Bar")
                     .As(new SetBaseTypeCodeGenerator("Bar"))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
+                factory.EmptyHtml()
             };
 
             var expectedErrors = new[]
@@ -241,13 +257,17 @@ namespace Microsoft.AspNet.Mvc.Razor.Host.Test
                 factory.MetaCode("inherits ")
                     .Accepts(AcceptedCharacters.None),
                 factory.Code("Bar" + Environment.NewLine)
-                    .As(new SetBaseTypeCodeGenerator("Bar")),
+                    .As(new SetBaseTypeCodeGenerator("Bar"))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
+                factory.EmptyHtml(),
                 factory.CodeTransition(SyntaxConstants.TransitionString)
                     .Accepts(AcceptedCharacters.None),
                 factory.MetaCode("model ")
                     .Accepts(AcceptedCharacters.None),
                 factory.Code("Foo")
                     .As(new ModelCodeGenerator(DefaultBaseType, "Foo"))
+                    .Accepts(AcceptedCharacters.AnyExceptNewline),
+                factory.EmptyHtml()
             };
 
             var expectedErrors = new[]


### PR DESCRIPTION
- Also modified existing tests to account for aspnet/Razor#332 which fixed models formatting after newline.
- Updated tests for inject to understand new formatting parsing.

aspnet/Razor#332

**Razor PR:** https://github.com/aspnet/Razor/pull/360