### PR TITLE
[Design] Wrapper stream writer which prevents writing flushing to avoid chunke…

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/Formatters/JsonOutputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Formatters/JsonOutputFormatter.cs
@@ -70,8 +70,7 @@ namespace Microsoft.AspNet.Mvc
             var response = context.ActionContext.HttpContext.Response;
             var selectedEncoding = context.SelectedEncoding;
 
-            using (var nonDisposableStream = new NonDisposableStream(response.Body))
-            using (var writer = new StreamWriter(nonDisposableStream, selectedEncoding, 1024, leaveOpen: true))
+            using (var writer = new HttpResponseStreamWriter(response.Body, selectedEncoding))
             {
                 WriteObject(writer, context.Object);
             }

--- a/src/Microsoft.AspNet.Mvc.Core/HttpResponseStreamWriter.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/HttpResponseStreamWriter.cs
@@ -1,0 +1,73 @@
+﻿using System.IO;
+using System.Text;
+using Microsoft.AspNet.Mvc.Internal;
+
+namespace Microsoft.AspNet.Mvc
+{
+    /// <summary>
+    /// Wraps the supplied <see cref="Stream"/> to prevent it from flushing (which can cause response to be sent
+    /// in Chunked encoding) and disposing (as the hosting layers own the stream).
+    /// Also wraps the supplied <see cref="Encoding"/> to prevent writing the preamble or BOM bytes to the response.
+    /// </summary>
+    public class HttpResponseStreamWriter : StreamWriter
+    {
+        private const int DefaultBufferSize = 1024;
+
+        public HttpResponseStreamWriter(Stream stream, Encoding encoding)
+            : this(stream, encoding, DefaultBufferSize)
+        {
+        }
+
+        public HttpResponseStreamWriter(Stream stream, Encoding encoding, int bufferSize)
+            : base(new NonDisposableStream(stream), new NonBomEncodingWrapper(encoding), bufferSize, leaveOpen: true)
+        {
+        }
+
+        private class NonBomEncodingWrapper : Encoding
+        {
+            private readonly Encoding _originalEncoding;
+
+            public NonBomEncodingWrapper(Encoding encoding)
+            {
+                _originalEncoding = encoding;
+            }
+
+            public override int GetByteCount(char[] chars, int index, int count)
+            {
+                return _originalEncoding.GetByteCount(chars, index, count);
+            }
+
+            public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
+            {
+                return _originalEncoding.GetBytes(chars, charIndex, charCount, bytes, byteIndex);
+            }
+
+            public override int GetCharCount(byte[] bytes, int index, int count)
+            {
+                return _originalEncoding.GetCharCount(bytes, index, count);
+            }
+
+            public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
+            {
+                return _originalEncoding.GetChars(bytes, byteIndex, byteCount, chars, charIndex);
+            }
+
+            public override int GetMaxByteCount(int charCount)
+            {
+                return _originalEncoding.GetMaxByteCount(charCount);
+            }
+
+            public override int GetMaxCharCount(int byteCount)
+            {
+                return _originalEncoding.GetMaxCharCount(byteCount);
+            }
+
+            public override byte[] GetPreamble()
+            {
+                // Returning a byte array of length zero, to indicate that a preamble is not required.
+                // From: https://msdn.microsoft.com/en-us/library/system.text.encoding.getpreamble%28v=vs.110%29.aspx
+                return new byte[] { };
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/JsonOutputFormatterTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/JsonOutputFormatterTests.cs
@@ -142,11 +142,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test.Formatters
             var formattedContent = "\"" + content + "\"";
             var mediaType = string.Format("application/json; charset={0}", encodingAsString);
             var encoding = CreateOrGetSupportedEncoding(formatter, encodingAsString, isDefaultEncoding);
-            var preamble = encoding.GetPreamble();
-            var data = encoding.GetBytes(formattedContent);
-            var expectedData = new byte[preamble.Length + data.Length];
-            Buffer.BlockCopy(preamble, 0, expectedData, 0, preamble.Length);
-            Buffer.BlockCopy(data, 0, expectedData, preamble.Length, data.Length);
+            var expectedData = encoding.GetBytes(formattedContent);
 
             var memStream = new MemoryStream();
             var outputFormatterContext = new OutputFormatterContext

--- a/test/Microsoft.AspNet.Mvc.Core.Test/JsonResultTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/JsonResultTest.cs
@@ -107,7 +107,7 @@ namespace Microsoft.AspNet.Mvc
         public async Task ExecuteResultAsync_UsesPassedInFormatter()
         {
             // Arrange
-            var expected = Enumerable.Concat(Encoding.UTF8.GetPreamble(), _abcdUTF8Bytes);
+            var expected = _abcdUTF8Bytes;
 
             var context = GetHttpContext();
             var actionContext = new ActionContext(context, new RouteData(), new ActionDescriptor());


### PR DESCRIPTION
…d encoding and avoids writing preamble or BOM bytes.

Right, the `HttpResponseStreamWriter` here doesn't do much different than what I have tried earlier before but probably a little improvement is that we wrap the stream and encoding within the writer itself...

I have 'fixed' few tests (json output formatter) which earlier expected BOM bytes to not check them anymore.

Please ignore the location of the `HttpResponseStreamWriter`...we could later move it to some other repo if we are happy with this change...

@pranavkm @rynowak @Tratcher 

Related issue: https://github.com/dotnet/coreclr/issues/933
