### PR TITLE
Included default route template in docs

### DIFF
--- a/src/Microsoft.AspNet.Mvc/BuilderExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc/BuilderExtensions.cs
@@ -31,7 +31,8 @@ namespace Microsoft.AspNet.Builder
 
         /// <summary>
         /// Adds MVC to the <see cref="IApplicationBuilder"/> request execution pipeline
-        /// with a default route.
+        /// with a default route named 'default' and the following template:
+        /// '{controller=Home}/{action=Index}/{id?}'.
         /// </summary>
         /// <param name="app">The <see cref="IApplicationBuilder"/>.</param>
         /// <returns>The <paramref name="app"/>.</returns>


### PR DESCRIPTION
Added the exact route being used in the
`BuilderExtensions.UseMvcWithDefaultRoute()` method.

#1885