### PR TITLE
Make sure references are readable multiple times

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/Precompilation/RazorPreCompiler.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Precompilation/RazorPreCompiler.cs
@@ -165,8 +165,9 @@ namespace Microsoft.AspNet.Mvc.Razor.Precompilation
             else
             {
                 assemblyStream.Position = 0;
+                var assemblyBytes = assemblyStream.ToArray();
                 var assemblyResource = new ResourceDescription(assemblyResourceName,
-                                                               () => assemblyStream,
+                                                               () => new MemoryStream(assemblyBytes),
                                                                isPublic: true);
                 CompileContext.Resources.Add(assemblyResource);
 
@@ -175,9 +176,10 @@ namespace Microsoft.AspNet.Mvc.Razor.Precompilation
                 {
                     symbolsResourceName = resourcePrefix + ".pdb";
                     pdbStream.Position = 0;
+                    var pdbBytes = pdbStream.ToArray();
 
                     var pdbResource = new ResourceDescription(symbolsResourceName,
-                                                              () => pdbStream,
+                                                              () => new MemoryStream(pdbBytes),
                                                               isPublic: true);
 
                     CompileContext.Resources.Add(pdbResource);


### PR DESCRIPTION
When you reference a project containing precompiled Razor views from a project that uses a custom compiler (like F#), the result is often that the project get's compiled multiple times. Roslyn closes the resource streams when it's done with them, so therefore just using a single `MemoryStream` ends up with `ObjectDisposedException` on the second compilation. This commit fixes that.