### PR TITLE
Throw exception with unknown attributeName

### DIFF
--- a/src/Microsoft.AspNet.Mvc.TagHelpers/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/Properties/Resources.Designer.cs
@@ -122,6 +122,22 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             return string.Format(CultureInfo.CurrentCulture, GetString("InvalidEnumArgument"), p0, p1, p2);
         }
 
+        /// <summary>
+        /// The attribute '{0}' does not exist in the {1}.
+        /// </summary>
+        internal static string TagHelperOutput_AttributeDoesNotExist
+        {
+            get { return GetString("TagHelperOutput_AttributeDoesNotExist"); }
+        }
+
+        /// <summary>
+        /// The attribute '{0}' does not exist in the {1}.
+        /// </summary>
+        internal static string FormatTagHelperOutput_AttributeDoesNotExist(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperOutput_AttributeDoesNotExist"), p0, p1);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/Resources.resx
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/Resources.resx
@@ -138,4 +138,7 @@
   <data name="InvalidEnumArgument" xml:space="preserve">
     <value>The value of argument '{0}' ({1}) is invalid for Enum type '{2}'.</value>
   </data>
+  <data name="TagHelperOutput_AttributeDoesNotExist" xml:space="preserve">
+    <value>The attribute '{0}' does not exist in the {1}.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/TagHelperOutputExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/TagHelperOutputExtensions.cs
@@ -35,8 +35,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 // We look for the original attribute so we can restore the exact attribute name the user typed.
                 // Approach also ignores changes made to tagHelperOutput[attributeName].
-                var entry = context.AllAttributes.First(
+                var entry = context.AllAttributes.FirstOrDefault(
                     attribute => attribute.Key.Equals(attributeName, StringComparison.OrdinalIgnoreCase));
+
+                if (entry.Equals(default(KeyValuePair<string, object>)))
+                {
+                    throw new ArgumentException(
+                        Resources.FormatTagHelperOutput_AttributeDoesNotExist(attributeName, nameof(TagHelperContext)),
+                        nameof(attributeName));
+                }
+                
                 tagHelperOutput.Attributes.Add(entry.Key, entry.Value);
             }
         }

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TagHelperOutputExtensionsTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TagHelperOutputExtensionsTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
+using Microsoft.AspNet.Testing;
 using Microsoft.Framework.WebEncoders;
 using Xunit;
 
@@ -77,6 +78,35 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Assert
             var attribute = Assert.Single(tagHelperOutput.Attributes);
             Assert.Equal(expectedAttribute, attribute);
+        }
+
+        [Fact]
+        public void CopyHtmlAttribute_ThrowsWhenUnknownAttribute()
+        {
+            // Arrange
+            var invalidAttributeName = "hello2";
+            var tagHelperOutput = new TagHelperOutput(
+                "p",
+                attributes: new Dictionary<string, object>());
+            var tagHelperContext = new TagHelperContext(
+                allAttributes: new Dictionary<string, object>(StringComparer.Ordinal)
+                {
+                    { "hello", "world" }
+                },
+                items: new Dictionary<object, object>(),
+                uniqueId: "test",
+                getChildContentAsync: () =>
+                {
+                    var tagHelperContent = new DefaultTagHelperContent();
+                    tagHelperContent.Append("Something");
+                    return Task.FromResult<TagHelperContent>(tagHelperContent);
+                });
+
+            // Act & Assert
+            ExceptionAssert.ThrowsArgument(
+                () => tagHelperOutput.CopyHtmlAttribute(invalidAttributeName, tagHelperContext),
+                "attributeName",
+                "The attribute 'hello2' does not exist in the TagHelperContext.");
         }
 
         [Fact]


### PR DESCRIPTION
Throw a meaningful exception if the attribute to copy does not exists
in the attributes of the TagHelperContext rather than:
```
System.InvalidOperationException : Sequence contains no matching element.
```

Added test too.

#1586