### PR TITLE
Use DateTimeOffset with fixed time zone in tests to allow it to work in

### DIFF
--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingTest.cs
@@ -1474,7 +1474,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
                 Year = 2013,
                 InspectedDates = new DateTimeOffset[]
                 {
-                    new DateTime(2008, 11, 01)
+                    new DateTimeOffset(new DateTime(2008, 11, 01), TimeSpan.FromHours(-7))
                 },
                 Make = "RealSlowCars",
                 Model = "Epsum",


### PR DESCRIPTION
non-PST timezones.