### PR TITLE
Use `ClosedGenericMatcher.ExtractGenericInterface()` from Common repo

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Common/TypeExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Common/TypeExtensions.cs
@@ -45,15 +45,6 @@ namespace Microsoft.AspNet.Mvc
             return type.GetTypeInfo().BaseType;
         }
 
-        public static Type ExtractGenericInterface([NotNull] this Type queryType, Type interfaceType)
-        {
-            Func<Type, bool> matchesInterface =
-                t => t.IsGenericType() && t.GetGenericTypeDefinition() == interfaceType;
-            return (matchesInterface(queryType)) ?
-                queryType :
-                queryType.GetInterfaces().FirstOrDefault(matchesInterface);
-        }
-
 #if NETFX_CORE || DNXCORE50
         public static Type[] GetGenericArguments([NotNull] this Type type)
         {

--- a/src/Microsoft.AspNet.Mvc.Core/DefaultControllerActionArgumentBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/DefaultControllerActionArgumentBinder.cs
@@ -151,8 +151,9 @@ namespace Microsoft.AspNet.Mvc
                 }
 
                 // Determine T if this is an ICollection<T> property.
-                var collectionTypeArguments = propertyType
-                    .ExtractGenericInterface(typeof(ICollection<>))
+                var collectionTypeArguments = ClosedGenericMatcher.ExtractGenericInterface(
+                        propertyType,
+                        typeof(ICollection<>))
                     ?.GenericTypeArguments;
                 if (collectionTypeArguments == null)
                 {

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/MutableObjectModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/MutableObjectModelBinder.cs
@@ -555,8 +555,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             // Determine T if this is an ICollection<T> property. No need for a T[] case because CanUpdateProperty()
             // ensures property is either settable or not an array. Underlying assumption is that CanUpdateProperty()
             // and SetProperty() are overridden together.
-            var collectionTypeArguments = propertyExplorer.ModelType
-                .ExtractGenericInterface(typeof(ICollection<>))
+            var collectionTypeArguments = ClosedGenericMatcher.ExtractGenericInterface(
+                    propertyExplorer.ModelType,
+                    typeof(ICollection<>))
                 ?.GenericTypeArguments;
             if (collectionTypeArguments == null)
             {

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Expressions/TryGetValueProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Expressions/TryGetValueProvider.cs
@@ -38,13 +38,13 @@ namespace Microsoft.AspNet.Mvc.Rendering.Expressions
                 _tryGetValueDelegateCacheLock.ExitReadLock();
             }
 
-            var dictionaryType = targetType.ExtractGenericInterface(typeof(IDictionary<,>));
+            var dictionaryType = ClosedGenericMatcher.ExtractGenericInterface(targetType, typeof(IDictionary<,>));
 
             // Just wrap a call to the underlying IDictionary<TKey, TValue>.TryGetValue() where string can be cast to
             // TKey.
             if (dictionaryType != null)
             {
-                var typeArguments = dictionaryType.GetGenericArguments();
+                var typeArguments = dictionaryType.GenericTypeArguments;
                 var keyType = typeArguments[0];
                 var returnType = typeArguments[1];
 

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/DefaultDisplayTemplates.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/DefaultDisplayTemplates.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNet.Mvc.Core;
 using Microsoft.AspNet.Mvc.ModelBinding;
 using Microsoft.AspNet.Mvc.Rendering.Internal;
 using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Mvc.Rendering
 {
@@ -106,10 +107,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
             }
 
             var typeInCollection = typeof(string);
-            var genericEnumerableType = collection.GetType().ExtractGenericInterface(typeof(IEnumerable<>));
+            var genericEnumerableType = ClosedGenericMatcher.ExtractGenericInterface(
+                collection.GetType(),
+                typeof(IEnumerable<>));
             if (genericEnumerableType != null)
             {
-                typeInCollection = genericEnumerableType.GetGenericArguments()[0];
+                typeInCollection = genericEnumerableType.GenericTypeArguments[0];
             }
 
             var typeInCollectionIsNullableValueType = typeInCollection.IsNullableValueType();

--- a/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/DefaultEditorTemplates.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Rendering/Html/DefaultEditorTemplates.cs
@@ -68,10 +68,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
             }
 
             var typeInCollection = typeof(string);
-            var genericEnumerableType = collection.GetType().ExtractGenericInterface(typeof(IEnumerable<>));
+            var genericEnumerableType = ClosedGenericMatcher.ExtractGenericInterface(
+                collection.GetType(),
+                typeof(IEnumerable<>));
             if (genericEnumerableType != null)
             {
-                typeInCollection = genericEnumerableType.GetGenericArguments()[0];
+                typeInCollection = genericEnumerableType.GenericTypeArguments[0];
             }
 
             var typeInCollectionIsNullableValueType = typeInCollection.IsNullableValueType();

--- a/src/Microsoft.AspNet.Mvc.Core/project.json
+++ b/src/Microsoft.AspNet.Mvc.Core/project.json
@@ -13,18 +13,19 @@
         "Microsoft.AspNet.FileProviders.Abstractions": "1.0.0-*",
         "Microsoft.AspNet.Hosting.Abstractions": "1.0.0-*",
         "Microsoft.AspNet.Http.Extensions": "1.0.0-*",
+        "Microsoft.AspNet.JsonPatch": "1.0.0-*",
         "Microsoft.AspNet.Mvc.Abstractions": "6.0.0-*",
         "Microsoft.AspNet.Mvc.Common": { "version": "6.0.0-*", "type": "build" },
         "Microsoft.AspNet.Routing": "1.0.0-*",
         "Microsoft.Framework.BufferEntryCollection.Sources": { "version": "1.0.0-*", "type": "build" },
+        "Microsoft.Framework.ClosedGenericMatcher.Sources": { "version": "1.0.0-*", "type": "build" },
         "Microsoft.Framework.CopyOnWriteDictionary.Sources": { "version": "1.0.0-*", "type": "build" },
         "Microsoft.Framework.Logging.Abstractions": "1.0.0-*",
         "Microsoft.Framework.NotNullAttribute.Sources": { "version": "1.0.0-*", "type": "build" },
         "Microsoft.Framework.PropertyActivator.Sources": { "version": "1.0.0-*", "type": "build" },
         "Microsoft.Framework.PropertyHelper.Sources": { "version": "1.0.0-*", "type": "build" },
         "Microsoft.Framework.Runtime.Abstractions": "1.0.0-*",
-        "Microsoft.Framework.WebEncoders": "1.0.0-*",
-        "Microsoft.AspNet.JsonPatch": "1.0.0-*"
+        "Microsoft.Framework.WebEncoders": "1.0.0-*"
     },
     "frameworks": {
         "dnx451": {

--- a/src/Microsoft.AspNet.Mvc.Xml/EnumerableWrapperProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Xml/EnumerableWrapperProvider.cs
@@ -9,7 +9,7 @@ using Microsoft.Framework.Internal;
 namespace Microsoft.AspNet.Mvc.Xml
 {
     /// <summary>
-    /// Provides a <see cref="IWrapperProvider"/> for interface types which implement 
+    /// Provides a <see cref="IWrapperProvider"/> for interface types which implement
     /// <see cref="IEnumerable{T}"/>.
     /// </summary>
     public class EnumerableWrapperProvider : IWrapperProvider
@@ -20,7 +20,7 @@ namespace Microsoft.AspNet.Mvc.Xml
         /// <summary>
         /// Initializes an instance of <see cref="EnumerableWrapperProvider"/>.
         /// </summary>
-        /// <param name="sourceEnumerableOfT">Type of the original <see cref="IEnumerable{T}" /> 
+        /// <param name="sourceEnumerableOfT">Type of the original <see cref="IEnumerable{T}" />
         /// that is being wrapped.</param>
         /// <param name="elementWrapperProvider">The <see cref="IWrapperProvider"/> for the element type.
         /// Can be null.</param>
@@ -28,17 +28,19 @@ namespace Microsoft.AspNet.Mvc.Xml
             [NotNull] Type sourceEnumerableOfT,
             IWrapperProvider elementWrapperProvider)
         {
-            var enumerableOfT = sourceEnumerableOfT.ExtractGenericInterface(typeof(IEnumerable<>));
+            var enumerableOfT = ClosedGenericMatcher.ExtractGenericInterface(
+                sourceEnumerableOfT,
+                typeof(IEnumerable<>));
             if (!sourceEnumerableOfT.IsInterface() || enumerableOfT == null)
             {
                 throw new ArgumentException(
-                    Resources.FormatEnumerableWrapperProvider_InvalidSourceEnumerableOfT(typeof(IEnumerable<>).Name), 
+                    Resources.FormatEnumerableWrapperProvider_InvalidSourceEnumerableOfT(typeof(IEnumerable<>).Name),
                     nameof(sourceEnumerableOfT));
             }
 
             _wrapperProvider = elementWrapperProvider;
 
-            var declaredElementType = enumerableOfT.GetGenericArguments()[0];
+            var declaredElementType = enumerableOfT.GenericTypeArguments[0];
             var wrappedElementType = elementWrapperProvider?.WrappingType ?? declaredElementType;
             WrappingType = typeof(DelegatingEnumerable<,>).MakeGenericType(wrappedElementType, declaredElementType);
 

--- a/src/Microsoft.AspNet.Mvc.Xml/EnumerableWrapperProviderFactory.cs
+++ b/src/Microsoft.AspNet.Mvc.Xml/EnumerableWrapperProviderFactory.cs
@@ -8,7 +8,7 @@ using Microsoft.Framework.Internal;
 namespace Microsoft.AspNet.Mvc.Xml
 {
     /// <summary>
-    /// Creates an <see cref="EnumerableWrapperProvider"/> for interface types implementing the 
+    /// Creates an <see cref="EnumerableWrapperProvider"/> for interface types implementing the
     /// <see cref="IEnumerable{T}"/> type.
     /// </summary>
     public class EnumerableWrapperProviderFactory : IWrapperProviderFactory
@@ -42,16 +42,16 @@ namespace Microsoft.AspNet.Mvc.Xml
                 // concrete types like List<T>, Collection<T> which implement IEnumerable<T>.
                 if (declaredType != null && declaredType.IsInterface() && declaredType.IsGenericType())
                 {
-                    var enumerableOfT = declaredType.ExtractGenericInterface(typeof(IEnumerable<>));
+                    var enumerableOfT = ClosedGenericMatcher.ExtractGenericInterface(
+                        declaredType,
+                        typeof(IEnumerable<>));
                     if (enumerableOfT != null)
                     {
-                        var elementType = enumerableOfT.GetGenericArguments()[0];
+                        var elementType = enumerableOfT.GenericTypeArguments[0];
+                        var wrapperProviderContext = new WrapperProviderContext(elementType, context.IsSerialization);
 
-                        var wrapperProviderContext = new WrapperProviderContext(
-                                                                    elementType,
-                                                                    context.IsSerialization);
-
-                        var elementWrapperProvider = _wrapperProviderFactories.GetWrapperProvider(wrapperProviderContext);
+                        var elementWrapperProvider =
+                            _wrapperProviderFactories.GetWrapperProvider(wrapperProviderContext);
 
                         return new EnumerableWrapperProvider(enumerableOfT, elementWrapperProvider);
                     }

--- a/src/Microsoft.AspNet.Mvc.Xml/RequiredValidationHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Xml/RequiredValidationHelper.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNet.Mvc.Xml
         {
             var visitedTypes = new HashSet<Type>();
 
-            // Every node maintains a dictionary of Type => Errors. 
+            // Every node maintains a dictionary of Type => Errors.
             // It's a dictionary as we want to avoid adding duplicate error messages.
             // Example:
             // In the following case, from the perspective of type 'Store', we should not see duplicate
@@ -83,16 +83,16 @@ namespace Microsoft.AspNet.Mvc.Xml
             HashSet<Type> visitedTypes,
             Dictionary<Type, List<string>> errors)
         {
-            // We don't need to code special handling for KeyValuePair (for example, when the model type 
-            // is Dictionary<,> which implements IEnumerable<KeyValuePair<TKey, TValue>>) as the model 
+            // We don't need to code special handling for KeyValuePair (for example, when the model type
+            // is Dictionary<,> which implements IEnumerable<KeyValuePair<TKey, TValue>>) as the model
             // type here would be KeyValuePair<TKey, TValue> where Key and Value are public properties
             // which would also be probed for Required attribute validation.
             if (modelType.IsGenericType())
             {
-                var enumerableOfT = modelType.ExtractGenericInterface(typeof(IEnumerable<>));
+                var enumerableOfT = ClosedGenericMatcher.ExtractGenericInterface(modelType, typeof(IEnumerable<>));
                 if (enumerableOfT != null)
                 {
-                    modelType = enumerableOfT.GetGenericArguments()[0];
+                    modelType = enumerableOfT.GenericTypeArguments[0];
                 }
             }
 
@@ -143,10 +143,10 @@ namespace Microsoft.AspNet.Mvc.Xml
                             typeof(DataMemberAttribute).FullName,
                             nameof(DataMemberAttribute.IsRequired),
                             bool.TrueString,
-                            validationError.PropertyName, 
+                            validationError.PropertyName,
                             validationError.ModelType.FullName));
                     }
-                    
+
                     // if the type is not primitve, then it could be a struct in which case
                     // we need to probe its properties for validation
                     if (propertyType.GetTypeInfo().IsPrimitive)

--- a/src/Microsoft.AspNet.Mvc.Xml/project.json
+++ b/src/Microsoft.AspNet.Mvc.Xml/project.json
@@ -7,14 +7,15 @@
     "dependencies": {
         "Microsoft.AspNet.Mvc.Common": { "version": "6.0.0-*", "type": "build" },
         "Microsoft.AspNet.Mvc.Core": "6.0.0-*",
-        "Microsoft.Framework.PropertyHelper.Sources": { "version": "1.0.0-*", "type": "build" },
-        "Microsoft.Framework.NotNullAttribute.Sources": { "version": "1.0.0-*", "type": "build" }
+        "Microsoft.Framework.ClosedGenericMatcher.Sources": { "version": "1.0.0-*", "type": "build" },
+        "Microsoft.Framework.NotNullAttribute.Sources": { "version": "1.0.0-*", "type": "build" },
+        "Microsoft.Framework.PropertyHelper.Sources": { "version": "1.0.0-*", "type": "build" }
     },
     "frameworks": {
         "dnx451": {
             "frameworkAssemblies": {
-                "System.Xml": "",
-                "System.Runtime.Serialization": ""
+                "System.Runtime.Serialization": "",
+                "System.Xml": ""
             }
         },
         "dnxcore50": {


### PR DESCRIPTION
- added in aspnet/Common@aae8e6e

nits:
- reorder dependencies alphabetically
- avoid `GetGenericArguments()` extension method with `ExtractGenericInterface()` return value
 - use `GenericTypeArguments`
- usual trailing whitespace auto-removals