### PR TITLE
Fix #1712 - remove reflection from validation code in MutableObjectModel...

### DIFF
--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/BindingMetadata.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/BindingMetadata.cs
@@ -29,6 +29,13 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         public Type BinderType { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether or not the property can be model bound.
+        /// Will be ignored if the model metadata being created is not a property.
+        /// See <see cref="ModelMetadata.IsBindingAllowed"/>.
+        /// </summary>
+        public bool IsBindingAllowed { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets a value indicating whether or not the request must contain a value for the model.
         /// Will be ignored if the model metadata being created is not a property.
         /// See <see cref="ModelMetadata.IsBindingRequired"/>.

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/BindingMetadata.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/BindingMetadata.cs
@@ -30,14 +30,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
 
         /// <summary>
         /// Gets or sets a value indicating whether or not the property can be model bound.
-        /// Will be ignored if the model metadata being created is not a property.
+        /// Will be ignored if the model metadata being created does not represent a property.
         /// See <see cref="ModelMetadata.IsBindingAllowed"/>.
         /// </summary>
         public bool IsBindingAllowed { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a value indicating whether or not the request must contain a value for the model.
-        /// Will be ignored if the model metadata being created is not a property.
+        /// Will be ignored if the model metadata being created does not represent a property.
         /// See <see cref="ModelMetadata.IsBindingRequired"/>.
         /// </summary>
         public bool IsBindingRequired { get; set; }

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/DefaultModelMetadata.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/Metadata/DefaultModelMetadata.cs
@@ -256,11 +256,34 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         }
 
         /// <inheritdoc />
+        public override bool IsBindingAllowed
+        {
+            get
+            {
+                if (MetadataKind == ModelMetadataKind.Property)
+                {
+                    return BindingMetadata.IsBindingAllowed;
+                }
+                else
+                {
+                    return true;
+                }
+            }
+        }
+
+        /// <inheritdoc />
         public override bool IsBindingRequired
         {
             get
             {
-                return BindingMetadata.IsBindingRequired;
+                if (MetadataKind == ModelMetadataKind.Property)
+                {
+                    return BindingMetadata.IsBindingRequired;
+                }
+                else
+                {
+                    return false;
+                }
             }
         }
 

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/ModelMetadata.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/ModelMetadata.cs
@@ -167,7 +167,17 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         public abstract bool HideSurroundingHtml { get; }
 
         /// <summary>
-        /// Gets a value indicating whether or not the model value is required by model binding. This is only
+        /// Gets a value indicating whether or not the model value can be bound by model-binding. This is only
+        /// applicable when the current instance represents a property.
+        /// </summary>
+        /// <remarks>
+        /// If <c>true</c> then the model value is considered supported by model-binding and can be set
+        /// based on provided input in the request.
+        /// </remarks>
+        public abstract bool IsBindingAllowed { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether or not the model value is required by model-binding. This is only
         /// applicable when the current instance represents a property.
         /// </summary>
         /// <remarks>

--- a/src/Microsoft.AspNet.Mvc.ModelBinding/ModelMetadata.cs
+++ b/src/Microsoft.AspNet.Mvc.ModelBinding/ModelMetadata.cs
@@ -167,21 +167,21 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         public abstract bool HideSurroundingHtml { get; }
 
         /// <summary>
-        /// Gets a value indicating whether or not the model value can be bound by model-binding. This is only
+        /// Gets a value indicating whether or not the model value can be bound by model binding. This is only
         /// applicable when the current instance represents a property.
         /// </summary>
         /// <remarks>
-        /// If <c>true</c> then the model value is considered supported by model-binding and can be set
+        /// If <c>true</c> then the model value is considered supported by model binding and can be set
         /// based on provided input in the request.
         /// </remarks>
         public abstract bool IsBindingAllowed { get; }
 
         /// <summary>
-        /// Gets a value indicating whether or not the model value is required by model-binding. This is only
+        /// Gets a value indicating whether or not the model value is required by model binding. This is only
         /// applicable when the current instance represents a property.
         /// </summary>
         /// <remarks>
-        /// If <c>true</c> then the model value is considered required by model-binding and must have a value
+        /// If <c>true</c> then the model value is considered required by model binding and must have a value
         /// supplied in the request to be considered valid.
         /// </remarks>
         public abstract bool IsBindingRequired { get; }

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/DefaultBindingMetadataProviderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/DefaultBindingMetadataProviderTest.cs
@@ -147,5 +147,358 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
             // Assert
             Assert.Equal(BindingSource.Body, context.BindingMetadata.BindingSource);
         }
+
+        [Fact]
+        public void GetBindingDetails_FindsBindingBehaviorNever_OnProperty()
+        {
+            // Arrange
+            var propertyAttributes = new object[]
+            {
+                new BindingBehaviorAttribute(BindingBehavior.Never),
+            };
+
+            var context = new BindingMetadataProviderContext(
+                ModelMetadataIdentity.ForProperty(typeof(int), "Length", typeof(string)),
+                new ModelAttributes(propertyAttributes, typeAttributes: new object[0]));
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.False(context.BindingMetadata.IsBindingAllowed);
+            Assert.False(context.BindingMetadata.IsBindingRequired);
+        }
+
+        [Fact]
+        public void GetBindingDetails_FindsBindNever_OnProperty()
+        {
+            // Arrange
+            var propertyAttributes = new object[]
+            {
+                new BindNeverAttribute(),
+            };
+
+            var context = new BindingMetadataProviderContext(
+                ModelMetadataIdentity.ForProperty(typeof(int), "Length", typeof(string)),
+                new ModelAttributes(propertyAttributes, typeAttributes: new object[0]));
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.False(context.BindingMetadata.IsBindingAllowed);
+            Assert.False(context.BindingMetadata.IsBindingRequired);
+        }
+
+        [Fact]
+        public void GetBindingDetails_FindsBindingBehaviorOptional_OnProperty()
+        {
+            // Arrange
+            var propertyAttributes = new object[]
+            {
+                new BindingBehaviorAttribute(BindingBehavior.Optional),
+            };
+
+            var context = new BindingMetadataProviderContext(
+                ModelMetadataIdentity.ForProperty(typeof(int), "Length", typeof(string)),
+                new ModelAttributes(propertyAttributes, typeAttributes: new object[0]));
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.True(context.BindingMetadata.IsBindingAllowed);
+            Assert.False(context.BindingMetadata.IsBindingRequired);
+        }
+
+        [Fact]
+        public void GetBindingDetails_FindsBindingBehaviorRequired_OnProperty()
+        {
+            // Arrange
+            var propertyAttributes = new object[]
+            {
+                new BindingBehaviorAttribute(BindingBehavior.Required),
+            };
+
+            var context = new BindingMetadataProviderContext(
+                ModelMetadataIdentity.ForProperty(typeof(int), "Length", typeof(string)),
+                new ModelAttributes(propertyAttributes, typeAttributes: new object[0]));
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.True(context.BindingMetadata.IsBindingAllowed);
+            Assert.True(context.BindingMetadata.IsBindingRequired);
+        }
+
+        [Fact]
+        public void GetBindingDetails_FindsBindRequired_OnProperty()
+        {
+            // Arrange
+            var propertyAttributes = new object[]
+            {
+                new BindingBehaviorAttribute(BindingBehavior.Required),
+            };
+
+            var context = new BindingMetadataProviderContext(
+                ModelMetadataIdentity.ForProperty(typeof(int), "Length", typeof(string)),
+                new ModelAttributes(propertyAttributes, typeAttributes: new object[0]));
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.True(context.BindingMetadata.IsBindingAllowed);
+            Assert.True(context.BindingMetadata.IsBindingRequired);
+        }
+
+        // These attributes have conflicting behavior - the 'required' behavior should be used because
+        // of ordering.
+        [Fact]
+        public void GetBindingDetails_UsesFirstAttribute()
+        {
+            // Arrange
+            var propertyAttributes = new object[]
+            {
+                new BindingBehaviorAttribute(BindingBehavior.Required),
+                new BindNeverAttribute(),
+            };
+
+            var context = new BindingMetadataProviderContext(
+                ModelMetadataIdentity.ForProperty(typeof(int), "Length", typeof(string)),
+                new ModelAttributes(propertyAttributes, typeAttributes: new object[0]));
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.True(context.BindingMetadata.IsBindingAllowed);
+            Assert.True(context.BindingMetadata.IsBindingRequired);
+        }
+
+        [Fact]
+        public void GetBindingDetails_FindsBindRequired_OnContainerClass()
+        {
+            // Arrange
+            var propertyAttributes = new object[]
+            {
+            };
+
+            var context = new BindingMetadataProviderContext(
+                ModelMetadataIdentity.ForProperty(typeof(string), "Property", typeof(BindRequiredOnClass)),
+                new ModelAttributes(propertyAttributes, typeAttributes: new object[0]));
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.True(context.BindingMetadata.IsBindingAllowed);
+            Assert.True(context.BindingMetadata.IsBindingRequired);
+        }
+
+        [Fact]
+        public void GetBindingDetails_FindsBindNever_OnContainerClass()
+        {
+            // Arrange
+            var propertyAttributes = new object[]
+            {
+            };
+
+            var context = new BindingMetadataProviderContext(
+                ModelMetadataIdentity.ForProperty(typeof(string), "Property", typeof(BindNeverOnClass)),
+                new ModelAttributes(propertyAttributes, typeAttributes: new object[0]));
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.False(context.BindingMetadata.IsBindingAllowed);
+            Assert.False(context.BindingMetadata.IsBindingRequired);
+        }
+
+        [Fact]
+        public void GetBindingDetails_OverrideBehaviorOnClass_OverrideWithOptional()
+        {
+            // Arrange
+            var propertyAttributes = new object[]
+            {
+                new BindingBehaviorAttribute(BindingBehavior.Optional)
+            };
+
+            var context = new BindingMetadataProviderContext(
+                ModelMetadataIdentity.ForProperty(typeof(string), "Property", typeof(BindNeverOnClass)),
+                new ModelAttributes(propertyAttributes, typeAttributes: new object[0]));
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.True(context.BindingMetadata.IsBindingAllowed);
+            Assert.False(context.BindingMetadata.IsBindingRequired);
+        }
+
+        [Fact]
+        public void GetBindingDetails_OverrideBehaviorOnClass_OverrideWithRequired()
+        {
+            // Arrange
+            var propertyAttributes = new object[]
+            {
+                new BindRequiredAttribute()
+            };
+
+            var context = new BindingMetadataProviderContext(
+                ModelMetadataIdentity.ForProperty(typeof(string), "Property", typeof(BindNeverOnClass)),
+                new ModelAttributes(propertyAttributes, typeAttributes: new object[0]));
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.True(context.BindingMetadata.IsBindingAllowed);
+            Assert.True(context.BindingMetadata.IsBindingRequired);
+        }
+
+        [Fact]
+        public void GetBindingDetails_OverrideInheritedBehaviorOnClass_OverrideWithRequired()
+        {
+            // Arrange
+            var propertyAttributes = new object[]
+            {
+                new BindRequiredAttribute()
+            };
+
+            var context = new BindingMetadataProviderContext(
+                ModelMetadataIdentity.ForProperty(typeof(string), "Property", typeof(InheritedBindNeverOnClass)),
+                new ModelAttributes(propertyAttributes, typeAttributes: new object[0]));
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.True(context.BindingMetadata.IsBindingAllowed);
+            Assert.True(context.BindingMetadata.IsBindingRequired);
+        }
+
+        [Fact]
+        public void GetBindingDetails_OverrideBehaviorOnClass_OverrideWithNever()
+        {
+            // Arrange
+            var propertyAttributes = new object[]
+            {
+                new BindNeverAttribute(),
+            };
+
+            var context = new BindingMetadataProviderContext(
+                ModelMetadataIdentity.ForProperty(typeof(string), "Property", typeof(BindRequiredOnClass)),
+                new ModelAttributes(propertyAttributes, typeAttributes: new object[0]));
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.False(context.BindingMetadata.IsBindingAllowed);
+            Assert.False(context.BindingMetadata.IsBindingRequired);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void GetBindingDetails_BindingBehaviorLeftAlone_ForTypeMetadata(bool initialValue)
+        {
+            // Arrange
+            var attributes = new object[]
+            {
+                new BindingBehaviorAttribute(BindingBehavior.Required),
+            };
+
+            var context = new BindingMetadataProviderContext(
+                ModelMetadataIdentity.ForType(typeof(string)),
+                new ModelAttributes(attributes));
+
+            // These values shouldn't be changed since this is a Type-Metadata
+            context.BindingMetadata.IsBindingAllowed = initialValue;
+            context.BindingMetadata.IsBindingRequired = initialValue;
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.Equal(initialValue, context.BindingMetadata.IsBindingAllowed);
+            Assert.Equal(initialValue, context.BindingMetadata.IsBindingRequired);
+        }
+
+        // Unlike most model metadata settings, BindingBehavior can be specified on the *container type*
+        // but not on the property type.
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void GetBindingDetails_BindingBehaviorLeftAlone_ForAttributeOnPropertyType(bool initialValue)
+        {
+            // Arrange
+            var typeAttributes = new object[]
+            {
+                new BindingBehaviorAttribute(BindingBehavior.Required),
+            };
+
+            var context = new BindingMetadataProviderContext(
+                ModelMetadataIdentity.ForProperty(typeof(int), "Length", typeof(string)),
+                new ModelAttributes(propertyAttributes: new object[0], typeAttributes: typeAttributes));
+
+            // These values shouldn't be changed since this is a Type-Metadata
+            context.BindingMetadata.IsBindingAllowed = initialValue;
+            context.BindingMetadata.IsBindingRequired = initialValue;
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.Equal(initialValue, context.BindingMetadata.IsBindingAllowed);
+            Assert.Equal(initialValue, context.BindingMetadata.IsBindingRequired);
+        }
+
+        [BindNever]
+        private class BindNeverOnClass
+        {
+            public string Property { get; set; }
+        }
+
+        private class InheritedBindNeverOnClass : BindNeverOnClass
+        {
+        }
+
+        [BindRequired]
+        private class BindRequiredOnClass
+        {
+            public string Property { get; set; }
+        }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/DefaultBindingMetadataProviderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/DefaultBindingMetadataProviderTest.cs
@@ -326,6 +326,24 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         }
 
         [Fact]
+        public void GetBindingDetails_FindsBindNever_OnBaseClass()
+        {
+            // Arrange
+            var context = new BindingMetadataProviderContext(
+                ModelMetadataIdentity.ForProperty(typeof(string), "Property", typeof(InheritedBindNeverOnClass)),
+                new ModelAttributes(propertyAttributes: new object[0], typeAttributes: new object[0]));
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.False(context.BindingMetadata.IsBindingAllowed);
+            Assert.False(context.BindingMetadata.IsBindingRequired);
+        }
+
+        [Fact]
         public void GetBindingDetails_OverrideBehaviorOnClass_OverrideWithOptional()
         {
             // Arrange
@@ -417,6 +435,25 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
             Assert.False(context.BindingMetadata.IsBindingRequired);
         }
 
+        // This overrides an inherited class-level attribute with a different class-level attribute.
+        [Fact]
+        public void GetBindingDetails_OverrideBehaviorOnBaseClass_OverrideWithRequired_OnClass()
+        {
+            // Arrange
+            var context = new BindingMetadataProviderContext(
+                ModelMetadataIdentity.ForProperty(typeof(string), "Property", typeof(BindRequiredOverridesInheritedBindNever)),
+                new ModelAttributes(propertyAttributes: new object[0], typeAttributes: new object[0]));
+
+            var provider = new DefaultBindingMetadataProvider();
+
+            // Act
+            provider.GetBindingMetadata(context);
+
+            // Assert
+            Assert.True(context.BindingMetadata.IsBindingAllowed);
+            Assert.True(context.BindingMetadata.IsBindingRequired);
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -491,6 +528,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         private class BindRequiredOnClass
         {
             public string Property { get; set; }
+        }
+
+        [BindRequired]
+        private class BindRequiredOverridesInheritedBindNever : BindNeverOnClass
+        {
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/DefaultBindingMetadataProviderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/DefaultBindingMetadataProviderTest.cs
@@ -246,7 +246,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
             // Arrange
             var propertyAttributes = new object[]
             {
-                new BindingBehaviorAttribute(BindingBehavior.Required),
+                new BindRequiredAttribute(),
             };
 
             var context = new BindingMetadataProviderContext(
@@ -293,13 +293,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         public void GetBindingDetails_FindsBindRequired_OnContainerClass()
         {
             // Arrange
-            var propertyAttributes = new object[]
-            {
-            };
-
             var context = new BindingMetadataProviderContext(
                 ModelMetadataIdentity.ForProperty(typeof(string), "Property", typeof(BindRequiredOnClass)),
-                new ModelAttributes(propertyAttributes, typeAttributes: new object[0]));
+                new ModelAttributes(propertyAttributes: new object[0], typeAttributes: new object[0]));
 
             var provider = new DefaultBindingMetadataProvider();
 
@@ -315,13 +311,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         public void GetBindingDetails_FindsBindNever_OnContainerClass()
         {
             // Arrange
-            var propertyAttributes = new object[]
-            {
-            };
-
             var context = new BindingMetadataProviderContext(
                 ModelMetadataIdentity.ForProperty(typeof(string), "Property", typeof(BindNeverOnClass)),
-                new ModelAttributes(propertyAttributes, typeAttributes: new object[0]));
+                new ModelAttributes(propertyAttributes: new object[0], typeAttributes: new object[0]));
 
             var provider = new DefaultBindingMetadataProvider();
 

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/ModelMetadataProviderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/ModelMetadataProviderTest.cs
@@ -712,7 +712,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
             Assert.Null(metadata.PropertySetter);
             Assert.NotNull(metadata.PropertyGetter);
         }
-
+        
         [Fact]
         public void Metadata_Null_ForPrivateGetProperty()
         {
@@ -724,6 +724,85 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
             // Act & Assert
             var metadata = metadataProvider.GetMetadataForType(type);
             Assert.Null(metadata.Properties[propertyName]);
+        }
+
+        [Fact]
+        public void BindingBehavior_GetMetadataForType_UsesDefaultValues()
+        {
+            // Arrange
+            var metadataProvider = TestModelMetadataProvider.CreateDefaultProvider();
+            var type = typeof(BindingBehaviorModel);
+
+            // Act
+            var metadata = metadataProvider.GetMetadataForType(type);
+
+            // Assert
+            Assert.True(metadata.IsBindingAllowed);
+            Assert.False(metadata.IsBindingRequired);
+        }
+
+        [Fact]
+        public void BindingBehavior_Override_RequiredOnProperty()
+        {
+            // Arrange
+            var metadataProvider = TestModelMetadataProvider.CreateDefaultProvider();
+            var type = typeof(BindingBehaviorModel);
+            var propertyName = nameof(BindingBehaviorModel.BindRequiredOverride);
+
+            // Act
+            var metadata = metadataProvider.GetMetadataForProperty(type, propertyName);
+
+            // Assert
+            Assert.True(metadata.IsBindingAllowed);
+            Assert.True(metadata.IsBindingRequired);
+        }
+
+        [Fact]
+        public void BindingBehavior_Override_OptionalOnProperty()
+        {
+            // Arrange
+            var metadataProvider = TestModelMetadataProvider.CreateDefaultProvider();
+            var type = typeof(BindingBehaviorModel);
+            var propertyName = nameof(BindingBehaviorModel.BindingBehaviorOptionalOverride);
+
+            // Act
+            var metadata = metadataProvider.GetMetadataForProperty(type, propertyName);
+
+            // Assert
+            Assert.True(metadata.IsBindingAllowed);
+            Assert.False(metadata.IsBindingRequired);
+        }
+
+        [Fact]
+        public void BindingBehavior_Never_SetOnPropertyAndClass()
+        {
+            // Arrange
+            var metadataProvider = TestModelMetadataProvider.CreateDefaultProvider();
+            var type = typeof(BindingBehaviorModel);
+            var propertyName = nameof(BindingBehaviorModel.BindingBehaviorNever);
+
+            // Act
+            var metadata = metadataProvider.GetMetadataForProperty(type, propertyName);
+
+            // Assert
+            Assert.False(metadata.IsBindingAllowed);
+            Assert.False(metadata.IsBindingRequired);
+        }
+
+        [Fact]
+        public void BindingBehavior_Never_SetOnClass()
+        {
+            // Arrange
+            var metadataProvider = TestModelMetadataProvider.CreateDefaultProvider();
+            var type = typeof(BindingBehaviorModel);
+            var propertyName = nameof(BindingBehaviorModel.BindingBehaviorNever);
+
+            // Act
+            var metadata = metadataProvider.GetMetadataForProperty(type, propertyName);
+
+            // Assert
+            Assert.False(metadata.IsBindingAllowed);
+            Assert.False(metadata.IsBindingRequired);
         }
 
         private IModelMetadataProvider CreateProvider(params object[] attributes)
@@ -867,6 +946,21 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         {
             [Required]
             public string RequiredProperty { get; set; }
+        }
+
+        [BindNever]
+        private class BindingBehaviorModel
+        {
+            [BindRequired]
+            public int BindRequiredOverride { get; set; }
+
+            [BindingBehavior(BindingBehavior.Optional)]
+            public int BindingBehaviorOptionalOverride { get; set; }
+
+            [BindingBehavior(BindingBehavior.Never)]
+            public int BindingBehaviorNever { get; set; }
+
+            public int BindingBehaviorNeverSetOnClass { get; set; }
         }
 
         private class AttributeInjectModelMetadataProvider : DefaultModelMetadataProvider

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/ModelMetadataProviderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/ModelMetadataProviderTest.cs
@@ -774,12 +774,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         }
 
         [Fact]
-        public void BindingBehavior_Never_SetOnPropertyAndClass()
+        public void BindingBehavior_Never_DuplicatedPropertyAndClass()
         {
             // Arrange
             var metadataProvider = TestModelMetadataProvider.CreateDefaultProvider();
             var type = typeof(BindingBehaviorModel);
-            var propertyName = nameof(BindingBehaviorModel.BindingBehaviorNever);
+            var propertyName = nameof(BindingBehaviorModel.BindingBehaviorNeverDuplicatedFromClass);
 
             // Act
             var metadata = metadataProvider.GetMetadataForProperty(type, propertyName);
@@ -795,7 +795,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
             // Arrange
             var metadataProvider = TestModelMetadataProvider.CreateDefaultProvider();
             var type = typeof(BindingBehaviorModel);
-            var propertyName = nameof(BindingBehaviorModel.BindingBehaviorNever);
+            var propertyName = nameof(BindingBehaviorModel.BindingBehaviorNeverSetOnClass);
 
             // Act
             var metadata = metadataProvider.GetMetadataForProperty(type, propertyName);
@@ -958,7 +958,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
             public int BindingBehaviorOptionalOverride { get; set; }
 
             [BindingBehavior(BindingBehavior.Never)]
-            public int BindingBehaviorNever { get; set; }
+            public int BindingBehaviorNeverDuplicatedFromClass { get; set; }
 
             public int BindingBehaviorNeverSetOnClass { get; set; }
         }

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/ModelMetadataProviderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/ModelMetadataProviderTest.cs
@@ -712,7 +712,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
             Assert.Null(metadata.PropertySetter);
             Assert.NotNull(metadata.PropertyGetter);
         }
-        
+
         [Fact]
         public void Metadata_Null_ForPrivateGetProperty()
         {

--- a/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/ModelMetadataTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ModelBinding.Test/Metadata/ModelMetadataTest.cs
@@ -309,6 +309,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 }
             }
 
+            public override bool IsBindingAllowed
+            {
+                get
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
             public override bool IsBindingRequired
             {
                 get


### PR DESCRIPTION
...Binder

This change moves [BindingBehavior(...)] and friends into the model
metadata layer, and removes the reflection code from
MutableObjectModelBinder that was looking for them previously.