### PR TITLE
Update ModelBinderAttribute not to throw exceptions from BinderType 

### DIFF
--- a/src/Microsoft.AspNet.Mvc.ModelBinding/BinderMetadata/ModelBinderAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/BinderMetadata/ModelBinderAttribute.cs
@@ -26,39 +26,17 @@ namespace Microsoft.AspNet.Mvc
         Inherited = true)]
     public class ModelBinderAttribute : Attribute, IModelNameProvider, IBinderTypeProviderMetadata
     {
-        private Type _binderType;
         private BindingSource _bindingSource;
 
         /// <inheritdoc />
-        public Type BinderType
-        {
-            get
-            {
-                return _binderType;
-            }
-            set
-            {
-                if (value != null)
-                {
-                    if (!typeof(IModelBinder).IsAssignableFrom(value))
-                    {
-                        throw new InvalidOperationException(
-                            Resources.FormatBinderType_MustBeIModelBinder(
-                                value.FullName,
-                                typeof(IModelBinder).FullName));
-                    }
-                }
-
-                _binderType = value;
-            }
-        }
+        public Type BinderType { get; set; }
 
         /// <inheritdoc />
         public BindingSource BindingSource
         {
             get
             {
-                if (_bindingSource == null && _binderType != null)
+                if (_bindingSource == null && BinderType != null)
                 {
                     return BindingSource.Custom;
                 }

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/ModelBinderAttributeTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/ModelBinderAttributeTest.cs
@@ -9,23 +9,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
     public class ModelBinderAttributeTest
     {
         [Fact]
-        public void InvalidBinderType_Throws()
-        {
-            // Arrange
-            var attribute = new ModelBinderAttribute();
-
-            var expected =
-                $"The type 'System.String' must implement '{typeof(IModelBinder).FullName}' " +
-                "to be used as a model binder.";
-
-            // Act
-            var ex = Assert.Throws<InvalidOperationException>(() => { attribute.BinderType = typeof(string); });
-
-            // Assert
-            Assert.Equal(expected, ex.Message);
-        }
-
-        [Fact]
         public void NoBinderType_NoBindingSource()
         {
             // Arrange


### PR DESCRIPTION
@pranavkm 

Please review this. I don't think we need to add more tests since 

BindModel_ReturnsFalseIfNoBinderTypeIsSet()
BindModel_ForNonModelBinder_Throw()

covers those cases where BinderType == null or not an IModelBinder type

