### PR TITLE
Fix: Unable to use an incomplete `CacheProfile`

### DIFF
--- a/test/Microsoft.AspNet.Mvc.Core.Test/Filters/ResponseCacheAttributeTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Filters/ResponseCacheAttributeTest.cs
@@ -162,7 +162,7 @@ namespace Microsoft.AspNet.Mvc
         }
 
         [Fact]
-        public void CreateInstance_ThrowsWhenTheDurationIsNotSet_WithNoStoreFalse()
+        public void CreateInstance_DoesNotThrowWhenTheDurationIsNotSet_WithNoStoreFalse()
         {
             // Arrange
             var responseCache = new ResponseCacheAttribute()
@@ -172,12 +172,11 @@ namespace Microsoft.AspNet.Mvc
             var cacheProfiles = new Dictionary<string, CacheProfile>();
             cacheProfiles.Add("Test", new CacheProfile { NoStore = false });
 
-            // Act & Assert
-            var ex = Assert.Throws<InvalidOperationException>(
-                () => responseCache.CreateInstance(GetServiceProvider(cacheProfiles)));
-            Assert.Equal(
-                "If the 'NoStore' property is not set to true, 'Duration' property must be specified.",
-                ex.Message);
+            // Act
+	        var filter = responseCache.CreateInstance(GetServiceProvider(cacheProfiles));
+
+			// Assert
+	        Assert.NotNull(filter);
         }
 
         private IServiceProvider GetServiceProvider(Dictionary<string, CacheProfile> cacheProfiles)

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Filters/ResponseCacheFilterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Filters/ResponseCacheFilterTest.cs
@@ -323,6 +323,85 @@ namespace Microsoft.AspNet.Mvc
             Assert.False(cache.IsOverridden(context));
         }
 
+        [Fact]
+        public void FilterDurationProperty_OverridesCachePolicySetting()
+        {
+            // Arrange
+            var cache = new ResponseCacheFilter(
+                new CacheProfile
+                {
+                    Duration = 10
+                });
+            cache.Duration = 20;
+            var context = GetActionExecutingContext(new List<IFilter> { cache });
+
+            // Act
+            cache.OnActionExecuting(context);
+
+            // Assert
+            Assert.Equal("public,max-age=20", context.HttpContext.Response.Headers.Get("Cache-control"));
+        }
+
+        [Fact]
+        public void FilterLocationProperty_OverridesCachePolicySetting()
+        {
+            // Arrange
+            var cache = new ResponseCacheFilter(
+                new CacheProfile
+                {
+                    Duration = 10,
+                    Location = ResponseCacheLocation.None
+                });
+            cache.Location = ResponseCacheLocation.Client;
+            var context = GetActionExecutingContext(new List<IFilter> { cache });
+
+            // Act
+            cache.OnActionExecuting(context);
+
+            // Assert
+            Assert.Equal("private,max-age=10", context.HttpContext.Response.Headers.Get("Cache-control"));
+        }
+
+        [Fact]
+        public void FilterNoStoreProperty_OverridesCachePolicySetting()
+        {
+            // Arrange
+            var cache = new ResponseCacheFilter(
+                new CacheProfile
+                {
+                    NoStore = true
+                });
+            cache.NoStore = false;
+            cache.Duration = 10;
+            var context = GetActionExecutingContext(new List<IFilter> { cache });
+
+            // Act
+            cache.OnActionExecuting(context);
+
+            // Assert
+            Assert.Equal("public,max-age=10", context.HttpContext.Response.Headers.Get("Cache-control"));
+        }
+
+        [Fact]
+        public void FilterVaryByProperty_OverridesCachePolicySetting()
+        {
+            // Arrange
+            var cache = new ResponseCacheFilter(
+                new CacheProfile
+                {
+                    NoStore = true,
+                    VaryByHeader = "Accept"
+                });
+            cache.VaryByHeader = "Test";
+            var context = GetActionExecutingContext(new List<IFilter> { cache });
+
+            // Act
+            cache.OnActionExecuting(context);
+
+            // Assert
+            Assert.Equal("Test", context.HttpContext.Response.Headers.Get("Vary"));
+        }
+
         private ActionExecutingContext GetActionExecutingContext(List<IFilter> filters = null)
         {
             return new ActionExecutingContext(

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Filters/ResponseCacheFilterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Filters/ResponseCacheFilterTest.cs
@@ -31,17 +31,34 @@ namespace Microsoft.AspNet.Mvc
         }
 
         [Fact]
-        public void ResponseCacheFilter_ThrowsIfDurationIsNotSet_WhenNoStoreIsFalse()
+        public void ResponseCacheFilter_DoesNotThrowIfDurationIsNotSet_WhenNoStoreIsFalse()
         {
-            // Arrange, Act & Assert
-            var ex = Assert.Throws<InvalidOperationException>(
-                () => new ResponseCacheFilter(
-                    new CacheProfile
-                    {
-                        Duration = null
-                    }));
-            Assert.Equal(
-                "If the 'NoStore' property is not set to true, 'Duration' property must be specified.",
+            // Arrange, Act
+            var cache = new ResponseCacheFilter(
+                new CacheProfile
+                {
+                    Duration = null
+                });
+
+            // Assert
+            Assert.NotNull(cache);
+        }
+
+        [Fact]
+        public void OnActionExecuting_ThrowsIfDurationIsNotSet_WhenNoStoreIsFalse()
+        {
+            // Arrange
+            var cache = new ResponseCacheFilter(
+                new CacheProfile()
+                {
+                    Duration = null
+                });
+
+            var context = GetActionExecutingContext(new List<IFilter> { cache });
+
+            // Act & Assert
+            var ex = Assert.Throws<InvalidOperationException>(() => cache.OnActionExecuting(context));
+            Assert.Equal("If the 'NoStore' property is not set to true, 'Duration' property must be specified.",
                 ex.Message);
         }
 

--- a/test/WebSites/ResponseCacheWebSite/Controllers/CacheProfilesOverridesController.cs
+++ b/test/WebSites/ResponseCacheWebSite/Controllers/CacheProfilesOverridesController.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.AspNet.Mvc;
+
+namespace ResponseCacheWebSite.Controllers
+{
+    public class CacheProfilesOverridesController
+    {
+        [HttpGet("/CacheProfileOverrides/PublicCache30SecTo15Sec")]
+        [ResponseCache(CacheProfileName = "PublicCache30Sec", Duration = 15)]
+        public string PublicCache30SecTo15Sec()
+        {
+            return "Hello World!";
+        }
+
+        [HttpGet("/CacheProfileOverrides/PublicCache30SecToPrivateCache")]
+        [ResponseCache(CacheProfileName = "PublicCache30Sec", Location = ResponseCacheLocation.Client)]
+        public string PublicCache30SecToPrivateCache()
+        {
+            return "Hello World!";
+        }
+
+        [HttpGet("/CacheProfileOverrides/PublicCache30SecToNoStore")]
+        [ResponseCache(CacheProfileName = "PublicCache30Sec", NoStore = true)]
+        public string PublicCache30SecToNoStore()
+        {
+            return "Hello World!";
+        }
+
+        [HttpGet("/CacheProfileOverrides/PublicCache30SecWithVaryByAcceptToVaryByTest")]
+        [ResponseCache(CacheProfileName = "PublicCache30Sec", VaryByHeader = "Test")]
+        public string PublicCache30SecWithVaryByAcceptToVaryByTest()
+        {
+            return "Hello World!";
+        }
+
+        [HttpGet("/CacheProfileOverrides/PublicCache30SecWithVaryByAcceptToVaryByNone")]
+        [ResponseCache(CacheProfileName = "PublicCache30Sec", VaryByHeader = null)]
+        public string PublicCache30SecWithVaryByAcceptToVaryByNone()
+        {
+            return "Hello World!";
+        }
+    }
+}

--- a/test/WebSites/ResponseCacheWebSite/Startup.cs
+++ b/test/WebSites/ResponseCacheWebSite/Startup.cs
@@ -37,6 +37,14 @@ namespace ResponseCacheWebSite
                         Location = ResponseCacheLocation.None
                     });
 
+                options.CacheProfiles.Add(
+                    "PublicCache30SecVaryByAcceptHeader", new CacheProfile
+                    {
+                        Duration = 30,
+                        Location = ResponseCacheLocation.Any,
+                        VaryByHeader = "Accept"
+                    });
+
                 options.Filters.Add(new ResponseCacheFilter(new CacheProfile
                 {
                     NoStore = true,


### PR DESCRIPTION
Updated the `ResponseCacheFilter` to defer checking of cache parameters until `OnActionExecuting`

Resolves #2310 