### PR TITLE
Fix MVC packages being broken on CoreCLR

### DIFF
--- a/src/Microsoft.AspNet.JsonPatch/project.json
+++ b/src/Microsoft.AspNet.JsonPatch/project.json
@@ -15,7 +15,10 @@
                 "System.Collections": "4.0.10-beta-*",
                 "System.Collections.Concurrent": "4.0.10-beta-*",
                 "System.Globalization": "4.0.10-beta-*",
-                "System.Runtime.Extensions": "4.0.10-beta-*"
+                "System.Runtime.Extensions": "4.0.10-beta-*",
+                "System.ComponentModel.TypeConverter": "4.0.0-beta-*",
+                "System.Reflection.Extensions": "4.0.0-beta-*",
+                "System.Text.Encoding.Extensions": "4.0.10-beta-*"
             }
         }
     }

--- a/src/Microsoft.AspNet.JsonPatch/project.json
+++ b/src/Microsoft.AspNet.JsonPatch/project.json
@@ -14,10 +14,10 @@
                 "Microsoft.CSharp": "4.0.0-beta-*",
                 "System.Collections": "4.0.10-beta-*",
                 "System.Collections.Concurrent": "4.0.10-beta-*",
-                "System.Globalization": "4.0.10-beta-*",
-                "System.Runtime.Extensions": "4.0.10-beta-*",
                 "System.ComponentModel.TypeConverter": "4.0.0-beta-*",
+                "System.Globalization": "4.0.10-beta-*",
                 "System.Reflection.Extensions": "4.0.0-beta-*",
+                "System.Runtime.Extensions": "4.0.10-beta-*",
                 "System.Text.Encoding.Extensions": "4.0.10-beta-*"
             }
         }

--- a/src/Microsoft.AspNet.Mvc.Abstractions/project.json
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/project.json
@@ -15,7 +15,10 @@
     "dnx451": {},
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.CSharp": "4.0.0-beta-*"
+        "Microsoft.CSharp": "4.0.0-beta-*",
+        "System.ComponentModel.TypeConverter": "4.0.0-beta-*",
+        "System.Reflection.Extensions": "4.0.0-beta-*",
+        "System.Text.Encoding.Extensions": "4.0.10-beta-*"
       }
     }
   }

--- a/src/Microsoft.AspNet.Mvc.Common/project.json
+++ b/src/Microsoft.AspNet.Mvc.Common/project.json
@@ -8,9 +8,7 @@
         "dnx451": { },
         "dnxcore50": {
             "dependencies": {
-		"System.ComponentModel.TypeConverter": "4.0.0-beta-*",
-                "System.Reflection.Extensions": "4.0.0-beta-*",
-                "System.Text.Encoding.Extensions": "4.0.10-beta-*"
+                "System.Runtime": "4.0.20-beta-*"
             }
         }
     }

--- a/src/Microsoft.AspNet.Mvc.Razor.Host/project.json
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/project.json
@@ -22,7 +22,10 @@
         "dnxcore50": {
             "dependencies": {
                 "System.Collections.Concurrent": "4.0.10-beta-*",
-                "Microsoft.Framework.Runtime.Abstractions": "1.0.0-*"
+                "Microsoft.Framework.Runtime.Abstractions": "1.0.0-*",
+                "System.ComponentModel.TypeConverter": "4.0.0-beta-*",
+                "System.Reflection.Extensions": "4.0.0-beta-*",
+                "System.Text.Encoding.Extensions": "4.0.10-beta-*"
             }
         }
     }

--- a/src/Microsoft.AspNet.Mvc.Razor.Host/project.json
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/project.json
@@ -21,8 +21,8 @@
         },
         "dnxcore50": {
             "dependencies": {
-                "System.Collections.Concurrent": "4.0.10-beta-*",
                 "Microsoft.Framework.Runtime.Abstractions": "1.0.0-*",
+                "System.Collections.Concurrent": "4.0.10-beta-*",
                 "System.ComponentModel.TypeConverter": "4.0.0-beta-*",
                 "System.Reflection.Extensions": "4.0.0-beta-*",
                 "System.Text.Encoding.Extensions": "4.0.10-beta-*"

--- a/test/Microsoft.AspNet.Mvc.Common.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.Common.Test/project.json
@@ -20,6 +20,12 @@
                 "Moq": "4.2.1312.1622"
             }
         },
-        "dnxcore50": { }
+        "dnxcore50": { 
+            "dependencies": {
+                "System.ComponentModel.TypeConverter": "4.0.0-beta-*",
+                "System.Reflection.Extensions": "4.0.0-beta-*",
+                "System.Text.Encoding.Extensions": "4.0.10-beta-*"
+            }
+        }
     }
 }


### PR DESCRIPTION
- Mvc is currently broken on CoreCLR because it is
inheriting dependencies from Microsoft.AspNet.Mvc.Common but the resulting
dependency to Microsoft.AspNet.Mvc.Common is then erased at pack time.
This change moves the dependencies down and makes the shared package
only depend on System.Runtime.

#2507 

/cc @rynowak 