### PR TITLE
Use `string.IsNullOrEmpty()` instead of empty string check.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/FormatterMappings.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/FormatterMappings.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNet.Mvc
 
         private string RemovePeriodIfPresent(string format)
         {
-            if (format == "")
+            if (string.IsNullOrEmpty(format))
             {
                 throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(format));
             }


### PR DESCRIPTION
Noticed this in #2421.