### PR TITLE
Fix #2582 - Remove @inject dependency on [Activate]

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor.Host/InjectChunkVisitor.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/InjectChunkVisitor.cs
@@ -10,21 +10,21 @@ namespace Microsoft.AspNet.Mvc.Razor
 {
     public class InjectChunkVisitor : MvcCSharpCodeVisitor
     {
-        private readonly string _activateAttribute;
+        private readonly string _injectAttribute;
 
         public InjectChunkVisitor([NotNull] CSharpCodeWriter writer,
                                   [NotNull] CodeBuilderContext context,
-                                  [NotNull] string activateAttributeName)
+                                  [NotNull] string injectAttributeName)
             : base(writer, context)
         {
-            _activateAttribute = "[" + activateAttributeName + "]";
+            _injectAttribute = "[" + injectAttributeName + "]";
         }
 
         public IList<InjectChunk> InjectChunks { get; } = new List<InjectChunk>();
 
         protected override void Visit([NotNull] InjectChunk chunk)
         {
-            Writer.WriteLine(_activateAttribute);
+            Writer.WriteLine(_injectAttribute);
 
             // Some of the chunks that we visit are either InjectDescriptors that are added by default or
             // are chunks from _ViewStart files and are not associated with any Spans. Invoking

--- a/src/Microsoft.AspNet.Mvc.Razor.Host/MvcCSharpCodeBuilder.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/MvcCSharpCodeBuilder.cs
@@ -14,17 +14,17 @@ namespace Microsoft.AspNet.Mvc.Razor
     {
         private readonly GeneratedTagHelperAttributeContext _tagHelperAttributeContext;
         private readonly string _defaultModel;
-        private readonly string _activateAttribute;
+        private readonly string _injectAttribute;
 
         public MvcCSharpCodeBuilder([NotNull] CodeBuilderContext context,
                                     [NotNull] string defaultModel,
-                                    [NotNull] string activateAttribute,
+                                    [NotNull] string injectAttribute,
                                     [NotNull] GeneratedTagHelperAttributeContext tagHelperAttributeContext)
             : base(context)
         {
             _tagHelperAttributeContext = tagHelperAttributeContext;
             _defaultModel = defaultModel;
-            _activateAttribute = activateAttribute;
+            _injectAttribute = injectAttribute;
         }
 
         private string Model { get; set; }
@@ -72,7 +72,7 @@ namespace Microsoft.AspNet.Mvc.Razor
 
             writer.WriteLineHiddenDirective();
 
-            var injectVisitor = new InjectChunkVisitor(writer, Context, _activateAttribute);
+            var injectVisitor = new InjectChunkVisitor(writer, Context, _injectAttribute);
             injectVisitor.Accept(Context.CodeTreeBuilder.CodeTree.Chunks);
 
             writer.WriteLine();

--- a/src/Microsoft.AspNet.Mvc.Razor.Host/MvcRazorHost.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/MvcRazorHost.cs
@@ -159,9 +159,9 @@ namespace Microsoft.AspNet.Mvc.Razor
         /// Gets or sets the name attribute that is used to decorate properties that are injected and need to be
         /// activated.
         /// </summary>
-        public virtual string ActivateAttribute
+        public virtual string InjectAttribute
         {
-            get { return "Microsoft.AspNet.Mvc.ActivateAttribute"; }
+            get { return "Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute"; }
         }
 
         /// <summary>
@@ -238,7 +238,7 @@ namespace Microsoft.AspNet.Mvc.Razor
 
             return new MvcCSharpCodeBuilder(context,
                                             DefaultModel,
-                                            ActivateAttribute,
+                                            InjectAttribute,
                                             new GeneratedTagHelperAttributeContext
                                             {
                                                 ModelExpressionTypeName = ModelExpressionType,

--- a/src/Microsoft.AspNet.Mvc.Razor/Internal/RazorInjectAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Internal/RazorInjectAttribute.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNet.Mvc.Razor.Internal
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public class RazorInjectAttribute : Attribute
+    {
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
+using Microsoft.AspNet.Mvc.Razor.Internal;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.PageExecutionInstrumentation;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
@@ -65,7 +66,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         /// <summary>
         /// Gets the <see cref="IHtmlEncoder"/> to be used for encoding HTML.
         /// </summary>
-        [Activate]
+        [RazorInject]
         public IHtmlEncoder HtmlEncoder { get; set; }
 
         /// <inheritdoc />

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorPageActivator.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorPageActivator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Reflection;
 using Microsoft.AspNet.Mvc.ModelBinding;
+using Microsoft.AspNet.Mvc.Razor.Internal;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.Internal;
@@ -50,14 +51,16 @@ namespace Microsoft.AspNet.Mvc.Razor
             if (context.ViewData == null)
             {
                 // Create ViewDataDictionary<TModel>(IModelMetadataProvider, ModelStateDictionary).
-                return (ViewDataDictionary)Activator.CreateInstance(activationInfo.ViewDataDictionaryType,
+                return (ViewDataDictionary)Activator.CreateInstance(
+                    activationInfo.ViewDataDictionaryType,
                     _metadataProvider,
                     context.ModelState);
             }
             else if (context.ViewData.GetType() != activationInfo.ViewDataDictionaryType)
             {
                 // Create ViewDataDictionary<TModel>(ViewDataDictionary).
-                return (ViewDataDictionary)Activator.CreateInstance(activationInfo.ViewDataDictionaryType,
+                return (ViewDataDictionary)Activator.CreateInstance(
+                    activationInfo.ViewDataDictionaryType,
                     context.ViewData);
             }
 
@@ -81,9 +84,10 @@ namespace Microsoft.AspNet.Mvc.Razor
             return new PageActivationInfo
             {
                 ViewDataDictionaryType = viewDataType,
-                PropertyActivators = PropertyActivator<ViewContext>.GetPropertiesToActivate(type,
-                                                                                            typeof(ActivateAttribute),
-                                                                                            CreateActivateInfo)
+                PropertyActivators = PropertyActivator<ViewContext>.GetPropertiesToActivate(
+                    type,
+                    typeof(RazorInjectAttribute),
+                    CreateActivateInfo)
             };
         }
 

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorPageOfT.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorPageOfT.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using Microsoft.AspNet.Mvc.ModelBinding;
+using Microsoft.AspNet.Mvc.Razor.Internal;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Mvc.Rendering.Expressions;
 using Microsoft.Framework.DependencyInjection;
@@ -27,7 +28,7 @@ namespace Microsoft.AspNet.Mvc.Razor
             }
         }
 
-        [Activate]
+        [RazorInject]
         public ViewDataDictionary<TModel> ViewData { get; set; }
 
         /// <summary>

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/InjectChunkVisitorTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/InjectChunkVisitorTest.cs
@@ -71,7 +71,7 @@ public MyType2 @MyPropertyName2 { get; private set; }
         {
             // Arrange
             var expected = string.Join(Environment.NewLine,
-@"[Microsoft.AspNet.Mvc.ActivateAttribute]",
+@"[Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]",
 @"public",
 @"#line 1 """"",
 @"MyType1 MyPropertyName1",
@@ -79,7 +79,7 @@ public MyType2 @MyPropertyName2 { get; private set; }
 @"#line default",
 @"#line hidden",
 @"{ get; private set; }",
-@"[Microsoft.AspNet.Mvc.ActivateAttribute]",
+@"[Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]",
 @"public",
 @"#line 1 """"",
 @"MyType2 @MyPropertyName2",
@@ -92,7 +92,7 @@ public MyType2 @MyPropertyName2 { get; private set; }
             var context = CreateContext();
             context.Host.DesignTimeMode = true;
 
-            var visitor = new InjectChunkVisitor(writer, context, "Microsoft.AspNet.Mvc.ActivateAttribute");
+            var visitor = new InjectChunkVisitor(writer, context, "Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute");
             var factory = SpanFactory.CreateCsHtml();
             var node = (Span)factory.Code("Some code")
                                     .As(new InjectParameterGenerator("MyType", "MyPropertyName"));
@@ -114,7 +114,7 @@ public MyType2 @MyPropertyName2 { get; private set; }
         public void Visit_WithDesignTimeHost_GeneratesPropertiesAndLinePragmas_ForPartialInjectChunks()
         {
             // Arrange
-            var expected = @"[Microsoft.AspNet.Mvc.ActivateAttribute]
+            var expected = @"[Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
 public
 #line 1 """"
 MyType1
@@ -127,7 +127,7 @@ MyType1
             var context = CreateContext();
             context.Host.DesignTimeMode = true;
 
-            var visitor = new InjectChunkVisitor(writer, context, "Microsoft.AspNet.Mvc.ActivateAttribute");
+            var visitor = new InjectChunkVisitor(writer, context, "Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute");
             var factory = SpanFactory.CreateCsHtml();
             var node = (Span)factory.Code("Some code")
                                     .As(new InjectParameterGenerator("MyType", "MyPropertyName"));

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/MvcRazorHostTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/MvcRazorHostTest.cs
@@ -121,7 +121,7 @@ namespace Microsoft.AspNet.Mvc.Razor
                 BuildLineMapping(documentAbsoluteIndex: 139,
                                  documentLineIndex: 4,
                                  documentCharacterIndex: 17,
-                                 generatedAbsoluteIndex: 2241,
+                                 generatedAbsoluteIndex: 2313,
                                  generatedLineIndex: 55,
                                  generatedCharacterIndex: 95,
                                  contentLength: 3),
@@ -129,7 +129,7 @@ namespace Microsoft.AspNet.Mvc.Razor
                     documentAbsoluteIndex: 166,
                     documentLineIndex: 5,
                     documentCharacterIndex: 18,
-                    generatedAbsoluteIndex: 2554,
+                    generatedAbsoluteIndex: 2626,
                     generatedLineIndex: 61,
                     generatedCharacterIndex: 87,
                     contentLength: 5),
@@ -171,7 +171,7 @@ namespace Microsoft.AspNet.Mvc.Razor
             var expectedLineMappings = new List<LineMapping>
             {
                 BuildLineMapping(1, 0, 1, 59, 3, 0, 17),
-                BuildLineMapping(28, 1, 8, 688, 26, 8, 20)
+                BuildLineMapping(28, 1, 8, 706, 26, 8, 20)
             };
 
             // Act and Assert
@@ -191,8 +191,8 @@ namespace Microsoft.AspNet.Mvc.Razor
             var expectedLineMappings = new[]
             {
                 BuildLineMapping(7, 0, 7, 214, 6, 7, 7),
-                BuildLineMapping(24, 1, 8, 713, 26, 8, 20),
-                BuildLineMapping(54, 2, 8, 921, 34, 8, 23)
+                BuildLineMapping(24, 1, 8, 731, 26, 8, 20),
+                BuildLineMapping(54, 2, 8, 957, 34, 8, 23)
             };
 
             // Act and Assert
@@ -209,13 +209,13 @@ namespace Microsoft.AspNet.Mvc.Razor
                 DesignTimeMode = true
             };
             host.NamespaceImports.Clear();
-            var expectedLineMappings = new[]
+            var expectedLineMappings = new []
             {
                 BuildLineMapping(7, 0, 7, 222, 6, 7, 7),
-                BuildLineMapping(24, 1, 8, 729, 26, 8, 20),
-                BuildLineMapping(58, 2, 8, 941, 34, 8, 23),
-                BuildLineMapping(93, 3, 8, 1156, 42, 8, 21),
-                BuildLineMapping(129, 4, 8, 1369, 50, 8, 24),
+                BuildLineMapping(24, 1, 8, 747, 26, 8, 20),
+                BuildLineMapping(58, 2, 8, 977, 34, 8, 23),
+                BuildLineMapping(93, 3, 8, 1210, 42, 8, 21),
+                BuildLineMapping(129, 4, 8, 1441, 50, 8, 24),
             };
 
             // Act and Assert
@@ -352,7 +352,7 @@ namespace Microsoft.AspNet.Mvc.Razor
 
                 return new TestCSharpCodeBuilder(context,
                                                  DefaultModel,
-                                                 ActivateAttribute,
+                                                 "Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute",
                                                  new GeneratedTagHelperAttributeContext
                                                  {
                                                      ModelExpressionTypeName = ModelExpressionType,

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/Basic.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/Basic.cs
@@ -14,13 +14,13 @@
         {
         }
         #line hidden
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<dynamic> Html { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
 
         #line hidden

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/Inject.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/Inject.cs
@@ -21,7 +21,7 @@ using MyNamespace
         {
         }
         #line hidden
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public
 #line 2 "TestFiles/Input/Inject.cshtml"
         MyApp MyPropertyName
@@ -29,13 +29,13 @@ using MyNamespace
 #line default
 #line hidden
         { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<dynamic> Html { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
 
         #line hidden

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/InjectWithModel.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/InjectWithModel.cs
@@ -21,7 +21,7 @@
         {
         }
         #line hidden
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public
 #line 2 "TestFiles/Input/InjectWithModel.cshtml"
         MyApp MyPropertyName
@@ -29,7 +29,7 @@
 #line default
 #line hidden
         { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public
 #line 3 "TestFiles/Input/InjectWithModel.cshtml"
         MyService<MyModel> Html
@@ -37,11 +37,11 @@
 #line default
 #line hidden
         { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
 
         #line hidden

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/InjectWithSemicolon.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/InjectWithSemicolon.cs
@@ -21,7 +21,7 @@
         {
         }
         #line hidden
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public
 #line 2 "TestFiles/Input/InjectWithSemicolon.cshtml"
         MyApp MyPropertyName
@@ -29,7 +29,7 @@
 #line default
 #line hidden
         { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public
 #line 3 "TestFiles/Input/InjectWithSemicolon.cshtml"
         MyService<MyModel> Html
@@ -37,7 +37,7 @@
 #line default
 #line hidden
         { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public
 #line 4 "TestFiles/Input/InjectWithSemicolon.cshtml"
         MyApp MyPropertyName2
@@ -45,7 +45,7 @@
 #line default
 #line hidden
         { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public
 #line 5 "TestFiles/Input/InjectWithSemicolon.cshtml"
         MyService<MyModel> Html2
@@ -53,11 +53,11 @@
 #line default
 #line hidden
         { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
 
         #line hidden

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/Model.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/Model.cs
@@ -21,13 +21,13 @@
         {
         }
         #line hidden
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<System.Collections.IEnumerable> Html { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
 
         #line hidden

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/ModelExpressionTagHelper.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/ModelExpressionTagHelper.cs
@@ -37,13 +37,13 @@
         {
         }
         #line hidden
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<DateTime> Html { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
 
         #line hidden

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/Basic.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/Basic.cs
@@ -15,13 +15,13 @@ namespace Asp
         {
         }
         #line hidden
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<dynamic> Html { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
 
         #line hidden

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/Inject.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/Inject.cs
@@ -21,15 +21,15 @@ using MyNamespace
         {
         }
         #line hidden
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public MyApp MyPropertyName { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<dynamic> Html { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
 
         #line hidden

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/InjectWithModel.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/InjectWithModel.cs
@@ -21,15 +21,15 @@ namespace Asp
         {
         }
         #line hidden
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public MyApp MyPropertyName { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public MyService<MyModel> Html { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
 
         #line hidden

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/InjectWithSemicolon.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/InjectWithSemicolon.cs
@@ -21,19 +21,19 @@ namespace Asp
         {
         }
         #line hidden
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public MyApp MyPropertyName { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public MyService<MyModel> Html { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public MyApp MyPropertyName2 { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public MyService<MyModel> Html2 { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
 
         #line hidden

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/Model.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/Model.cs
@@ -21,13 +21,13 @@ namespace Asp
         {
         }
         #line hidden
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<System.Collections.IEnumerable> Html { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
 
         #line hidden

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/ModelExpressionTagHelper.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/ModelExpressionTagHelper.cs
@@ -30,13 +30,13 @@ namespace Asp
         {
         }
         #line hidden
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<DateTime> Html { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
-        [Microsoft.AspNet.Mvc.ActivateAttribute]
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
 
         #line hidden

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/RazorPageActivatorTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/RazorPageActivatorTest.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Mvc.ModelBinding;
+using Microsoft.AspNet.Mvc.Razor.Internal;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Routing;
 using Microsoft.Framework.WebEncoders;
@@ -206,7 +207,7 @@ namespace Microsoft.AspNet.Mvc.Razor
 
         private abstract class TestPageBase<TModel> : RazorPage<TModel>
         {
-            [Activate]
+            [RazorInject]
             public MyService MyService { get; set; }
 
             public MyService MyService2 { get; set; }
@@ -214,7 +215,7 @@ namespace Microsoft.AspNet.Mvc.Razor
 
         private class TestRazorPage : TestPageBase<MyModel>
         {
-            [Activate]
+            [RazorInject]
             internal IHtmlHelper<object> Html { get; private set; }
 
             public override Task ExecuteAsync()


### PR DESCRIPTION
Removes usage of [Activate] in razor code generation. Razor will now use
it's own special attribute recognized by the Razor activator.