### PR TITLE
Restore validation node

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/ModelBindingResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/ModelBindingResult.cs
@@ -16,10 +16,25 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// <param name="isModelSet">A value that represents if the model has been set by the
         /// <see cref="IModelBinder"/>.</param>
         public ModelBindingResult(object model, string key, bool isModelSet)
+            : this (model, key, isModelSet, validationNode: null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ModelBindingResult"/>.
+        /// </summary>
+        /// <param name="model">The model which was created by the <see cref="IModelBinder"/>.</param>
+        /// <param name="key">The key using which was used to attempt binding the model.</param>
+        /// <param name="isModelSet">A value that represents if the model has been set by the
+        /// <see cref="IModelBinder"/>.</param>
+        /// <param name="validationNode">A <see cref="ModelValidationNode"/> which captures the validation information.
+        /// </param>
+        public ModelBindingResult(object model, string key, bool isModelSet, ModelValidationNode validationNode)
         {
             Model = model;
             Key = key;
             IsModelSet = isModelSet;
+            ValidationNode = validationNode;
         }
 
         /// <summary>
@@ -47,5 +62,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// </para>
         /// </summary>
         public bool IsModelSet { get; }
+
+        /// <summary>
+        /// A <see cref="ModelValidationNode"/> associated with the current <see cref="ModelBindingResult"/>.
+        /// </summary>
+        public ModelValidationNode ValidationNode { get; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/ModelValidationNode.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/ModelValidationNode.cs
@@ -1,0 +1,76 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Framework.Internal;
+
+namespace Microsoft.AspNet.Mvc.ModelBinding
+{
+    /// <summary>
+    /// Captures the validation information for a particular model.
+    /// </summary>
+    public class ModelValidationNode
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="ModelValidationNode"/>.
+        /// </summary>
+        /// <param name="key">The key that will be used by the validation system to find <see cref="ModelState"/>
+        /// entries.</param>
+        /// <param name="modelMetadata">The <see cref="ModelMetadata"/> for the <paramref name="model"/>.</param>
+        /// <param name="model">The model object which is to be validated.</param>
+        public ModelValidationNode([NotNull] string key, [NotNull] ModelMetadata modelMetadata, object model)
+            : this (key, modelMetadata, model, new List<ModelValidationNode>())
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="ModelValidationNode"/>.
+        /// </summary>
+        /// <param name="key">The key that will be used by the validation system to add
+        /// <see cref="ModelStateDictionary"/> entries.</param>
+        /// <param name="modelMetadata">The <see cref="ModelMetadata"/> for the <paramref name="model"/>.</param>
+        /// <param name="model">The model object which will be validated.</param>
+        /// <param name="childNodes">A collection of child nodes.</param>
+        public ModelValidationNode(
+            [NotNull] string key,
+            [NotNull] ModelMetadata modelMetadata,
+            object model,
+            [NotNull] IList<ModelValidationNode> childNodes)
+        {
+            Key = key;
+            ModelMetadata = modelMetadata;
+            ChildNodes = childNodes;
+            Model = model;
+        }
+
+        /// <summary>
+        /// Gets the key used for adding <see cref="ModelStateDictionary"/> entries.
+        /// </summary>
+        public string Key { get; }
+
+        /// <summary>
+        /// Gets the <see cref="ModelMetadata"/>.
+        /// </summary>
+        public ModelMetadata ModelMetadata { get; }
+
+        /// <summary>
+        /// Gets the model instance which is to be validated.
+        /// </summary>
+        public object Model { get; }
+
+        /// <summary>
+        /// Gets the child nodes.
+        /// </summary>
+        public IList<ModelValidationNode> ChildNodes { get; }
+
+        /// <summary>
+        /// Gets or sets a value that indicates whether all properties of the model should be validated.
+        /// </summary>
+        public bool ValidateAllProperties { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that indicates whether validation should be suppressed.
+        /// </summary>
+        public bool SuppressValidation { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/Validation/ModelValidationContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/Validation/ModelValidationContext.cs
@@ -10,23 +10,21 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         public ModelValidationContext(
             [NotNull] ModelBindingContext bindingContext,
             [NotNull] ModelExplorer modelExplorer)
-            : this(bindingContext.ModelName,
-                   bindingContext.BindingSource,
-                   bindingContext.OperationBindingContext.ValidatorProvider,
-                   bindingContext.ModelState,
-                   modelExplorer)
+            : this(
+                 bindingContext.BindingSource,
+                 bindingContext.OperationBindingContext.ValidatorProvider,
+                 bindingContext.ModelState,
+                 modelExplorer)
         {
         }
 
         public ModelValidationContext(
-            string rootPrefix,
             BindingSource bindingSource,
             [NotNull] IModelValidatorProvider validatorProvider,
             [NotNull] ModelStateDictionary modelState,
             [NotNull] ModelExplorer modelExplorer)
         {
             ModelState = modelState;
-            RootPrefix = rootPrefix;
             ValidatorProvider = validatorProvider;
             ModelExplorer = modelExplorer;
             BindingSource = bindingSource;
@@ -45,7 +43,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             [NotNull] ModelExplorer modelExplorer)
         {
             return new ModelValidationContext(
-                parentContext.RootPrefix,
                 modelExplorer.Metadata.BindingSource,
                 parentContext.ValidatorProvider,
                 parentContext.ModelState,
@@ -55,8 +52,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         public ModelExplorer ModelExplorer { get; }
 
         public ModelStateDictionary ModelState { get; }
-
-        public string RootPrefix { get; set; }
 
         public BindingSource BindingSource { get; set; }
 

--- a/src/Microsoft.AspNet.Mvc.Core/Controller.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Controller.cs
@@ -1336,13 +1336,17 @@ namespace Microsoft.AspNet.Mvc
                 modelName);
 
             var validationContext = new ModelValidationContext(
-                modelName,
                 bindingSource: null,
                 validatorProvider: BindingContext.ValidatorProvider,
                 modelState: ModelState,
                 modelExplorer: modelExplorer);
 
-            ObjectValidator.Validate(validationContext);
+            ObjectValidator.Validate(
+                validationContext,
+                new ModelValidationNode(modelName, modelExplorer.Metadata, model)
+                {
+                    ValidateAllProperties = true
+                });
             return ModelState.IsValid;
         }
 

--- a/src/Microsoft.AspNet.Mvc.Core/DefaultControllerActionArgumentBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/DefaultControllerActionArgumentBinder.cs
@@ -90,12 +90,11 @@ namespace Microsoft.AspNet.Mvc
                     modelBindingResult.Model);
 
                 var validationContext = new ModelValidationContext(
-                    key,
                     modelBindingContext.BindingSource,
                     operationContext.ValidatorProvider,
                     modelState,
                     modelExplorer);
-                _validator.Validate(validationContext);
+                _validator.Validate(validationContext, modelBindingResult.ValidationNode);
             }
 
             return modelBindingResult;

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/BinderTypeBasedModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/BinderTypeBasedModelBinder.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var result = await modelBinder.BindModelAsync(bindingContext);
 
             var modelBindingResult = result != null ?
-                new ModelBindingResult(result.Model, result.Key, result.IsModelSet) :
+                new ModelBindingResult(result.Model, result.Key, result.IsModelSet, result.ValidationNode) :
                 new ModelBindingResult(model: null, key: bindingContext.ModelName, isModelSet: false);
 
             // A model binder was specified by metadata and this binder handles all such cases.

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/BindingSourceModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/BindingSourceModelBinder.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             var modelBindingResult =
                 result != null ?
-                    new ModelBindingResult(result.Model, result.Key, result.IsModelSet) :
+                    new ModelBindingResult(result.Model, result.Key, result.IsModelSet, result.ValidationNode) :
                     new ModelBindingResult(model: null, key: context.ModelName, isModelSet: false);
 
             // This model binder is the only handler for its binding source.

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/BodyModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/BodyModelBinder.cs
@@ -54,11 +54,21 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
                 var isTopLevelObject = bindingContext.ModelMetadata.ContainerType == null;
 
-                // For compatibility with MVC 5.0 for top level object we want to consider an empty key instead of 
+                // For compatibility with MVC 5.0 for top level object we want to consider an empty key instead of
                 // the parameter name/a custom name. In all other cases (like when binding body to a property) we
                 // consider the entire ModelName as a prefix.
                 var modelBindingKey = isTopLevelObject ? string.Empty : bindingContext.ModelName;
-                return new ModelBindingResult(model, key: modelBindingKey, isModelSet: true);
+
+                var validationNode = new ModelValidationNode(modelBindingKey, bindingContext.ModelMetadata, model)
+                {
+                    ValidateAllProperties = true
+                };
+
+                return new ModelBindingResult(
+                    model,
+                    key: modelBindingKey,
+                    isModelSet: true,
+                    validationNode: validationNode);
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/ByteArrayModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/ByteArrayModelBinder.cs
@@ -39,7 +39,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             try
             {
                 var model = Convert.FromBase64String(value);
-                return new ModelBindingResult(model, bindingContext.ModelName, isModelSet: true);
+
+                // We do not need to set an explict ModelValidationNode since CompositeModelBinder does that automatically.
+                return new ModelBindingResult(
+                    model,
+                    bindingContext.ModelName,
+                    isModelSet: true);
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/CollectionModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/CollectionModelBinder.cs
@@ -31,16 +31,19 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var valueProviderResult = await bindingContext.ValueProvider.GetValueAsync(bindingContext.ModelName);
 
             IEnumerable<TElement> boundCollection;
+            CollectionResult result;
             if (valueProviderResult == null)
             {
-                boundCollection = await BindComplexCollection(bindingContext);
+                result = await BindComplexCollection(bindingContext);
+                boundCollection = result.Model;
             }
             else
             {
-                boundCollection = await BindSimpleCollection(
+                result = await BindSimpleCollection(
                     bindingContext,
                     valueProviderResult.RawValue,
                     valueProviderResult.Culture);
+                boundCollection = result.Model;
             }
 
             var model = bindingContext.Model;
@@ -54,12 +57,16 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 CopyToModel(model, boundCollection);
             }
 
-            return new ModelBindingResult(model, bindingContext.ModelName, isModelSet: true);
+            return new ModelBindingResult(
+                model,
+                bindingContext.ModelName,
+                isModelSet: true,
+                validationNode: result?.ValidationNode);
         }
 
         // Used when the ValueProvider contains the collection to be bound as a single element, e.g. the raw value
         // is [ "1", "2" ] and needs to be converted to an int[].
-        internal async Task<IEnumerable<TElement>> BindSimpleCollection(
+        internal async Task<CollectionResult> BindSimpleCollection(
             ModelBindingContext bindingContext,
             object rawValue,
             CultureInfo culture)
@@ -74,6 +81,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var metadataProvider = bindingContext.OperationBindingContext.MetadataProvider;
             var elementMetadata = metadataProvider.GetMetadataForType(typeof(TElement));
 
+            var validationNode = new ModelValidationNode(
+                bindingContext.ModelName,
+                bindingContext.ModelMetadata,
+                boundCollection);
             var rawValueArray = RawValueToObjectArray(rawValue);
             foreach (var rawValueElement in rawValueArray)
             {
@@ -91,18 +102,26 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 object boundValue = null;
                 var result =
                     await bindingContext.OperationBindingContext.ModelBinder.BindModelAsync(innerBindingContext);
-                if (result != null)
+                if (result != null && result.IsModelSet)
                 {
                     boundValue = result.Model;
+                    if (result.ValidationNode != null)
+                    {
+                        validationNode.ChildNodes.Add(result.ValidationNode);
+                    }
                 }
                 boundCollection.Add(ModelBindingHelper.CastOrDefault<TElement>(boundValue));
             }
 
-            return boundCollection;
+            return new CollectionResult
+            {
+                ValidationNode = validationNode,
+                Model = boundCollection
+            };
         }
 
         // Used when the ValueProvider contains the collection to be bound as multiple elements, e.g. foo[0], foo[1].
-        private async Task<IEnumerable<TElement>> BindComplexCollection(ModelBindingContext bindingContext)
+        private async Task<CollectionResult> BindComplexCollection(ModelBindingContext bindingContext)
         {
             var indexPropertyName = ModelNames.CreatePropertyModelName(bindingContext.ModelName, "index");
             var valueProviderResultIndex = await bindingContext.ValueProvider.GetValueAsync(indexPropertyName);
@@ -111,7 +130,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             return await BindComplexCollectionFromIndexes(bindingContext, indexNames);
         }
 
-        internal async Task<IEnumerable<TElement>> BindComplexCollectionFromIndexes(
+        internal async Task<CollectionResult> BindComplexCollectionFromIndexes(
             ModelBindingContext bindingContext,
             IEnumerable<string> indexNames)
         {
@@ -131,6 +150,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var elementMetadata = metadataProvider.GetMetadataForType(typeof(TElement));
 
             var boundCollection = new List<TElement>();
+            var validationNode = new ModelValidationNode(
+                bindingContext.ModelName,
+                bindingContext.ModelMetadata,
+                boundCollection);
             foreach (var indexName in indexNames)
             {
                 var fullChildName = ModelNames.CreateIndexModelName(bindingContext.ModelName, indexName);
@@ -146,10 +169,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
                 var result =
                     await bindingContext.OperationBindingContext.ModelBinder.BindModelAsync(childBindingContext);
-                if (result != null)
+                if (result != null && result.IsModelSet)
                 {
                     didBind = true;
                     boundValue = result.Model;
+                    if (result.ValidationNode != null)
+                    {
+                        validationNode.ChildNodes.Add(result.ValidationNode);
+                    }
                 }
 
                 // infinite size collection stops on first bind failure
@@ -161,7 +188,18 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 boundCollection.Add(ModelBindingHelper.CastOrDefault<TElement>(boundValue));
             }
 
-            return boundCollection;
+            return new CollectionResult
+            {
+                ValidationNode = validationNode,
+                Model = boundCollection
+            };
+        }
+
+        internal class CollectionResult
+        {
+            public ModelValidationNode ValidationNode { get; set; }
+
+            public IEnumerable<TElement> Model { get; set; }
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/GenericModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/GenericModelBinder.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 var result = await binder.BindModelAsync(bindingContext);
 
                 var modelBindingResult = result != null ?
-                    new ModelBindingResult(result.Model, result.Key, result.IsModelSet) :
+                    new ModelBindingResult(result.Model, result.Key, result.IsModelSet, result.ValidationNode) :
                     new ModelBindingResult(model: null, key: bindingContext.ModelName, isModelSet: false);
 
                 // Were able to resolve a binder type.

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/HeaderModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/HeaderModelBinder.cs
@@ -51,7 +51,21 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 }
             }
 
-            return Task.FromResult(new ModelBindingResult(model, bindingContext.ModelName, isModelSet: model != null));
+            ModelValidationNode validationNode = null;
+            if (model != null)
+            {
+                validationNode = new ModelValidationNode(
+                    bindingContext.ModelName,
+                    bindingContext.ModelMetadata,
+                    model);
+            }
+
+            return Task.FromResult(
+                new ModelBindingResult(
+                    model,
+                    bindingContext.ModelName,
+                    isModelSet: model != null,
+                    validationNode: validationNode));
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/ServicesModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/ServicesModelBinder.cs
@@ -26,7 +26,17 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         {
             var requestServices = bindingContext.OperationBindingContext.HttpContext.RequestServices;
             var model = requestServices.GetRequiredService(bindingContext.ModelType);
-            return Task.FromResult(new ModelBindingResult(model, bindingContext.ModelName, isModelSet: true));
+            var validationNode =
+                new ModelValidationNode(bindingContext.ModelName, bindingContext.ModelMetadata, model)
+                {
+                    SuppressValidation = true
+                };
+
+            return Task.FromResult(new ModelBindingResult(
+                    model,
+                    bindingContext.ModelName,
+                    isModelSet: true,
+                    validationNode: validationNode));
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/TypeConverterModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/TypeConverterModelBinder.cs
@@ -30,7 +30,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             {
                 newModel = valueProviderResult.ConvertTo(bindingContext.ModelType);
                 ModelBindingHelper.ReplaceEmptyStringWithNull(bindingContext.ModelMetadata, ref newModel);
-                return new ModelBindingResult(newModel, bindingContext.ModelName, isModelSet: true);
+
+                // We do not need to set an explict ModelValidationNode since CompositeModelBinder does that automatically.
+                return new ModelBindingResult(
+                    newModel,
+                    bindingContext.ModelName,
+                    isModelSet: true);
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/TypeMatchModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/TypeMatchModelBinder.cs
@@ -19,7 +19,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             bindingContext.ModelState.SetModelValue(bindingContext.ModelName, valueProviderResult);
             var model = valueProviderResult.RawValue;
             ModelBindingHelper.ReplaceEmptyStringWithNull(bindingContext.ModelMetadata, ref model);
-            return new ModelBindingResult(model, bindingContext.ModelName, isModelSet: true);
+
+            // We do not need to set an explict ModelValidationNode since CompositeModelBinder does that automatically.
+            return new ModelBindingResult(
+                model,
+                bindingContext.ModelName,
+                isModelSet: true);
         }
 
         internal static async Task<ValueProviderResult> GetCompatibleValueProviderResult(ModelBindingContext context)

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Validation/IObjectModelValidator.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Validation/IObjectModelValidator.cs
@@ -13,6 +13,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         /// </summary>
         /// <param name="validationContext">The <see cref="ModelValidationContext"/> associated with the current call.
         /// </param>
-        void Validate(ModelValidationContext validationContext);
+        /// <param name="validationNode">The <see cref="ModelValidationNode"/> for the model which gets validated.
+        /// </param>
+        void Validate(ModelValidationContext validationContext, ModelValidationNode validationNode);
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ParameterBinding/ModelBindingHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ParameterBinding/ModelBindingHelper.cs
@@ -312,8 +312,12 @@ namespace Microsoft.AspNet.Mvc
             {
                 var modelExplorer = new ModelExplorer(metadataProvider, modelMetadata, modelBindingResult.Model);
                 var modelValidationContext = new ModelValidationContext(modelBindingContext, modelExplorer);
-                modelValidationContext.RootPrefix = prefix;
-                objectModelValidator.Validate(modelValidationContext);
+                objectModelValidator.Validate(
+                    modelValidationContext,
+                    new ModelValidationNode(prefix, modelBindingContext.ModelMetadata, modelBindingResult.Model)
+                    {
+                        ValidateAllProperties = true
+                    });
                 return modelState.IsValid;
             }
 

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/ApiController.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/ApiController.cs
@@ -417,13 +417,17 @@ namespace System.Web.Http
             var modelExplorer = MetadataProvider.GetModelExplorerForType(typeof(TEntity), entity);
 
             var modelValidationContext = new ModelValidationContext(
-                keyPrefix,
                 bindingSource: null,
                 validatorProvider: BindingContext.ValidatorProvider,
                 modelState: ModelState,
                 modelExplorer: modelExplorer);
 
-            ObjectValidator.Validate(modelValidationContext);
+            ObjectValidator.Validate(
+                modelValidationContext,
+                new ModelValidationNode(keyPrefix, modelExplorer.Metadata, entity)
+                {
+                    ValidateAllProperties = true
+                });
         }
 
         protected virtual void Dispose(bool disposing)

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BinderTypeBasedModelBinderModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BinderTypeBasedModelBinderModelBinderTest.cs
@@ -51,7 +51,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var bindingContext = GetBindingContext(typeof(Person), binderType: typeof(TrueModelBinder));
 
             var model = new Person();
-            var innerModelBinder = new TrueModelBinder();
             var serviceProvider = new ServiceCollection()
                 .AddSingleton(typeof(IModelBinder))
                 .BuildServiceProvider();
@@ -67,6 +66,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var p = (Person)binderResult.Model;
             Assert.Equal(model.Age, p.Age);
             Assert.Equal(model.Name, p.Name);
+            Assert.NotNull(binderResult.ValidationNode);
+            Assert.Equal(bindingContext.ModelName, binderResult.ValidationNode.Key);
+            Assert.Same(binderResult.Model, binderResult.ValidationNode.Model);
         }
 
         [Fact]
@@ -138,7 +140,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
 
             public Task<ModelBindingResult> BindModelAsync(ModelBindingContext bindingContext)
             {
-                return Task.FromResult(new ModelBindingResult(_model, bindingContext.ModelName, true));
+                var validationNode =
+                    new ModelValidationNode(bindingContext.ModelName, bindingContext.ModelMetadata, _model);
+                return Task.FromResult(new ModelBindingResult(_model, bindingContext.ModelName, true, validationNode));
             }
         }
     }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BodyModelBinderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BodyModelBinderTests.cs
@@ -50,6 +50,13 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             mockInputFormatter.Verify(v => v.ReadAsync(It.IsAny<InputFormatterContext>()), Times.Once);
             Assert.NotNull(binderResult);
             Assert.True(binderResult.IsModelSet);
+            Assert.NotNull(binderResult.ValidationNode);
+            Assert.True(binderResult.ValidationNode.ValidateAllProperties);
+            Assert.False(binderResult.ValidationNode.SuppressValidation);
+            Assert.Empty(binderResult.ValidationNode.ChildNodes);
+            Assert.Equal(binderResult.Key, binderResult.ValidationNode.Key);
+            Assert.Equal(bindingContext.ModelMetadata, binderResult.ValidationNode.ModelMetadata);
+            Assert.Same(binderResult.Model, binderResult.ValidationNode.Model);
         }
 
         [Fact]
@@ -71,6 +78,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             // Returns true because it understands the metadata type.
             Assert.NotNull(binderResult);
             Assert.False(binderResult.IsModelSet);
+            Assert.Null(binderResult.ValidationNode);
             Assert.Null(binderResult.Model);
             Assert.True(bindingContext.ModelState.ContainsKey("someName"));
         }
@@ -92,6 +100,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             // Assert
             Assert.NotNull(binderResult);
             Assert.False(binderResult.IsModelSet);
+            Assert.Null(binderResult.ValidationNode);
         }
 
         [Fact]
@@ -159,6 +168,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             // Returns true because it understands the metadata type.
             Assert.NotNull(binderResult);
             Assert.False(binderResult.IsModelSet);
+            Assert.Null(binderResult.ValidationNode);
             Assert.Null(binderResult.Model);
             Assert.True(bindingContext.ModelState.ContainsKey("someName"));
             var errorMessage = bindingContext.ModelState["someName"].Errors[0].Exception.Message;
@@ -192,6 +202,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             Assert.NotNull(binderResult);
             Assert.False(binderResult.IsModelSet);
             Assert.Null(binderResult.Model);
+            Assert.Null(binderResult.ValidationNode);
             Assert.True(bindingContext.ModelState.ContainsKey("someName"));
             var errorMessage = bindingContext.ModelState["someName"].Errors[0].ErrorMessage;
             Assert.Equal("Unsupported content type 'text/xyz'.", errorMessage);

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CollectionModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CollectionModelBinderTest.cs
@@ -33,7 +33,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var boundCollection = await binder.BindComplexCollectionFromIndexes(bindingContext, new[] { "foo", "bar", "baz" });
 
             // Assert
-            Assert.Equal(new[] { 42, 0, 200 }, boundCollection.ToArray());
+            Assert.Equal(new[] { 42, 0, 200 }, boundCollection.Model.ToArray());
+            Assert.Equal(
+                new[] { "someName[foo]", "someName[baz]" },
+                boundCollection.ValidationNode.ChildNodes.Select(o => o.Key).ToArray());
         }
 
         [Fact]
@@ -53,7 +56,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var boundCollection = await binder.BindComplexCollectionFromIndexes(bindingContext, indexNames: null);
 
             // Assert
-            Assert.Equal(new[] { 42, 100 }, boundCollection.ToArray());
+            Assert.Equal(new[] { 42, 100 }, boundCollection.Model.ToArray());
+            Assert.Equal(
+                new[] { "someName[0]", "someName[1]" },
+                boundCollection.ValidationNode.ChildNodes.Select(o => o.Key).ToArray());
         }
 
         [Theory]
@@ -193,8 +199,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var boundCollection = await binder.BindSimpleCollection(context, rawValue: new object[0], culture: null);
 
             // Assert
-            Assert.NotNull(boundCollection);
-            Assert.Empty(boundCollection);
+            Assert.NotNull(boundCollection.Model);
+            Assert.Empty(boundCollection.Model);
         }
 
         [Fact]
@@ -217,13 +223,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             // Arrange
             var culture = new CultureInfo("fr-FR");
             var bindingContext = GetModelBindingContext(new SimpleHttpValueProvider());
-
+            ModelValidationNode childValidationNode = null;
             Mock.Get<IModelBinder>(bindingContext.OperationBindingContext.ModelBinder)
                 .Setup(o => o.BindModelAsync(It.IsAny<ModelBindingContext>()))
                 .Returns((ModelBindingContext mbc) =>
                 {
                     Assert.Equal("someName", mbc.ModelName);
-                    return Task.FromResult(new ModelBindingResult(42, mbc.ModelName, true));
+                    childValidationNode = new ModelValidationNode("someName", mbc.ModelMetadata, mbc.Model);
+                    return Task.FromResult(new ModelBindingResult(42, mbc.ModelName, true, childValidationNode));
                 });
             var modelBinder = new CollectionModelBinder<int>();
 
@@ -231,7 +238,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var boundCollection = await modelBinder.BindSimpleCollection(bindingContext, new int[1], culture);
 
             // Assert
-            Assert.Equal(new[] { 42 }, boundCollection.ToArray());
+            Assert.Equal(new[] { 42 }, boundCollection.Model.ToArray());
+            Assert.Equal(new[] { childValidationNode }, boundCollection.ValidationNode.ChildNodes.ToArray());
         }
 
         private static ModelBindingContext GetModelBindingContext(
@@ -267,7 +275,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
                     if (value != null)
                     {
                         var model = value.ConvertTo(mbc.ModelType);
-                        return new ModelBindingResult(model, mbc.ModelName, true);
+                        var modelValidationNode = new ModelValidationNode(mbc.ModelName, mbc.ModelMetadata, model);
+                        return new ModelBindingResult(model, mbc.ModelName, true, modelValidationNode);
                     }
 
                     return null;

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/Validation/DataAnnotationsModelValidatorTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/Validation/DataAnnotationsModelValidatorTest.cs
@@ -231,7 +231,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         private static ModelValidationContext CreateValidationContext(ModelExplorer modelExplorer)
         {
             return new ModelValidationContext(
-                rootPrefix: null,
                 bindingSource: null,
                 modelState: null,
                 validatorProvider: null,

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ParameterBinding/ControllerActionArgumentBinderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ParameterBinding/ControllerActionArgumentBinderTests.cs
@@ -154,7 +154,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
 
             var mockValidatorProvider = new Mock<IObjectModelValidator>(MockBehavior.Strict);
             mockValidatorProvider
-                .Setup(o => o.Validate(It.IsAny<ModelValidationContext>()))
+                .Setup(o => o.Validate(It.IsAny<ModelValidationContext>(), It.IsAny<ModelValidationNode>()))
                 .Verifiable();
             var argumentBinder = GetArgumentBinder(mockValidatorProvider.Object);
 
@@ -164,7 +164,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
 
             // Assert
             mockValidatorProvider.Verify(
-                o => o.Validate(It.IsAny<ModelValidationContext>()), Times.Once());
+                o => o.Validate(It.IsAny<ModelValidationContext>(), It.IsAny<ModelValidationNode>()), Times.Once());
         }
 
         [Fact]
@@ -197,8 +197,9 @@ namespace Microsoft.AspNet.Mvc.Core.Test
             };
 
             var mockValidatorProvider = new Mock<IObjectModelValidator>(MockBehavior.Strict);
-            mockValidatorProvider.Setup(o => o.Validate(It.IsAny<ModelValidationContext>()))
-                                 .Verifiable();
+            mockValidatorProvider
+                .Setup(o => o.Validate(It.IsAny<ModelValidationContext>(), It.IsAny<ModelValidationNode>()))
+                .Verifiable();
             var argumentBinder = GetArgumentBinder(mockValidatorProvider.Object);
 
             // Act
@@ -206,7 +207,9 @@ namespace Microsoft.AspNet.Mvc.Core.Test
                 .BindActionArgumentsAsync(actionContext, actionBindingContext, new TestController());
 
             // Assert
-            mockValidatorProvider.Verify(o => o.Validate(It.IsAny<ModelValidationContext>()), Times.Never());
+            mockValidatorProvider.Verify(
+                o => o.Validate(It.IsAny<ModelValidationContext>(), It.IsAny<ModelValidationNode>()),
+                Times.Never());
         }
 
         [Fact]
@@ -226,7 +229,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
 
             var mockValidatorProvider = new Mock<IObjectModelValidator>(MockBehavior.Strict);
             mockValidatorProvider
-                .Setup(o => o.Validate(It.IsAny<ModelValidationContext>()))
+                .Setup(o => o.Validate(It.IsAny<ModelValidationContext>(), It.IsAny<ModelValidationNode>()))
                 .Verifiable();
             var argumentBinder = GetArgumentBinder(mockValidatorProvider.Object);
 
@@ -236,7 +239,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
 
             // Assert
             mockValidatorProvider.Verify(
-                o => o.Validate(It.IsAny<ModelValidationContext>()), Times.Once());
+                o => o.Validate(It.IsAny<ModelValidationContext>(), It.IsAny<ModelValidationNode>()), Times.Once());
         }
 
         [Fact]
@@ -268,8 +271,10 @@ namespace Microsoft.AspNet.Mvc.Core.Test
             };
 
             var mockValidatorProvider = new Mock<IObjectModelValidator>(MockBehavior.Strict);
-            mockValidatorProvider.Setup(o => o.Validate(It.IsAny<ModelValidationContext>()))
-                                 .Verifiable();
+            mockValidatorProvider
+                .Setup(o => o.Validate(It.IsAny<ModelValidationContext>(), It.IsAny<ModelValidationNode>()))
+                .Verifiable();
+
             var argumentBinder = GetArgumentBinder(mockValidatorProvider.Object);
 
             // Act
@@ -277,7 +282,9 @@ namespace Microsoft.AspNet.Mvc.Core.Test
                 .BindActionArgumentsAsync(actionContext, actionBindingContext, new TestController());
 
             // Assert
-            mockValidatorProvider.Verify(o => o.Validate(It.IsAny<ModelValidationContext>()), Times.Never());
+            mockValidatorProvider.Verify(
+                o => o.Validate(It.IsAny<ModelValidationContext>(), It.IsAny<ModelValidationNode>()),
+                Times.Never());
         }
 
         [Fact]
@@ -596,7 +603,8 @@ namespace Microsoft.AspNet.Mvc.Core.Test
             if (validator == null)
             {
                 var mockValidator = new Mock<IObjectModelValidator>(MockBehavior.Strict);
-                mockValidator.Setup(o => o.Validate(It.IsAny<ModelValidationContext>()));
+                mockValidator.Setup(
+                    o => o.Validate(It.IsAny<ModelValidationContext>(), It.IsAny<ModelValidationNode>()));
                 validator = mockValidator.Object;
             }
 

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/BinderTypeBasedModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/BinderTypeBasedModelBinderIntegrationTest.cs
@@ -281,7 +281,12 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
         {
             public Task<ModelBindingResult> BindModelAsync(ModelBindingContext bindingContext)
             {
-                return Task.FromResult(new ModelBindingResult("Success", bindingContext.ModelName, true));
+                var model = "Success";
+                var modelValidationNode = new ModelValidationNode(
+                    bindingContext.ModelName,
+                    bindingContext.ModelMetadata,
+                    model);
+                return Task.FromResult(new ModelBindingResult(model, bindingContext.ModelName, true, modelValidationNode));
             }
         }
 

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/CollectionModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/CollectionModelBinderIntegrationTest.cs
@@ -2,8 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
+using Microsoft.AspNet.Http.Internal;
 using Microsoft.AspNet.Mvc.ModelBinding;
 using Xunit;
 
@@ -535,6 +538,64 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal(0, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
+        }
+
+        private class Person4
+        {
+            public IList<Address4> Addresses { get; set; }
+        }
+
+        private class Address4
+        {
+            public int Zip { get; set; }
+
+            public string Street { get; set; }
+        }
+
+        [Fact(Skip = "Extra ModelState key because of #2446")]
+        public async Task CollectionModelBinder_UsesCustomIndexes()
+        {
+            // Arrange
+            var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
+            var parameter = new ParameterDescriptor()
+            {
+                Name = "parameter",
+                ParameterType = typeof(Person4)
+            };
+
+            var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
+            {
+                var formCollection = new FormCollection(new Dictionary<string, string[]>()
+                {
+                    { "Addresses.index", new [] { "Key1", "Key2" } },
+                    { "Addresses[Key1].Street", new [] { "Street1" } },
+                    { "Addresses[Key2].Street", new [] { "Street2" } },
+                });
+
+                request.Form = formCollection;
+                request.ContentType = "application/x-www-form-urlencoded";
+            });
+
+            var modelState = new ModelStateDictionary();
+
+            // Act
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+
+            // Assert
+            Assert.NotNull(modelBindingResult);
+            Assert.True(modelBindingResult.IsModelSet);
+            Assert.IsType<Person4>(modelBindingResult.Model);
+
+            Assert.Equal(2, modelState.Count);
+            Assert.Equal(0, modelState.ErrorCount);
+            Assert.True(modelState.IsValid);
+            var entry = Assert.Single(modelState, kvp => kvp.Key == "Addresses[Key1].Street").Value;
+            Assert.Equal("Street1", entry.Value.AttemptedValue);
+            Assert.Equal("Street1", entry.Value.RawValue);
+
+            entry = Assert.Single(modelState, kvp => kvp.Key == "Addresses[Key2].Street").Value;
+            Assert.Equal("Street2", entry.Value.AttemptedValue);
+            Assert.Equal("Street2", entry.Value.RawValue);
         }
     }
 }


### PR DESCRIPTION
Current changes only take care of ensuring that 
a. Tree walk is dependend on ModelValidationNode. In cases like body and pre-existing models ( like TryUpdate/TryValidate), ModelValidationNode tree is built up on demand. 

b. For collections, if there was a custom index it will be handled correctly (i.e fixes #2294).

This PR does not address
a. Extra model state keys #2446.
b. docs / additional tests need to be added. 

This PR does not bring back some aspects of ModelValidationNode like Validated and Validating events. (we can add that if we ever find a user scenario for it). 


@dougbu @rynowak 