### PR TITLE
Fix #2407 - Part 1 - Make model binding behavior for [Required] compatible with MVC5

### DIFF
--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingFromHeaderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingFromHeaderTest.cs
@@ -295,9 +295,9 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 
         // This model sets a value for 'Title', and the model binder won't trounce it.
         //
-        // There's a validation error because we validate the value in the request (not present).
+        // There's no validation error because we validate the value on the model.
         [Fact]
-        public async Task FromHeader_BindHeader_ToModel_NoValues_InitializedValue_ValidationError()
+        public async Task FromHeader_BindHeader_ToModel_NoValues_InitializedValue_NoValidationError()
         {
             // Arrange
             var server = TestHelper.CreateServer(_app, SiteName, _configureServices);
@@ -321,8 +321,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("How to Make Soup", result.HeaderValue);
             Assert.Equal<string>(new[] { "Cooking" }, result.HeaderValues);
 
-            var error = Assert.Single(result.ModelStateErrors);
-            Assert.Equal("Title", error);
+            Assert.Empty(result.ModelStateErrors);
         }
 
         private class Result

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/MvcTagHelpersWebSite.MvcTagHelper_Customer.Index.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/MvcTagHelpersWebSite.MvcTagHelper_Customer.Index.html
@@ -7,7 +7,7 @@
         <div>
             <label class="order" for="Number">Number</label>
             <input class="form-control input-validation-error" type="number" data-val="true" data-val-range="The field Number must be between 1 and 100." data-val-range-max="100" data-val-range-min="1" id="Number" name="Number" value="" />
-            <span class="field-validation-error" data-valmsg-for="Number" data-valmsg-replace="true">A value is required.</span>
+            <span class="field-validation-error" data-valmsg-for="Number" data-valmsg-replace="true">The value &#x27;&#x27; is invalid.</span>
         </div>
         <div>
             <label class="order" for="Name">Name</label>
@@ -33,8 +33,7 @@
             <input type="radio" value="Female" id="Gender" name="Gender" /> Female
             <span class="field-validation-valid" data-valmsg-for="Gender" data-valmsg-replace="true"></span>
         </div>
-        <div class="order validation-summary-errors" data-valmsg-summary="true"><ul><li>A value is required.</li>
-<li>The Password field is required.</li>
+        <div class="order validation-summary-errors" data-valmsg-summary="true"><ul><li>The Password field is required.</li>
 </ul></div>
         <div class="order validation-summary-errors"><ul><li style="display:none"></li>
 </ul></div>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/TagHelpersWebSite.Employee.Create.Invalid.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/TagHelpersWebSite.Employee.Create.Invalid.html
@@ -55,7 +55,7 @@
             <div class="form-group">
                 <label class="control-label col-md-2" for="JoinDate">JoinDate</label>
                 <div class="col-md-10">
-                    <input class="form-control input-validation-error" type="date" data-val="true" data-val-required="The JoinDate field is required." id="JoinDate" name="JoinDate" value="0001-01-01" />
+                    <input class="form-control input-validation-error" type="date" data-val="true" data-val-required="The JoinDate field is required." id="JoinDate" name="JoinDate" value="" />
                     <span class="field-validation-error" data-valmsg-for="JoinDate" data-valmsg-replace="true">The JoinDate field is required.</span>
                 </div>
             </div>

--- a/test/WebSites/TagHelpersWebSite/Models/Employee.cs
+++ b/test/WebSites/TagHelpersWebSite/Models/Employee.cs
@@ -21,7 +21,7 @@ namespace TagHelpersWebSite.Models
 
         [Required]
         [DataType(DataType.Date)]
-        public DateTimeOffset JoinDate { get; set; }
+        public DateTimeOffset? JoinDate { get; set; }
 
         [DataType(DataType.EmailAddress)]
         public string Email { get; set; }


### PR DESCRIPTION
This change removes the behavior in model binding to validate values 'on
the wire' for requiredness instead of the looking at the model. This
restores the behavior of [Required] for model binding to the MVC5
semantics.