### PR TITLE
Correct test expectations

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/DefaultControllerActionArgumentBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/DefaultControllerActionArgumentBinder.cs
@@ -81,24 +81,21 @@ namespace Microsoft.AspNet.Mvc
                 operationContext);
 
             var modelBindingResult = await operationContext.ModelBinder.BindModelAsync(modelBindingContext);
-            if (modelBindingResult != null && modelBindingResult.IsModelSet)
+            if (modelBindingResult != null &&
+                modelBindingResult.IsModelSet &&
+                modelBindingResult.ValidationNode != null)
             {
-                var key = modelBindingResult.Key;
                 var modelExplorer = new ModelExplorer(
                     _modelMetadataProvider,
                     metadata,
                     modelBindingResult.Model);
+                var validationContext = new ModelValidationContext(
+                    modelBindingContext.BindingSource,
+                    operationContext.ValidatorProvider,
+                    modelState,
+                    modelExplorer);
 
-                if (modelBindingResult.ValidationNode != null)
-                {
-                    var validationContext = new ModelValidationContext(
-                        modelBindingContext.BindingSource,
-                        operationContext.ValidatorProvider,
-                        modelState,
-                        modelExplorer);
-
-                    _validator.Validate(validationContext, modelBindingResult.ValidationNode);
-                }
+                _validator.Validate(validationContext, modelBindingResult.ValidationNode);
             }
 
             return modelBindingResult;

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/ComplexModelDtoModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/ComplexModelDtoModelBinder.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                     await bindingContext.OperationBindingContext.ModelBinder.BindModelAsync(propertyBindingContext);
                 if (modelBindingResult == null)
                 {
-                    // Could not bind. Add a result so MutableObjectModelBinder will check for [DefaultValue].
+                    // Could not bind. Let MutableObjectModelBinder know explicitly.
                     dto.Results[propertyMetadata] =
                         new ModelBindingResult(model: null, key: propertyModelName, isModelSet: false);
                 }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BinderTypeBasedModelBinderModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BinderTypeBasedModelBinderModelBinderTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
     public class BinderTypeBasedModelBinderModelBinderTest
     {
         [Fact]
-        public async Task BindModel_ReturnsFalseIfNoBinderTypeIsSet()
+        public async Task BindModel_ReturnsNull_IfNoBinderTypeIsSet()
         {
             // Arrange
             var bindingContext = GetBindingContext(typeof(Person));
@@ -30,10 +30,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         }
 
         [Fact]
-        public async Task BindModel_ReturnsTrueEvenIfSelectedBinderReturnsFalse()
+        public async Task BindModel_ReturnsNotNull_EvenIfSelectedBinderReturnsNull()
         {
             // Arrange
-            var bindingContext = GetBindingContext(typeof(Person), binderType: typeof(FalseModelBinder));
+            var bindingContext = GetBindingContext(typeof(Person), binderType: typeof(NullModelBinder));
 
             var binder = new BinderTypeBasedModelBinder();
 
@@ -48,7 +48,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         public async Task BindModel_CallsBindAsync_OnProvidedModelBinder()
         {
             // Arrange
-            var bindingContext = GetBindingContext(typeof(Person), binderType: typeof(TrueModelBinder));
+            var bindingContext = GetBindingContext(typeof(Person), binderType: typeof(NotNullModelBinder));
 
             var model = new Person();
             var serviceProvider = new ServiceCollection()
@@ -121,7 +121,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             public int Age { get; set; }
         }
 
-        private class FalseModelBinder : IModelBinder
+        private class NullModelBinder : IModelBinder
         {
             public Task<ModelBindingResult> BindModelAsync(ModelBindingContext bindingContext)
             {
@@ -129,11 +129,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             }
         }
 
-        private class TrueModelBinder : IModelBinder
+        private class NotNullModelBinder : IModelBinder
         {
             private readonly object _model;
 
-            public TrueModelBinder()
+            public NotNullModelBinder()
             {
                 _model = new Person();
             }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BindingSourceModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BindingSourceModelBinderTest.cs
@@ -27,18 +27,18 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             // Act & Assert
             var exception = Assert.Throws<ArgumentException>(
-                () => new TestableBindingSourceModelBinder(bindingSource));
+                () => new TestableBindingSourceModelBinder(bindingSource, isModelSet: false));
             Assert.Equal(expected, exception.Message);
         }
 
         [Fact]
-        public async Task BindingSourceModelBinder_ReturnsFalse_WithNoSource()
+        public async Task BindingSourceModelBinder_ReturnsNull_WithNoSource()
         {
             // Arrange
             var context = new ModelBindingContext();
             context.ModelMetadata = new EmptyModelMetadataProvider().GetMetadataForType(typeof(string));
 
-            var binder = new TestableBindingSourceModelBinder(BindingSource.Body);
+            var binder = new TestableBindingSourceModelBinder(BindingSource.Body, isModelSet: false);
 
             // Act
             var result = await binder.BindModelAsync(context);
@@ -49,7 +49,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         }
 
         [Fact]
-        public async Task BindingSourceModelBinder_ReturnsFalse_NonMatchingSource()
+        public async Task BindingSourceModelBinder_ReturnsNull_NonMatchingSource()
         {
             // Arrange
             var provider = new TestModelMetadataProvider();
@@ -58,7 +58,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var context = new ModelBindingContext();
             context.ModelMetadata = provider.GetMetadataForType(typeof(string));
 
-            var binder = new TestableBindingSourceModelBinder(BindingSource.Body);
+            var binder = new TestableBindingSourceModelBinder(BindingSource.Body, isModelSet: false);
 
             // Act
             var result = await binder.BindModelAsync(context);
@@ -68,8 +68,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             Assert.False(binder.WasBindModelCoreCalled);
         }
 
-        [Fact]
-        public async Task BindingSourceModelBinder_ReturnsTrue_MatchingSource()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task BindingSourceModelBinder_ReturnsNonNull_MatchingSource(bool isModelSet)
         {
             // Arrange
             var provider = new TestModelMetadataProvider();
@@ -82,30 +84,35 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 BinderModelName = modelMetadata.BinderModelName
             };
 
-            var binder = new TestableBindingSourceModelBinder(BindingSource.Body);
+            var binder = new TestableBindingSourceModelBinder(BindingSource.Body, isModelSet);
 
             // Act
             var result = await binder.BindModelAsync(context);
 
             // Assert
             Assert.NotNull(result);
-            Assert.False(result.IsModelSet);
+            Assert.Equal(isModelSet, result.IsModelSet);
+            Assert.Null(result.Model);
             Assert.True(binder.WasBindModelCoreCalled);
         }
 
         private class TestableBindingSourceModelBinder : BindingSourceModelBinder
         {
-            public bool WasBindModelCoreCalled { get; private set; }
+            bool _isModelSet;
 
-            public TestableBindingSourceModelBinder(BindingSource source)
+            public TestableBindingSourceModelBinder(BindingSource source, bool isModelSet)
                 : base(source)
             {
+                _isModelSet = isModelSet;
             }
+
+            public bool WasBindModelCoreCalled { get; private set; }
 
             protected override Task<ModelBindingResult> BindModelCoreAsync([NotNull] ModelBindingContext bindingContext)
             {
                 WasBindModelCoreCalled = true;
-                return Task.FromResult(new ModelBindingResult(model: null, key: bindingContext.ModelName, isModelSet: false));
+                return Task.FromResult(
+                    new ModelBindingResult(model: null, key: bindingContext.ModelName, isModelSet: _isModelSet));
             }
         }
     }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BindingSourceModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BindingSourceModelBinderTest.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             var binder = new TestableBindingSourceModelBinder(BindingSource.Body);
 
-            // Act 
+            // Act
             var result = await binder.BindModelAsync(context);
 
             // Assert
@@ -60,7 +60,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             var binder = new TestableBindingSourceModelBinder(BindingSource.Body);
 
-            // Act 
+            // Act
             var result = await binder.BindModelAsync(context);
 
             // Assert
@@ -84,12 +84,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             var binder = new TestableBindingSourceModelBinder(BindingSource.Body);
 
-            // Act 
+            // Act
             var result = await binder.BindModelAsync(context);
 
             // Assert
             Assert.NotNull(result);
-            Assert.True(result.IsModelSet);
+            Assert.False(result.IsModelSet);
             Assert.True(binder.WasBindModelCoreCalled);
         }
 
@@ -105,7 +105,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             protected override Task<ModelBindingResult> BindModelCoreAsync([NotNull] ModelBindingContext bindingContext)
             {
                 WasBindModelCoreCalled = true;
-                return Task.FromResult(new ModelBindingResult(null, bindingContext.ModelName, true));
+                return Task.FromResult(new ModelBindingResult(model: null, key: bindingContext.ModelName, isModelSet: false));
             }
         }
     }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/ByteArrayModelBinderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/ByteArrayModelBinderTests.cs
@@ -3,7 +3,6 @@
 
 #if DNX451
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Testing;
 using Xunit;
@@ -81,7 +80,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         }
 
         [Fact]
-        public async Task BindModelReturnsFalseWhenValueNotFound()
+        public async Task BindModel_ReturnsNull_WhenValueNotFound()
         {
             // Arrange
             var valueProvider = new SimpleHttpValueProvider()
@@ -100,7 +99,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         }
 
         [Fact]
-        public async Task ByteArrayModelBinderReturnsFalseForOtherTypes()
+        public async Task BindModel_ReturnsNull_ForOtherTypes()
         {
             // Arrange
             var bindingContext = GetBindingContext(null, typeof(int[]));

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CancellationTokenModelBinderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CancellationTokenModelBinderTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
     public class CancellationTokenModelBinderTests
     {
         [Fact]
-        public async Task CancellationTokenModelBinder_ReturnsTrue_ForCancellationTokenType()
+        public async Task CancellationTokenModelBinder_ReturnsNotNull_ForCancellationTokenType()
         {
             // Arrange
             var bindingContext = GetBindingContext(typeof(CancellationToken));
@@ -30,7 +30,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         [InlineData(typeof(int))]
         [InlineData(typeof(object))]
         [InlineData(typeof(CancellationTokenModelBinderTests))]
-        public async Task CancellationTokenModelBinder_ReturnsFalse_ForNonCancellationTokenType(Type t)
+        public async Task CancellationTokenModelBinder_ReturnsNull_ForNonCancellationTokenType(Type t)
         {
             // Arrange
             var bindingContext = GetBindingContext(t);

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CompositeModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CompositeModelBinderTest.cs
@@ -291,7 +291,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var modelBinder = new Mock<IModelBinder>();
             modelBinder
                 .Setup(mb => mb.BindModelAsync(It.IsAny<ModelBindingContext>()))
-                .Returns(Task.FromResult(new ModelBindingResult(null, "someName", true)));
+                .Returns(Task.FromResult(new ModelBindingResult(model: "some value", key: "someName", isModelSet: true)));
 
             var composite = CreateCompositeBinder(modelBinder.Object);
 
@@ -302,7 +302,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             Assert.NotNull(result);
             Assert.True(result.IsModelSet);
             Assert.Equal("someName", result.Key);
-            Assert.Null(result.Model);
+            Assert.Equal("some value", result.Model);
         }
 
         [Fact]
@@ -445,6 +445,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
                 .Returns(
                     delegate (ModelBindingContext context)
                     {
+                        // Note this ModelBindingResult is not valid.
                         return Task.FromResult(
                             new ModelBindingResult(model: 42, key: "someName", isModelSet: false));
                     });
@@ -455,7 +456,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            // The result is null because of issue #2473
             Assert.Null(result);
         }
 

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CompositeModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CompositeModelBinderTest.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc.ModelBinding.Validation;
 using Moq;
@@ -268,10 +267,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         }
 
         [Fact]
-        public async Task ModelBinder_ReturnsTrue_SetsNullValue_SetsModelStateKey()
+        public async Task ModelBinder_ReturnsNotNull_SetsNullValue_SetsModelStateKey()
         {
             // Arrange
-
             var bindingContext = new ModelBindingContext
             {
                 FallbackToEmptyPrefix = true,
@@ -291,7 +289,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var modelBinder = new Mock<IModelBinder>();
             modelBinder
                 .Setup(mb => mb.BindModelAsync(It.IsAny<ModelBindingContext>()))
-                .Returns(Task.FromResult(new ModelBindingResult(model: "some value", key: "someName", isModelSet: true)));
+                .Returns(Task.FromResult(new ModelBindingResult(model: null, key: "someName", isModelSet: true)));
 
             var composite = CreateCompositeBinder(modelBinder.Object);
 
@@ -302,7 +300,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             Assert.NotNull(result);
             Assert.True(result.IsModelSet);
             Assert.Equal("someName", result.Key);
-            Assert.Equal("some value", result.Model);
+            Assert.Null(result.Model);
         }
 
         [Fact]
@@ -445,7 +443,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
                 .Returns(
                     delegate (ModelBindingContext context)
                     {
-                        // Note this ModelBindingResult is not valid.
                         return Task.FromResult(
                             new ModelBindingResult(model: 42, key: "someName", isModelSet: false));
                     });

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/FormValueProviderFactoryTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/FormValueProviderFactoryTests.cs
@@ -33,8 +33,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         [Theory]
         [InlineData("application/x-www-form-urlencoded")]
         [InlineData("application/x-www-form-urlencoded;charset=utf-8")]
-        [InlineData("multipart/form-data")]
-        [InlineData("multipart/form-data;charset=utf-8")]
+        [InlineData("multipart/form-data; boundary=----WebKitFormBoundarymx2fSWqWSd0OxQqq")]
+        [InlineData("multipart/form-data; boundary=----WebKitFormBoundarymx2fSWqWSd0OxQqq; charset=utf-8")]
         public void GetValueProvider_ReturnsValueProviderInstanceWithInvariantCulture(string contentType)
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/HeaderModelBinderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/HeaderModelBinderTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         [InlineData(typeof(int))]
         [InlineData(typeof(int[]))]
         [InlineData(typeof(BindingSource))]
-        public async Task BindModelAsync_ReturnsTrue_ForAllTypes(Type type)
+        public async Task BindModelAsync_ReturnsNotNull_ForAllTypes(Type type)
         {
             // Arrange
             var binder = new HeaderModelBinder();

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/KeyValuePairModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/KeyValuePairModelBinderTest.cs
@@ -139,13 +139,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var innerBinder = new Mock<IModelBinder>();
             innerBinder
                 .Setup(o => o.BindModelAsync(It.IsAny<ModelBindingContext>()))
-                .Returns((ModelBindingContext mbc) =>
+                .Returns((ModelBindingContext context) =>
                 {
-                    Assert.Equal("someName.key", mbc.ModelName);
-                    return Task.FromResult(new ModelBindingResult(null, string.Empty, true));
+                    Assert.Equal("someName.key", context.ModelName);
+                    return Task.FromResult(new ModelBindingResult(model: "not int", key: string.Empty, isModelSet: true));
                 });
             var bindingContext = GetBindingContext(new SimpleHttpValueProvider(), innerBinder.Object);
-
 
             var binder = new KeyValuePairModelBinder<int, string>();
             var modelValidationNodeList = new List<ModelValidationNode>();
@@ -155,7 +154,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
 
             // Assert
             Assert.True(result.IsModelSet);
-            Assert.Null(result.Model);
+            Assert.Equal("not int", result.Model);
             Assert.Empty(bindingContext.ModelState);
         }
 

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/TypeConverterModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/TypeConverterModelBinderTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         [InlineData(typeof(object))]
         [InlineData(typeof(Calendar))]
         [InlineData(typeof(TestClass))]
-        public async Task BindModel_ReturnsFalse_IfTypeCannotBeConverted(Type destinationType)
+        public async Task BindModel_ReturnsNull_IfTypeCannotBeConverted(Type destinationType)
         {
             // Arrange
             var bindingContext = GetBindingContext(destinationType);
@@ -42,7 +42,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         [InlineData(typeof(DateTimeOffset))]
         [InlineData(typeof(double))]
         [InlineData(typeof(DayOfWeek))]
-        public async Task BindModel_ReturnsTrue_IfTypeCanBeConverted(Type destinationType)
+        public async Task BindModel_ReturnsNotNull_IfTypeCanBeConverted(Type destinationType)
         {
             if (TestPlatformHelper.IsMono &&
                 destinationType == typeof(DateTimeOffset))
@@ -92,7 +92,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         }
 
         [Fact]
-        public async Task BindModel_NullValueProviderResult_ReturnsFalse()
+        public async Task BindModel_NullValueProviderResult_ReturnsNull()
         {
             // Arrange
             var bindingContext = GetBindingContext(typeof(int));

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/TypeMatchModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/TypeMatchModelBinderTest.cs
@@ -1,9 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Framework.Internal;
 using Xunit;
 
 namespace Microsoft.AspNet.Mvc.ModelBinding.Test
@@ -11,7 +9,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
     public class TypeMatchModelBinderTest
     {
         [Fact]
-        public async Task BindModel_InvalidValueProviderResult_ReturnsFalse()
+        public async Task BindModel_InvalidValueProviderResult_ReturnsNull()
         {
             // Arrange
             var bindingContext = GetBindingContext();
@@ -33,7 +31,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         }
 
         [Fact]
-        public async Task BindModel_ValidValueProviderResult_ReturnsTrue()
+        public async Task BindModel_ValidValueProviderResult_ReturnsNotNull()
         {
             // Arrange
             var bindingContext = GetBindingContext();

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ParameterBinding/ControllerActionArgumentBinderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ParameterBinding/ControllerActionArgumentBinderTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
     public class ControllerActionArgumentBinderTests
     {
         [Fact]
-        public async Task BindActionArgumentsAsync_DoesNotAddActionArguments_IfBinderReturnsFalse()
+        public async Task BindActionArgumentsAsync_DoesNotAddActionArguments_IfBinderReturnsNull()
         {
             // Arrange
             var actionDescriptor = GetActionDescriptor();
@@ -91,7 +91,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
         }
 
         [Fact]
-        public async Task BindActionArgumentsAsync_AddsActionArguments_IfBinderReturnsTrue()
+        public async Task BindActionArgumentsAsync_AddsActionArguments_IfBinderReturnsNotNull()
         {
             // Arrange
             Func<object, int> method = foo => 1;
@@ -114,7 +114,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
                 {
                     context.ModelMetadata = metadataProvider.GetMetadataForType(typeof(string));
                 })
-                .Returns(Task.FromResult(result: new ModelBindingResult(value, "", true)));
+                .Returns(Task.FromResult(result: new ModelBindingResult(value, key: string.Empty, isModelSet: true)));
 
             var actionContext = new ActionContext(
                 new DefaultHttpContext(),
@@ -342,8 +342,10 @@ namespace Microsoft.AspNet.Mvc.Core.Test
             Assert.Null(controller.UntouchedProperty);
         }
 
-        [Fact]
-        public async Task BindActionArgumentsAsync_DoesNotSetNullValues_ForNonNullableProperties()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task BindActionArgumentsAsync_DoesNotSetNullValues_ForNonNullableProperties(bool isModelSet)
         {
             // Arrange
             var actionDescriptor = GetActionDescriptor();
@@ -361,7 +363,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
             binder
                 .Setup(b => b.BindModelAsync(It.IsAny<ModelBindingContext>()))
                 .Returns(Task.FromResult(
-                    result: new ModelBindingResult(model: null, key: string.Empty, isModelSet: false)));
+                    result: new ModelBindingResult(model: null, key: string.Empty, isModelSet: isModelSet)));
             var actionBindingContext = new ActionBindingContext()
             {
                 ModelBinder = binder.Object,

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ParameterBinding/ControllerActionArgumentBinderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ParameterBinding/ControllerActionArgumentBinderTests.cs
@@ -361,7 +361,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
             binder
                 .Setup(b => b.BindModelAsync(It.IsAny<ModelBindingContext>()))
                 .Returns(Task.FromResult(
-                    result: new ModelBindingResult(model: null, key: string.Empty, isModelSet: true)));
+                    result: new ModelBindingResult(model: null, key: string.Empty, isModelSet: false)));
             var actionBindingContext = new ActionBindingContext()
             {
                 ModelBinder = binder.Object,

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ParameterBinding/ModelBindingHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ParameterBinding/ModelBindingHelperTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNet.Mvc.Test
     public class ModelBindingHelperTest
     {
         [Fact]
-        public async Task TryUpdateModel_ReturnsFalse_IfBinderReturnsFalse()
+        public async Task TryUpdateModel_ReturnsFalse_IfBinderReturnsNull()
         {
             // Arrange
             var metadataProvider = new EmptyModelMetadataProvider();
@@ -28,7 +28,7 @@ namespace Microsoft.AspNet.Mvc.Test
             binder.Setup(b => b.BindModelAsync(It.IsAny<ModelBindingContext>()))
                   .Returns(Task.FromResult<ModelBindingResult>(null));
             var model = new MyModel();
-            
+
             // Act
             var result = await ModelBindingHelper.TryUpdateModelAsync(
                 model,
@@ -130,7 +130,7 @@ namespace Microsoft.AspNet.Mvc.Test
         }
 
         [Fact]
-        public async Task TryUpdateModel_UsingIncludePredicateOverload_ReturnsFalse_IfBinderReturnsFalse()
+        public async Task TryUpdateModel_UsingIncludePredicateOverload_ReturnsFalse_IfBinderReturnsNull()
         {
             // Arrange
             var metadataProvider = new EmptyModelMetadataProvider();
@@ -219,7 +219,7 @@ namespace Microsoft.AspNet.Mvc.Test
         }
 
         [Fact]
-        public async Task TryUpdateModel_UsingIncludeExpressionOverload_ReturnsFalse_IfBinderReturnsFalse()
+        public async Task TryUpdateModel_UsingIncludeExpressionOverload_ReturnsFalse_IfBinderReturnsNull()
         {
             // Arrange
             var metadataProvider = new EmptyModelMetadataProvider();
@@ -475,7 +475,7 @@ namespace Microsoft.AspNet.Mvc.Test
         }
 
         [Fact]
-        public async Task TryUpdateModelNonGeneric_PredicateOverload_ReturnsFalse_IfBinderReturnsFalse()
+        public async Task TryUpdateModelNonGeneric_PredicateOverload_ReturnsFalse_IfBinderReturnsNull()
         {
             // Arrange
             var metadataProvider = new EmptyModelMetadataProvider();
@@ -568,7 +568,7 @@ namespace Microsoft.AspNet.Mvc.Test
         }
 
         [Fact]
-        public async Task TryUpdateModelNonGeneric_ModelTypeOverload_ReturnsFalse_IfBinderReturnsFalse()
+        public async Task TryUpdateModelNonGeneric_ModelTypeOverload_ReturnsFalse_IfBinderReturnsNull()
         {
             // Arrange
             var metadataProvider = new EmptyModelMetadataProvider();
@@ -774,7 +774,7 @@ namespace Microsoft.AspNet.Mvc.Test
             dictionary["product.Category.Name"] = new ModelState { ValidationState = ModelValidationState.Valid };
             dictionary["product.Order[0].Name"] = new ModelState { ValidationState = ModelValidationState.Invalid };
             dictionary.AddModelError("product.Order[0].Name", "Order name invalid.");
-            dictionary["product.Order[0].Address.Street"] = 
+            dictionary["product.Order[0].Address.Street"] =
                 new ModelState { ValidationState = ModelValidationState.Invalid };
             dictionary.AddModelError("product.Order[0].Address.Street", "Street invalid.");
             dictionary["product.Order[1].Name"] = new ModelState { ValidationState = ModelValidationState.Valid };

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/FormCollectionModelBindingIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/FormCollectionModelBindingIntegrationTest.cs
@@ -144,9 +144,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 ParameterType = typeof(FormCollection)
             };
 
-            // No data is passed. The FormCollectionModelBinder should ensure no later binders run.
-            var operationContext = ModelBindingTestHelper.GetOperationBindingContext(
-                updateOptions: ModelBindingTestHelper.UpdateOptionsToEnsureNothingFollows<FormCollectionModelBinder>);
+            // No data is passed.
+            var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
+            {
+            });
 
             var modelState = new ModelStateDictionary();
 

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/FormCollectionModelBindingIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/FormCollectionModelBindingIntegrationTest.cs
@@ -128,8 +128,8 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Empty(modelState.Keys);
         }
 
-        [Fact(Skip = "FormCollection should not return null modelBindingResult for a type that matches. #2456")]
-        public async Task BindParameter_NoData_DoesNotGetBound()
+        [Fact]
+        public async Task BindParameter_NoData_BindsWithEmptyCollection()
         {
             // Arrange
             var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
@@ -144,10 +144,9 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 ParameterType = typeof(FormCollection)
             };
 
-            // No data is passed.
-            var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
-            {
-            });
+            // No data is passed. The FormCollectionModelBinder should ensure no later binders run.
+            var operationContext = ModelBindingTestHelper.GetOperationBindingContext(
+                updateOptions: ModelBindingTestHelper.UpdateOptionsToEnsureNothingFollows<FormCollectionModelBinder>);
 
             var modelState = new ModelStateDictionary();
 
@@ -158,11 +157,16 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             // ModelBindingResult
             Assert.NotNull(modelBindingResult);
-            Assert.Null(modelBindingResult.Model);
+            var collection = Assert.IsType<FormCollection>(modelBindingResult.Model);
 
             // ModelState
             Assert.True(modelState.IsValid);
             Assert.Empty(modelState.Keys);
+
+            // FormCollection
+            Assert.Empty(collection);
+            Assert.Empty(collection.Files);
+            Assert.Empty(collection.Keys);
         }
 
         private void UpdateRequest(HttpRequest request, string data, string name)
@@ -172,7 +176,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(data));
 
             request.Form = formCollection;
-            request.ContentType = "multipart/form-data";
+            request.ContentType = "multipart/form-data; boundary=----WebKitFormBoundarymx2fSWqWSd0OxQqq";
             request.Headers["Content-Disposition"] = "form-data; name=" + name + "; filename=text.txt";
             fileCollection.Add(new FormFile(memoryStream, 0, data.Length)
             {

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/FormFileModelBindingIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/FormFileModelBindingIntegrationTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -125,7 +126,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Empty(modelState.Keys);
         }
 
-        [Fact(Skip = "FormFile Should not return null modelBindingResult for a type that matches. #2456")]
+        [Fact]
         public async Task BindParameter_NoData_DoesNotGetBound()
         {
             // Arrange
@@ -141,11 +142,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 ParameterType = typeof(IFormFile)
             };
 
-            // No data is passed.
-            var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
-            {
-                request.ContentType = "multipart/form-data";
-            });
+            // No data is passed. The FormFileModelBinder should ensure no later binders run.
+            var operationContext = ModelBindingTestHelper.GetOperationBindingContext(
+                request => UpdateRequest(request, data: null, name: null),
+                ModelBindingTestHelper.UpdateOptionsToEnsureNothingFollows<FormFileModelBinder>);
 
             var modelState = new ModelStateDictionary();
 
@@ -154,9 +154,8 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             // Assert
 
-            // ModelBindingResult
-            Assert.NotNull(modelBindingResult); // Fails due to bug #2456
-            Assert.Null(modelBindingResult.Model);
+            // ModelBindingResult; expect null because binding failed.
+            Assert.Null(modelBindingResult);
 
             // ModelState
             Assert.True(modelState.IsValid);
@@ -167,11 +166,19 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
         {
             var fileCollection = new FormFileCollection();
             var formCollection = new FormCollection(new Dictionary<string, string[]>(), fileCollection);
-            var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(data));
 
             request.Form = formCollection;
-            request.ContentType = "multipart/form-data";
+            request.ContentType = "multipart/form-data; boundary=----WebKitFormBoundarymx2fSWqWSd0OxQqq";
+
+            if (string.IsNullOrEmpty(data) || string.IsNullOrEmpty(name))
+            {
+                // Leave the submission empty.
+                return;
+            }
+
             request.Headers["Content-Disposition"] = "form-data; name=" + name + "; filename=text.txt";
+
+            var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(data));
             fileCollection.Add(new FormFile(memoryStream, 0, data.Length)
             {
                 Headers = request.Headers

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/FormFileModelBindingIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/FormFileModelBindingIntegrationTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -142,10 +141,9 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 ParameterType = typeof(IFormFile)
             };
 
-            // No data is passed. The FormFileModelBinder should ensure no later binders run.
+            // No data is passed.
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext(
-                request => UpdateRequest(request, data: null, name: null),
-                ModelBindingTestHelper.UpdateOptionsToEnsureNothingFollows<FormFileModelBinder>);
+                request => UpdateRequest(request, data: null, name: null));
 
             var modelState = new ModelStateDictionary();
 

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/HeaderModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/HeaderModelBinderIntegrationTest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             };
 
             // Do not add any headers.
-            var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request => { });
+            var operationContext = ModelBindingTestHelper.GetOperationBindingContext();
             var modelState = new ModelStateDictionary();
 
             // Act

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/ModelBindingTestHelper.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/ModelBindingTestHelper.cs
@@ -2,12 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Internal;
 using Microsoft.AspNet.Mvc.ModelBinding;
 using Microsoft.AspNet.Mvc.ModelBinding.Validation;
 using Microsoft.AspNet.Routing;
 using Microsoft.Framework.DependencyInjection;
+using Xunit;
 
 namespace Microsoft.AspNet.Mvc.IntegrationTests
 {
@@ -67,6 +69,21 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                     metadataProvider);
         }
 
+        public static void UpdateOptionsToEnsureNothingFollows<TModelBinder>(MvcOptions options)
+        {
+            var index = 0;
+            for (; index < options.ModelBinders.Count; index++)
+            {
+                if (typeof(TModelBinder) == options.ModelBinders[index].GetType())
+                {
+                    options.ModelBinders.Insert(index + 1, new AssertIfCalledModelBinder());
+                    return;
+                }
+            }
+
+            Assert.False(true, $"Unable to find { typeof(TModelBinder).FullName } in { nameof(MvcOptions) }.");
+        }
+
         private static void InitializeServices(HttpContext httpContext, Action<MvcOptions> updateOptions = null)
         {
             var serviceCollection = new ServiceCollection();
@@ -109,6 +126,16 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 ModelBinder = new CompositeModelBinder(options.ModelBinders),
                 ValueProvider = valueProvider
             };
+        }
+
+        private class AssertIfCalledModelBinder : IModelBinder
+        {
+            public Task<ModelBindingResult> BindModelAsync(ModelBindingContext bindingContext)
+            {
+                Assert.False(true, "This model binder should never be used");
+
+                return Task.FromResult<ModelBindingResult>(result: null);
+            }
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/ModelBindingTestHelper.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/ModelBindingTestHelper.cs
@@ -2,14 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Internal;
 using Microsoft.AspNet.Mvc.ModelBinding;
 using Microsoft.AspNet.Mvc.ModelBinding.Validation;
 using Microsoft.AspNet.Routing;
 using Microsoft.Framework.DependencyInjection;
-using Xunit;
 
 namespace Microsoft.AspNet.Mvc.IntegrationTests
 {
@@ -69,21 +67,6 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                     metadataProvider);
         }
 
-        public static void UpdateOptionsToEnsureNothingFollows<TModelBinder>(MvcOptions options)
-        {
-            var index = 0;
-            for (; index < options.ModelBinders.Count; index++)
-            {
-                if (typeof(TModelBinder) == options.ModelBinders[index].GetType())
-                {
-                    options.ModelBinders.Insert(index + 1, new AssertIfCalledModelBinder());
-                    return;
-                }
-            }
-
-            Assert.False(true, $"Unable to find { typeof(TModelBinder).FullName } in { nameof(MvcOptions) }.");
-        }
-
         private static void InitializeServices(HttpContext httpContext, Action<MvcOptions> updateOptions = null)
         {
             var serviceCollection = new ServiceCollection();
@@ -126,16 +109,6 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 ModelBinder = new CompositeModelBinder(options.ModelBinders),
                 ValueProvider = valueProvider
             };
-        }
-
-        private class AssertIfCalledModelBinder : IModelBinder
-        {
-            public Task<ModelBindingResult> BindModelAsync(ModelBindingContext bindingContext)
-            {
-                Assert.False(true, "This model binder should never be used");
-
-                return Task.FromResult<ModelBindingResult>(result: null);
-            }
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/MutableObjectModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/MutableObjectModelBinderIntegrationTest.cs
@@ -2043,7 +2043,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(content));
 
             request.Form = formCollection;
-            request.ContentType = "multipart/form-data";
+            request.ContentType = "multipart/form-data; boundary=----WebKitFormBoundarymx2fSWqWSd0OxQqq";
             request.Headers["Content-Disposition"] = "form-data; name=" + name + "; filename=text.txt";
 
             fileCollection.Add(new FormFile(memoryStream, 0, memoryStream.Length)

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/MutableObjectModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/MutableObjectModelBinderIntegrationTest.cs
@@ -397,7 +397,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
         // We don't provide enough data in this test for the 'Person' model to be created. So even though there is
         // a [FromServices], it won't be used.
-        [Fact(Skip = "Extra entries in model state  #2646.")]
+        [Fact]
         public async Task MutableObjectModelBinder_BindsNestedPOCO_WithServicesModelBinder_WithPrefix_NoData()
         {
             // Arrange


### PR DESCRIPTION
### Correct test expectations
- use valid `multipart/form-data` content type; include a `boundary`
- correct expectations of `FormCollection` model binder's operation
 - restore tests actually skipped for either of the above reasons
- add more tests with `ModelBindingResult.Model==null` and both `IsModelSet` values

#### Remove test references to Won't Fix bug #2473
- restore #2473 tests; update test expectations
- expect `null` composite results whenever binding fails

#### Restore test skipped due to "#2646"
- that issue does not exist; was likely #2466 or similar fixed bug

#### Rename model binding tests that still mention `ReturnsFalse` or `ReturnsTrue`

#### Minor src changes
- remove unused variable and unnecessary nesting in `DefaultControllerActionArgumentBinder`
- remove dangling mention of `[DefaultValue]` in `ComplexModelDtoModelBinder`

#### nits:
- remove empty delegates from some `GetOperationBindingContext` calls; `null` fine
- do some `using` cleanup
- combine two test methods in `KeyValuePairModelBinderTest`
- name a few more arguments