### PR TITLE
Part of #2151 - Remove [Activate] from TagHelpers

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ViewContextAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ViewContextAttribute.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNet.Mvc
+{
+    /// <summary>
+    /// Specifies that a tag helper property should be set with the current
+    /// <see cref="ViewContext"/> when creating the tag helper. The property must have a public
+    /// set method.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public class ViewContextAttribute : Attribute
+    {
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/AnchorTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/AnchorTagHelper.cs
@@ -32,9 +32,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         private const string RouteValuesPrefix = "asp-route-";
         private const string Href = "href";
 
-        [Activate]
-        [HtmlAttributeNotBound]
-        public IHtmlGenerator Generator { get; set; }
+        /// <summary>
+        /// Creates a new <see cref="AnchorTagHelper"/>.
+        /// </summary>
+        /// <param name="generator">The <see cref="IHtmlGenerator"/>.</param>
+        public AnchorTagHelper(IHtmlGenerator generator)
+        {
+            Generator = generator;
+        }
+
+        protected IHtmlGenerator Generator { get; }
 
         /// <summary>
         /// The name of the action method.

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/CacheTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/CacheTagHelper.cs
@@ -37,17 +37,24 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         private static readonly char[] AttributeSeparator = new[] { ',' };
 
         /// <summary>
-        /// Gets or sets the <see cref="IMemoryCache"/> instance used to cache entries.
+        /// Creates a new <see cref="CacheTagHelper"/>.
         /// </summary>
-        [Activate]
-        [HtmlAttributeNotBound]
-        public IMemoryCache MemoryCache { get; set; }
+        /// <param name="memoryCache">The <see cref="IMemoryCache"/>.</param>
+        public CacheTagHelper(IMemoryCache memoryCache)
+        {
+            MemoryCache = memoryCache;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IMemoryCache"/> instance used to cache entries.
+        /// </summary>
+        protected IMemoryCache MemoryCache { get; }
 
         /// <summary>
         /// Gets or sets the <see cref="ViewContext"/> for the current executing View.
         /// </summary>
-        [Activate]
         [HtmlAttributeNotBound]
+        [ViewContext]
         public ViewContext ViewContext { get; set; }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/EnvironmentTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/EnvironmentTagHelper.cs
@@ -17,6 +17,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         private static readonly char[] NameSeparator = new[] { ',' };
 
         /// <summary>
+        /// Creates a new <see cref="EnvironmentTagHelper"/>.
+        /// </summary>
+        /// <param name="hostingEnvironment">The <see cref="IHostingEnvironment"/>.</param>
+        public EnvironmentTagHelper(IHostingEnvironment hostingEnvironment)
+        {
+            HostingEnvironment = hostingEnvironment;
+        }
+
+        /// <summary>
         /// A comma separated list of environment names in which the content should be rendered.
         /// </summary>
         /// <remarks>
@@ -25,9 +34,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         /// </remarks>
         public string Names { get; set; }
 
-        [Activate]
-        [HtmlAttributeNotBound]
-        public IHostingEnvironment HostingEnvironment { get; set; }
+        protected IHostingEnvironment HostingEnvironment { get; }
 
         /// <inheritdoc />
         public override void Process(TagHelperContext context, TagHelperOutput output)

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/FormTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/FormTagHelper.cs
@@ -28,13 +28,20 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         private const string RouteValuesPrefix = "asp-route-";
         private const string HtmlActionAttributeName = "action";
 
-        [Activate]
+        /// <summary>
+        /// Creates a new <see cref="FormTagHelper"/>.
+        /// </summary>
+        /// <param name="generator">The <see cref="IHtmlGenerator"/>.</param>
+        public FormTagHelper(IHtmlGenerator generator)
+        {
+            Generator = generator;
+        }
+
         [HtmlAttributeNotBound]
+        [ViewContext]
         public ViewContext ViewContext { get; set; }
 
-        [Activate]
-        [HtmlAttributeNotBound]
-        public IHtmlGenerator Generator { get; set; }
+        protected IHtmlGenerator Generator { get; }
 
         /// <summary>
         /// The name of the action method.

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ImageTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ImageTagHelper.cs
@@ -26,6 +26,17 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         private FileVersionProvider _fileVersionProvider;
 
         /// <summary>
+        /// Creates a new <see cref="ImageTagHelper"/>.
+        /// </summary>
+        /// <param name="hostingEnvironment">The <see cref="IHostingEnvironment"/>.</param>
+        /// <param name="cache">The <see cref="IMemoryCache"/>.</param>
+        public ImageTagHelper(IHostingEnvironment hostingEnvironment, IMemoryCache cache)
+        {
+            HostingEnvironment = hostingEnvironment;
+            Cache = cache;
+        }
+
+        /// <summary>
         /// Source of the image.
         /// </summary>
         /// <remarks>
@@ -43,17 +54,12 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         [HtmlAttributeName(FileVersionAttributeName)]
         public bool FileVersion { get; set; }
 
-        [Activate]
-        [HtmlAttributeNotBound]
-        public IHostingEnvironment HostingEnvironment { get; set; }
+        protected IHostingEnvironment HostingEnvironment { get; }
 
-        [Activate]
-        [HtmlAttributeNotBound]
+        [ViewContext]
         public ViewContext ViewContext { get; set; }
 
-        [Activate]
-        [HtmlAttributeNotBound]
-        public IMemoryCache Cache { get; set; }
+        protected IMemoryCache Cache { get; }
 
         /// <inheritdoc />
         public override void Process(TagHelperContext context, TagHelperOutput output)

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/InputTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/InputTagHelper.cs
@@ -62,12 +62,19 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 { "time", "{0:HH:mm:ss.fff}" },
             };
 
-        [Activate]
-        [HtmlAttributeNotBound]
-        public IHtmlGenerator Generator { get; set; }
+        /// <summary>
+        /// Creates a new <see cref="InputTagHelper"/>.
+        /// </summary>
+        /// <param name="generator">The <see cref="IHtmlGenerator"/>.</param>
+        public InputTagHelper(IHtmlGenerator generator)
+        {
+            Generator = generator;
+        }
 
-        [Activate]
+        protected IHtmlGenerator Generator { get; }
+
         [HtmlAttributeNotBound]
+        [ViewContext]
         public ViewContext ViewContext { get; set; }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/LabelTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/LabelTagHelper.cs
@@ -15,13 +15,20 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     {
         private const string ForAttributeName = "asp-for";
 
-        [Activate]
+        /// <summary>
+        /// Creates a new <see cref="LabelTagHelper"/>.
+        /// </summary>
+        /// <param name="generator">The <see cref="IHtmlGenerator"/>.</param>
+        public LabelTagHelper(IHtmlGenerator generator)
+        {
+            Generator = generator;
+        }
+
         [HtmlAttributeNotBound]
+        [ViewContext]
         public ViewContext ViewContext { get; set; }
 
-        [Activate]
-        [HtmlAttributeNotBound]
-        public IHtmlGenerator Generator { get; set; }
+        protected IHtmlGenerator Generator { get; }
 
         /// <summary>
         /// An expression to be evaluated against the current model.

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/LinkTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/LinkTagHelper.cs
@@ -83,21 +83,26 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 }),
         };
 
-        private enum Mode
+        /// <summary>
+        /// Creates a new <see cref="LinkTagHelper"/>.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger{ScriptTagHelper}"/>.</param>
+        /// <param name="hostingEnvironment">The <see cref="IHostingEnvironment"/>.</param>
+        /// <param name="cache">The <see cref="IMemoryCache"/>.</param>
+        /// <param name="htmlEncoder">The <see cref="IHtmlEncoder"/>.</param>
+        /// <param name="javaScriptEncoder">The <see cref="IJavaScriptStringEncoder"/>.</param>
+        public LinkTagHelper(
+            ILogger<LinkTagHelper> logger,
+            IHostingEnvironment hostingEnvironment,
+            IMemoryCache cache,
+            IHtmlEncoder htmlEncoder,
+            IJavaScriptStringEncoder javaScriptEncoder)
         {
-            /// <summary>
-            /// Just adding a file version for the generated urls.
-            /// </summary>
-            FileVersion = 0,
-            /// <summary>
-            /// Just performing file globbing search for the href, rendering a separate &lt;link&gt; for each match.
-            /// </summary>
-            GlobbedHref = 1,
-            /// <summary>
-            /// Rendering a fallback block if primary stylesheet fails to load. Will also do globbing for both the
-            /// primary and fallback hrefs if the appropriate properties are set.
-            /// </summary>
-            Fallback = 2,
+            Logger = logger;
+            HostingEnvironment = hostingEnvironment;
+            Cache = cache;
+            HtmlEncoder = htmlEncoder;
+            JavaScriptEncoder = javaScriptEncoder;
         }
 
         /// <summary>
@@ -180,29 +185,19 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         [HtmlAttributeName(FallbackTestValueAttributeName)]
         public string FallbackTestValue { get; set; }
 
-        [Activate]
-        [HtmlAttributeNotBound]
-        protected internal ILogger<LinkTagHelper> Logger { get; set; }
+        protected ILogger<LinkTagHelper> Logger { get; }
 
-        [Activate]
-        [HtmlAttributeNotBound]
-        public IHostingEnvironment HostingEnvironment { get; set; }
+        protected IHostingEnvironment HostingEnvironment { get; }
 
-        [Activate]
         [HtmlAttributeNotBound]
+        [ViewContext]
         public ViewContext ViewContext { get; set; }
 
-        [Activate]
-        [HtmlAttributeNotBound]
-        public IMemoryCache Cache { get; set; }
+        protected IMemoryCache Cache { get; }
 
-        [Activate]
-        [HtmlAttributeNotBound]
-        public IHtmlEncoder HtmlEncoder { get; set; }
+        protected IHtmlEncoder HtmlEncoder { get; }
 
-        [Activate]
-        [HtmlAttributeNotBound]
-        public IJavaScriptStringEncoder JavaScriptEncoder { get; set; }
+        protected IJavaScriptStringEncoder JavaScriptEncoder { get; }
 
         // Internal for ease of use when testing.
         protected internal GlobbingUrlBuilder GlobbingUrlBuilder { get; set; }
@@ -364,6 +359,25 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             }
 
             builder.Append("/>");
+        }
+
+        private enum Mode
+        {
+            /// <summary>
+            /// Just adding a file version for the generated urls.
+            /// </summary>
+            FileVersion = 0,
+
+            /// <summary>
+            /// Just performing file globbing search for the href, rendering a separate &lt;link&gt; for each match.
+            /// </summary>
+            GlobbedHref = 1,
+
+            /// <summary>
+            /// Rendering a fallback block if primary stylesheet fails to load. Will also do globbing for both the
+            /// primary and fallback hrefs if the appropriate properties are set.
+            /// </summary>
+            Fallback = 2,
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/OptionTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/OptionTagHelper.cs
@@ -19,12 +19,19 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     /// </remarks>
     public class OptionTagHelper : TagHelper
     {
-        [Activate]
-        [HtmlAttributeNotBound]
-        public IHtmlGenerator Generator { get; set; }
+        /// <summary>
+        /// Creates a new <see cref="OptionTagHelper"/>.
+        /// </summary>
+        /// <param name="generator">The <see cref="IHtmlGenerator"/>.</param>
+        public OptionTagHelper(IHtmlGenerator generator)
+        {
+            Generator = generator;
+        }
 
-        [Activate]
+        protected IHtmlGenerator Generator { get; }
+
         [HtmlAttributeNotBound]
+        [ViewContext]
         public ViewContext ViewContext { get; set; }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ScriptTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ScriptTagHelper.cs
@@ -70,21 +70,26 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 }),
         };
 
-        private enum Mode
+        /// <summary>
+        /// Creates a new <see cref="ScriptTagHelper"/>.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger{ScriptTagHelper}"/>.</param>
+        /// <param name="hostingEnvironment">The <see cref="IHostingEnvironment"/>.</param>
+        /// <param name="cache">The <see cref="IMemoryCache"/>.</param>
+        /// <param name="htmlEncoder">The <see cref="IHtmlEncoder"/>.</param>
+        /// <param name="javaScriptEncoder">The <see cref="IJavaScriptStringEncoder"/>.</param>
+        public ScriptTagHelper(
+            ILogger<ScriptTagHelper> logger,
+            IHostingEnvironment hostingEnvironment,
+            IMemoryCache cache,
+            IHtmlEncoder htmlEncoder,
+            IJavaScriptStringEncoder javaScriptEncoder)
         {
-            /// <summary>
-            /// Just adding a file version for the generated urls.
-            /// </summary>
-            FileVersion = 0,
-            /// <summary>
-            /// Just performing file globbing search for the src, rendering a separate &lt;script&gt; for each match.
-            /// </summary>
-            GlobbedSrc = 1,
-            /// <summary>
-            /// Rendering a fallback block if primary javascript fails to load. Will also do globbing for both the
-            /// primary and fallback srcs if the appropriate properties are set.
-            /// </summary>
-            Fallback = 2
+            Logger = logger;
+            HostingEnvironment = hostingEnvironment;
+            Cache = cache;
+            HtmlEncoder = htmlEncoder;
+            JavaScriptEncoder = javaScriptEncoder;
         }
 
         /// <summary>
@@ -149,29 +154,19 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         [HtmlAttributeName(FallbackTestExpressionAttributeName)]
         public string FallbackTestExpression { get; set; }
 
-        [Activate]
-        [HtmlAttributeNotBound]
-        protected internal ILogger<ScriptTagHelper> Logger { get; set; }
+        protected ILogger<ScriptTagHelper> Logger { get; }
 
-        [Activate]
-        [HtmlAttributeNotBound]
-        public IHostingEnvironment HostingEnvironment { get; set; }
+        protected IHostingEnvironment HostingEnvironment { get; }
 
-        [Activate]
         [HtmlAttributeNotBound]
+        [ViewContext]
         public ViewContext ViewContext { get; set; }
 
-        [Activate]
-        [HtmlAttributeNotBound]
-        public IMemoryCache Cache { get; set; }
+        protected IMemoryCache Cache { get; }
 
-        [Activate]
-        [HtmlAttributeNotBound]
-        public IHtmlEncoder HtmlEncoder { get; set; }
+        protected IHtmlEncoder HtmlEncoder { get; }
 
-        [Activate]
-        [HtmlAttributeNotBound]
-        public IJavaScriptStringEncoder JavaScriptEncoder { get; set; }
+        protected IJavaScriptStringEncoder JavaScriptEncoder { get; }
 
         // Internal for ease of use when testing.
         protected internal GlobbingUrlBuilder GlobbingUrlBuilder { get; set; }
@@ -387,6 +382,25 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     .Append(HtmlEncoder, ViewContext.Writer.Encoding, value)
                     .Append("\"");
             }
+        }
+
+        private enum Mode
+        {
+            /// <summary>
+            /// Just adding a file version for the generated urls.
+            /// </summary>
+            FileVersion = 0,
+
+            /// <summary>
+            /// Just performing file globbing search for the src, rendering a separate &lt;script&gt; for each match.
+            /// </summary>
+            GlobbedSrc = 1,
+
+            /// <summary>
+            /// Rendering a fallback block if primary javascript fails to load. Will also do globbing for both the
+            /// primary and fallback srcs if the appropriate properties are set.
+            /// </summary>
+            Fallback = 2
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/SelectTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/SelectTagHelper.cs
@@ -31,12 +31,19 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         /// </remarks>
         public static readonly string SelectedValuesFormDataKey = nameof(SelectTagHelper) + "-SelectedValues";
 
-        [Activate]
-        [HtmlAttributeNotBound]
-        public IHtmlGenerator Generator { get; set; }
+        /// <summary>
+        /// Creates a new <see cref="SelectTagHelper"/>.
+        /// </summary>
+        /// <param name="generator">The <see cref="IHtmlGenerator"/>.</param>
+        public SelectTagHelper(IHtmlGenerator generator)
+        {
+            Generator = generator;
+        }
 
-        [Activate]
+        protected IHtmlGenerator Generator { get; }
+
         [HtmlAttributeNotBound]
+        [ViewContext]
         public ViewContext ViewContext { get; set; }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/TextAreaTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/TextAreaTagHelper.cs
@@ -14,12 +14,19 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     {
         private const string ForAttributeName = "asp-for";
 
-        [Activate]
-        [HtmlAttributeNotBound]
-        public IHtmlGenerator Generator { get; set; }
+        /// <summary>
+        /// Creates a new <see cref="TextAreaTagHelper"/>.
+        /// </summary>
+        /// <param name="generator">The <see cref="IHtmlGenerator"/>.</param>
+        public TextAreaTagHelper(IHtmlGenerator generator)
+        {
+            Generator = generator;
+        }
 
-        [Activate]
+        protected IHtmlGenerator Generator { get; }
+
         [HtmlAttributeNotBound]
+        [ViewContext]
         public ViewContext ViewContext { get; set; }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationMessageTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationMessageTagHelper.cs
@@ -16,13 +16,20 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     {
         private const string ValidationForAttributeName = "asp-validation-for";
 
-        [Activate]
+        /// <summary>
+        /// Creates a new <see cref="ValidationMessageTagHelper"/>.
+        /// </summary>
+        /// <param name="generator">The <see cref="IHtmlGenerator"/>.</param>
+        public ValidationMessageTagHelper(IHtmlGenerator generator)
+        {
+            Generator = generator;
+        }
+
         [HtmlAttributeNotBound]
+        [ViewContext]
         public ViewContext ViewContext { get; set; }
 
-        [Activate]
-        [HtmlAttributeNotBound]
-        public IHtmlGenerator Generator { get; set; }
+        protected IHtmlGenerator Generator { get; }
 
         /// <summary>
         /// Name to be validated on the current model.

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationSummaryTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationSummaryTagHelper.cs
@@ -17,13 +17,21 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         private const string ValidationSummaryAttributeName = "asp-validation-summary";
         private ValidationSummary _validationSummary;
 
-        [Activate]
+        /// <summary>
+        /// Creates a new <see cref="ValidationSummaryTagHelper"/>.
+        /// </summary>
+        /// <param name="generator">The <see cref="IHtmlGenerator"/>.</param>
+        public ValidationSummaryTagHelper(IHtmlGenerator generator)
+        {
+            Generator = generator;
+        }
+
         [HtmlAttributeNotBound]
+        [ViewContext]
         public ViewContext ViewContext { get; set; }
 
-        [Activate]
         [HtmlAttributeNotBound]
-        public IHtmlGenerator Generator { get; set; }
+        protected IHtmlGenerator Generator { get; }
 
         /// <summary>
         /// If <see cref="ValidationSummary.All"/> or <see cref="ValidationSummary.ModelOnly"/>, appends a validation

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ActivatorTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ActivatorTests.cs
@@ -147,7 +147,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         }
 
         [Fact]
-        public async Task TagHelperActivation_ActivateHtmlHelper_RendersProperly()
+        public async Task TagHelperActivation_ConstructorInjection_RendersProperly()
         {
             // Arrange
             var server = TestHelper.CreateServer(_app, SiteName, _configureServices);

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/DefaultTagHelperActivatorTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/DefaultTagHelperActivatorTest.cs
@@ -158,7 +158,7 @@ namespace Microsoft.AspNet.Mvc.Razor
 
             public object ViewDataValue { get; set; } = new object();
 
-            [Activate]
+            [ViewContext]
             public ViewContext ViewContext { get; set; }
         }
 
@@ -170,7 +170,7 @@ namespace Microsoft.AspNet.Mvc.Razor
 
             public object ViewDataValue { get; set; } = new object();
 
-            [Activate]
+            [ViewContext]
             public ViewContext ViewContext { get; set; }
         }
     }

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/RazorPageCreateTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/RazorPageCreateTagHelperTest.cs
@@ -57,56 +57,18 @@ namespace Microsoft.AspNet.Mvc.Razor
             Assert.NotNull(tagHelper.ViewContext);
         }
 
-        [Fact]
-        public void CreateTagHelper_ProvidesTagHelperWithViewData()
-        {
-            // Arrange
-            var instance = CreateTestRazorPage();
-
-            // Act
-            var tagHelper = instance.CreateTagHelper<ViewDataTagHelper>();
-
-            // Assert
-            Assert.NotNull(tagHelper.ViewData);
-        }
-
-        [Fact]
-        public void CreateTagHelper_ProvidesTagHelperWithInternalProperties()
-        {
-            // Arrange
-            var instance = CreateTestRazorPage();
-
-            // Act
-            var tagHelper = instance.CreateTagHelper<TagHelperWithInternalProperty>();
-
-            // Assert
-            Assert.NotNull(tagHelper.ViewData);
-            Assert.NotNull(tagHelper.ViewContext);
-        }
-
-        [Fact]
-        public void CreateTagHelper_ProvidesTagHelperTypeWithViewContextAndActivates()
-        {
-            // Arrange
-            var instance = CreateTestRazorPage();
-
-            // Act
-            var tagHelper = instance.CreateTagHelper<ViewContextServiceTagHelper>();
-
-            // Assert
-            Assert.NotNull(tagHelper.ViewContext);
-            Assert.NotNull(tagHelper.ActivatedService);
-        }
-
         private static TestRazorPage CreateTestRazorPage()
         {
             var activator = new RazorPageActivator(new EmptyModelMetadataProvider());
             var serviceProvider = new Mock<IServiceProvider>();
+            var typeActivator = new DefaultTypeActivatorCache();
             var myService = new MyService();
             serviceProvider.Setup(mock => mock.GetService(typeof(MyService)))
                            .Returns(myService);
             serviceProvider.Setup(mock => mock.GetService(typeof(ITagHelperActivator)))
                            .Returns(new DefaultTagHelperActivator());
+            serviceProvider.Setup(mock => mock.GetService(typeof(ITypeActivatorCache)))
+                           .Returns(typeActivator);
             serviceProvider.Setup(mock => mock.GetService(It.Is<Type>(serviceType =>
                 serviceType.IsGenericType && serviceType.GetGenericTypeDefinition() == typeof(IEnumerable<>))))
                 .Returns<Type>(serviceType =>
@@ -147,37 +109,19 @@ namespace Microsoft.AspNet.Mvc.Razor
 
         private class ServiceTagHelper : TagHelper
         {
-            [Activate]
+            public ServiceTagHelper(MyService service)
+            {
+                ActivatedService = service;
+            }
+
             [HtmlAttributeNotBound]
-            public MyService ActivatedService { get; set; }
+            public MyService ActivatedService { get; }
         }
 
         private class ViewContextTagHelper : TagHelper
         {
-            [Activate]
+            [ViewContext]
             public ViewContext ViewContext { get; set; }
-        }
-
-        private class ViewDataTagHelper : TagHelper
-        {
-            [Activate]
-            [HtmlAttributeNotBound]
-            public ViewDataDictionary ViewData { get; set; }
-        }
-
-        private class ViewContextServiceTagHelper : ViewContextTagHelper
-        {
-            [Activate]
-            public MyService ActivatedService { get; set; }
-        }
-
-        private class TagHelperWithInternalProperty : TagHelper
-        {
-            [Activate]
-            protected internal ViewDataDictionary ViewData { get; set; }
-
-            [Activate]
-            protected internal ViewContext ViewContext { get; set; }
         }
 
         private class MyService

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/AnchorTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/AnchorTagHelperTest.cs
@@ -58,12 +58,11 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var viewContext = TestableHtmlGenerator.GetViewContext(model: null,
                                                                    htmlGenerator: htmlGenerator,
                                                                    metadataProvider: metadataProvider);
-            var anchorTagHelper = new AnchorTagHelper
+            var anchorTagHelper = new AnchorTagHelper(htmlGenerator)
             {
                 Action = "index",
                 Controller = "home",
                 Fragment = "hello=world",
-                Generator = htmlGenerator,
                 Host = "contoso.com",
                 Protocol = "http",
                 RouteValues =
@@ -117,10 +116,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     null))
                 .Returns(new TagBuilder("a", new CommonTestEncoder()))
                 .Verifiable();
-            var anchorTagHelper = new AnchorTagHelper
+            var anchorTagHelper = new AnchorTagHelper(generator.Object)
             {
                 Fragment = "hello=world",
-                Generator = generator.Object,
                 Host = "contoso.com",
                 Protocol = "http",
                 Route = "Default",
@@ -167,12 +165,11 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     null))
                 .Returns(new TagBuilder("a", new CommonTestEncoder()))
                 .Verifiable();
-            var anchorTagHelper = new AnchorTagHelper
+            var anchorTagHelper = new AnchorTagHelper(generator.Object)
             {
                 Action = "Index",
                 Controller = "Home",
                 Fragment = "hello=world",
-                Generator = generator.Object,
                 Host = "contoso.com",
                 Protocol = "http",
             };
@@ -196,7 +193,11 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         public async Task ProcessAsync_ThrowsIfHrefConflictsWithBoundAttributes(string propertyName)
         {
             // Arrange
-            var anchorTagHelper = new AnchorTagHelper();
+            var metadataProvider = new EmptyModelMetadataProvider();
+            var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
+
+            var anchorTagHelper = new AnchorTagHelper(htmlGenerator);
+
             var output = new TagHelperOutput(
                 "a",
                 attributes: new TagHelperAttributeList
@@ -230,10 +231,14 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         public async Task ProcessAsync_ThrowsIfRouteAndActionOrControllerProvided(string propertyName)
         {
             // Arrange
-            var anchorTagHelper = new AnchorTagHelper
+            var metadataProvider = new EmptyModelMetadataProvider();
+            var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
+
+            var anchorTagHelper = new AnchorTagHelper(htmlGenerator)
             {
                 Route = "Default",
             };
+
             typeof(AnchorTagHelper).GetProperty(propertyName).SetValue(anchorTagHelper, "Home");
             var output = new TagHelperOutput(
                 "a",

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/CacheTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/CacheTagHelperTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var id = Guid.NewGuid().ToString();
             var tagHelperContext = GetTagHelperContext(id);
-            var cacheTagHelper = new CacheTagHelper
+            var cacheTagHelper = new CacheTagHelper(Mock.Of<IMemoryCache>())
             {
                 ViewContext = GetViewContext()
             };
@@ -52,7 +52,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             // Arrange
             var tagHelperContext = GetTagHelperContext();
-            var cacheTagHelper = new CacheTagHelper
+            var cacheTagHelper = new CacheTagHelper(Mock.Of<IMemoryCache>())
             {
                 ViewContext = GetViewContext(),
                 VaryBy = varyBy
@@ -80,7 +80,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             // Arrange
             var tagHelperContext = GetTagHelperContext();
-            var cacheTagHelper = new CacheTagHelper
+            var cacheTagHelper = new CacheTagHelper(Mock.Of<IMemoryCache>())
             {
                 ViewContext = GetViewContext(),
                 VaryByCookie = varyByCookie
@@ -105,7 +105,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             // Arrange
             var tagHelperContext = GetTagHelperContext();
-            var cacheTagHelper = new CacheTagHelper
+            var cacheTagHelper = new CacheTagHelper(Mock.Of<IMemoryCache>())
             {
                 ViewContext = GetViewContext(),
                 VaryByHeader = varyByHeader
@@ -132,7 +132,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             // Arrange
             var tagHelperContext = GetTagHelperContext();
-            var cacheTagHelper = new CacheTagHelper
+            var cacheTagHelper = new CacheTagHelper(Mock.Of<IMemoryCache>())
             {
                 ViewContext = GetViewContext(),
                 VaryByQuery = varyByQuery
@@ -157,7 +157,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             // Arrange
             var tagHelperContext = GetTagHelperContext();
-            var cacheTagHelper = new CacheTagHelper
+            var cacheTagHelper = new CacheTagHelper(Mock.Of<IMemoryCache>())
             {
                 ViewContext = GetViewContext(),
                 VaryByRoute = varyByRoute
@@ -178,7 +178,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var expected = "CacheTagHelper||testid||VaryByUser||";
             var tagHelperContext = GetTagHelperContext();
-            var cacheTagHelper = new CacheTagHelper
+            var cacheTagHelper = new CacheTagHelper(Mock.Of<IMemoryCache>())
             {
                 ViewContext = GetViewContext(),
                 VaryByUser = true
@@ -197,7 +197,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var expected = "CacheTagHelper||testid||VaryByUser||test_name";
             var tagHelperContext = GetTagHelperContext();
-            var cacheTagHelper = new CacheTagHelper
+            var cacheTagHelper = new CacheTagHelper(Mock.Of<IMemoryCache>())
             {
                 ViewContext = GetViewContext(),
                 VaryByUser = true
@@ -219,7 +219,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var expected = GetHashedBytes("CacheTagHelper||testid||VaryBy||custom-value||" +
                                           "VaryByHeader(content-type||text/html)||VaryByUser||someuser");
             var tagHelperContext = GetTagHelperContext();
-            var cacheTagHelper = new CacheTagHelper
+            var cacheTagHelper = new CacheTagHelper(Mock.Of<IMemoryCache>())
             {
                 ViewContext = GetViewContext(),
                 VaryByUser = true,
@@ -257,10 +257,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 .Returns(false);
             var tagHelperContext = GetTagHelperContext(id, childContent);
             var tagHelperOutput = new TagHelperOutput("cache", new TagHelperAttributeList());
-            var cacheTagHelper = new CacheTagHelper
+            var cacheTagHelper = new CacheTagHelper(cache.Object)
             {
                 ViewContext = GetViewContext(),
-                MemoryCache = cache.Object,
                 Enabled = false
             };
 
@@ -297,10 +296,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 .Returns(false);
             var tagHelperContext = GetTagHelperContext(id, childContent);
             var tagHelperOutput = new TagHelperOutput("cache", new TagHelperAttributeList());
-            var cacheTagHelper = new CacheTagHelper
+            var cacheTagHelper = new CacheTagHelper(cache.Object)
             {
                 ViewContext = GetViewContext(),
-                MemoryCache = cache.Object,
                 Enabled = true
             };
 
@@ -328,11 +326,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var cache = new MemoryCache(new MemoryCacheOptions());
             var tagHelperContext1 = GetTagHelperContext(id, childContent);
             var tagHelperOutput1 = new TagHelperOutput("cache", new TagHelperAttributeList());
-            var cacheTagHelper1 = new CacheTagHelper
+            var cacheTagHelper1 = new CacheTagHelper(cache)
             {
                 VaryByQuery = "key1,key2",
                 ViewContext = GetViewContext(),
-                MemoryCache = cache
             };
             cacheTagHelper1.ViewContext.HttpContext.Request.QueryString = new Http.QueryString(
                 "?key1=value1&key2=value2");
@@ -349,11 +346,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange - 2
             var tagHelperContext2 = GetTagHelperContext(id, "different-content");
             var tagHelperOutput2 = new TagHelperOutput("cache", new TagHelperAttributeList());
-            var cacheTagHelper2 = new CacheTagHelper
+            var cacheTagHelper2 = new CacheTagHelper(cache)
             {
                 VaryByQuery = "key1,key2",
                 ViewContext = GetViewContext(),
-                MemoryCache = cache
             };
             cacheTagHelper2.ViewContext.HttpContext.Request.QueryString = new Http.QueryString(
                 "?key1=value1&key2=value2");
@@ -379,11 +375,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var tagHelperOutput1 = new TagHelperOutput("cache", new TagHelperAttributeList { { "attr", "value" } });
             tagHelperOutput1.PreContent.Append("<cache>");
             tagHelperOutput1.PostContent.SetContent("</cache>");
-            var cacheTagHelper1 = new CacheTagHelper
+            var cacheTagHelper1 = new CacheTagHelper(cache)
             {
                 VaryByCookie = "cookie1,cookie2",
                 ViewContext = GetViewContext(),
-                MemoryCache = cache
             };
             cacheTagHelper1.ViewContext.HttpContext.Request.Headers["Cookie"] = "cookie1=value1;cookie2=value2";
 
@@ -402,11 +397,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var tagHelperOutput2 = new TagHelperOutput("cache", new TagHelperAttributeList { { "attr", "value" } });
             tagHelperOutput2.PreContent.SetContent("<cache>");
             tagHelperOutput2.PostContent.SetContent("</cache>");
-            var cacheTagHelper2 = new CacheTagHelper
+            var cacheTagHelper2 = new CacheTagHelper(cache)
             {
                 VaryByCookie = "cookie1,cookie2",
                 ViewContext = GetViewContext(),
-                MemoryCache = cache
             };
             cacheTagHelper2.ViewContext.HttpContext.Request.Headers["Cookie"] = "cookie1=value1;cookie2=not-value2";
 
@@ -426,9 +420,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var expiresOn = DateTimeOffset.UtcNow.AddMinutes(4);
             var cache = new MemoryCache(new MemoryCacheOptions());
-            var cacheTagHelper = new CacheTagHelper
+            var cacheTagHelper = new CacheTagHelper(cache)
             {
-                MemoryCache = cache,
                 ExpiresOn = expiresOn
             };
 
@@ -445,9 +438,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var expiresOn = DateTimeOffset.UtcNow.AddMinutes(7);
             var cache = new MemoryCache(new MemoryCacheOptions());
-            var cacheTagHelper = new CacheTagHelper
+            var cacheTagHelper = new CacheTagHelper(cache)
             {
-                MemoryCache = cache
             };
 
             var entryLink = new EntryLink();
@@ -467,9 +459,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var expiresOn1 = DateTimeOffset.UtcNow.AddDays(12);
             var expiresOn2 = DateTimeOffset.UtcNow.AddMinutes(4);
             var cache = new MemoryCache(new MemoryCacheOptions());
-            var cacheTagHelper = new CacheTagHelper
+            var cacheTagHelper = new CacheTagHelper(cache)
             {
-                MemoryCache = cache,
                 ExpiresOn = expiresOn1
             };
 
@@ -489,9 +480,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var expiresAfter = TimeSpan.FromSeconds(42);
             var cache = new MemoryCache(new MemoryCacheOptions());
-            var cacheTagHelper = new CacheTagHelper
+            var cacheTagHelper = new CacheTagHelper(cache)
             {
-                MemoryCache = cache,
                 ExpiresAfter = expiresAfter
             };
 
@@ -508,9 +498,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var expiresSliding = TimeSpan.FromSeconds(37);
             var cache = new MemoryCache(new MemoryCacheOptions());
-            var cacheTagHelper = new CacheTagHelper
+            var cacheTagHelper = new CacheTagHelper(cache)
             {
-                MemoryCache = cache,
                 ExpiresSliding = expiresSliding
             };
 
@@ -527,9 +516,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var priority = CacheItemPriority.High;
             var cache = new MemoryCache(new MemoryCacheOptions());
-            var cacheTagHelper = new CacheTagHelper
+            var cacheTagHelper = new CacheTagHelper(cache)
             {
-                MemoryCache = cache,
                 Priority = priority
             };
 
@@ -547,9 +535,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var expiresSliding = TimeSpan.FromSeconds(30);
             var expected = new[] { Mock.Of<IExpirationTrigger>(), Mock.Of<IExpirationTrigger>() };
             var cache = new MemoryCache(new MemoryCacheOptions());
-            var cacheTagHelper = new CacheTagHelper
+            var cacheTagHelper = new CacheTagHelper(cache)
             {
-                MemoryCache = cache,
                 ExpiresSliding = expiresSliding
             };
 
@@ -578,10 +565,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var tagHelperOutput1 = new TagHelperOutput("cache", new TagHelperAttributeList { { "attr", "value" } });
             tagHelperOutput1.PreContent.SetContent("<cache>");
             tagHelperOutput1.PostContent.SetContent("</cache>");
-            var cacheTagHelper1 = new CacheTagHelper
+            var cacheTagHelper1 = new CacheTagHelper(cache)
             {
                 ViewContext = GetViewContext(),
-                MemoryCache = cache,
                 ExpiresAfter = TimeSpan.FromMinutes(10)
             };
 
@@ -600,10 +586,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var tagHelperOutput2 = new TagHelperOutput("cache", new TagHelperAttributeList { { "attr", "value" } });
             tagHelperOutput2.PreContent.SetContent("<cache>");
             tagHelperOutput2.PostContent.SetContent("</cache>");
-            var cacheTagHelper2 = new CacheTagHelper
+            var cacheTagHelper2 = new CacheTagHelper(cache)
             {
                 ViewContext = GetViewContext(),
-                MemoryCache = cache,
                 ExpiresAfter = TimeSpan.FromMinutes(10)
             };
             currentTime = currentTime.AddMinutes(11);
@@ -633,10 +618,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var tagHelperOutput1 = new TagHelperOutput("cache", new TagHelperAttributeList { { "attr", "value" } });
             tagHelperOutput1.PreContent.SetContent("<cache>");
             tagHelperOutput1.PostContent.SetContent("</cache>");
-            var cacheTagHelper1 = new CacheTagHelper
+            var cacheTagHelper1 = new CacheTagHelper(cache)
             {
                 ViewContext = GetViewContext(),
-                MemoryCache = cache,
                 ExpiresOn = currentTime.AddMinutes(5)
             };
 
@@ -656,10 +640,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var tagHelperOutput2 = new TagHelperOutput("cache", new TagHelperAttributeList { { "attr", "value" } });
             tagHelperOutput2.PreContent.SetContent("<cache>");
             tagHelperOutput2.PostContent.SetContent("</cache>");
-            var cacheTagHelper2 = new CacheTagHelper
+            var cacheTagHelper2 = new CacheTagHelper(cache)
             {
                 ViewContext = GetViewContext(),
-                MemoryCache = cache,
                 ExpiresOn = currentTime.AddMinutes(5)
             };
 
@@ -688,10 +671,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var tagHelperOutput1 = new TagHelperOutput("cache", new TagHelperAttributeList { { "attr", "value" } });
             tagHelperOutput1.PreContent.SetContent("<cache>");
             tagHelperOutput1.PostContent.SetContent("</cache>");
-            var cacheTagHelper1 = new CacheTagHelper
+            var cacheTagHelper1 = new CacheTagHelper(cache)
             {
                 ViewContext = GetViewContext(),
-                MemoryCache = cache,
                 ExpiresSliding = TimeSpan.FromSeconds(30)
             };
 
@@ -711,10 +693,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var tagHelperOutput2 = new TagHelperOutput("cache", new TagHelperAttributeList { { "attr", "value" } });
             tagHelperOutput2.PreContent.SetContent("<cache>");
             tagHelperOutput2.PostContent.SetContent("</cache>");
-            var cacheTagHelper2 = new CacheTagHelper
+            var cacheTagHelper2 = new CacheTagHelper(cache)
             {
                 ViewContext = GetViewContext(),
-                MemoryCache = cache,
                 ExpiresSliding = TimeSpan.FromSeconds(30)
             };
 
@@ -757,10 +738,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var tagHelperOutput = new TagHelperOutput("cache", new TagHelperAttributeList { { "attr", "value" } });
             tagHelperOutput.PreContent.SetContent("<cache>");
             tagHelperOutput.PostContent.SetContent("</cache>");
-            var cacheTagHelper = new CacheTagHelper
+            var cacheTagHelper = new CacheTagHelper(cache)
             {
                 ViewContext = GetViewContext(),
-                MemoryCache = cache,
             };
             var key = cacheTagHelper.GenerateKey(tagHelperContext);
 

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/EnvironmentTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/EnvironmentTagHelperTest.cs
@@ -88,9 +88,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Test
             hostingEnvironment.Object.EnvironmentName = environmentName;
 
             // Act
-            var helper = new EnvironmentTagHelper
+            var helper = new EnvironmentTagHelper(hostingEnvironment.Object)
             {
-                HostingEnvironment = hostingEnvironment.Object,
                 Names = namesAttribute
             };
             helper.Process(context, output);
@@ -116,9 +115,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Test
             hostingEnvironment.Object.EnvironmentName = environmentName;
 
             // Act
-            var helper = new EnvironmentTagHelper
+            var helper = new EnvironmentTagHelper(hostingEnvironment.Object)
             {
-                HostingEnvironment = hostingEnvironment.Object,
                 Names = namesAttribute
             };
             helper.Process(context, output);

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/FormTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/FormTagHelperTest.cs
@@ -60,12 +60,11 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                                                                    metadataProvider: metadataProvider);
             var expectedPostContent = "Something" + htmlGenerator.GenerateAntiForgery(viewContext)
                                                                  .ToString(TagRenderMode.SelfClosing);
-            var formTagHelper = new FormTagHelper
+            var formTagHelper = new FormTagHelper(htmlGenerator)
             {
                 Action = "index",
                 AntiForgery = true,
                 Controller = "home",
-                Generator = htmlGenerator,
                 ViewContext = viewContext,
                 RouteValues =
                 {
@@ -127,11 +126,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             generator.Setup(mock => mock.GenerateAntiForgery(viewContext))
                      .Returns(new TagBuilder("input", new CommonTestEncoder()));
-            var formTagHelper = new FormTagHelper
+            var formTagHelper = new FormTagHelper(generator.Object)
             {
                 Action = "Index",
                 AntiForgery = antiForgery,
-                Generator = generator.Object,
                 ViewContext = viewContext,
             };
 
@@ -194,11 +192,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     })
                 .Returns(new TagBuilder("form", new CommonTestEncoder()))
                 .Verifiable();
-            var formTagHelper = new FormTagHelper
+            var formTagHelper = new FormTagHelper(generator.Object)
             {
                 Action = "Index",
                 AntiForgery = false,
-                Generator = generator.Object,
                 ViewContext = testViewContext,
                 RouteValues =
                 {
@@ -250,12 +247,11 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     null))
                 .Returns(new TagBuilder("form", new CommonTestEncoder()))
                 .Verifiable();
-            var formTagHelper = new FormTagHelper
+            var formTagHelper = new FormTagHelper(generator.Object)
             {
                 Action = "Index",
                 AntiForgery = false,
                 Controller = "Home",
-                Generator = generator.Object,
                 ViewContext = viewContext,
             };
 
@@ -301,11 +297,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     null))
                 .Returns(new TagBuilder("form", new CommonTestEncoder()))
                 .Verifiable();
-            var formTagHelper = new FormTagHelper
+            var formTagHelper = new FormTagHelper(generator.Object)
             {
                 AntiForgery = false,
                 Route = "Default",
-                Generator = generator.Object,
                 ViewContext = viewContext,
                 RouteValues =
                 {
@@ -341,10 +336,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             generator.Setup(mock => mock.GenerateAntiForgery(It.IsAny<ViewContext>()))
                      .Returns(new TagBuilder("input", new CommonTestEncoder()));
-            var formTagHelper = new FormTagHelper
+            var formTagHelper = new FormTagHelper(generator.Object)
             {
                 AntiForgery = antiForgery,
-                Generator = generator.Object,
                 ViewContext = viewContext,
             };
 
@@ -386,7 +380,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         public async Task ProcessAsync_ThrowsIfActionConflictsWithBoundAttributes(string propertyName)
         {
             // Arrange
-            var formTagHelper = new FormTagHelper();
+            var formTagHelper = new FormTagHelper(new TestableHtmlGenerator(new EmptyModelMetadataProvider()));
             var tagHelperOutput = new TagHelperOutput(
                 "form",
                 attributes: new TagHelperAttributeList
@@ -419,7 +413,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         public async Task ProcessAsync_ThrowsIfRouteAndActionOrControllerProvided(string propertyName)
         {
             // Arrange
-            var formTagHelper = new FormTagHelper
+            var formTagHelper = new FormTagHelper(new TestableHtmlGenerator(new EmptyModelMetadataProvider()))
             {
                 Route = "Default",
             };

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ImageTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ImageTagHelperTest.cs
@@ -56,13 +56,12 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             var hostingEnvironment = MakeHostingEnvironment();
             var viewContext = MakeViewContext();
-            var helper = new ImageTagHelper
+
+            var helper = new ImageTagHelper(hostingEnvironment, MakeCache())
             {
-                HostingEnvironment = hostingEnvironment,
                 ViewContext = viewContext,
                 Src = "testimage.png",
                 FileVersion = true,
-                Cache = MakeCache(),
             };
 
             // Act
@@ -98,13 +97,12 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             });
             var hostingEnvironment = MakeHostingEnvironment();
             var viewContext = MakeViewContext();
-            var helper = new ImageTagHelper
+
+            var helper = new ImageTagHelper(hostingEnvironment, MakeCache())
             {
-                HostingEnvironment = hostingEnvironment,
                 ViewContext = viewContext,
                 Src = "/images/test-image.png",
                 FileVersion = true,
-                Cache = MakeCache(),
             };
 
             // Act
@@ -135,13 +133,12 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             });
             var hostingEnvironment = MakeHostingEnvironment();
             var viewContext = MakeViewContext();
-            var helper = new ImageTagHelper
+
+            var helper = new ImageTagHelper(hostingEnvironment, MakeCache())
             {
-                HostingEnvironment = hostingEnvironment,
                 ViewContext = viewContext,
                 Src = "/images/test-image.png",
                 FileVersion = false,
-                Cache = MakeCache(),
             };
 
             // Act
@@ -172,13 +169,12 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             });
             var hostingEnvironment = MakeHostingEnvironment();
             var viewContext = MakeViewContext("/bar");
-            var helper = new ImageTagHelper
+
+            var helper = new ImageTagHelper(hostingEnvironment, MakeCache())
             {
-                HostingEnvironment = hostingEnvironment,
                 ViewContext = viewContext,
                 Src = "/bar/images/image.jpg",
                 FileVersion = true,
-                Cache = MakeCache(),
             };
 
             // Act

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/InputTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/InputTagHelperTest.cs
@@ -939,10 +939,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             var modelExpression = new ModelExpression(expressionName, modelExplorer);
             var viewContext = TestableHtmlGenerator.GetViewContext(container, htmlGenerator, metadataProvider);
-            var inputTagHelper = new InputTagHelper
+            var inputTagHelper = new InputTagHelper(htmlGenerator)
             {
                 For = modelExpression,
-                Generator = htmlGenerator,
                 ViewContext = viewContext,
             };
 

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LabelTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LabelTagHelperTest.cs
@@ -177,9 +177,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             var propertyMetadata = metadataProvider.GetMetadataForProperty(containerType, "Text");
             var modelExplorer = containerExplorer.GetExplorerForExpression(propertyMetadata, modelAccessor());
+            var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
 
             var modelExpression = new ModelExpression(propertyPath, modelExplorer);
-            var tagHelper = new LabelTagHelper
+            var tagHelper = new LabelTagHelper(htmlGenerator)
             {
                 For = modelExpression,
             };
@@ -211,11 +212,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 output.Content.SetContent(tagHelperOutputContent.OriginalContent);
             }
-
-            var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
+            
             var viewContext = TestableHtmlGenerator.GetViewContext(model, htmlGenerator, metadataProvider);
             tagHelper.ViewContext = viewContext;
-            tagHelper.Generator = htmlGenerator;
 
             // Act
             await tagHelper.ProcessAsync(tagHelperContext, output);

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LinkTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LinkTagHelperTest.cs
@@ -109,19 +109,20 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var logger = new Mock<ILogger<LinkTagHelper>>();
             var hostingEnvironment = MakeHostingEnvironment();
             var viewContext = MakeViewContext();
-            var helper = new LinkTagHelper
+
+            var helper = new LinkTagHelper(
+                logger.Object,
+                hostingEnvironment,
+                MakeCache(),
+                new CommonTestEncoder(),
+                new CommonTestEncoder())
             {
-                HtmlEncoder = new CommonTestEncoder(),
-                JavaScriptEncoder = new CommonTestEncoder(),
-                Logger = logger.Object,
-                HostingEnvironment = hostingEnvironment,
                 ViewContext = viewContext,
                 FallbackHref = "test.css",
                 FallbackTestClass = "hidden",
                 FallbackTestProperty = "visibility",
                 FallbackTestValue = "hidden",
                 Href = "test.css",
-                Cache = MakeCache(),
             };
 
             // Act
@@ -280,14 +281,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var logger = new Mock<ILogger<LinkTagHelper>>();
             var hostingEnvironment = MakeHostingEnvironment();
             var viewContext = MakeViewContext();
-            var helper = new LinkTagHelper
+
+            var helper = new LinkTagHelper(
+                logger.Object,
+                hostingEnvironment,
+                MakeCache(),
+                new CommonTestEncoder(),
+                new CommonTestEncoder())
             {
-                HtmlEncoder = new CommonTestEncoder(),
-                JavaScriptEncoder = new CommonTestEncoder(),
-                Logger = logger.Object,
-                HostingEnvironment = hostingEnvironment,
                 ViewContext = viewContext,
-                Cache = MakeCache()
             };
             setProperties(helper);
 
@@ -324,19 +326,20 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var logger = new Mock<ILogger<LinkTagHelper>>();
             var hostingEnvironment = MakeHostingEnvironment();
             var viewContext = MakeViewContext();
-            var helper = new LinkTagHelper
+
+            var helper = new LinkTagHelper(
+                logger.Object,
+                hostingEnvironment,
+                MakeCache(),
+                new CommonTestEncoder(),
+                new CommonTestEncoder())
             {
-                HtmlEncoder = new CommonTestEncoder(),
-                JavaScriptEncoder = new CommonTestEncoder(),
-                Logger = logger.Object,
-                HostingEnvironment = hostingEnvironment,
                 ViewContext = viewContext,
                 FallbackHref = "test.css",
                 FallbackTestClass = "hidden",
                 FallbackTestProperty = "visibility",
                 FallbackTestValue = "hidden",
                 Href = "test.css",
-                Cache = MakeCache(),
             };
 
             // Act
@@ -431,12 +434,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var logger = new Mock<ILogger<LinkTagHelper>>();
             var hostingEnvironment = MakeHostingEnvironment();
             var viewContext = MakeViewContext();
-            var helper = new LinkTagHelper
+
+            var helper = new LinkTagHelper(
+                logger.Object,
+                hostingEnvironment,
+                MakeCache(),
+                new CommonTestEncoder(),
+                new CommonTestEncoder())
             {
-                Logger = logger.Object,
-                HostingEnvironment = hostingEnvironment,
                 ViewContext = viewContext,
-                Cache = MakeCache(),
             };
             setProperties(helper);
 
@@ -457,12 +463,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var logger = new Mock<ILogger<LinkTagHelper>>();
             var hostingEnvironment = MakeHostingEnvironment();
             var viewContext = MakeViewContext();
-            var helper = new LinkTagHelper
+
+            var helper = new LinkTagHelper(
+                logger.Object,
+                hostingEnvironment,
+                MakeCache(),
+                new CommonTestEncoder(),
+                new CommonTestEncoder())
             {
-                Logger = logger.Object,
-                HostingEnvironment = hostingEnvironment,
                 ViewContext = viewContext,
-                Cache = MakeCache(),
             };
 
             // Act
@@ -494,16 +503,18 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var globbingUrlBuilder = new Mock<GlobbingUrlBuilder>();
             globbingUrlBuilder.Setup(g => g.BuildUrlList("/css/site.css", "**/*.css", null))
                 .Returns(new[] { "/css/site.css", "/base.css" });
-            var helper = new LinkTagHelper
+
+            var helper = new LinkTagHelper(
+                logger.Object,
+                hostingEnvironment,
+                MakeCache(),
+                new CommonTestEncoder(),
+                new CommonTestEncoder())
             {
-                HtmlEncoder = new CommonTestEncoder(),
                 GlobbingUrlBuilder = globbingUrlBuilder.Object,
-                Logger = logger.Object,
-                HostingEnvironment = hostingEnvironment,
                 ViewContext = viewContext,
                 Href = "/css/site.css",
                 HrefInclude = "**/*.css",
-                Cache = MakeCache(),
             };
 
             // Act
@@ -537,16 +548,18 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var globbingUrlBuilder = new Mock<GlobbingUrlBuilder>();
             globbingUrlBuilder.Setup(g => g.BuildUrlList("/css/site.css", "**/*.css", null))
                 .Returns(new[] { "/css/site.css", "/base.css" });
-            var helper = new LinkTagHelper
+
+            var helper = new LinkTagHelper(
+                logger.Object,
+                hostingEnvironment,
+                MakeCache(),
+                new CommonTestEncoder(),
+                new CommonTestEncoder())
             {
-                HtmlEncoder = new CommonTestEncoder(),
                 GlobbingUrlBuilder = globbingUrlBuilder.Object,
-                Logger = logger.Object,
-                HostingEnvironment = hostingEnvironment,
                 ViewContext = viewContext,
                 Href = "/css/site.css",
                 HrefInclude = "**/*.css",
-                Cache = MakeCache(),
             };
 
             // Act
@@ -577,16 +590,18 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var logger = new Mock<ILogger<LinkTagHelper>>();
             var hostingEnvironment = MakeHostingEnvironment();
             var viewContext = MakeViewContext();
-            var helper = new LinkTagHelper
+
+            var helper = new LinkTagHelper(
+                logger.Object,
+                hostingEnvironment,
+                MakeCache(),
+                new CommonTestEncoder(),
+                new CommonTestEncoder())
             {
-                HtmlEncoder = new CommonTestEncoder(),
-                Logger = logger.Object,
-                HostingEnvironment = hostingEnvironment,
                 ViewContext = viewContext,
                 Href = "/css/site.css",
                 HrefInclude = "**/*.css",
                 FileVersion = true,
-                Cache = MakeCache(),
             };
 
             // Act
@@ -616,16 +631,18 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var logger = new Mock<ILogger<LinkTagHelper>>();
             var hostingEnvironment = MakeHostingEnvironment();
             var viewContext = MakeViewContext("/bar");
-            var helper = new LinkTagHelper
+
+            var helper = new LinkTagHelper(
+                logger.Object,
+                hostingEnvironment,
+                MakeCache(),
+                new CommonTestEncoder(),
+                new CommonTestEncoder())
             {
-                HtmlEncoder = new CommonTestEncoder(),
-                Logger = logger.Object,
-                HostingEnvironment = hostingEnvironment,
                 ViewContext = viewContext,
                 Href = "/bar/css/site.css",
                 HrefInclude = "**/*.css",
                 FileVersion = true,
-                Cache = MakeCache(),
             };
 
             // Act
@@ -659,17 +676,19 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var globbingUrlBuilder = new Mock<GlobbingUrlBuilder>();
             globbingUrlBuilder.Setup(g => g.BuildUrlList("/css/site.css", "**/*.css", null))
                 .Returns(new[] { "/css/site.css", "/base.css" });
-            var helper = new LinkTagHelper
+
+            var helper = new LinkTagHelper(
+                logger.Object,
+                hostingEnvironment,
+                MakeCache(),
+                new CommonTestEncoder(),
+                new CommonTestEncoder())
             {
-                HtmlEncoder = new CommonTestEncoder(),
                 GlobbingUrlBuilder = globbingUrlBuilder.Object,
-                Logger = logger.Object,
-                HostingEnvironment = hostingEnvironment,
                 ViewContext = viewContext,
                 Href = "/css/site.css",
                 HrefInclude = "**/*.css",
                 FileVersion = true,
-                Cache = MakeCache(),
             };
 
             // Act

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/OptionTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/OptionTagHelperTest.cs
@@ -419,9 +419,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 htmlGenerator: htmlGenerator,
                 metadataProvider: metadataProvider);
             viewContext.FormContext.FormData[SelectTagHelper.SelectedValuesFormDataKey] = selectedValues;
-            var tagHelper = new OptionTagHelper
+            var tagHelper = new OptionTagHelper(htmlGenerator)
             {
-                Generator = htmlGenerator,
                 Value = value,
                 ViewContext = viewContext,
             };
@@ -489,7 +488,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 htmlGenerator: htmlGenerator,
                 metadataProvider: metadataProvider);
             viewContext.FormContext.FormData[SelectTagHelper.SelectedValuesFormDataKey] = selectedValues;
-            var tagHelper = new OptionTagHelper
+            var tagHelper = new OptionTagHelper(htmlGenerator)
             {
                 Value = value,
                 ViewContext = viewContext,
@@ -535,6 +534,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     tagHelperContent.SetContent(originalContent);
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
+
             var output = new TagHelperOutput(originalTagName, originalAttributes)
             {
                 SelfClosing = false,
@@ -543,7 +543,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             output.Content.SetContent(originalContent);
             output.PostContent.SetContent(originalPostContent);
 
-            var tagHelper = new OptionTagHelper
+            var metadataProvider = new EmptyModelMetadataProvider();
+            var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
+
+            var tagHelper = new OptionTagHelper(htmlGenerator)
             {
                 Value = value,
             };

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ScriptTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ScriptTagHelperTest.cs
@@ -55,17 +55,17 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var output = MakeTagHelperOutput("script", combinedOutputAttributes);
             var hostingEnvironment = MakeHostingEnvironment();
 
-            var helper = new ScriptTagHelper
+            var helper = new ScriptTagHelper(
+                CreateLogger(),
+                hostingEnvironment,
+                MakeCache(),
+                new CommonTestEncoder(),
+                new CommonTestEncoder())
             {
-                HtmlEncoder = new CommonTestEncoder(),
-                JavaScriptEncoder = new CommonTestEncoder(),
                 ViewContext = viewContext,
-                HostingEnvironment = hostingEnvironment,
                 FallbackSrc = "~/blank.js",
                 FallbackTestExpression = "http://www.example.com/blank.js",
                 Src = "/blank.js",
-                Cache = MakeCache(),
-                Logger = CreateLogger()
             };
 
             // Act
@@ -271,14 +271,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var logger = CreateLogger();
             var hostingEnvironment = MakeHostingEnvironment();
             var viewContext = MakeViewContext();
-            var helper = new ScriptTagHelper
+
+            var helper = new ScriptTagHelper(
+                CreateLogger(),
+                hostingEnvironment,
+                MakeCache(),
+                new CommonTestEncoder(),
+                new CommonTestEncoder())
             {
-                HtmlEncoder = new CommonTestEncoder(),
-                JavaScriptEncoder = new CommonTestEncoder(),
-                Logger = logger,
-                HostingEnvironment = hostingEnvironment,
                 ViewContext = viewContext,
-                Cache = MakeCache(),
             };
             setProperties(helper);
 
@@ -363,12 +364,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var logger = new Mock<ILogger<ScriptTagHelper>>();
             var hostingEnvironment = MakeHostingEnvironment();
             var viewContext = MakeViewContext();
-            var helper = new ScriptTagHelper
+
+            var helper = new ScriptTagHelper(
+                CreateLogger(),
+                hostingEnvironment,
+                MakeCache(),
+                new CommonTestEncoder(),
+                new CommonTestEncoder())
             {
-                Logger = logger.Object,
-                HostingEnvironment = hostingEnvironment,
                 ViewContext = viewContext,
-                Cache = MakeCache(),
             };
             setProperties(helper);
 
@@ -392,12 +396,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var logger = CreateLogger();
             var hostingEnvironment = MakeHostingEnvironment();
             var viewContext = MakeViewContext();
-            var helper = new ScriptTagHelper
+
+            var helper = new ScriptTagHelper(
+                logger,
+                hostingEnvironment,
+                MakeCache(),
+                new CommonTestEncoder(),
+                new CommonTestEncoder())
             {
-                Logger = logger,
-                HostingEnvironment = hostingEnvironment,
                 ViewContext = viewContext,
-                Cache = MakeCache(),
             };
             setProperties(helper);
 
@@ -431,11 +438,14 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var output = MakeTagHelperOutput("script");
             var logger = CreateLogger();
 
-            var helper = new ScriptTagHelper
+            var helper = new ScriptTagHelper(
+                CreateLogger(),
+                MakeHostingEnvironment(),
+                MakeCache(),
+                new CommonTestEncoder(),
+                new CommonTestEncoder())
             {
-                Logger = logger,
                 ViewContext = viewContext,
-                Cache = MakeCache(),
             };
 
             // Act
@@ -455,11 +465,14 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var output = MakeTagHelperOutput("script");
             var logger = CreateLogger();
 
-            var helper = new ScriptTagHelper
+            var helper = new ScriptTagHelper(
+                logger,
+                MakeHostingEnvironment(),
+                MakeCache(),
+                new CommonTestEncoder(),
+                new CommonTestEncoder())
             {
-                Logger = logger,
                 ViewContext = viewContext,
-                Cache = MakeCache(),
             };
 
             // Act
@@ -503,17 +516,17 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var logger = CreateLogger();
             var hostingEnvironment = MakeHostingEnvironment();
 
-            var helper = new ScriptTagHelper
+            var helper = new ScriptTagHelper(
+                logger,
+                hostingEnvironment,
+                MakeCache(),
+                new CommonTestEncoder(),
+                new CommonTestEncoder())
             {
-                HtmlEncoder = new CommonTestEncoder(),
-                JavaScriptEncoder = new CommonTestEncoder(),
-                Logger = logger,
                 ViewContext = viewContext,
-                HostingEnvironment = hostingEnvironment,
                 FallbackSrc = "~/blank.js",
                 FallbackTestExpression = "http://www.example.com/blank.js",
                 Src = "/blank.js",
-                Cache = MakeCache(),
             };
 
             // Act
@@ -543,16 +556,18 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var globbingUrlBuilder = new Mock<GlobbingUrlBuilder>();
             globbingUrlBuilder.Setup(g => g.BuildUrlList("/js/site.js", "**/*.js", null))
                 .Returns(new[] { "/js/site.js", "/common.js" });
-            var helper = new ScriptTagHelper
+
+            var helper = new ScriptTagHelper(
+                logger.Object,
+                hostingEnvironment,
+                MakeCache(),
+                new CommonTestEncoder(),
+                new CommonTestEncoder())
             {
                 GlobbingUrlBuilder = globbingUrlBuilder.Object,
-                Logger = logger.Object,
-                HostingEnvironment = hostingEnvironment,
                 ViewContext = viewContext,
                 Src = "/js/site.js",
                 SrcInclude = "**/*.js",
-                HtmlEncoder = new CommonTestEncoder(),
-                Cache = MakeCache(),
             };
 
             // Act
@@ -580,17 +595,18 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var globbingUrlBuilder = new Mock<GlobbingUrlBuilder>();
             globbingUrlBuilder.Setup(g => g.BuildUrlList("/js/site.js", "**/*.js", null))
                 .Returns(new[] { "/js/site.js", "/common.js" });
-            var helper = new ScriptTagHelper
+
+            var helper = new ScriptTagHelper(
+                logger.Object,
+                hostingEnvironment,
+                MakeCache(),
+                new CommonTestEncoder(),
+                new CommonTestEncoder())
             {
                 GlobbingUrlBuilder = globbingUrlBuilder.Object,
-                Logger = logger.Object,
-                HostingEnvironment = hostingEnvironment,
                 ViewContext = viewContext,
                 Src = "/js/site.js",
                 SrcInclude = "**/*.js",
-                HtmlEncoder = new CommonTestEncoder(),
-                JavaScriptEncoder = new TestJavaScriptEncoder(),
-                Cache = MakeCache(),
             };
 
             // Act
@@ -617,16 +633,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var hostingEnvironment = MakeHostingEnvironment();
             var viewContext = MakeViewContext();
 
-            var helper = new ScriptTagHelper
+            var helper = new ScriptTagHelper(
+                logger.Object,
+                MakeHostingEnvironment(),
+                MakeCache(),
+                new CommonTestEncoder(),
+                new CommonTestEncoder())
             {
-                Logger = logger.Object,
-                HostingEnvironment = hostingEnvironment,
                 ViewContext = viewContext,
                 FileVersion = true,
-                HtmlEncoder = new CommonTestEncoder(),
-                JavaScriptEncoder = new TestJavaScriptEncoder(),
                 Src = "/js/site.js",
-                Cache = MakeCache(),
             };
 
             // Act
@@ -654,16 +670,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var hostingEnvironment = MakeHostingEnvironment();
             var viewContext = MakeViewContext("/bar");
 
-            var helper = new ScriptTagHelper
+            var helper = new ScriptTagHelper(
+                logger.Object,
+                MakeHostingEnvironment(),
+                MakeCache(),
+                new CommonTestEncoder(),
+                new CommonTestEncoder())
             {
-                Logger = logger.Object,
-                HostingEnvironment = hostingEnvironment,
                 ViewContext = viewContext,
                 FileVersion = true,
-                HtmlEncoder = new CommonTestEncoder(),
-                JavaScriptEncoder = new TestJavaScriptEncoder(),
                 Src = "/bar/js/site.js",
-                Cache = MakeCache(),
             };
 
             // Act
@@ -693,18 +709,18 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var hostingEnvironment = MakeHostingEnvironment();
             var viewContext = MakeViewContext();
 
-            var helper = new ScriptTagHelper
+            var helper = new ScriptTagHelper(
+                logger.Object,
+                MakeHostingEnvironment(),
+                MakeCache(),
+                new CommonTestEncoder(),
+                new CommonTestEncoder())
             {
-                Logger = logger.Object,
-                HostingEnvironment = hostingEnvironment,
                 ViewContext = viewContext,
                 FallbackSrc = "fallback.js",
                 FallbackTestExpression = "isavailable()",
                 FileVersion = true,
-                HtmlEncoder = new CommonTestEncoder(),
-                JavaScriptEncoder = new TestJavaScriptEncoder(),
                 Src = "/js/site.js",
-                Cache = MakeCache(),
             };
 
             // Act
@@ -713,7 +729,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Assert
             Assert.Equal(
                 "<script src=\"HtmlEncode[[/js/site.js?v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk]]\">" +
-                "</script>\r\n<script>(isavailable()||document.write(\"<script src=\\\"JavaScriptEncode[[fallback.js" +
+                "</script>\r\n<script>(isavailable()||document.write(\"<script src=\\\"JavaScriptStringEncode[[fallback.js" +
                 "?v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk]]\\\"><\\/script>\"));</script>",
                 output.Content.GetContent());
         }
@@ -736,18 +752,19 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var globbingUrlBuilder = new Mock<GlobbingUrlBuilder>();
             globbingUrlBuilder.Setup(g => g.BuildUrlList("/js/site.js", "*.js", null))
                 .Returns(new[] { "/js/site.js", "/common.js" });
-            var helper = new ScriptTagHelper
+
+            var helper = new ScriptTagHelper(
+                logger.Object,
+                MakeHostingEnvironment(),
+                MakeCache(),
+                new CommonTestEncoder(),
+                new CommonTestEncoder())
             {
                 GlobbingUrlBuilder = globbingUrlBuilder.Object,
-                Logger = logger.Object,
-                HostingEnvironment = hostingEnvironment,
                 ViewContext = viewContext,
                 SrcInclude = "*.js",
                 FileVersion = true,
-                HtmlEncoder = new CommonTestEncoder(),
-                JavaScriptEncoder = new TestJavaScriptEncoder(),
                 Src = "/js/site.js",
-                Cache = MakeCache(),
             };
 
             // Act

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/SelectTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/SelectTagHelperTest.cs
@@ -224,10 +224,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 }
             };
             var viewContext = TestableHtmlGenerator.GetViewContext(model, htmlGenerator, metadataProvider);
-            var tagHelper = new SelectTagHelper
+            var tagHelper = new SelectTagHelper(htmlGenerator)
             {
                 For = modelExpression,
-                Generator = htmlGenerator,
                 ViewContext = viewContext,
             };
 
@@ -319,10 +318,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var savedSelected = items.Select(item => item.Selected).ToList();
             var savedText = items.Select(item => item.Text).ToList();
             var savedValue = items.Select(item => item.Value).ToList();
-            var tagHelper = new SelectTagHelper
+
+            var tagHelper = new SelectTagHelper(htmlGenerator)
             {
                 For = modelExpression,
-                Generator = htmlGenerator,
                 Items = items,
                 ViewContext = viewContext,
             };
@@ -422,10 +421,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var savedSelected = items.Select(item => item.Selected).ToList();
             var savedText = items.Select(item => item.Text).ToList();
             var savedValue = items.Select(item => item.Value).ToList();
-            var tagHelper = new SelectTagHelper
+
+            var tagHelper = new SelectTagHelper(htmlGenerator)
             {
                 For = modelExpression,
-                Generator = htmlGenerator,
                 Items = items,
                 ViewContext = viewContext,
             };
@@ -519,11 +518,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 .Returns((TagBuilder)null)
                 .Verifiable();
 
-            var tagHelper = new SelectTagHelper
+            var tagHelper = new SelectTagHelper(htmlGenerator.Object)
             {
                 For = modelExpression,
                 Items = inputItems,
-                Generator = htmlGenerator.Object,
                 ViewContext = viewContext,
             };
 
@@ -593,10 +591,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 .Returns((TagBuilder)null)
                 .Verifiable();
 
-            var tagHelper = new SelectTagHelper
+            var tagHelper = new SelectTagHelper(htmlGenerator.Object)
             {
                 For = modelExpression,
-                Generator = htmlGenerator.Object,
                 ViewContext = viewContext,
             };
 

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TextAreaTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TextAreaTagHelperTest.cs
@@ -106,9 +106,17 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var propertyMetadata = metadataProvider.GetMetadataForProperty(containerType, "Text");
             var modelExplorer = containerExplorer.GetExplorerForExpression(propertyMetadata, model);
 
+            var htmlGenerator = new TestableHtmlGenerator(metadataProvider)
+            {
+                ValidationAttributes =
+                {
+                    {  "valid", "from validation attributes" },
+                }
+            };
+
             // Property name is either nameof(Model.Text) or nameof(NestedModel.Text).
             var modelExpression = new ModelExpression(nameAndId.Name, modelExplorer);
-            var tagHelper = new TextAreaTagHelper
+            var tagHelper = new TextAreaTagHelper(htmlGenerator)
             {
                 For = modelExpression,
             };
@@ -134,16 +142,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             };
             output.Content.SetContent("original content");
 
-            var htmlGenerator = new TestableHtmlGenerator(metadataProvider)
-            {
-                ValidationAttributes =
-                {
-                    {  "valid", "from validation attributes" },
-                }
-            };
             var viewContext = TestableHtmlGenerator.GetViewContext(model, htmlGenerator, metadataProvider);
             tagHelper.ViewContext = viewContext;
-            tagHelper.Generator = htmlGenerator;
 
             // Act
             await tagHelper.ProcessAsync(tagHelperContext, output);

--- a/test/WebSites/ActivatorWebSite/TagHelpers/FooterTagHelper.cs
+++ b/test/WebSites/ActivatorWebSite/TagHelpers/FooterTagHelper.cs
@@ -2,23 +2,28 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNet.Mvc;
-using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
+using Microsoft.Framework.WebEncoders;
 
 namespace ActivatorWebSite.TagHelpers
 {
     [TargetElement("body")]
     public class FooterTagHelper : TagHelper
     {
-        [Activate]
-        public IHtmlHelper HtmlHelper { get; set; }
+        public FooterTagHelper(IHtmlEncoder encoder)
+        {
+            Encoder = encoder;
+        }
 
-        [Activate]
-        public ViewDataDictionary ViewData { get; set; }
+        public IHtmlEncoder Encoder { get; }
+
+        [HtmlAttributeNotBound]
+        [ViewContext]
+        public ViewContext ViewContext { get; set; }
 
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
-            output.PostContent.SetContent($"<footer>{HtmlHelper.Encode(ViewData["footer"])}</footer>");
+            output.PostContent.SetContent($"<footer>{Encoder.HtmlEncode((string)ViewContext.ViewData["footer"])}</footer>");
         }
     }
 }

--- a/test/WebSites/ActivatorWebSite/TagHelpers/HiddenTagHelper.cs
+++ b/test/WebSites/ActivatorWebSite/TagHelpers/HiddenTagHelper.cs
@@ -11,13 +11,23 @@ namespace ActivatorWebSite.TagHelpers
     [TargetElement("span")]
     public class HiddenTagHelper : TagHelper
     {
-        public string Name { get; set; }
+        public HiddenTagHelper(IHtmlHelper htmlHelper)
+        {
+            HtmlHelper = htmlHelper;
+        }
 
-        [Activate]
-        public IHtmlHelper HtmlHelper { get; set; }
+        public IHtmlHelper HtmlHelper { get; }
+
+        [HtmlAttributeNotBound]
+        [ViewContext]
+        public ViewContext ViewContext { get; set; }
+
+        public string Name { get; set; }
 
         public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
+            (HtmlHelper as ICanHasViewContext)?.Contextualize(ViewContext);
+
             var content = await context.GetChildContentAsync();
 
             output.Content.SetContent(HtmlHelper.Hidden(Name, content).ToString());

--- a/test/WebSites/ActivatorWebSite/TagHelpers/RepeatContentTagHelper.cs
+++ b/test/WebSites/ActivatorWebSite/TagHelpers/RepeatContentTagHelper.cs
@@ -11,15 +11,25 @@ namespace ActivatorWebSite.TagHelpers
     [TargetElement("div")]
     public class RepeatContentTagHelper : TagHelper
     {
+        public RepeatContentTagHelper(IHtmlHelper htmlHelper)
+        {
+            HtmlHelper = htmlHelper;
+        }
+
+        public IHtmlHelper HtmlHelper { get; }
+
+        [HtmlAttributeNotBound]
+        [ViewContext]
+        public ViewContext ViewContext { get; set; }
+
         public int RepeatContent { get; set; }
 
         public ModelExpression Expression { get; set; }
 
-        [Activate]
-        public IHtmlHelper HtmlHelper { get; set; }
-
         public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
+            (HtmlHelper as ICanHasViewContext)?.Contextualize(ViewContext);
+
             var content = await context.GetChildContentAsync();
             var repeatContent = HtmlHelper.Encode(Expression.Model.ToString());
 

--- a/test/WebSites/ActivatorWebSite/TagHelpers/TitleTagHelper.cs
+++ b/test/WebSites/ActivatorWebSite/TagHelpers/TitleTagHelper.cs
@@ -4,21 +4,27 @@
 using Microsoft.AspNet.Mvc;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
-using Microsoft.AspNet.Razor.TagHelpers;
 
 namespace ActivatorWebSite.TagHelpers
 {
     [TargetElement("body")]
     public class TitleTagHelper : TagHelper
     {
-        [Activate]
-        public IHtmlHelper HtmlHelper { get; set; }
+        public TitleTagHelper(IHtmlHelper htmlHelper)
+        {
+            HtmlHelper = htmlHelper;
+        }
 
-        [Activate]
+        public IHtmlHelper HtmlHelper { get; }
+
+        [HtmlAttributeNotBound]
+        [ViewContext]
         public ViewContext ViewContext { get; set; }
 
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
+            (HtmlHelper as ICanHasViewContext)?.Contextualize(ViewContext);
+
             var builder = new TagBuilder("h2", HtmlHelper.HtmlEncoder);
             var title = ViewContext.ViewBag.Title;
             builder.InnerHtml = HtmlHelper.Encode(title);

--- a/test/WebSites/RequestServicesWebSite/RequestScopedTagHelper.cs
+++ b/test/WebSites/RequestServicesWebSite/RequestScopedTagHelper.cs
@@ -1,16 +1,18 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNet.Mvc;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
-using Microsoft.AspNet.Razor.TagHelpers;
 
 namespace RequestServicesWebSite
 {
     public class RequestScopedTagHelper : TagHelper
     {
-        [Activate]
-        public RequestIdService RequestIdService { get; set; }
+        public RequestScopedTagHelper(RequestIdService service)
+        {
+            RequestIdService = service;
+        }
+        
+        public RequestIdService RequestIdService { get; }
 
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/ATagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/ATagHelper.cs
@@ -9,9 +9,13 @@ namespace TagHelpersWebSite.TagHelpers
 {
     public class ATagHelper : TagHelper
     {
-        [Activate]
+        public ATagHelper(IUrlHelper urlHelper)
+        {
+            UrlHelper = urlHelper;
+        }
+
         [HtmlAttributeNotBound]
-        public IUrlHelper UrlHelper { get; set; }
+        public IUrlHelper UrlHelper { get; }
 
         public string Controller { get; set; }
 

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/PrettyTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/PrettyTagHelper.cs
@@ -25,7 +25,7 @@ namespace TagHelpersWebSite.TagHelpers
 
         public string Style { get; set; }
 
-        [Activate]
+        [ViewContext]
         [HtmlAttributeNotBound]
         public ViewContext ViewContext { get; set; }
 

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/TagCloudViewComponentTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/TagCloudViewComponentTagHelper.cs
@@ -25,8 +25,8 @@ namespace MvcSample.Web.Components
 
         public int Count { get; set; }
 
-        [Activate]
         [HtmlAttributeNotBound]
+        [ViewContext]
         public ViewContext ViewContext { get; set; }
 
         public int Order { get; } = 0;


### PR DESCRIPTION
This change removes [Activate] support from TagHelpers. TagHelpers which
need access to context should use [ViewContext] to have it injected. To
access services, use constructor injection.