### PR TITLE
Fixes #2464 - Does not add extra skipped entries for model bound from…

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/ModelStateDictionary.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/ModelStateDictionary.cs
@@ -502,7 +502,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             return GetEnumerator();
         }
 
-        private static IEnumerable<KeyValuePair<string, TValue>> FindKeysWithPrefix<TValue>(
+        public static IEnumerable<KeyValuePair<string, TValue>> FindKeysWithPrefix<TValue>(
             [NotNull] IDictionary<string, TValue> dictionary,
             [NotNull] string prefix)
         {
@@ -523,8 +523,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
                 if (key.StartsWith("[", StringComparison.OrdinalIgnoreCase))
                 {
-                    key = key.Substring(key.IndexOf('.') + 1);
-                    if (string.Equals(prefix, key, StringComparison.Ordinal))
+                    var subKey = key.Substring(key.IndexOf('.') + 1);
+                    if (string.Equals(prefix, subKey, StringComparison.Ordinal))
                     {
                         yield return entry;
                         continue;

--- a/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/ModelStateDictionary.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/ModelStateDictionary.cs
@@ -281,7 +281,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// state errors; <see cref="ModelValidationState.Valid"/> otherwise.</returns>
         public ModelValidationState GetFieldValidationState([NotNull] string key)
         {
-            var entries = FindKeysWithPrefix(this, key);
+            var entries = FindKeysWithPrefix(key);
             if (!entries.Any())
             {
                 return ModelValidationState.Unvalidated;
@@ -378,7 +378,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             // If key is null or empty, clear all entries in the dictionary
             // else just clear the ones that have key as prefix
             var entries  = (string.IsNullOrEmpty(key)) ?
-                _innerDictionary : FindKeysWithPrefix(this, key);
+                _innerDictionary : FindKeysWithPrefix(key);
 
             foreach (var entry in entries)
             {
@@ -502,17 +502,15 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             return GetEnumerator();
         }
 
-        public static IEnumerable<KeyValuePair<string, TValue>> FindKeysWithPrefix<TValue>(
-            [NotNull] IDictionary<string, TValue> dictionary,
-            [NotNull] string prefix)
+        public IEnumerable<KeyValuePair<string, ModelState>> FindKeysWithPrefix([NotNull] string prefix)
         {
-            TValue exactMatchValue;
-            if (dictionary.TryGetValue(prefix, out exactMatchValue))
+            ModelState exactMatchValue;
+            if (_innerDictionary.TryGetValue(prefix, out exactMatchValue))
             {
-                yield return new KeyValuePair<string, TValue>(prefix, exactMatchValue);
+                yield return new KeyValuePair<string, ModelState>(prefix, exactMatchValue);
             }
 
-            foreach (var entry in dictionary)
+            foreach (var entry in _innerDictionary)
             {
                 var key = entry.Key;
 

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Validation/DefaultObjectValidator.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Validation/DefaultObjectValidator.cs
@@ -142,7 +142,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             }
 
             // At this point we just want to mark all sub-entries present in the model state as skipped.
-            var entries = ModelStateDictionary.FindKeysWithPrefix(modelState, currentModelKey);
+            var entries = modelState.FindKeysWithPrefix(currentModelKey);
             foreach (var entry in entries)
             {
                 entry.Value.ValidationState = ModelValidationState.Skipped;

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Validation/DefaultObjectValidator.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Validation/DefaultObjectValidator.cs
@@ -66,12 +66,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             var currentValidationNode = validationContext.ValidationNode;
             if (currentValidationNode.SuppressValidation)
             {
-                // Short circuit if the node is marked to be suppressed
-                var validationState = modelState.GetFieldValidationState(modelKey);
-                if (validationState == ModelValidationState.Unvalidated)
-                {
-                    modelValidationContext.ModelState.MarkFieldSkipped(modelKey);
-                }
+                // Short circuit if the node is marked to be suppressed.
+                // If there are any sub entries which were model bound, they need to be marked as skipped,
+                // Otherwise they will remain as unvalidated and the model state would be Invalid.
+                MarkChildNodesAsSkipped(modelKey, modelExplorer.Metadata, validationContext);
 
                 // For validation purposes this model is valid.
                 return true;
@@ -103,7 +101,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             if (IsTypeExcludedFromValidation(_excludeFilters, modelType))
             {
                 var result = ShallowValidate(modelKey, modelExplorer, validationContext, validators);
-                MarkPropertiesAsSkipped(modelKey, modelExplorer.Metadata, validationContext);
+
+                // If there are any sub entries which were model bound, they need to be marked as skipped,
+                // Otherwise they will remain as unvalidated and the model state would be Invalid.
+                MarkChildNodesAsSkipped(modelKey, modelExplorer.Metadata, validationContext);
                 return result;
             }
 
@@ -127,7 +128,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             return isValid;
         }
 
-        private void MarkPropertiesAsSkipped(string currentModelKey, ModelMetadata metadata, ValidationContext validationContext)
+        private void MarkChildNodesAsSkipped(string currentModelKey, ModelMetadata metadata, ValidationContext validationContext)
         {
             var modelState = validationContext.ModelValidationContext.ModelState;
             var fieldValidationState = modelState.GetFieldValidationState(currentModelKey);
@@ -140,15 +141,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
                 return;
             }
 
-            foreach (var childMetadata in metadata.Properties)
+            // At this point we just want to mark all sub-entries present in the model state as skipped.
+            var entries = ModelStateDictionary.FindKeysWithPrefix(modelState, currentModelKey);
+            foreach (var entry in entries)
             {
-                var childKey = ModelNames.CreatePropertyModelName(currentModelKey, childMetadata.PropertyName);
-                var validationState = modelState.GetFieldValidationState(childKey);
-
-                if (validationState == ModelValidationState.Unvalidated)
-                {
-                    validationContext.ModelValidationContext.ModelState.MarkFieldSkipped(childKey);
-                }
+                entry.Value.ValidationState = ModelValidationState.Skipped;
             }
         }
 
@@ -248,12 +245,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
                 }
             }
 
-            if (modelState.ContainsKey(modelKey))
+            if (modelState.ContainsKey(modelKey) && isValid)
             {
-                if (isValid)
-                {
-                    validationContext.ModelValidationContext.ModelState.MarkFieldValid(modelKey);
-                }
+                validationContext.ModelValidationContext.ModelState.MarkFieldValid(modelKey);
             }
 
             return isValid;

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/Validation/DefaultObjectValidatorTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/Validation/DefaultObjectValidatorTests.cs
@@ -427,7 +427,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             validator.Validate(validationContext, topLevelValidationNode);
 
             // Assert
-            Assert.Equal(new[] { "key1", "user.Password", "", "user.ConfirmPassword" },
+            Assert.Equal(new[] { "key1", "", "user.ConfirmPassword" },
                 validationContext.ModelState.Keys.ToArray());
             var modelState = validationContext.ModelState["user.ConfirmPassword"];
             Assert.Empty(modelState.Errors);
@@ -438,7 +438,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         }
 
         [Fact]
-        public void ForExcludedNonModelBoundType_Properties_NotMarkedAsSkiped()
+        public void ForExcludedNonModelBoundTypes_NoEntryInModelState()
         {
             // Arrange
             var user = new User()
@@ -468,11 +468,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             validator.Validate(validationContext, topLevelValidationNode);
 
             // Assert
-            Assert.False(validationContext.ModelState.ContainsKey("user.Password"));
-            Assert.False(validationContext.ModelState.ContainsKey("user.ConfirmPassword"));
-            var modelState = validationContext.ModelState["user"];
-            Assert.Empty(modelState.Errors);
-            Assert.Equal(modelState.ValidationState, ModelValidationState.Valid);
+            Assert.True(validationContext.ModelState.IsValid);
+            Assert.Empty(validationContext.ModelState);
         }
 
         [Fact]
@@ -511,13 +508,15 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             validator.Validate(validationContext, topLevelValidationNode);
 
             // Assert
-            var modelState = validationContext.ModelState["user.Password"];
-            Assert.Empty(modelState.Errors);
-            Assert.Equal(modelState.ValidationState, ModelValidationState.Skipped);
+            var entry = Assert.Single(validationContext.ModelState);
+            Assert.Equal("user.Password", entry.Key);
+            Assert.Empty(entry.Value.Errors);
+            Assert.Equal(entry.Value.ValidationState, ModelValidationState.Skipped);
+        }
 
-            modelState = validationContext.ModelState["user.ConfirmPassword"];
-            Assert.Empty(modelState.Errors);
-            Assert.Equal(modelState.ValidationState, ModelValidationState.Skipped);
+        private class Person2
+        {
+            public Address Address { get; set; }
         }
 
         [Fact]
@@ -525,22 +524,28 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var testValidationContext = GetModelValidationContext(
-                new TestServiceProvider(),
-                typeof(TestServiceProvider));
-
+                new Person2()
+                {
+                    Address = new Address { Street = "GreaterThan5Characters" }
+                },
+                typeof(Person2));
             var validationContext = testValidationContext.ModelValidationContext;
+
+            // Create an entry like a model binder would.
+            validationContext.ModelState.Add("person.Address", new ModelState());
+
             var validator = new DefaultObjectValidator(
                 testValidationContext.ExcludeFilters, 
                 testValidationContext.ModelMetadataProvider);
             var modelExplorer = testValidationContext.ModelValidationContext.ModelExplorer;
             var topLevelValidationNode = new ModelValidationNode(
-                "serviceProvider",
+                "person",
                 modelExplorer.Metadata,
                 modelExplorer.Model);
 
-            var propertyExplorer = modelExplorer.GetExplorerForProperty("TestService");
+            var propertyExplorer = modelExplorer.GetExplorerForProperty("Address");
             var childNode = new ModelValidationNode(
-                "serviceProvider.TestService",
+                "person.Address",
                 propertyExplorer.Metadata,
                 propertyExplorer.Model)
             {
@@ -554,8 +559,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
 
             // Assert
             Assert.True(validationContext.ModelState.IsValid);
-            var modelState = validationContext.ModelState["serviceProvider.TestService"];
-            Assert.Empty(modelState.Errors);
+            var modelState = validationContext.ModelState["person.Address"];
             Assert.Equal(modelState.ValidationState, ModelValidationState.Skipped);
         }
 
@@ -603,7 +607,13 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
 
             // Assert
             Assert.True(validationContext.ModelState.IsValid);
-            var modelState = validationContext.ModelState["items"];
+            var modelState = validationContext.ModelState["items[0]"];
+            Assert.Equal(modelState.ValidationState, ModelValidationState.Valid);
+
+            modelState = validationContext.ModelState["items[1]"];
+            Assert.Equal(modelState.ValidationState, ModelValidationState.Valid);
+
+            modelState = validationContext.ModelState["items[2]"];
             Assert.Equal(modelState.ValidationState, ModelValidationState.Valid);
         }
 
@@ -653,16 +663,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
 
             // Assert
             Assert.True(validationContext.ModelState.IsValid);
-            var modelState = validationContext.ModelState["items"];
-            Assert.Equal(modelState.ValidationState, ModelValidationState.Valid);
-            modelState = validationContext.ModelState["items[0].Key"];
-            Assert.Equal(modelState.ValidationState, ModelValidationState.Skipped);
+            var modelState = validationContext.ModelState["items[0].Key"];
+            Assert.Equal(ModelValidationState.Skipped, modelState.ValidationState);
             modelState = validationContext.ModelState["items[0].Value"];
-            Assert.Equal(modelState.ValidationState, ModelValidationState.Skipped);
+            Assert.Equal(ModelValidationState.Skipped, modelState.ValidationState);
             modelState = validationContext.ModelState["items[1].Key"];
-            Assert.Equal(modelState.ValidationState, ModelValidationState.Skipped);
+            Assert.Equal(ModelValidationState.Skipped, modelState.ValidationState);
             modelState = validationContext.ModelState["items[1].Value"];
-            Assert.Equal(modelState.ValidationState, ModelValidationState.Skipped);
+            Assert.Equal(ModelValidationState.Skipped, modelState.ValidationState);
         }
 
         [Fact]
@@ -690,8 +698,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
 
             // Assert
             Assert.True(validationContext.ModelState.IsValid);
-            var key = Assert.Single(validationContext.ModelState.Keys);
-            Assert.Equal("person", key);
+
+            // Since Person is not IValidatable and we do not look at its properties, the state is empty.
+            Assert.Empty(validationContext.ModelState.Keys);
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/Validation/DefaultObjectValidatorTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/Validation/DefaultObjectValidatorTests.cs
@@ -360,6 +360,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
                 .Validate(validationContext, topLevelValidationNode);
 
             // Assert
+            Assert.Equal(1, validationContext.ModelState.Count);
             Assert.Contains("Street", validationContext.ModelState.Keys);
             var streetState = validationContext.ModelState["Street"];
             Assert.Equal(2, streetState.Errors.Count);
@@ -559,6 +560,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
 
             // Assert
             Assert.True(validationContext.ModelState.IsValid);
+            Assert.Equal(1, validationContext.ModelState.Count);
             var modelState = validationContext.ModelState["person.Address"];
             Assert.Equal(modelState.ValidationState, ModelValidationState.Skipped);
         }
@@ -607,6 +609,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
 
             // Assert
             Assert.True(validationContext.ModelState.IsValid);
+            Assert.Equal(3, validationContext.ModelState.Count);
             var modelState = validationContext.ModelState["items[0]"];
             Assert.Equal(modelState.ValidationState, ModelValidationState.Valid);
 
@@ -663,6 +666,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
 
             // Assert
             Assert.True(validationContext.ModelState.IsValid);
+            Assert.Equal(4, validationContext.ModelState.Count);
             var modelState = validationContext.ModelState["items[0].Key"];
             Assert.Equal(ModelValidationState.Skipped, modelState.ValidationState);
             modelState = validationContext.ModelState["items[0].Value"];

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/InputObjectValidationTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/InputObjectValidationTests.cs
@@ -171,7 +171,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         }
 
         [Fact]
-        public async Task CheckIfExcludedField_IsValidatedForNonBodyBoundModels()
+        public async Task CheckIfExcludedField_IsNotValidatedForNonBodyBoundModels()
         {
             // Arrange
             var server = TestHelper.CreateServer(_app, SiteName, _configureServices);
@@ -185,7 +185,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 
             //Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal("The Name field is required.", await response.Content.ReadAsStringAsync());
+            Assert.Equal("xyz", await response.Content.ReadAsStringAsync());
         }
 
         private class ErrorCollection

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/BodyValidationIntegrationTests.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/BodyValidationIntegrationTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext(
               request =>
               {
-                  request.Body = new MemoryStream(Encoding.UTF8.GetBytes("{ \"Id\":1234 }"));
+                  request.Body = new MemoryStream(Encoding.UTF8.GetBytes(string.Empty));
                   request.ContentType = "application/json";
               });
 
@@ -71,7 +71,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
         }
 
         [Fact]
-        public async Task FromBodyOnActionParameter_EmptyBody_AddsModelStateError()
+        public async Task FromBodyOnActionParameter_EmptyBody_BindsToNullValue()
         {
             // Arrange
             var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
@@ -89,7 +89,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext(
                 request =>
                 {
-                    request.Body = new MemoryStream(Encoding.UTF8.GetBytes("{ \"Id\":1234 }"));
+                    request.Body = new MemoryStream(Encoding.UTF8.GetBytes(string.Empty));
                     request.ContentType = "application/json";
                 });
 
@@ -102,13 +102,9 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             // Assert
             Assert.NotNull(modelBindingResult);
             Assert.True(modelBindingResult.IsModelSet);
-            var boundPerson = Assert.IsType<Person>(modelBindingResult.Model);
-            Assert.NotNull(boundPerson);
-            var key = Assert.Single(modelState.Keys);
-            Assert.Equal("Address", key);
-            Assert.False(modelState.IsValid);
-            var error = Assert.Single(modelState[key].Errors);
-            Assert.Equal("The Address field is required.",error.ErrorMessage);
+            Assert.Null(modelBindingResult.Model);
+            Assert.Empty(modelState.Keys);
+            Assert.True(modelState.IsValid);
         }
 
         private class Person4

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/MutableObjectModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/MutableObjectModelBinderIntegrationTest.cs
@@ -273,7 +273,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public IScopedInstance<ActionBindingContext> BindingContext { get; set; }
         }
 
-        [Fact(Skip = "FromServices should not have an entry in model state #2464.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsNestedPOCO_WithServicesModelBinder_WithPrefix_Success()
         {
             // Arrange
@@ -313,7 +313,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("bill", entry.Value.RawValue);
         }
 
-        [Fact(Skip = "FromServices should not have an entry in model state #2464.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsNestedPOCO_WithServicesModelBinder_WithEmptyPrefix_Success()
         {
             // Arrange
@@ -355,7 +355,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
         // We don't provide enough data in this test for the 'Person' model to be created. So even though there is
         // a [FromServices], it won't be used.
-        [Fact(Skip = "FromServices should not have an entry in model state #2464.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsNestedPOCO_WithServicesModelBinder_WithPrefix_PartialData()
         {
             // Arrange
@@ -427,7 +427,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Order2>(modelBindingResult.Model);
             Assert.Null(model.Customer);
 
-            Assert.Equal(0, modelState.Count); // Fails due to #2464
+            Assert.Equal(0, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
         }

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/ServicesModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/ServicesModelBinderIntegrationTest.cs
@@ -60,15 +60,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             // ModelState
             Assert.True(modelState.IsValid);
-
-            Assert.Equal(1, modelState.Keys.Count);
-            var key = Assert.Single(modelState.Keys, k => k == "CustomParameter.Address.OutputFormatter");
-            Assert.Equal(ModelValidationState.Skipped, modelState[key].ValidationState);
-            Assert.Null(modelState[key].Value);
-            Assert.Empty(modelState[key].Errors);
+            Assert.Empty(modelState.Keys);
         }
 
-        [Fact(Skip = "Should be no entry for model bound using services. #2464")]
+        [Fact]
         public async Task BindPropertyFromService_WithData_WithEmptyPrefix_GetsBound()
         {
             // Arrange
@@ -99,13 +94,12 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             // ModelState
             Assert.True(modelState.IsValid);
-            Assert.Equal(1, modelState.Keys.Count);
-            var key = Assert.Single(modelState.Keys, k => k == "Address");
-            Assert.Null(modelState[key].Value); // For non user bound models there should be no value.
-            Assert.Empty(modelState[key].Errors);
+
+            // For non user bound models there should be no entry in model state.
+            Assert.Empty(modelState);
         }
 
-        [Fact(Skip = "#2464 ModelState should not have entry for non request bound models.")]
+        [Fact]
         public async Task BindParameterFromService_WithData_GetsBound()
         {
             // Arrange

--- a/test/WebSites/FormatterWebSite/Controllers/ValidationController.cs
+++ b/test/WebSites/FormatterWebSite/Controllers/ValidationController.cs
@@ -46,7 +46,6 @@ namespace FormatterWebSite
         [HttpPost]
         public string GetDeveloperAlias(Developer developer)
         {
-            // Since validation exclusion is currently only effective in case of body bound models.
             if (ModelState.IsValid)
             {
                 return developer.Alias;

--- a/test/WebSites/ModelBindingWebSite/Controllers/ValidationController.cs
+++ b/test/WebSites/ModelBindingWebSite/Controllers/ValidationController.cs
@@ -1,10 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.AspNet.Mvc;
-using Microsoft.AspNet.Mvc.ModelBinding;
 using ModelBindingWebSite.Models;
 
 namespace ModelBindingWebSite.Controllers

--- a/test/WebSites/ModelBindingWebSite/Controllers/ValidationController.cs
+++ b/test/WebSites/ModelBindingWebSite/Controllers/ValidationController.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNet.Mvc;
 using Microsoft.AspNet.Mvc.ModelBinding;
 using ModelBindingWebSite.Models;
@@ -14,19 +15,19 @@ namespace ModelBindingWebSite.Controllers
         [FromServices]
         public ITestService ControllerService { get; set; }
 
-        public bool SkipValidation(Resident resident)
+        public object SkipValidation(Resident resident)
         {
-            return ModelState.IsValid;
+            return ModelState;
         }
 
-        public bool AvoidRecursive(SelfishPerson selfishPerson)
+        public object AvoidRecursive(SelfishPerson selfishPerson)
         {
-            return ModelState.IsValid;
+            return ModelState;
         }
 
-        public bool DoNotValidateParameter([FromServices] ITestService service)
+        public object DoNotValidateParameter([FromServices] ITestService service)
         {
-            return ModelState.IsValid;
+            return ModelState;
         }
     }
 


### PR DESCRIPTION
… services.

Also ensures that when a type is marked as skipped, any sub property which is model bound (and hence a modelstate un validated entry),
is marked as skipped (otherwise it would cause the ModelState to be invalid).
Also fixing a bug in model state dictionary FindKeyWithPrefix was not considering [0] & [0][0] as a valid prefix.