### PR TITLE
Renamed FileVersion to AppendVersion in tag helpers that support cache busting

### DIFF
--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ImageTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ImageTagHelper.cs
@@ -15,12 +15,12 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     /// <remarks>
     /// The tag helper won't process for cases with just the 'src' attribute.
     /// </remarks>
-    [TargetElement("img", Attributes = FileVersionAttributeName + "," + SrcAttributeName)]
+    [TargetElement("img", Attributes = AppendVersionAttributeName + "," + SrcAttributeName)]
     public class ImageTagHelper : TagHelper
     {
         private static readonly string Namespace = typeof(ImageTagHelper).Namespace;
 
-        private const string FileVersionAttributeName = "asp-file-version";
+        private const string AppendVersionAttributeName = "asp-append-version";
         private const string SrcAttributeName = "src";
 
         private FileVersionProvider _fileVersionProvider;
@@ -51,8 +51,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         /// <remarks>
         /// If <c>true</c> then a query string "v" with the encoded content of the file is added.
         /// </remarks>
-        [HtmlAttributeName(FileVersionAttributeName)]
-        public bool FileVersion { get; set; }
+        [HtmlAttributeName(AppendVersionAttributeName)]
+        public bool AppendVersion { get; set; }
 
         protected IHostingEnvironment HostingEnvironment { get; }
 
@@ -64,7 +64,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         /// <inheritdoc />
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
-            if (FileVersion)
+            if (AppendVersion)
             {
                 EnsureFileVersionProvider();
                 output.Attributes[SrcAttributeName] = _fileVersionProvider.AddFileVersionToPath(Src);

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/LinkTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/LinkTagHelper.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     [TargetElement("link", Attributes = FallbackTestClassAttributeName)]
     [TargetElement("link", Attributes = FallbackTestPropertyAttributeName)]
     [TargetElement("link", Attributes = FallbackTestValueAttributeName)]
-    [TargetElement("link", Attributes = FileVersionAttributeName)]
+    [TargetElement("link", Attributes = AppendVersionAttributeName)]
     public class LinkTagHelper : TagHelper
     {
         private static readonly string Namespace = typeof(LinkTagHelper).Namespace;
@@ -43,14 +43,14 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         private const string FallbackTestPropertyAttributeName = "asp-fallback-test-property";
         private const string FallbackTestValueAttributeName = "asp-fallback-test-value";
         private readonly string FallbackJavaScriptResourceName = Namespace + ".compiler.resources.LinkTagHelper_FallbackJavaScript.js";
-        private const string FileVersionAttributeName = "asp-file-version";
+        private const string AppendVersionAttributeName = "asp-append-version";
         private const string HrefAttributeName = "href";
 
         private FileVersionProvider _fileVersionProvider;
 
         private static readonly ModeAttributes<Mode>[] ModeDetails = new[] {
             // Regular src with file version alone
-            ModeAttributes.Create(Mode.FileVersion, new[] { FileVersionAttributeName }),
+            ModeAttributes.Create(Mode.AppendVersion, new[] { AppendVersionAttributeName }),
             // Globbed Href (include only) no static href
             ModeAttributes.Create(Mode.GlobbedHref, new [] { HrefIncludeAttributeName }),
             // Globbed Href (include & exclude), no static href
@@ -141,8 +141,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         /// <remarks>
         /// If <c>true</c> then a query string "v" with the encoded content of the file is added.
         /// </remarks>
-        [HtmlAttributeName(FileVersionAttributeName)]
-        public bool? FileVersion { get; set; }
+        [HtmlAttributeName(AppendVersionAttributeName)]
+        public bool? AppendVersion { get; set; }
 
         /// <summary>
         /// A comma separated list of globbed file patterns of CSS stylesheets to fallback to in the case the primary
@@ -229,7 +229,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             var builder = new DefaultTagHelperContent();
 
-            if (mode == Mode.Fallback && string.IsNullOrEmpty(HrefInclude) || mode == Mode.FileVersion)
+            if (mode == Mode.Fallback && string.IsNullOrEmpty(HrefInclude) || mode == Mode.AppendVersion)
             {
                 // No globbing to do, just build a <link /> tag to match the original one in the source file.
                 // Or just add file version to the link tag.
@@ -274,7 +274,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             if (fallbackHrefs.Length > 0)
             {
-                if (FileVersion == true)
+                if (AppendVersion == true)
                 {
                     for (var i=0; i < fallbackHrefs.Length; i++)
                     {
@@ -338,7 +338,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             foreach (var attribute in attributes)
             {
                 var attributeValue = attribute.Value;
-                if (FileVersion == true &&
+                if (AppendVersion == true &&
                     string.Equals(attribute.Name, HrefAttributeName, StringComparison.OrdinalIgnoreCase))
                 {
                     // "href" values come from bound attributes and globbing. So anything but a non-null string is
@@ -366,7 +366,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             /// <summary>
             /// Just adding a file version for the generated urls.
             /// </summary>
-            FileVersion = 0,
+            AppendVersion = 0,
 
             /// <summary>
             /// Just performing file globbing search for the href, rendering a separate &lt;link&gt; for each match.

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ScriptTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ScriptTagHelper.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     [TargetElement("script", Attributes = FallbackSrcIncludeAttributeName)]
     [TargetElement("script", Attributes = FallbackSrcExcludeAttributeName)]
     [TargetElement("script", Attributes = FallbackTestExpressionAttributeName)]
-    [TargetElement("script", Attributes = FileVersionAttributeName)]
+    [TargetElement("script", Attributes = AppendVersionAttributeName)]
     public class ScriptTagHelper : TagHelper
     {
         private const string SrcIncludeAttributeName = "asp-src-include";
@@ -37,13 +37,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         private const string FallbackSrcExcludeAttributeName = "asp-fallback-src-exclude";
         private const string FallbackTestExpressionAttributeName = "asp-fallback-test";
         private const string SrcAttributeName = "src";
-        private const string FileVersionAttributeName = "asp-file-version";
+        private const string AppendVersionAttributeName = "asp-append-version";
 
         private FileVersionProvider _fileVersionProvider;
 
         private static readonly ModeAttributes<Mode>[] ModeDetails = new[] {
             // Regular src with file version alone
-            ModeAttributes.Create(Mode.FileVersion, new[] { FileVersionAttributeName }),
+            ModeAttributes.Create(Mode.AppendVersion, new[] { AppendVersionAttributeName }),
             // Globbed src (include only)
             ModeAttributes.Create(Mode.GlobbedSrc, new [] { SrcIncludeAttributeName }),
             // Globbed src (include & exclude)
@@ -128,8 +128,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         /// <remarks>
         /// A query string "v" with the encoded content of the file is added.
         /// </remarks>
-        [HtmlAttributeName(FileVersionAttributeName)]
-        public bool? FileVersion { get; set; }
+        [HtmlAttributeName(AppendVersionAttributeName)]
+        public bool? AppendVersion { get; set; }
 
         /// <summary>
         /// A comma separated list of globbed file patterns of JavaScript scripts to fallback to in the case the
@@ -199,7 +199,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var builder = new DefaultTagHelperContent();
             var originalContent = await context.GetChildContentAsync();
 
-            if (mode == Mode.Fallback && string.IsNullOrEmpty(SrcInclude) || mode == Mode.FileVersion)
+            if (mode == Mode.Fallback && string.IsNullOrEmpty(SrcInclude) || mode == Mode.AppendVersion)
             {
                 // No globbing to do, just build a <script /> tag to match the original one in the source file
                 // Or just add file version to the script tag.
@@ -288,7 +288,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                         {
                             // Ignore attribute.Value; use src instead.
                             var attributeValue = src;
-                            if (FileVersion == true)
+                            if (AppendVersion == true)
                             {
                                 attributeValue = _fileVersionProvider.AddFileVersionToPath(attributeValue);
                             }
@@ -340,7 +340,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             foreach (var attribute in attributes)
             {
                 var attributeValue = attribute.Value;
-                if (FileVersion == true &&
+                if (AppendVersion == true &&
                     string.Equals(attribute.Name, SrcAttributeName, StringComparison.OrdinalIgnoreCase))
                 {
                     // "src" values come from bound attributes and globbing. So anything but a non-null string is
@@ -389,7 +389,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             /// <summary>
             /// Just adding a file version for the generated urls.
             /// </summary>
-            FileVersion = 0,
+            AppendVersion = 0,
 
             /// <summary>
             /// Just performing file globbing search for the src, rendering a separate &lt;script&gt; for each match.

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ImageTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ImageTagHelperTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     { "data-extra", new HtmlString("something") },                    
                     { "title", new HtmlString("Image title") },
                     { "src", "testimage.png" },
-                    { "asp-file-version", "true" }
+                    { "asp-append-version", "true" }
                 });
             var output = MakeImageTagHelperOutput(
                 attributes: new TagHelperAttributeList
@@ -61,7 +61,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 ViewContext = viewContext,
                 Src = "testimage.png",
-                FileVersion = true,
+                AppendVersion = true,
             };
 
             // Act
@@ -89,7 +89,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 {
                     { "alt", new HtmlString("Alt image text") },
                     { "src", "/images/test-image.png" },
-                    { "asp-file-version", "true" }
+                    { "asp-append-version", "true" }
                 });
             var output = MakeImageTagHelperOutput(attributes: new TagHelperAttributeList
             {
@@ -102,7 +102,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 ViewContext = viewContext,
                 Src = "/images/test-image.png",
-                FileVersion = true,
+                AppendVersion = true
             };
 
             // Act
@@ -125,7 +125,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 {
                     { "alt", new HtmlString("Alt image text") },
                     { "src", "/images/test-image.png" },
-                    { "asp-file-version", "false" }
+                    { "asp-append-version", "false" }
                 });
             var output = MakeImageTagHelperOutput(attributes: new TagHelperAttributeList
             {
@@ -138,7 +138,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 ViewContext = viewContext,
                 Src = "/images/test-image.png",
-                FileVersion = false,
+                AppendVersion = false
             };
 
             // Act
@@ -161,7 +161,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 {
                     { "alt", new HtmlString("alt text") },
                     { "src", "/bar/images/image.jpg" },
-                    { "asp-file-version", "true" },
+                    { "asp-append-version", "true" },
                 });
             var output = MakeImageTagHelperOutput(attributes: new TagHelperAttributeList
             {
@@ -174,7 +174,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 ViewContext = viewContext,
                 Src = "/bar/images/image.jpg",
-                FileVersion = true,
+                AppendVersion = true
             };
 
             // Act

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LinkTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LinkTagHelperTest.cs
@@ -196,23 +196,23 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     {
                         new TagHelperAttributeList
                         {
-                            ["asp-file-version"] = "true"
+                            ["asp-append-version"] = "true"
                         },
                         tagHelper =>
                         {
-                            tagHelper.FileVersion = true;
+                            tagHelper.AppendVersion = true;
                         }
                     },
                     {
                         new TagHelperAttributeList
                         {
                             ["asp-href-include"] = "*.css",
-                            ["asp-file-version"] = "true"
+                            ["asp-append-version"] = "true"
                         },
                         tagHelper =>
                         {
                             tagHelper.HrefInclude = "*.css";
-                            tagHelper.FileVersion = true;
+                            tagHelper.AppendVersion = true;
                         }
                     },
                     {
@@ -220,13 +220,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                         {
                             ["asp-href-include"] = "*.css",
                             ["asp-href-exclude"] = "*.min.css",
-                            ["asp-file-version"] = "true"
+                            ["asp-append-version"] = "true"
                         },
                         tagHelper =>
                         {
                             tagHelper.HrefInclude = "*.css";
                             tagHelper.HrefExclude = "*.min.css";
-                            tagHelper.FileVersion = true;
+                            tagHelper.AppendVersion = true;
                         }
                     },
                     {
@@ -236,7 +236,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                             ["asp-fallback-test-class"] = "hidden",
                             ["asp-fallback-test-property"] = "visibility",
                             ["asp-fallback-test-value"] = "hidden",
-                            ["asp-file-version"] = "true"
+                            ["asp-append-version"] = "true"
                         },
                         tagHelper =>
                         {
@@ -244,7 +244,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                             tagHelper.FallbackTestClass = "hidden";
                             tagHelper.FallbackTestProperty = "visibility";
                             tagHelper.FallbackTestValue = "hidden";
-                            tagHelper.FileVersion = true;
+                            tagHelper.AppendVersion = true;
                         }
                     },
                     {
@@ -254,7 +254,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                             ["asp-fallback-test-class"] = "hidden",
                             ["asp-fallback-test-property"] = "visibility",
                             ["asp-fallback-test-value"] = "hidden",
-                            ["asp-file-version"] = "true"
+                            ["asp-append-version"] = "true"
                         },
                         tagHelper =>
                         {
@@ -262,7 +262,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                             tagHelper.FallbackTestClass = "hidden";
                             tagHelper.FallbackTestProperty = "visibility";
                             tagHelper.FallbackTestValue = "hidden";
-                            tagHelper.FileVersion = true;
+                            tagHelper.AppendVersion = true;
                         }
                     }
                 };
@@ -581,7 +581,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 {
                     { "rel", new HtmlString("stylesheet") },
                     { "href", "/css/site.css" },
-                    { "asp-file-version", "true" }
+                    { "asp-append-version", "true" }
                 });
             var output = MakeTagHelperOutput("link", attributes: new TagHelperAttributeList
             {
@@ -601,7 +601,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 ViewContext = viewContext,
                 Href = "/css/site.css",
                 HrefInclude = "**/*.css",
-                FileVersion = true,
+                AppendVersion = true
             };
 
             // Act
@@ -622,7 +622,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 {
                     { "rel", new HtmlString("stylesheet") },
                     { "href", "/bar/css/site.css" },
-                    { "asp-file-version", "true" },
+                    { "asp-append-version", "true" },
                 });
             var output = MakeTagHelperOutput("link", attributes: new TagHelperAttributeList
             {
@@ -642,7 +642,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 ViewContext = viewContext,
                 Href = "/bar/css/site.css",
                 HrefInclude = "**/*.css",
-                FileVersion = true,
+                AppendVersion = true
             };
 
             // Act
@@ -664,7 +664,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     { "rel", new HtmlString("stylesheet") },
                     { "href", "/css/site.css" },
                     { "asp-href-include", "**/*.css" },
-                    { "asp-file-version", "true" },
+                    { "asp-append-version", "true" },
                 });
             var output = MakeTagHelperOutput("link", attributes: new TagHelperAttributeList
             {
@@ -688,7 +688,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 ViewContext = viewContext,
                 Href = "/css/site.css",
                 HrefInclude = "**/*.css",
-                FileVersion = true,
+                AppendVersion = true
             };
 
             // Act

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ScriptTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ScriptTagHelperTest.cs
@@ -162,23 +162,23 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     {
                         new TagHelperAttributeList
                         {
-                            ["asp-file-version"] = "true"
+                            ["asp-append-version"] = "true"
                         },
                         tagHelper =>
                         {
-                            tagHelper.FileVersion = true;
+                            tagHelper.AppendVersion = true;
                         }
                     },
                     {
                         new TagHelperAttributeList
                         {
                             ["asp-src-include"] = "*.js",
-                            ["asp-file-version"] = "true"
+                            ["asp-append-version"] = "true"
                         },
                         tagHelper =>
                         {
                             tagHelper.SrcInclude = "*.js";
-                            tagHelper.FileVersion = true;
+                            tagHelper.AppendVersion = true;
                         }
                     },
                     {
@@ -186,13 +186,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                         {
                             ["asp-src-include"] = "*.js",
                             ["asp-src-exclude"] = "*.min.js",
-                            ["asp-file-version"] = "true"
+                            ["asp-append-version"] = "true"
                         },
                         tagHelper =>
                         {
                             tagHelper.SrcInclude = "*.js";
                             tagHelper.SrcExclude = "*.min.js";
-                            tagHelper.FileVersion = true;
+                            tagHelper.AppendVersion = true;
                         }
                     },
                     {
@@ -200,13 +200,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                         {
                             ["asp-fallback-src"] = "test.js",
                             ["asp-fallback-test"] = "isavailable()",
-                            ["asp-file-version"] = "true"
+                            ["asp-append-version"] = "true"
                         },
                         tagHelper =>
                         {
                             tagHelper.FallbackSrc = "test.js";
                             tagHelper.FallbackTestExpression = "isavailable()";
-                            tagHelper.FileVersion = true;
+                            tagHelper.AppendVersion = true;
                         }
                     },
                     {
@@ -214,13 +214,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                         {
                             ["asp-fallback-src-include"] = "*.js",
                             ["asp-fallback-test"] = "isavailable()",
-                            ["asp-file-version"] = "true"
+                            ["asp-append-version"] = "true"
                         },
                         tagHelper =>
                         {
                             tagHelper.FallbackSrcInclude = "*.css";
                             tagHelper.FallbackTestExpression = "isavailable()";
-                            tagHelper.FileVersion = true;
+                            tagHelper.AppendVersion = true;
                         }
                     },
                     {
@@ -229,14 +229,14 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                             ["asp-fallback-src"] = "test.js",
                             ["asp-fallback-src-include"] = "*.js",
                             ["asp-fallback-test"] = "isavailable()",
-                            ["asp-file-version"] = "true"
+                            ["asp-append-version"] = "true"
                         },
                         tagHelper =>
                         {
                             tagHelper.FallbackSrc = "test.js";
                             tagHelper.FallbackSrcInclude = "*.css";
                             tagHelper.FallbackTestExpression = "isavailable()";
-                            tagHelper.FileVersion = true;
+                            tagHelper.AppendVersion = true;
                         }
                     },
                     {
@@ -245,14 +245,14 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                             ["asp-fallback-src-include"] = "*.js",
                             ["asp-fallback-src-exclude"] = "*.min.js",
                             ["asp-fallback-test"] = "isavailable()",
-                            ["asp-file-version"] = "true"
+                            ["asp-append-version"] = "true"
                         },
                         tagHelper =>
                         {
                             tagHelper.FallbackSrcInclude = "*.css";
                             tagHelper.FallbackSrcExclude = "*.min.css";
                             tagHelper.FallbackTestExpression = "isavailable()";
-                            tagHelper.FileVersion = true;
+                            tagHelper.AppendVersion = true;
                         }
                     }
                 };
@@ -625,7 +625,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 attributes: new TagHelperAttributeList
                 {
                     ["src"] = "/js/site.js",
-                    ["asp-file-version"] = "true"
+                    ["asp-append-version"] = "true"
                 });
             var output = MakeTagHelperOutput("script", attributes: new TagHelperAttributeList());
 
@@ -641,7 +641,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 new CommonTestEncoder())
             {
                 ViewContext = viewContext,
-                FileVersion = true,
+                AppendVersion = true,
                 Src = "/js/site.js",
             };
 
@@ -662,7 +662,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 attributes: new TagHelperAttributeList
                 {
                     ["src"] = "/bar/js/site.js",
-                    ["asp-file-version"] = "true"
+                    ["asp-append-version"] = "true"
                 });
             var output = MakeTagHelperOutput("script", attributes: new TagHelperAttributeList());
 
@@ -678,7 +678,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 new CommonTestEncoder())
             {
                 ViewContext = viewContext,
-                FileVersion = true,
+                AppendVersion = true,
                 Src = "/bar/js/site.js",
             };
 
@@ -701,7 +701,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     ["src"] = "/js/site.js",
                     ["asp-fallback-src-include"] = "fallback.js",
                     ["asp-fallback-test"] = "isavailable()",
-                    ["asp-file-version"] = "true"
+                    ["asp-append-version"] = "true"
                 });
             var output = MakeTagHelperOutput("script", attributes: new TagHelperAttributeList());
 
@@ -719,7 +719,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 ViewContext = viewContext,
                 FallbackSrc = "fallback.js",
                 FallbackTestExpression = "isavailable()",
-                FileVersion = true,
+                AppendVersion = true,
                 Src = "/js/site.js",
             };
 
@@ -743,7 +743,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 {
                     ["src"] = "/js/site.js",
                     ["asp-src-include"] = "*.js",
-                    ["asp-file-version"] = "true"
+                    ["asp-append-version"] = "true"
                 });
             var output = MakeTagHelperOutput("script", attributes: new TagHelperAttributeList());
             var logger = new Mock<ILogger<ScriptTagHelper>>();
@@ -763,7 +763,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 GlobbingUrlBuilder = globbingUrlBuilder.Object,
                 ViewContext = viewContext,
                 SrcInclude = "*.js",
-                FileVersion = true,
+                AppendVersion = true,
                 Src = "/js/site.js",
             };
 

--- a/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/Image.cshtml
+++ b/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/Image.cshtml
@@ -14,9 +14,9 @@
     <img src="~/images/red.png" alt="Red block" title="&lt;the title>">
 
     <!-- Plain image  tag with file version -->
-    <img src="~/images/red.png" alt="Red versioned" title="Red versioned" asp-file-version="true" />
+    <img src="~/images/red.png" alt="Red versioned" title="Red versioned" asp-append-version="true" />
 
     <!-- Plain image  tag with file version set to false -->
-    <img src="~/images/red.png" alt="Red explicitly not versioned" title="Red versioned" asp-file-version="false" />
+    <img src="~/images/red.png" alt="Red explicitly not versioned" title="Red versioned" asp-append-version="false" />
 </body>
 </html>

--- a/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/Link.cshtml
+++ b/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/Link.cshtml
@@ -183,10 +183,10 @@
           asp-fallback-test-property="visibility" />
 
     <!-- Plain link tag with file version -->
-    <link href="~/site.css" rel="stylesheet" asp-file-version="true" />
+    <link href="~/site.css" rel="stylesheet" asp-append-version="true" />
 
     <!-- Globbed link tag with existing file and file version -->
-    <link asp-href-include="**/site.css" rel="stylesheet" asp-file-version="true" />
+    <link asp-href-include="**/site.css" rel="stylesheet" asp-append-version="true" />
 
     <!-- Fallback with file version -->
     <link href="~/site.min.css" rel="stylesheet" data-extra="test"
@@ -194,10 +194,10 @@
           asp-fallback-test-class="hidden"
           asp-fallback-test-property="visibility"
           asp-fallback-test-value="hidden"
-          asp-file-version="true" />
+          asp-append-version="true" />
 
     <!-- Globbed link tag with existing file, static href and file version -->
-    <link href="~/site.css" asp-href-include="**/*.css" rel="stylesheet" asp-file-version="true" />
+    <link href="~/site.css" asp-href-include="**/*.css" rel="stylesheet" asp-append-version="true" />
 </head>
 <body>
 

--- a/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/Script.cshtml
+++ b/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/Script.cshtml
@@ -106,25 +106,25 @@
         // Globbed script tag with existing file and static src should dedupe
     </script>
 
-    <script src="~/blank.js" asp-fallback-src="~/site.js" asp-fallback-test="false" asp-file-version="true">
+    <script src="~/blank.js" asp-fallback-src="~/site.js" asp-fallback-test="false" asp-append-version="true">
         // TagHelper script with comment in body, and file version.
     </script>
 
-    <script src="~/blank.js" asp-fallback-src-include="**/site.js" asp-fallback-test="false" asp-file-version="true">
+    <script src="~/blank.js" asp-fallback-src-include="**/site.js" asp-fallback-test="false" asp-append-version="true">
         // Fallback to globbed src with file version.
     </script>
 
-    <script src="~/site.js" asp-file-version="true">
+    <script src="~/site.js" asp-append-version="true">
         // Regular script with comment in body, and file version.
     </script>
 
     <!-- Globbed script tag with existing files and version -->
-    <script asp-src-include="**/*.js" asp-file-version="true">
+    <script asp-src-include="**/*.js" asp-append-version="true">
         // This comment shouldn't be emitted
     </script>
 
     <!-- Globbed script tag with existing file, exclude and version -->
-    <script asp-src-include="**/*.js" asp-src-exclude="**/site3.js" asp-file-version="true">
+    <script asp-src-include="**/*.js" asp-src-exclude="**/site3.js" asp-append-version="true">
         // This comment shouldn't be emitted
     </script>
 </body>


### PR DESCRIPTION
FileVersion property renamed to AppendVersion in ImageTagHelper, LinkTagHelper and ScriptTagHelper.

asp-file-version attribute renamed to asp-append-version.

Resolves issue #2540