### PR TITLE
Fix for #2357 : We prevent assigining null values to non nullable contro...

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/DefaultControllerActionArgumentBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/DefaultControllerActionArgumentBinder.cs
@@ -111,7 +111,11 @@ namespace Microsoft.AspNet.Mvc
                     return;
                 }
 
-                propertyHelper.SetValue(controller, property.Value);
+                // Do not set the property if the type is a non nullable type.
+                if (property.Value != null || propertyHelper.Property.PropertyType.AllowsNullValue())
+                {
+                    propertyHelper.SetValue(controller, property.Value);
+                }
             }
         }
 


### PR DESCRIPTION
...ller properties.

We do not add a model state error for this case to ensure we have a similar behavior as mvc 5.0 (in terms of no model state errors for value types). see #2423