### PR TITLE
Bind to readonly non-`null` collections

### DIFF
--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/ArrayModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/ArrayModelBinder.cs
@@ -4,12 +4,18 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Mvc.ModelBinding
 {
+    /// <summary>
+    /// <see cref="IModelBinder"/> implementation for binding array values.
+    /// </summary>
+    /// <typeparam name="TElement">Type of elements in the array.</typeparam>
     public class ArrayModelBinder<TElement> : CollectionModelBinder<TElement>
     {
-        public override Task<ModelBindingResult> BindModelAsync(ModelBindingContext bindingContext)
+        /// <inheritdoc />
+        public override Task<ModelBindingResult> BindModelAsync([NotNull] ModelBindingContext bindingContext)
         {
             if (bindingContext.ModelMetadata.IsReadOnly)
             {
@@ -19,9 +25,17 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             return base.BindModelAsync(bindingContext);
         }
 
+        /// <inheritdoc />
         protected override object GetModel(IEnumerable<TElement> newCollection)
         {
-            return newCollection.ToArray();
+            return newCollection?.ToArray();
+        }
+
+        /// <inheritdoc />
+        protected override void CopyToModel([NotNull] object target, IEnumerable<TElement> sourceCollection)
+        {
+            // Do not attempt to copy values into an array because an array's length is immutable. This choice is also
+            // consistent with MutableObjectModelBinder's handling of a read-only array property.
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/DictionaryModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Binders/DictionaryModelBinder.cs
@@ -1,17 +1,22 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Microsoft.AspNet.Mvc.ModelBinding
 {
+    /// <summary>
+    /// <see cref="IModelBinder"/> implementation for binding dictionary values.
+    /// </summary>
+    /// <typeparam name="TKey">Type of keys in the dictionary.</typeparam>
+    /// <typeparam name="TValue">Type of values in the dictionary.</typeparam>
     public class DictionaryModelBinder<TKey, TValue> : CollectionModelBinder<KeyValuePair<TKey, TValue>>
     {
+        /// <inheritdoc />
         protected override object GetModel(IEnumerable<KeyValuePair<TKey, TValue>> newCollection)
         {
-            return newCollection.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            return newCollection?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
     }
 }


### PR DESCRIPTION
- parts 1/3 and 2/3 of #2294
- fill readonly gaps in `CollectionModelBinder` and `MutableObjectModelBinder`
 - `CollectionModelBinder.CopyToModel()` and `MutableObjectModelBinder.AddToProperty()` methods
 - add `CopyToModel()` override in `ArrayModelBinder`
- avoid NREs in `GetModel()` overrides

Test handling of readonly collections
- previous tests barely touched this scenario

nits:
- add missing `[NotNull]` attributes
- add missing doc comments
- consolidate a few `[Fact]`s into `[Theory]`s
- simplify some wrapping; shorten a few lines