### PR TITLE
Fixing #2466, #2446.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Validation/DefaultObjectValidator.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Validation/DefaultObjectValidator.cs
@@ -257,7 +257,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
                 }
             }
 
-            if (isValid)
+            // Add an entry only if there was an entry which was added by a model binder.
+            // This prevents adding spurious entries.
+            if (modelState.ContainsKey(modelKey) && isValid)
             {
                 validationContext.ModelValidationContext.ModelState.MarkFieldValid(modelKey);
             }

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/ActionParametersIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/ActionParametersIntegrationTest.cs
@@ -28,20 +28,20 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public List<Address> Address { get; }
         }
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task ActionParameter_NonSettableCollectionModel_EmptyPrefix_GetsBound()
         {
             // Arrange
             var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
             var parameter = new ParameterDescriptor()
             {
-                Name = "Address",
+                Name = "prefix",
                 ParameterType = typeof(Person3)
             };
 
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
             {
-                request.QueryString = QueryString.Create("[0].Street", "SomeStreet");
+                request.QueryString = QueryString.Create("Address[0].Street", "SomeStreet");
             });
 
             var modelState = new ModelStateDictionary();
@@ -64,7 +64,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.True(modelState.IsValid);
 
             Assert.Equal(1, modelState.Keys.Count);
-            var key = Assert.Single(modelState.Keys, k => k == "[0].Street");
+            var key = Assert.Single(modelState.Keys, k => k == "Address[0].Street");
             Assert.NotNull(modelState[key].Value);
             Assert.Equal("SomeStreet", modelState[key].Value.AttemptedValue);
             Assert.Equal("SomeStreet", modelState[key].Value.RawValue);
@@ -77,19 +77,19 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public CustomReadOnlyCollection<Address> Address { get; set; }
         }
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task ActionParameter_ReadOnlyCollectionModel_EmptyPrefix_DoesNotGetBound()
         {
             // Arrange
             var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
             var parameter = new ParameterDescriptor()
             {
-                Name = "Address",
+                Name = "prefix",
                 ParameterType = typeof(Person6)
             };
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
             {
-                request.QueryString = QueryString.Create("[0].Street", "SomeStreet");
+                request.QueryString = QueryString.Create("Address[0].Street", "SomeStreet");
             });
 
             var modelState = new ModelStateDictionary();
@@ -119,20 +119,20 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public Address[] Address { get; set; }
         }
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task ActionParameter_SettableArrayModel_EmptyPrefix_GetsBound()
         {
             // Arrange
             var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
             var parameter = new ParameterDescriptor()
             {
-                Name = "Address",
+                Name = "prefix",
                 ParameterType = typeof(Person4)
             };
 
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
             {
-                request.QueryString = QueryString.Create("[0].Street", "SomeStreet");
+                request.QueryString = QueryString.Create("Address[0].Street", "SomeStreet");
             });
 
             var modelState = new ModelStateDictionary();
@@ -147,6 +147,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             // Model
             Assert.NotNull(modelBindingResult.Model);
             var boundModel = Assert.IsType<Person4>(modelBindingResult.Model);
+            Assert.NotNull(boundModel.Address);
             Assert.Equal(1, boundModel.Address.Count());
             Assert.Equal("SomeStreet", boundModel.Address[0].Street);
 
@@ -154,7 +155,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.True(modelState.IsValid);
 
             Assert.Equal(1, modelState.Keys.Count);
-            var key = Assert.Single(modelState.Keys, k => k == "[0].Street");
+            var key = Assert.Single(modelState.Keys, k => k == "Address[0].Street");
             Assert.NotNull(modelState[key].Value);
             Assert.Equal("SomeStreet", modelState[key].Value.AttemptedValue);
             Assert.Equal("SomeStreet", modelState[key].Value.RawValue);
@@ -167,20 +168,20 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public Address[] Address { get; } = new Address[] { };
         }
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task ActionParameter_NonSettableArrayModel_EmptyPrefix_DoesNotGetBound()
         {
             // Arrange
             var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
             var parameter = new ParameterDescriptor()
             {
-                Name = "Address",
+                Name = "prefix",
                 ParameterType = typeof(Person5)
             };
 
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
             {
-                request.QueryString = QueryString.Create("[0].Street", "SomeStreet");
+                request.QueryString = QueryString.Create("Address[0].Street", "SomeStreet");
             });
 
             var modelState = new ModelStateDictionary();
@@ -204,7 +205,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Empty(modelState.Keys);
         }
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task ActionParameter_NonSettableCollectionModel_WithPrefix_GetsBound()
         {
             // Arrange
@@ -251,7 +252,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal(ModelValidationState.Valid, modelState[key].ValidationState);
         }
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task ActionParameter_ReadOnlyCollectionModel_WithPrefix_DoesNotGetBound()
         {
             // Arrange
@@ -292,7 +293,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Empty(modelState.Keys);
         }
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task ActionParameter_SettableArrayModel_WithPrefix_GetsBound()
         {
             // Arrange
@@ -339,7 +340,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal(ModelValidationState.Valid, modelState[key].ValidationState);
         }
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task ActionParameter_NonSettableArrayModel_WithPrefix_DoesNotGetBound()
         {
             // Arrange
@@ -369,7 +370,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             // Model
             Assert.NotNull(modelBindingResult.Model);
-            var boundModel = Assert.IsType<Person4>(modelBindingResult.Model);
+            var boundModel = Assert.IsType<Person5>(modelBindingResult.Model);
 
             // Arrays should not be updated.
             Assert.Equal(0, boundModel.Address.Count());

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/ArrayModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/ArrayModelBinderIntegrationTest.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
     // Integration tests targeting the behavior of the ArrayModelBinder with other model binders.
     public class ArrayModelBinderIntegrationTest
     {
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task ArrayModelBinder_BindsArrayOfSimpleType_WithPrefix_Success()
         {
             // Arrange
@@ -39,7 +39,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<int[]>(modelBindingResult.Model);
             Assert.Equal(new int[] { 10, 11 }, model);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -52,7 +52,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("11", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task ArrayModelBinder_BindsArrayOfSimpleType_WithExplicitPrefix_Success()
         {
             // Arrange
@@ -84,7 +84,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<int[]>(modelBindingResult.Model);
             Assert.Equal(new int[] { 10, 11 }, model);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -97,7 +97,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("11", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task ArrayModelBinder_BindsArrayOfSimpleType_EmptyPrefix_Success()
         {
             // Arrange
@@ -125,7 +125,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<int[]>(modelBindingResult.Model);
             Assert.Equal(new int[] { 10, 11 }, model);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -174,7 +174,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public string Name { get; set; }
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task ArrayModelBinder_BindsArrayOfComplexType_WithPrefix_Success()
         {
             // Arrange
@@ -203,7 +203,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", model[0].Name);
             Assert.Equal("lang", model[1].Name);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -216,7 +216,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("lang", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task ArrayModelBinder_BindsArrayOfComplexType_WithExplicitPrefix_Success()
         {
             // Arrange
@@ -233,7 +233,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
             {
-                request.QueryString = new QueryString("?prefix[0].Name=bill&prefix[1]=lang");
+                request.QueryString = new QueryString("?prefix[0].Name=bill&prefix[1].Name=lang");
             });
 
             var modelState = new ModelStateDictionary();
@@ -249,7 +249,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", model[0].Name);
             Assert.Equal("lang", model[1].Name);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -262,7 +262,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("lang", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task ArrayModelBinder_BindsArrayOfComplexType_EmptyPrefix_Success()
         {
             // Arrange
@@ -291,7 +291,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", model[0].Name);
             Assert.Equal("lang", model[1].Name);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/ByteArrayModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/ByteArrayModelBinderIntegrationTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public byte[] Token { get; set; }
         }
 
-        [Theory(Skip = "Extra entries in model state #2446, ModelState.Value not set due to #2445, #2447")]
+        [Theory(Skip = "ModelState.Value not set due to #2445, #2447")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task BindProperty_WithData_GetsBound(bool fallBackScenario)
@@ -61,7 +61,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             // ModelState
             Assert.True(modelState.IsValid);
 
-            Assert.Equal(2, modelState.Keys.Count); // Should be only two keys. bug #2446
+            Assert.Equal(2, modelState.Keys.Count);
             Assert.Single(modelState.Keys, k => k == prefix);
             Assert.Single(modelState.Keys, k => k == queryStringKey);
 
@@ -109,7 +109,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Empty(modelState.Keys);
         }
 
-        [Fact(Skip = "ModelState.Value not set due to #2445, #2446")]
+        [Fact(Skip = "ModelState.Value not set due to #2445")]
         public async Task BindParameter_WithData_GetsBound()
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/CancellationTokenModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/CancellationTokenModelBinderIntegrationTest.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal(ModelValidationState.Skipped, modelState[key].ValidationState);
         }
 
-        [Fact(Skip = "CancellationToken should not be validated #2447,Extra entries in model state dictionary. #2466")]
+        [Fact(Skip = "CancellationToken should not be validated #2447")]
         public async Task BindProperty_WithData__WithEmptyPrefix_GetsBound()
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/CollectionModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/CollectionModelBinderIntegrationTest.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
     // Note that CollectionModelBinder handles both ICollection{T} and IList{T}
     public class CollectionModelBinderIntegrationTest
     {
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task CollectionModelBinder_BindsListOfSimpleType_WithPrefix_Success()
         {
             // Arrange
@@ -45,7 +45,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<List<int>>(modelBindingResult.Model);
             Assert.Equal(new List<int>() { 10, 11 }, model);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -58,7 +58,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("11", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task CollectionModelBinder_BindsListOfSimpleType_WithExplicitPrefix_Success()
         {
             // Arrange
@@ -90,7 +90,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<List<int>>(modelBindingResult.Model);
             Assert.Equal(new List<int>() { 10, 11 }, model);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -103,7 +103,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("11", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task CollectionModelBinder_BindsCollectionOfSimpleType_EmptyPrefix_Success()
         {
             // Arrange
@@ -131,7 +131,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<List<int>>(modelBindingResult.Model);
             Assert.Equal(new List<int> { 10, 11 }, model);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -180,7 +180,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public int Id { get; set; }
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task CollectionModelBinder_BindsListOfComplexType_WithPrefix_Success()
         {
             // Arrange
@@ -209,7 +209,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal(10, model[0].Id);
             Assert.Equal(11, model[1].Id);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -222,7 +222,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("11", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task CollectionModelBinder_BindsListOfComplexType_WithExplicitPrefix_Success()
         {
             // Arrange
@@ -255,7 +255,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal(10, model[0].Id);
             Assert.Equal(11, model[1].Id);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -268,7 +268,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("11", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task CollectionModelBinder_BindsCollectionOfComplexType_EmptyPrefix_Success()
         {
             // Arrange
@@ -276,7 +276,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var parameter = new ParameterDescriptor()
             {
                 Name = "parameter",
-                ParameterType = typeof(ICollection<int>)
+                ParameterType = typeof(List<Person>)
             };
 
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
@@ -297,7 +297,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal(10, model[0].Id);
             Assert.Equal(11, model[1].Id);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -552,7 +552,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public string Street { get; set; }
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task CollectionModelBinder_UsesCustomIndexes()
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/DictionaryModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/DictionaryModelBinderIntegrationTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
     // Integration tests targeting the behavior of the DictionaryModelBinder with other model binders.
     public class DictionaryModelBinderIntegrationTest
     {
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task DictionaryModelBinder_BindsDictionaryOfSimpleType_WithPrefix_Success()
         {
             // Arrange
@@ -41,7 +41,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Dictionary<string, int>>(modelBindingResult.Model);
             Assert.Equal(new Dictionary<string, int>() { { "key0", 10 } }, model);
 
-            Assert.Equal(2, modelState.Count); // Fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -54,7 +54,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("10", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task DictionaryModelBinder_BindsDictionaryOfSimpleType_WithExplicitPrefix_Success()
         {
             // Arrange
@@ -86,7 +86,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Dictionary<string, int>>(modelBindingResult.Model);
             Assert.Equal(new Dictionary<string, int>() { { "key0", 10 }, }, model);
 
-            Assert.Equal(2, modelState.Count); // Fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -99,7 +99,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("10", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446, IsValue == false because of #2470")]
+        [Fact(Skip = "IsValid == false because of #2470")]
         public async Task DictionaryModelBinder_BindsDictionaryOfSimpleType_EmptyPrefix_Success()
         {
             // Arrange
@@ -127,7 +127,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Dictionary<string, int>>(modelBindingResult.Model);
             Assert.Equal(new Dictionary<string, int>() { { "key0", 10 }, }, model);
 
-            Assert.Equal(2, modelState.Count); // Fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid); // Fails due to #2470
 
@@ -176,7 +176,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public int Id { get; set; }
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task DictionaryModelBinder_BindsDictionaryOfComplexType_WithPrefix_Success()
         {
             // Arrange
@@ -206,7 +206,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("key0", model.Keys.First());
             Assert.Equal(model.Values, model.Values);
 
-            Assert.Equal(2, modelState.Count); // Fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -219,7 +219,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("10", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task DictionaryModelBinder_BindsDictionaryOfComplexType_WithExplicitPrefix_Success()
         {
             // Arrange
@@ -253,7 +253,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("key0", model.Keys.First());
             Assert.Equal(model.Values, model.Values);
 
-            Assert.Equal(2, modelState.Count); // Fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -266,7 +266,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("10", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446, IsValue == false because of #2470")]
+        [Fact(Skip = "IsValid == false because of #2470")]
         public async Task DictionaryModelBinder_BindsDictionaryOfComplexType_EmptyPrefix_Success()
         {
             // Arrange
@@ -296,7 +296,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("key0", model.Keys.First());
             Assert.Equal(model.Values, model.Values);
 
-            Assert.Equal(2, modelState.Count); // Fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid); // Fails due to #2470
 

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/FormCollectionModelBindingIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/FormCollectionModelBindingIntegrationTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public FormCollection FileCollection { get; set; }
         }
 
-        [Fact(Skip = "ModelState.Value not set due to #2445, Extra entries in model state #2446.")]
+        [Fact(Skip = "ModelState.Value not set due to #2445")]
         public async Task BindProperty_WithData_WithEmptyPrefix_GetsBound()
         {
             // Arrange
@@ -71,13 +71,13 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.True(modelState.IsValid);
             Assert.Equal(2, modelState.Count);
             Assert.Single(modelState.Keys, k => k == "Address.Zip");
-            var key = Assert.Single(modelState.Keys, k => k == "Address.File"); // Should be only one key. bug #2446
+            var key = Assert.Single(modelState.Keys, k => k == "Address.File");
             Assert.NotNull(modelState[key].Value); // should be non null bug #2445.
             Assert.Empty(modelState[key].Errors);
             Assert.Equal(ModelValidationState.Valid, modelState[key].ValidationState);
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task BindParameter_WithData_GetsBound()
         {
             // Arrange
@@ -125,10 +125,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             // Validation should be skipped because we do not validate any parameters and since IFormFile is not
             // IValidatableObject, we should have no entries in the model state dictionary.
-            Assert.Empty(modelState.Keys); // Enable when we fix #2446.
+            Assert.Empty(modelState.Keys);
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact(Skip = "FormCollection should not return null modelBindingResult for a type that matches. #2456")]
         public async Task BindParameter_NoData_DoesNotGetBound()
         {
             // Arrange
@@ -147,7 +147,6 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             // No data is passed.
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
             {
-                request.ContentType = "multipart/form-data";
             });
 
             var modelState = new ModelStateDictionary();
@@ -158,7 +157,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             // Assert
 
             // ModelBindingResult
-            Assert.NotNull(modelBindingResult); // Fails due to bug #2456
+            Assert.NotNull(modelBindingResult);
             Assert.Null(modelBindingResult.Model);
 
             // ModelState

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/FormFileModelBindingIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/FormFileModelBindingIntegrationTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public IFormFile File { get; set; }
         }
 
-        [Fact(Skip = "ModelState.Value not set due to #2445, Extra entries in model state #2446.")]
+        [Fact(Skip = "ModelState.Value not set due to #2445")]
         public async Task BindProperty_WithData_WithEmptyPrefix_GetsBound()
         {
             // Arrange
@@ -70,13 +70,13 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.True(modelState.IsValid);
             Assert.Equal(2, modelState.Count);
             Assert.Single(modelState.Keys, k => k == "Address.Zip");
-            var key = Assert.Single(modelState.Keys, k => k == "Address.File"); // Should be only one key. bug #2446
+            var key = Assert.Single(modelState.Keys, k => k == "Address.File");
             Assert.NotNull(modelState[key].Value); // should be non null bug #2445.
             Assert.Empty(modelState[key].Errors);
             Assert.Equal(ModelValidationState.Valid, modelState[key].ValidationState);
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task BindParameter_WithData_GetsBound()
         {
             // Arrange
@@ -122,10 +122,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             // Validation should be skipped because we do not validate any parameters and since IFormFile is not
             // IValidatableObject, we should have no entries in the model state dictionary.
-            Assert.Empty(modelState.Keys); // Enable when we fix #2446.
+            Assert.Empty(modelState.Keys);
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact(Skip = "FormFile Should not return null modelBindingResult for a type that matches. #2456")]
         public async Task BindParameter_NoData_DoesNotGetBound()
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/GenericModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/GenericModelBinderIntegrationTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
         //
         // In this example we choose IFormCollection - because IFormCollection has a dedicated
         // model  binder.
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task GenericModelBinder_BindsCollection_ElementTypeFromGreedyModelBinder_WithPrefix_Success()
         {
             // Arrange
@@ -50,7 +50,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal(1, model.Count);
             Assert.NotNull(model[0]);
 
-            Assert.Equal(0, modelState.Count); // This fails due to #2446
+            Assert.Equal(0, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
         }
@@ -60,7 +60,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
         //
         // In this example we choose IFormCollection - because IFormCollection has a dedicated
         // model  binder.
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task GenericModelBinder_BindsCollection_ElementTypeFromGreedyModelBinder_EmptyPrefix_Success()
         {
             // Arrange
@@ -89,7 +89,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal(1, model.Count);
             Assert.NotNull(model[0]);
 
-            Assert.Equal(0, modelState.Count); // This fails due to #2446
+            Assert.Equal(0, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
         }
@@ -169,7 +169,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
         // This isn't an especially useful scenario - but it exercises what happens when you
         // try to use a Collection of something that is bound greedily by binding source.
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task GenericModelBinder_BindsCollection_ElementTypeUsesGreedyModelBinder_WithPrefix_Success()
         {
             // Arrange
@@ -199,14 +199,14 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal(1, model.Length);
             Assert.NotNull(model[0]);
 
-            Assert.Equal(0, modelState.Count); // This fails due to #2446
+            Assert.Equal(0, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
         }
 
         // This is part of a random sampling of scenarios where a GenericModelBinder is used
         // recursively.
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task GenericModelBinder_BindsArrayOfDictionary_WithPrefix_Success()
         {
             // Arrange
@@ -237,7 +237,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("key0", kvp.Key);
             Assert.Equal(10, kvp.Value);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -252,7 +252,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
         // This is part of a random sampling of scenarios where a GenericModelBinder is used
         // recursively.
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task GenericModelBinder_BindsArrayOfDictionary_EmptyPrefix_Success()
         {
             // Arrange
@@ -283,7 +283,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("key0", kvp.Key);
             Assert.Equal(10, kvp.Value);
 
-            Assert.Equal(1, modelState.Count);  // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -334,7 +334,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
         // This is part of a random sampling of scenarios where a GenericModelBinder is used
         // recursively.
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task GenericModelBinder_BindsCollectionOfKeyValuePair_WithPrefix_Success()
         {
             // Arrange
@@ -364,7 +364,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("key0", kvp.Key);
             Assert.Equal(10, kvp.Value);
 
-            Assert.Equal(2, modelState.Count); // Fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -379,7 +379,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
         // This is part of a random sampling of scenarios where a GenericModelBinder is used
         // recursively.
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task GenericModelBinder_BindsCollectionOfKeyValuePair_EmptyPrefix_Success()
         {
             // Arrange
@@ -409,7 +409,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("key0", kvp.Key);
             Assert.Equal(10, kvp.Value);
 
-            Assert.Equal(2, modelState.Count); //Fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -460,7 +460,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
         // This is part of a random sampling of scenarios where a GenericModelBinder is used
         // recursively.
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task GenericModelBinder_BindsDictionaryOfList_WithPrefix_Success()
         {
             // Arrange
@@ -491,7 +491,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("key0", kvp.Key);
             Assert.Equal(new List<int>() { 10, 11 }, kvp.Value);
 
-            Assert.Equal(3, modelState.Count); // Fails due to #2446
+            Assert.Equal(3, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -510,7 +510,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
         // This is part of a random sampling of scenarios where a GenericModelBinder is used
         // recursively.
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task GenericModelBinder_BindsDictionaryOfList_EmptyPrefix_Success()
         {
             // Arrange
@@ -540,7 +540,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("key0", kvp.Key);
             Assert.Equal(new List<int>() { 10, 11 }, kvp.Value);
 
-            Assert.Equal(3, modelState.Count); // Fails due to #2446
+            Assert.Equal(3, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/HeaderModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/HeaderModelBinderIntegrationTest.cs
@@ -116,7 +116,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
         // The scenario is interesting as we to bind the top level model we fallback to empty prefix,
         // and hence the model state keys have an empty prefix.
-        [Fact(Skip = "ModelState.Value not set due to #2445. ModelState should not have empty key #2466.")]
+        [Fact(Skip = "ModelState.Value not set due to #2445.")]
         public async Task BindPropertyFromHeader_WithData_WithEmptyPrefix_GetsBound()
         {
             // Arrange
@@ -160,8 +160,8 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("someValue", modelState[key].Value.AttemptedValue);
         }
 
-        [Theory(Skip = "Extra entries in model state #2446.")]
-        [InlineData(typeof(string[]), "value1, value2, value3")] 
+        [Theory(Skip = "Greedy Model Binders should add a value in model state #2445.")]
+        [InlineData(typeof(string[]), "value1, value2, value3")]
         [InlineData(typeof(string), "value")]
         public async Task BindParameterFromHeader_WithData_WithPrefix_ModelGetsBound(Type modelType, string value)
         {

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/KeyValuePairModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/KeyValuePairModelBinderIntegrationTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
     // Integration tests targeting the behavior of the KeyValuePairModelBinder with other model binders.
     public class KeyValuePairModelBinderIntegrationTest
     {
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task KeyValuePairModelBinder_BindsKeyValuePairOfSimpleType_WithPrefix_Success()
         {
             // Arrange
@@ -40,7 +40,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<KeyValuePair<string, int>>(modelBindingResult.Model);
             Assert.Equal(new KeyValuePair<string, int>("key0", 10), model);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -53,7 +53,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("10", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task KeyValuePairModelBinder_BindsKeyValuePairOfSimpleType_WithExplicitPrefix_Success()
         {
             // Arrange
@@ -85,7 +85,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<KeyValuePair<string, int>>(modelBindingResult.Model);
             Assert.Equal(new KeyValuePair<string, int>("key0", 10), model);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -98,7 +98,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("10", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task KeyValuePairModelBinder_BindsKeyValuePairOfSimpleType_EmptyPrefix_Success()
         {
             // Arrange
@@ -126,7 +126,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<KeyValuePair<string, int>>(modelBindingResult.Model);
             Assert.Equal(new KeyValuePair<string, int>("key0", 10), model);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -176,7 +176,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public int Id { get; set; }
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task KeyValuePairModelBinder_BindsKeyValuePairOfComplexType_WithPrefix_Success()
         {
             // Arrange
@@ -205,7 +205,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("key0", model.Key);
             Assert.Equal(10, model.Value.Id);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -215,10 +215,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             entry = Assert.Single(modelState, kvp => kvp.Key == "parameter.Value.Id").Value;
             Assert.Equal("10", entry.Value.AttemptedValue);
-            Assert.Same(model.Value, entry.Value.RawValue);
+            Assert.Equal(model.Value.Id.ToString(), entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task KeyValuePairModelBinder_BindsKeyValuePairOfComplexType_WithExplicitPrefix_Success()
         {
             // Arrange
@@ -251,7 +251,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("key0", model.Key);
             Assert.Equal(10, model.Value.Id);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -264,7 +264,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("10", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task KeyValuePairModelBinder_BindsKeyValuePairOfComplexType_EmptyPrefix_Success()
         {
             // Arrange
@@ -293,7 +293,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("key0", model.Key);
             Assert.Equal(10, model.Value.Id);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/MutableObjectModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/MutableObjectModelBinderIntegrationTest.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public string Street { get; set; }
         }
 
-        [Fact(Skip = "Extra entries in model state #2446, ModelState.Value not set due to #2445.")]
+        [Fact(Skip = "ModelState.Value not set due to #2445.")]
         public async Task MutableObjectModelBinder_BindsNestedPOCO_WithBodyModelBinder_WithPrefix_Success()
         {
             // Arrange
@@ -77,7 +77,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.NotNull(model.Customer.Address);
             Assert.Equal(AddressStreetContent, model.Customer.Address.Street);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -91,7 +91,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Same(model.Customer.Address, entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra entries in model state #2446, ModelState.Value not set due to #2445.")]
+        [Fact(Skip = "ModelState.Value not set due to #2445.")]
         public async Task MutableObjectModelBinder_BindsNestedPOCO_WithBodyModelBinder_WithEmptyPrefix_Success()
         {
             // Arrange
@@ -124,7 +124,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.NotNull(model.Customer.Address);
             Assert.Equal(AddressStreetContent, model.Customer.Address.Street);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -138,7 +138,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Same(model.Customer.Address, entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsNestedPOCO_WithBodyModelBinder_WithPrefix_NoBodyData()
         {
             // Arrange
@@ -153,6 +153,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
             {
                 request.QueryString = new QueryString("?parameter.Customer.Name=bill");
+                request.ContentType = "application/json";
             });
 
             var modelState = new ModelStateDictionary();
@@ -169,7 +170,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", model.Customer.Name);
             Assert.Null(model.Customer.Address);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -180,7 +181,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
         // We don't provide enough data in this test for the 'Person' model to be created. So even though there is
         // body data in the request, it won't be used.
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsNestedPOCO_WithBodyModelBinder_WithPrefix_PartialData()
         {
             // Arrange
@@ -211,7 +212,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Null(model.Customer);
             Assert.Equal(10, model.ProductId);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -222,7 +223,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
         // We don't provide enough data in this test for the 'Person' model to be created. So even though there is
         // body data in the request, it won't be used.
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsNestedPOCO_WithBodyModelBinder_WithPrefix_NoData()
         {
             // Arrange
@@ -252,7 +253,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Order1>(modelBindingResult.Model);
             Assert.Null(model.Customer);
 
-            Assert.Equal(0, modelState.Count); // This fails due to #2446
+            Assert.Equal(0, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
         }
@@ -272,7 +273,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public IScopedInstance<ActionBindingContext> BindingContext { get; set; }
         }
 
-        [Fact(Skip = "Extra entries in model state #2446, #2646.")]
+        [Fact(Skip = "FromServices should not have an entry in model state #2464.")]
         public async Task MutableObjectModelBinder_BindsNestedPOCO_WithServicesModelBinder_WithPrefix_Success()
         {
             // Arrange
@@ -303,7 +304,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", model.Customer.Name);
             Assert.NotNull(model.Customer.BindingContext);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -312,7 +313,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra entries in model state #2446, #2646.")]
+        [Fact(Skip = "FromServices should not have an entry in model state #2464.")]
         public async Task MutableObjectModelBinder_BindsNestedPOCO_WithServicesModelBinder_WithEmptyPrefix_Success()
         {
             // Arrange
@@ -343,7 +344,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", model.Customer.Name);
             Assert.NotNull(model.Customer.BindingContext);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -354,7 +355,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
         // We don't provide enough data in this test for the 'Person' model to be created. So even though there is
         // a [FromServices], it won't be used.
-        [Fact(Skip = "Extra entries in model state #2446, #2646.")]
+        [Fact(Skip = "FromServices should not have an entry in model state #2464.")]
         public async Task MutableObjectModelBinder_BindsNestedPOCO_WithServicesModelBinder_WithPrefix_PartialData()
         {
             // Arrange
@@ -385,7 +386,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Null(model.Customer);
             Assert.Equal(10, model.ProductId);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -396,7 +397,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
         // We don't provide enough data in this test for the 'Person' model to be created. So even though there is
         // a [FromServices], it won't be used.
-        [Fact(Skip = "Extra entries in model state #2446, #2646.")]
+        [Fact(Skip = "Extra entries in model state  #2646.")]
         public async Task MutableObjectModelBinder_BindsNestedPOCO_WithServicesModelBinder_WithPrefix_NoData()
         {
             // Arrange
@@ -426,7 +427,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Order2>(modelBindingResult.Model);
             Assert.Null(model.Customer);
 
-            Assert.Equal(0, modelState.Count); // This fails due to #2446, #2464
+            Assert.Equal(0, modelState.Count); // Fails due to #2464
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
         }
@@ -445,7 +446,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public byte[] Token { get; set; }
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact(Skip = "Greedy model binders should set value. #2445")]
         public async Task MutableObjectModelBinder_BindsNestedPOCO_WithByteArrayModelBinder_WithPrefix_Success()
         {
             // Arrange
@@ -477,7 +478,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", model.Customer.Name);
             Assert.Equal(ByteArrayContent, model.Customer.Token);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count); // This fails due to #2445
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -491,7 +492,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal(ByteArrayEncoded, entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact(Skip = "Greedy model binders should set value. #2445")]
         public async Task MutableObjectModelBinder_BindsNestedPOCO_WithByteArrayModelBinder_WithEmptyPrefix_Success()
         {
             // Arrange
@@ -522,7 +523,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", model.Customer.Name);
             Assert.Equal(ByteArrayContent, model.Customer.Token);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -535,7 +536,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal(ByteArrayEncoded, entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsNestedPOCO_WithByteArrayModelBinder_WithPrefix_NoData()
         {
             // Arrange
@@ -550,6 +551,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
             {
                 request.QueryString = new QueryString("?parameter.Customer.Name=bill");
+
+                // This is set so that the input formatter does not add an error to model state.
+                // Thus this prevents addition of an extra error unrelated to the test scenario.
+                request.ContentType = "application/json";
             });
 
             var modelState = new ModelStateDictionary();
@@ -566,7 +571,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", model.Customer.Name);
             Assert.Null(model.Customer.Address);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -589,7 +594,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public IEnumerable<IFormFile> Documents { get; set; }
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact(Skip = "Greedy model binders should set value. #2445")]
         public async Task MutableObjectModelBinder_BindsNestedPOCO_WithFormFileModelBinder_WithPrefix_Success()
         {
             // Arrange
@@ -621,7 +626,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", model.Customer.Name);
             Assert.Single(model.Customer.Documents);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count); // This fails due to #2445
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -634,7 +639,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Same(model.Customer.Documents, entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact(Skip = "Greedy model binders should set value. #2445")]
         public async Task MutableObjectModelBinder_BindsNestedPOCO_WithFormFileModelBinder_WithEmptyPrefix_Success()
         {
             // Arrange
@@ -666,7 +671,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", model.Customer.Name);
             Assert.Single(model.Customer.Documents);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -679,7 +684,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Same(model.Customer.Documents, entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsNestedPOCO_WithFormFileModelBinder_WithPrefix_NoBodyData()
         {
             // Arrange
@@ -710,9 +715,9 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Order4>(modelBindingResult.Model);
             Assert.NotNull(model.Customer);
             Assert.Equal("bill", model.Customer.Name);
-            Assert.Null(model.Customer.Documents);
+            Assert.Empty(model.Customer.Documents);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -723,7 +728,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
         // We don't provide enough data in this test for the 'Person' model to be created. So even though there are
         // form files in the request, it won't be used.
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsNestedPOCO_WithFormFileModelBinder_WithPrefix_PartialData()
         {
             // Arrange
@@ -754,7 +759,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Null(model.Customer);
             Assert.Equal(10, model.ProductId);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -765,7 +770,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
         // We don't provide enough data in this test for the 'Person' model to be created. So even though there is
         // body data in the request, it won't be used.
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsNestedPOCO_WithFormFileModelBinder_WithPrefix_NoData()
         {
             // Arrange
@@ -795,7 +800,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Order4>(modelBindingResult.Model);
             Assert.Null(model.Customer);
 
-            Assert.Equal(0, modelState.Count); // This fails due to #2446
+            Assert.Equal(0, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
         }
@@ -807,7 +812,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public int[] ProductIds { get; set; }
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsArrayProperty_WithPrefix_Success()
         {
             // Arrange
@@ -838,7 +843,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", model.Name);
             Assert.Equal(new int[] { 10, 11 }, model.ProductIds);
 
-            Assert.Equal(3, modelState.Count); // This fails due to #2446
+            Assert.Equal(3, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -855,7 +860,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("11", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsArrayProperty_EmptyPrefix_Success()
         {
             // Arrange
@@ -886,7 +891,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", model.Name);
             Assert.Equal(new int[] { 10, 11 }, model.ProductIds);
 
-            Assert.Equal(3, modelState.Count); // This fails due to #2446
+            Assert.Equal(3, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -903,7 +908,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("11", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsArrayProperty_NoCollectionData()
         {
             // Arrange
@@ -933,7 +938,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", model.Name);
             Assert.Null(model.ProductIds);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -942,7 +947,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsArrayProperty_NoData()
         {
             // Arrange
@@ -972,7 +977,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Null(model.Name);
             Assert.Null(model.ProductIds);
 
-            Assert.Equal(0, modelState.Count); // This fails due to #2446
+            Assert.Equal(0, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
         }
@@ -984,7 +989,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public List<int> ProductIds { get; set; }
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsListProperty_WithPrefix_Success()
         {
             // Arrange
@@ -1015,7 +1020,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", model.Name);
             Assert.Equal(new List<int>() { 10, 11 }, model.ProductIds);
 
-            Assert.Equal(3, modelState.Count); // This fails due to #2446
+            Assert.Equal(3, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -1032,7 +1037,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("11", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsListProperty_EmptyPrefix_Success()
         {
             // Arrange
@@ -1063,7 +1068,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", model.Name);
             Assert.Equal(new List<int>() { 10, 11 }, model.ProductIds);
 
-            Assert.Equal(3, modelState.Count); // This fails due to #2446
+            Assert.Equal(3, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -1080,7 +1085,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("11", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsListProperty_NoCollectionData()
         {
             // Arrange
@@ -1110,7 +1115,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", model.Name);
             Assert.Null(model.ProductIds);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -1119,7 +1124,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsListProperty_NoData()
         {
             // Arrange
@@ -1149,7 +1154,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Null(model.Name);
             Assert.Null(model.ProductIds);
 
-            Assert.Equal(0, modelState.Count); // This fails due to #2446
+            Assert.Equal(0, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
         }
@@ -1161,7 +1166,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public Dictionary<string, int> ProductIds { get; set; }
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsDictionaryProperty_WithPrefix_Success()
         {
             // Arrange
@@ -1192,7 +1197,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", model.Name);
             Assert.Equal(new Dictionary<string, int>() { { "key0", 10 } }, model.ProductIds);
 
-            Assert.Equal(3, modelState.Count); // This fails due to #2446
+            Assert.Equal(3, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -1209,7 +1214,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("10", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsDictionaryProperty_EmptyPrefix_Success()
         {
             // Arrange
@@ -1240,7 +1245,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", model.Name);
             Assert.Equal(new Dictionary<string, int>() { { "key0", 10 } }, model.ProductIds);
 
-            Assert.Equal(3, modelState.Count); // This fails due to #2446
+            Assert.Equal(3, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -1257,7 +1262,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("10", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsDictionaryProperty_NoCollectionData()
         {
             // Arrange
@@ -1287,7 +1292,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", model.Name);
             Assert.Null(model.ProductIds);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -1296,7 +1301,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsDictionaryProperty_NoData()
         {
             // Arrange
@@ -1326,7 +1331,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Null(model.Name);
             Assert.Null(model.ProductIds);
 
-            Assert.Equal(0, modelState.Count); // This fails due to #2446
+            Assert.Equal(0, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
         }
@@ -1338,7 +1343,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public KeyValuePair<string, int> ProductId { get; set; }
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsKeyValuePairProperty_WithPrefix_Success()
         {
             // Arrange
@@ -1369,7 +1374,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", model.Name);
             Assert.Equal(new KeyValuePair<string, int>("key0", 10), model.ProductId);
 
-            Assert.Equal(3, modelState.Count); // This fails due to #2446
+            Assert.Equal(3, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -1386,7 +1391,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("10", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsKeyValuePairProperty_EmptyPrefix_Success()
         {
             // Arrange
@@ -1417,7 +1422,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", model.Name);
             Assert.Equal(new KeyValuePair<string, int>("key0", 10), model.ProductId);
 
-            Assert.Equal(3, modelState.Count); // This fails due to #2446
+            Assert.Equal(3, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -1434,7 +1439,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("10", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsKeyValuePairProperty_NoCollectionData()
         {
             // Arrange
@@ -1464,7 +1469,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", model.Name);
             Assert.Equal(default(KeyValuePair<string, int>), model.ProductId);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -1473,7 +1478,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "Extra entries in model state #2446.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsKeyValuePairProperty_NoData()
         {
             // Arrange
@@ -1503,7 +1508,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Null(model.Name);
             Assert.Equal(default(KeyValuePair<string, int>), model.ProductId);
 
-            Assert.Equal(0, modelState.Count); // This fails due to #2446
+            Assert.Equal(0, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
         }
@@ -1524,7 +1529,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
         // If a nested POCO object has all properties bound from a greedy source, then it should be populated
         // if the top-level object is created.
-        [Fact(Skip = "Extra entries in model state #2446, ModelState.Value not set due to #2445.")]
+        [Fact(Skip = "ModelState.Value not set due to #2445.")]
         public async Task MutableObjectModelBinder_BindsNestedPOCO_WithAllGreedyBoundProperties()
         {
             // Arrange
@@ -1557,7 +1562,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.NotNull(model.Customer.Address);
             Assert.Equal(AddressStreetContent, model.Customer.Address.Street);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -1605,7 +1610,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Order10>(modelBindingResult.Model);
             Assert.Null(model.Customer);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(1, modelState.ErrorCount);
             Assert.False(modelState.IsValid);
 
@@ -1659,7 +1664,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal(123, model.Customer.Id);
             Assert.Null(model.Customer.Name);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(1, modelState.ErrorCount);
             Assert.False(modelState.IsValid);
 
@@ -1705,7 +1710,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal(123, model.Customer.Id);
             Assert.Null(model.Customer.Name);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(1, modelState.ErrorCount);
             Assert.False(modelState.IsValid);
 
@@ -1755,7 +1760,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal(123, model.Customer.Id);
             Assert.Null(model.Customer.Name);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(1, modelState.ErrorCount);
             Assert.False(modelState.IsValid);
 
@@ -1805,7 +1810,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Order12>(modelBindingResult.Model);
             Assert.Null(model.ProductName);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(1, modelState.ErrorCount);
             Assert.False(modelState.IsValid);
 
@@ -1858,7 +1863,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("The ProductName field is required.", error.ErrorMessage);
         }
 
-        [Fact(Skip = "Extra model state entry due to #2446")]
+        [Fact]
         public async Task MutableObjectModelBinder_WithRequiredProperty_WithData_EmptyPrefix_GetsBound()
         {
             // Arrange
@@ -1887,7 +1892,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Order12>(modelBindingResult.Model);
             Assert.Equal("abc", model.ProductName);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -1985,7 +1990,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("The OrderIds field is required.", error.ErrorMessage);
         }
 
-        [Fact(Skip = "Extra model state entry due to #2446")]
+        [Fact]
         public async Task MutableObjectModelBinder_WithRequiredCollectionProperty_WithData_EmptyPrefix_GetsBound()
         {
             // Arrange
@@ -2014,7 +2019,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Order13>(modelBindingResult.Model);
             Assert.Equal(new[] { 123 }, model.OrderIds.ToArray());
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/ServicesModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/ServicesModelBinderIntegrationTest.cs
@@ -61,17 +61,14 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             // ModelState
             Assert.True(modelState.IsValid);
 
-            Assert.Equal(3, modelState.Keys.Count);
-            Assert.Single(modelState.Keys, k => k == "CustomParameter");
-            Assert.Single(modelState.Keys, k => k == "CustomParameter.Address");
-
+            Assert.Equal(1, modelState.Keys.Count);
             var key = Assert.Single(modelState.Keys, k => k == "CustomParameter.Address.OutputFormatter");
             Assert.Equal(ModelValidationState.Skipped, modelState[key].ValidationState);
             Assert.Null(modelState[key].Value);
             Assert.Empty(modelState[key].Errors);
         }
 
-        [Fact(Skip = "ModelState should not have empty key #2466.")]
+        [Fact(Skip = "Should be no entry for model bound using services. #2464")]
         public async Task BindPropertyFromService_WithData_WithEmptyPrefix_GetsBound()
         {
             // Arrange
@@ -102,10 +99,8 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             // ModelState
             Assert.True(modelState.IsValid);
-            Assert.Equal(2, modelState.Keys.Count);
-            Assert.Single(modelState.Keys, k => k == "Address");
-            var key = Assert.Single(modelState.Keys, k => k == "Address.OutputFormatter");
-            Assert.Equal(ModelValidationState.Skipped, modelState[key].ValidationState);
+            Assert.Equal(1, modelState.Keys.Count);
+            var key = Assert.Single(modelState.Keys, k => k == "Address");
             Assert.Null(modelState[key].Value); // For non user bound models there should be no value.
             Assert.Empty(modelState[key].Errors);
         }

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/TryUpdateModelIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/TryUpdateModelIntegrationTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public string Street { get; set; }
         }
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task TryUpdateModel_ExistingModel_EmptyPrefix_GetsOverWritten()
         {
             // Arrange
@@ -53,7 +53,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal(ModelValidationState.Valid, modelState[key].ValidationState);
         }
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task TryUpdateModel_ExistingModel_EmptyPrefix_GetsBound()
         {
             // Arrange
@@ -90,7 +90,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public List<Address> Address { get; set; }
         }
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task TryUpdateModel_SettableCollectionModel_EmptyPrefix_GetsBound()
         {
             // Arrange
@@ -134,7 +134,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public List<Address> Address { get; }
         }
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task TryUpdateModel_NonSettableCollectionModel_EmptyPrefix_GetsBound()
         {
             // Arrange
@@ -173,7 +173,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public CustomReadOnlyCollection<Address> Address { get; set; }
         }
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task TryUpdateModel_ReadOnlyCollectionModel_EmptyPrefix_DoesNotGetBound()
         {
             // Arrange
@@ -206,7 +206,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public Address[] Address { get; set; }
         }
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task TryUpdateModel_SettableArrayModel_EmptyPrefix_GetsBound()
         {
             // Arrange
@@ -245,7 +245,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public Address[] Address { get; } = new Address[] { };
         }
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task TryUpdateModel_NonSettableArrayModel_EmptyPrefix_GetsBound()
         {
             // Arrange
@@ -274,7 +274,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
         }
 
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task TryUpdateModel_ExistingModel_WithPrefix_GetsOverWritten()
         {
             // Arrange
@@ -309,7 +309,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal(ModelValidationState.Valid, modelState[key].ValidationState);
         }
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task TryUpdateModel_ExistingModel_WithPrefix_GetsBound()
         {
             // Arrange
@@ -341,7 +341,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal(ModelValidationState.Valid, modelState[key].ValidationState);
         }
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task TryUpdateModel_SettableCollectionModel_WithPrefix_GetsBound()
         {
             // Arrange
@@ -353,7 +353,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var modelState = new ModelStateDictionary();
             var model = new Person2();
             // Act
-            var result = await TryUpdateModel(model, string.Empty, operationContext, modelState);
+            var result = await TryUpdateModel(model, "prefix", operationContext, modelState);
 
             // Assert
             Assert.True(result);
@@ -375,7 +375,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal(ModelValidationState.Valid, modelState[key].ValidationState);
         }
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task TryUpdateModel_NonSettableCollectionModel_WithPrefix_GetsBound()
         {
             // Arrange
@@ -409,7 +409,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal(ModelValidationState.Valid, modelState[key].ValidationState);
         }
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task TryUpdateModel_ReadOnlyCollectionModel_WithPrefix_DoesNotGetBound()
         {
             // Arrange
@@ -437,7 +437,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Empty(modelState.Keys);
         }
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task TryUpdateModel_SettableArrayModel_WithPrefix_GetsBound()
         {
             // Arrange
@@ -463,7 +463,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.True(modelState.IsValid);
 
             Assert.Equal(1, modelState.Keys.Count);
-            var key = Assert.Single(modelState.Keys, k => k == "Address[0].Street");
+            var key = Assert.Single(modelState.Keys, k => k == "prefix.Address[0].Street");
             Assert.NotNull(modelState[key].Value);
             Assert.Equal("SomeStreet", modelState[key].Value.AttemptedValue);
             Assert.Equal("SomeStreet", modelState[key].Value.RawValue);
@@ -471,7 +471,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal(ModelValidationState.Valid, modelState[key].ValidationState);
         }
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task TryUpdateModel_NonSettableArrayModel_WithPrefix_DoesNotGetBound()
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/TypeConverterModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/TypeConverterModelBinderIntegrationTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public int Zip { get; set; }
         }
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task BindProperty_WithData_WithPrefix_GetsBound()
         {
             // Arrange
@@ -62,16 +62,16 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.True(modelState.IsValid);
 
             Assert.Equal(1, modelState.Keys.Count);
-            var key = Assert.Single(modelState.Keys, k => k == "CustomParameter.Address.Street");
+            var key = Assert.Single(modelState.Keys, k => k == "CustomParameter.Address.Zip");
             Assert.NotNull(modelState[key].Value);
             Assert.Equal("1", modelState[key].Value.AttemptedValue);
-            Assert.Equal(1, modelState[key].Value.RawValue);
+            Assert.Equal("1", modelState[key].Value.RawValue);
             Assert.NotNull(modelState[key].Value);
             Assert.Empty(modelState[key].Errors);
             Assert.Equal(ModelValidationState.Valid, modelState[key].ValidationState);
         }
 
-        [Fact(Skip = "Extra entries in model state dictionary. #2466")]
+        [Fact]
         public async Task BindProperty_WithData_WithEmptyPrefix_GetsBound()
         {
             // Arrange
@@ -112,7 +112,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var key = Assert.Single(modelState.Keys, k => k == "Address.Zip");
             Assert.NotNull(modelState[key].Value);
             Assert.Equal("1", modelState[key].Value.AttemptedValue);
-            Assert.Equal(1, modelState[key].Value.RawValue);
+            Assert.Equal("1", modelState[key].Value.RawValue);
             Assert.NotNull(modelState[key].Value);
             Assert.Empty(modelState[key].Errors);
             Assert.Equal(ModelValidationState.Valid, modelState[key].ValidationState);

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/ValidationIntegrationTests.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/ValidationIntegrationTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public string CustomerName { get; set; }
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task Validation_RequiredAttribute_OnSimpleTypeProperty_WithData()
         {
             // Arrange
@@ -47,7 +47,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Order1>(modelBindingResult.Model);
             Assert.Equal("bill", model.CustomerName);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -57,7 +57,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Empty(entry.Errors);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task Validation_RequiredAttribute_OnSimpleTypeProperty_NoData()
         {
             // Arrange
@@ -85,7 +85,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Order1>(modelBindingResult.Model);
             Assert.Null(model.CustomerName);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(1, modelState.ErrorCount);
             Assert.False(modelState.IsValid);
 
@@ -108,7 +108,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public string Name { get; set; }
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task Validation_RequiredAttribute_OnPOCOProperty_WithData()
         {
             // Arrange
@@ -137,7 +137,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.NotNull(model.Customer);
             Assert.Equal("bill", model.Customer.Name);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -200,7 +200,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public string Name { get; set; }
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task Validation_RequiredAttribute_OnNestedSimpleTypeProperty_WithData()
         {
             // Arrange
@@ -229,7 +229,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.NotNull(model.Customer);
             Assert.Equal("bill", model.Customer.Name);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -239,7 +239,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Empty(entry.Errors);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task Validation_RequiredAttribute_OnNestedSimpleTypeProperty_NoDataForRequiredProperty()
         {
             // Arrange
@@ -270,7 +270,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal(17, model.Customer.Age);
             Assert.Null(model.Customer.Name);
 
-            Assert.Equal(2, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(1, modelState.ErrorCount);
             Assert.False(modelState.IsValid);
 
@@ -293,7 +293,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public int ItemId { get; set; }
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task Validation_RequiredAttribute_OnCollectionProperty_WithData()
         {
             // Arrange
@@ -322,7 +322,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.NotNull(model.Items);
             Assert.Equal(17, Assert.Single(model.Items).ItemId);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -381,7 +381,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public string Name { get; set; }
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task Validation_RequiredAttribute_OnPOCOPropertyOfBoundElement_WithData()
         {
             // Arrange
@@ -409,7 +409,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<List<Order5>>(modelBindingResult.Model);
             Assert.Equal(17, Assert.Single(model).ProductId);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -468,7 +468,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public string Name { get; set; }
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task Validation_StringLengthAttribute_OnPropertyOfPOCO_Valid()
         {
             // Arrange
@@ -496,7 +496,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Order6>(modelBindingResult.Model);
             Assert.Equal("bill", model.Name);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -506,7 +506,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Empty(entry.Errors);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task Validation_StringLengthAttribute_OnPropertyOfPOCO_Invalid()
         {
             // Arrange
@@ -534,7 +534,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Order6>(modelBindingResult.Model);
             Assert.Equal("billybob", model.Name);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(1, modelState.ErrorCount);
             Assert.False(modelState.IsValid);
 
@@ -558,7 +558,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public string Name { get; set; }
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task Validation_StringLengthAttribute_OnPropertyOfNestedPOCO_Valid()
         {
             // Arrange
@@ -586,7 +586,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Order7>(modelBindingResult.Model);
             Assert.Equal("bill", model.Customer.Name);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -596,7 +596,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Empty(entry.Errors);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task Validation_StringLengthAttribute_OnPropertyOfNestedPOCO_Invalid()
         {
             // Arrange
@@ -624,7 +624,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Order7>(modelBindingResult.Model);
             Assert.Equal("billybob", model.Customer.Name);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(1, modelState.ErrorCount);
             Assert.False(modelState.IsValid);
 
@@ -637,7 +637,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Null(error.Exception);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task Validation_StringLengthAttribute_OnPropertyOfNestedPOCO_NoData()
         {
             // Arrange
@@ -665,7 +665,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Order7>(modelBindingResult.Model);
             Assert.Null(model.Customer);
 
-            Assert.Equal(0, modelState.Count); // This fails due to #2446
+            Assert.Equal(0, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
         }
@@ -696,7 +696,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             }
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task Validation_CustomAttribute_OnPOCOProperty_Valid()
         {
             // Arrange
@@ -724,7 +724,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Order8>(modelBindingResult.Model);
             Assert.Equal("bill", model.Customer.Name);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -734,7 +734,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Empty(entry.Errors);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task Validation_CustomAttribute_OnPOCOProperty_Invalid()
         {
             // Arrange
@@ -762,7 +762,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Order8>(modelBindingResult.Model);
             Assert.Equal("billybob", model.Customer.Name);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(1, modelState.ErrorCount);
             Assert.False(modelState.IsValid);
 
@@ -804,7 +804,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             }
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task Validation_CustomAttribute_OnCollectionElement_Valid()
         {
             // Arrange
@@ -832,7 +832,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Order9>(modelBindingResult.Model);
             Assert.Equal("bill", Assert.Single(model.Products).Name);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -842,7 +842,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Empty(entry.Errors);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task Validation_CustomAttribute_OnCollectionElement_Invalid()
         {
             // Arrange
@@ -870,7 +870,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Order9>(modelBindingResult.Model);
             Assert.Equal("billybob", Assert.Single(model.Products).Name);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(2, modelState.Count);
             Assert.Equal(1, modelState.ErrorCount);
             Assert.False(modelState.IsValid);
 
@@ -893,7 +893,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public string Name { get; set; }
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task Validation_StringLengthAttribute_OnProperyOfCollectionElement_Valid()
         {
             // Arrange
@@ -921,7 +921,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<List<Order10>>(modelBindingResult.Model);
             Assert.Equal("bill", Assert.Single(model).Name);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
@@ -931,7 +931,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Empty(entry.Errors);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446")]
+        [Fact]
         public async Task Validation_StringLengthAttribute_OnProperyOfCollectionElement_Invalid()
         {
             // Arrange
@@ -959,7 +959,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<List<Order10>>(modelBindingResult.Model);
             Assert.Equal("billybob", Assert.Single(model).Name);
 
-            Assert.Equal(1, modelState.Count); // This fails due to #2446
+            Assert.Equal(1, modelState.Count);
             Assert.Equal(1, modelState.ErrorCount);
             Assert.False(modelState.IsValid);
 
@@ -972,7 +972,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Null(error.Exception);
         }
 
-        [Fact(Skip = "Extra ModelState key because of #2446, Empty collection should be created by the collection model binder #1579")]
+        [Fact(Skip = "Empty collection should be created by the collection model binder #1579")]
         public async Task Validation_StringLengthAttribute_OnProperyOfCollectionElement_NoData()
         {
             // Arrange
@@ -1000,7 +1000,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<List<Order10>>(modelBindingResult.Model);
             Assert.Empty(model);
 
-            //Assert.Equal(0, modelState.Count); // This fails due to #2446
+            Assert.Equal(0, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.False(modelState.IsValid);
         }


### PR DESCRIPTION
The assumption is ModelState should have entries if
1. An error is explicitly added by a model binder.
2. There is validation error reported while validating the model.
3. There is value bound by the model binder.

With this change there should be no extra entry other than for the cases mentioned above.

Also enabling the integration test cases.