### PR TITLE
Add required attributes to AnchorTagHelper and FormTagHelper.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.TagHelpers/AnchorTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/AnchorTagHelper.cs
@@ -12,7 +12,14 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     /// <summary>
     /// <see cref="ITagHelper"/> implementation targeting &lt;a&gt; elements.
     /// </summary>
-    [TargetElement("a")]
+    [TargetElement("a", Attributes = ActionAttributeName)]
+    [TargetElement("a", Attributes = ControllerAttributeName)]
+    [TargetElement("a", Attributes = FragmentAttributeName)]
+    [TargetElement("a", Attributes = HostAttributeName)]
+    [TargetElement("a", Attributes = ProtocolAttributeName)]
+    [TargetElement("a", Attributes = RouteAttributeName)]
+    [TargetElement("a", Attributes = RouteValuesDictionaryName)]
+    [TargetElement("a", Attributes = RouteValuesPrefix + "*")]
     public class AnchorTagHelper : TagHelper
     {
         private const string ActionAttributeName = "asp-action";

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/FormTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/FormTagHelper.cs
@@ -12,6 +12,12 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     /// <summary>
     /// <see cref="ITagHelper"/> implementation targeting &lt;form&gt; elements.
     /// </summary>
+    [TargetElement("form", Attributes = ActionAttributeName)]
+    [TargetElement("form", Attributes = AntiForgeryAttributeName)]
+    [TargetElement("form", Attributes = ControllerAttributeName)]
+    [TargetElement("form", Attributes = RouteAttributeName)]
+    [TargetElement("form", Attributes = RouteValuesDictionaryName)]
+    [TargetElement("form", Attributes = RouteValuesPrefix + "*")]
     public class FormTagHelper : TagHelper
     {
         private const string ActionAttributeName = "asp-action";

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Form.Options.AntiForgery.False.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Form.Options.AntiForgery.False.html
@@ -8,6 +8,7 @@
 
     <h2>Form Tag Helper Test</h2>
     
+    <form></form>
     <form action="/MvcTagHelper_Home/Form" method="post"></form>
     <form action="/MvcTagHelper_Home/Form" method="post"><input name="__RequestVerificationToken" type="hidden" value="{0}" /></form>
     <form action="/MvcTagHelper_Home/Form" method="post"></form>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Form.Options.AntiForgery.True.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Form.Options.AntiForgery.True.html
@@ -8,6 +8,7 @@
 
     <h2>Form Tag Helper Test</h2>
     
+    <form></form>
     <form action="/MvcTagHelper_Home/Form" method="post"><input name="__RequestVerificationToken" type="hidden" value="{0}" /></form>
     <form action="/MvcTagHelper_Home/Form" method="post"><input name="__RequestVerificationToken" type="hidden" value="{1}" /></form>
     <form action="/MvcTagHelper_Home/Form" method="post"></form>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Form.Options.AntiForgery.null.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Form.Options.AntiForgery.null.html
@@ -8,6 +8,7 @@
 
     <h2>Form Tag Helper Test</h2>
     
+    <form></form>
     <form action="/MvcTagHelper_Home/Form" method="post"><input name="__RequestVerificationToken" type="hidden" value="{0}" /></form>
     <form action="/MvcTagHelper_Home/Form" method="post"><input name="__RequestVerificationToken" type="hidden" value="{1}" /></form>
     <form action="/MvcTagHelper_Home/Form" method="post"></form>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Index.Encoded.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Index.Encoded.html
@@ -10,7 +10,7 @@
         <a title="&quot;the&quot; title" href="">Product List</a>
     </div>
     <div>
-        <a id="MvcTagHelperTestIndex" href="HtmlEncode[[/]]">MvcTagHelperTest Index</a>
+        <a id="MvcTagHelperTestIndex">MvcTagHelperTest Index</a>
     </div>
     <div>
         <a href="HtmlEncode[[/]]">Default Controller</a>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Index.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/MvcTagHelpersWebSite.MvcTagHelper_Home.Index.html
@@ -10,7 +10,7 @@
         <a title="&quot;the&quot; title" href="">Product List</a>
     </div>
     <div>
-        <a id="MvcTagHelperTestIndex" href="/">MvcTagHelperTest Index</a>
+        <a id="MvcTagHelperTestIndex">MvcTagHelperTest Index</a>
     </div>
     <div>
         <a href="/">Default Controller</a>

--- a/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/Form.cshtml
+++ b/test/WebSites/MvcTagHelpersWebSite/Views/MvcTagHelper_Home/Form.cshtml
@@ -10,6 +10,7 @@
 
     <h2>Form Tag Helper Test</h2>
     
+    <form></form>
     <form asp-controller="MvcTagHelper_Home" asp-action="Form"></form>
     <form asp-controller="MvcTagHelper_Home" asp-action="Form" asp-anti-forgery="true"></form>
     <form asp-controller="MvcTagHelper_Home" asp-action="Form" asp-anti-forgery="false"></form>


### PR DESCRIPTION
- This involved also adding required attributes with wildcards.
- With this change AnchorTagHelpers and FormTagHelpers should no longer light up on every `<form>` or `<a>` tag.

#2581