### PR TITLE
React to aspnet/Razor#182 fix

### DIFF
--- a/src/Microsoft.AspNet.Mvc.TagHelpers/AnchorTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/AnchorTagHelper.cs
@@ -24,9 +24,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         private const string RouteAttributePrefix = "asp-route-";
         private const string Href = "href";
 
-        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
-        [Activate]
-        protected internal IHtmlGenerator Generator { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public IHtmlGenerator Generator { get; set; }
 
         /// <summary>
         /// The name of the action method.

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/CacheTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/CacheTagHelper.cs
@@ -39,14 +39,14 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         /// <summary>
         /// Gets or sets the <see cref="IMemoryCache"/> instance used to cache entries.
         /// </summary>
-        [Activate]
-        protected internal IMemoryCache MemoryCache { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public IMemoryCache MemoryCache { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="ViewContext"/> for the current executing View.
         /// </summary>
-        [Activate]
-        protected internal ViewContext ViewContext { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public ViewContext ViewContext { get; set; }
 
         /// <summary>
         /// Gets or sets a <see cref="string" /> to vary the cached result by.

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/EnvironmentTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/EnvironmentTagHelper.cs
@@ -25,9 +25,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         /// </remarks>
         public string Names { get; set; }
 
-        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
-        [Activate]
-        protected internal IHostingEnvironment HostingEnvironment { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public IHostingEnvironment HostingEnvironment { get; set; }
 
         /// <inheritdoc />
         public override void Process(TagHelperContext context, TagHelperOutput output)

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/FormTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/FormTagHelper.cs
@@ -21,13 +21,11 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         private const string RouteAttributePrefix = "asp-route-";
         private const string HtmlActionAttributeName = "action";
 
-        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
-        [Activate]
-        protected internal ViewContext ViewContext { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public ViewContext ViewContext { get; set; }
 
-        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
-        [Activate]
-        protected internal IHtmlGenerator Generator { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public IHtmlGenerator Generator { get; set; }
 
         /// <summary>
         /// The name of the action method.

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/InputTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/InputTagHelper.cs
@@ -62,13 +62,11 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "time", "{0:HH:mm:ss.fff}" },
             };
 
-        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
-        [Activate]
-        protected internal IHtmlGenerator Generator { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public IHtmlGenerator Generator { get; set; }
 
-        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
-        [Activate]
-        protected internal ViewContext ViewContext { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public ViewContext ViewContext { get; set; }
 
         /// <summary>
         /// An expression to be evaluated against the current model.

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/LabelTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/LabelTagHelper.cs
@@ -15,13 +15,11 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     {
         private const string ForAttributeName = "asp-for";
 
-        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
-        [Activate]
-        protected internal ViewContext ViewContext { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public ViewContext ViewContext { get; set; }
 
-        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
-        [Activate]
-        protected internal IHtmlGenerator Generator { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public IHtmlGenerator Generator { get; set; }
 
         /// <summary>
         /// An expression to be evaluated against the current model.

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/LinkTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/LinkTagHelper.cs
@@ -180,28 +180,27 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         [HtmlAttributeName(FallbackTestValueAttributeName)]
         public string FallbackTestValue { get; set; }
 
-        // Properties are protected to ensure subclasses are correctly activated.
-        // Internal for ease of use when testing.
-        [Activate]
-        protected internal ILoggerFactory LoggerFactory { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public ILoggerFactory LoggerFactory { get; set; }
 
         // TODO: will remove LoggerFactory and activate logger once DI/hosting bug is fixed
-        internal ILogger<LinkTagHelper> Logger { get; set; }
+        [HtmlAttributeNotBound]
+        public ILogger<LinkTagHelper> Logger { get; set; }
 
-        [Activate]
-        protected internal IHostingEnvironment HostingEnvironment { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public IHostingEnvironment HostingEnvironment { get; set; }
 
-        [Activate]
-        protected internal ViewContext ViewContext { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public ViewContext ViewContext { get; set; }
 
-        [Activate]
-        protected internal IMemoryCache Cache { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public IMemoryCache Cache { get; set; }
 
-        [Activate]
-        protected internal IHtmlEncoder HtmlEncoder { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public IHtmlEncoder HtmlEncoder { get; set; }
 
-        [Activate]
-        protected internal IJavaScriptStringEncoder JavaScriptEncoder { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public IJavaScriptStringEncoder JavaScriptEncoder { get; set; }
 
         // Internal for ease of use when testing.
         protected internal GlobbingUrlBuilder GlobbingUrlBuilder { get; set; }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/OptionTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/OptionTagHelper.cs
@@ -19,13 +19,11 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     /// </remarks>
     public class OptionTagHelper : TagHelper
     {
-        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
-        [Activate]
-        protected internal IHtmlGenerator Generator { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public IHtmlGenerator Generator { get; set; }
 
-        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
-        [Activate]
-        protected internal ViewContext ViewContext { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public ViewContext ViewContext { get; set; }
 
         /// <summary>
         /// Specifies a value for the &lt;option&gt; element.

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ScriptTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ScriptTagHelper.cs
@@ -149,27 +149,27 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         [HtmlAttributeName(FallbackTestExpressionAttributeName)]
         public string FallbackTestExpression { get; set; }
 
-        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
-        [Activate]
-        protected internal ILoggerFactory LoggerFactory { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public ILoggerFactory LoggerFactory { get; set; }
 
         // TODO: will remove LoggerFactory and activate logger once DI/hosting bug is fixed
-        internal ILogger<ScriptTagHelper> Logger { get; set; }
+        [HtmlAttributeNotBound]
+        public ILogger<ScriptTagHelper> Logger { get; set; }
 
-        [Activate]
-        protected internal IHostingEnvironment HostingEnvironment { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public IHostingEnvironment HostingEnvironment { get; set; }
 
-        [Activate]
-        protected internal ViewContext ViewContext { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public ViewContext ViewContext { get; set; }
 
-        [Activate]
-        protected internal IMemoryCache Cache { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public IMemoryCache Cache { get; set; }
 
-        [Activate]
-        protected internal IHtmlEncoder HtmlEncoder { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public IHtmlEncoder HtmlEncoder { get; set; }
 
-        [Activate]
-        protected internal IJavaScriptStringEncoder JavaScriptEncoder { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public IJavaScriptStringEncoder JavaScriptEncoder { get; set; }
 
         // Internal for ease of use when testing.
         protected internal GlobbingUrlBuilder GlobbingUrlBuilder { get; set; }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/SelectTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/SelectTagHelper.cs
@@ -30,13 +30,11 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         /// </remarks>
         public static readonly string SelectedValuesFormDataKey = nameof(SelectTagHelper) + "-SelectedValues";
 
-        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
-        [Activate]
-        protected internal IHtmlGenerator Generator { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public IHtmlGenerator Generator { get; set; }
 
-        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
-        [Activate]
-        protected internal ViewContext ViewContext { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public ViewContext ViewContext { get; set; }
 
         /// <summary>
         /// An expression to be evaluated against the current model.

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/TextAreaTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/TextAreaTagHelper.cs
@@ -15,13 +15,11 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     {
         private const string ForAttributeName = "asp-for";
 
-        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
-        [Activate]
-        protected internal IHtmlGenerator Generator { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public IHtmlGenerator Generator { get; set; }
 
-        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
-        [Activate]
-        protected internal ViewContext ViewContext { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public ViewContext ViewContext { get; set; }
 
         /// <summary>
         /// An expression to be evaluated against the current model.

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationMessageTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationMessageTagHelper.cs
@@ -16,13 +16,11 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     {
         private const string ValidationForAttributeName = "asp-validation-for";
 
-        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
-        [Activate]
-        protected internal ViewContext ViewContext { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public ViewContext ViewContext { get; set; }
 
-        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
-        [Activate]
-        protected internal IHtmlGenerator Generator { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public IHtmlGenerator Generator { get; set; }
 
         /// <summary>
         /// Name to be validated on the current model.

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationSummaryTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationSummaryTagHelper.cs
@@ -17,13 +17,11 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         private const string ValidationSummaryAttributeName = "asp-validation-summary";
         private ValidationSummary _validationSummary;
 
-        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
-        [Activate]
-        protected internal ViewContext ViewContext { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public ViewContext ViewContext { get; set; }
 
-        // Protected to ensure subclasses are correctly activated. Internal for ease of use when testing.
-        [Activate]
-        protected internal IHtmlGenerator Generator { get; set; }
+        [Activate, HtmlAttributeNotBound]
+        public IHtmlGenerator Generator { get; set; }
 
         /// <summary>
         /// If <see cref="ValidationSummary.All"/> or <see cref="ValidationSummary.ModelOnly"/>, appends a validation

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/RazorPageCreateTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/RazorPageCreateTagHelperTest.cs
@@ -147,7 +147,7 @@ namespace Microsoft.AspNet.Mvc.Razor
 
         private class ServiceTagHelper : TagHelper
         {
-            [Activate]
+            [Activate, HtmlAttributeNotBound]
             public MyService ActivatedService { get; set; }
         }
 
@@ -159,7 +159,7 @@ namespace Microsoft.AspNet.Mvc.Razor
 
         private class ViewDataTagHelper : TagHelper
         {
-            [Activate]
+            [Activate, HtmlAttributeNotBound]
             public ViewDataDictionary ViewData { get; set; }
         }
 

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/ATagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/ATagHelper.cs
@@ -4,13 +4,12 @@
 using System.Linq;
 using Microsoft.AspNet.Mvc;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
-using Microsoft.AspNet.Razor.TagHelpers;
 
 namespace TagHelpersWebSite.TagHelpers
 {
     public class ATagHelper : TagHelper
     {
-        [Activate]
+        [Activate, HtmlAttributeNotBound]
         public IUrlHelper UrlHelper { get; set; }
 
         public string Controller { get; set; }

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/PrettyTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/PrettyTagHelper.cs
@@ -25,7 +25,7 @@ namespace TagHelpersWebSite.TagHelpers
 
         public string Style { get; set; }
 
-        [Activate]
+        [Activate, HtmlAttributeNotBound]
         public ViewContext ViewContext { get; set; }
 
         public override void Process(TagHelperContext context, TagHelperOutput output)

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/TagCloudViewComponentTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/TagCloudViewComponentTagHelper.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc;
 using Microsoft.AspNet.Mvc.ViewComponents;
@@ -26,7 +25,7 @@ namespace MvcSample.Web.Components
 
         public int Count { get; set; }
 
-        [Activate]
+        [Activate, HtmlAttributeNotBound]
         public ViewContext ViewContext { get; set; }
 
         public int Order { get; } = 0;
@@ -35,7 +34,7 @@ namespace MvcSample.Web.Components
         {
             var result = await InvokeAsync(Count);
             var writer = new StringWriter();
-            
+
             var viewComponentDescriptor = new ViewComponentDescriptor()
             {
                 Type = typeof(TagCloudViewComponentTagHelper),


### PR DESCRIPTION
- use `[HtmlAttributeNotBound]` to make tag helper properties `public`
- properties remain invisible in Razor