### PR TITLE
Added the default constructor to ViewContext

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Abstractions/ActionContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/ActionContext.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNet.Mvc
     public class ActionContext
     {
         /// <summary>
-        /// Creates a empty <see cref="ActionContext"/>.
+        /// Creates an empty <see cref="ActionContext"/>.
         /// </summary>
         /// <remarks>
         /// The default constructor is provided for unit test purposes only.

--- a/src/Microsoft.AspNet.Mvc.Core/ViewComponents/ViewComponent.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ViewComponents/ViewComponent.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Security.Principal;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Mvc.ModelBinding;
@@ -17,6 +18,8 @@ namespace Microsoft.AspNet.Mvc
     public abstract class ViewComponent
     {
         private dynamic _viewBag;
+        private ViewContext _viewContext;
+        private ViewDataDictionary _viewData;
 
         /// <summary>
         /// Gets the <see cref="HttpContext"/>.
@@ -99,13 +102,49 @@ namespace Microsoft.AspNet.Mvc
         /// Gets or sets the <see cref="ViewContext"/>.
         /// </summary>
         [Activate]
-        public ViewContext ViewContext { get; set; }
+        public ViewContext ViewContext
+        {
+            get
+            {
+                if (_viewContext == null)
+                {
+                    // This should run only for the ViewComponent unit test scenarios
+                    _viewContext = new ViewContext();
+                }
+
+                return _viewContext;
+            }
+
+            [param: NotNull]
+            set
+            {
+                _viewContext = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the <see cref="ViewDataDictionary"/>.
         /// </summary>
         [Activate]
-        public ViewDataDictionary ViewData { get; set; }
+        public ViewDataDictionary ViewData
+        {
+            get
+            {
+                if (_viewData == null)
+                {
+                    // This should run only for the ViewComponent unit test scenarios
+                    _viewData = new ViewDataDictionary(ViewContext.ViewData);
+                }
+
+                return _viewData;
+            }
+
+            [param: NotNull]
+            set
+            {
+                _viewData = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the <see cref="ICompositeViewEngine"/>.

--- a/src/Microsoft.AspNet.Mvc.Core/ViewContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ViewContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
+using Microsoft.AspNet.Mvc.ModelBinding;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.Framework.Internal;
 
@@ -17,6 +18,17 @@ namespace Microsoft.AspNet.Mvc
 
         private FormContext _formContext;
         private DynamicViewData _viewBag;
+
+        /// <summary>
+        /// Creates an empty <see cref="ViewContext"/>.
+        /// </summary>
+        /// <remarks>
+        /// The default constructor is provided for unit test purposes only.
+        /// </remarks>
+        public ViewContext()
+        {
+            ViewData = new ViewDataDictionary(new EmptyModelMetadataProvider(), ModelState);
+        }
 
         /// <summary>
         /// Initializes a new instance of <see cref="ViewContext"/>.

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ViewComponentTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ViewComponentTests.cs
@@ -165,6 +165,24 @@ namespace Microsoft.AspNet.Mvc
             Assert.Equal("CustomViewName", actualResult.ViewName);
         }
 
+        [Fact]
+        public void ViewComponent_ViewContext_ViewData_ReturnsDefaultInstanceIfNull()
+        {
+            // Arrange && Act
+            var viewComponent = new TestViewComponent();
+
+            // Assert
+            // ViewComponent.ViewContext returns the default instance for the unit test scenarios
+            Assert.NotNull(viewComponent.ViewContext);
+            Assert.NotNull(viewComponent.ViewContext.ViewData);
+
+            // ViewComponent.ViewData returns the default instance for the unit test scenarios
+            Assert.Empty(viewComponent.ViewContext.ViewData);
+            Assert.NotNull(viewComponent.ViewData);
+            Assert.Empty(viewComponent.ViewData);
+            Assert.NotSame(viewComponent.ViewData, viewComponent.ViewContext.ViewData);
+        }
+
         private class TestViewComponent : ViewComponent
         {
         }


### PR DESCRIPTION
Added the default constructor for ViewContext. 

1. All properties already have the setter. 
2. I checked three unit test scenarios that this change can be useful
   - ViewComponent : Unit-testable with this default viewcontext 
  -  TagHelper, HtmlHelper : Not really, we still need more for example the default constructor for DefaultHtmlGenerator...

Thanks
