### PR TITLE
`ByteArrayModelBinder` should return `null` only when type is not matched

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/ByteArrayModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/ByteArrayModelBinder.cs
@@ -15,6 +15,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// <inheritdoc />
         public async Task<ModelBindingResult> BindModelAsync([NotNull] ModelBindingContext bindingContext)
         {
+            // Check if this binder applies.
             if (bindingContext.ModelType != typeof(byte[]))
             {
                 return null;
@@ -22,25 +23,26 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             var valueProviderResult = await bindingContext.ValueProvider.GetValueAsync(bindingContext.ModelName);
 
-            // case 1: there was no <input ... /> element containing this data
+            // Check for missing data case 1: There was no <input ... /> element containing this data.
             if (valueProviderResult == null)
             {
-                return null;
+                return new ModelBindingResult(model: null, key: bindingContext.ModelName, isModelSet: false);
             }
 
             var value = valueProviderResult.AttemptedValue;
 
-            // case 2: there was an <input ... /> element but it was left blank
+            // Check for missing data case 2: There was an <input ... /> element but it was left blank.
             if (string.IsNullOrEmpty(value))
             {
-                return null;
+                return new ModelBindingResult(model: null, key: bindingContext.ModelName, isModelSet: false);
             }
 
             try
             {
                 var model = Convert.FromBase64String(value);
 
-                // We do not need to set an explict ModelValidationNode since CompositeModelBinder does that automatically.
+                // We do not need to set an explicit ModelValidationNode since CompositeModelBinder does that
+                // automatically.
                 return new ModelBindingResult(
                     model,
                     bindingContext.ModelName,
@@ -51,8 +53,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 bindingContext.ModelState.TryAddModelError(bindingContext.ModelName, ex);
             }
 
-            // Matched the type (byte[]) only this binder supports.
-            // Always tell the model binding system to skip other model binders i.e. return non-null.
+            // Matched the type (byte[]) only this binder supports. As in missing data cases, always tell the model
+            // binding system to skip other model binders i.e. return non-null.
             return new ModelBindingResult(model: null, key: bindingContext.ModelName, isModelSet: false);
         }
     }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BindingSourceModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BindingSourceModelBinderTest.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             var binder = new TestableBindingSourceModelBinder(BindingSource.Body);
 
-            // Act 
+            // Act
             var result = await binder.BindModelAsync(context);
 
             // Assert
@@ -60,7 +60,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             var binder = new TestableBindingSourceModelBinder(BindingSource.Body);
 
-            // Act 
+            // Act
             var result = await binder.BindModelAsync(context);
 
             // Assert
@@ -84,12 +84,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             var binder = new TestableBindingSourceModelBinder(BindingSource.Body);
 
-            // Act 
+            // Act
             var result = await binder.BindModelAsync(context);
 
             // Assert
             Assert.NotNull(result);
-            Assert.True(result.IsModelSet);
+            Assert.False(result.IsModelSet);
             Assert.True(binder.WasBindModelCoreCalled);
         }
 
@@ -105,7 +105,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             protected override Task<ModelBindingResult> BindModelCoreAsync([NotNull] ModelBindingContext bindingContext)
             {
                 WasBindModelCoreCalled = true;
-                return Task.FromResult(new ModelBindingResult(null, bindingContext.ModelName, true));
+                return Task.FromResult(new ModelBindingResult(model: null, key: bindingContext.ModelName, isModelSet: false));
             }
         }
     }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/ByteArrayModelBinderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/ByteArrayModelBinderTests.cs
@@ -3,7 +3,6 @@
 
 #if DNX451
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Testing;
 using Xunit;
@@ -30,7 +29,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var binderResult = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.Null(binderResult);
+            Assert.NotNull(binderResult);
+            Assert.False(binderResult.IsModelSet);
+            Assert.Equal("foo", binderResult.Key);
+            Assert.Null(binderResult.Model);
+
+            Assert.Empty(bindingContext.ModelState); // No submitted value for "foo".
         }
 
         [Fact]
@@ -81,7 +85,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         }
 
         [Fact]
-        public async Task BindModelReturnsFalseWhenValueNotFound()
+        public async Task BindModelReturnsWithIsModelSetFalse_WhenValueNotFound()
         {
             // Arrange
             var valueProvider = new SimpleHttpValueProvider()
@@ -96,7 +100,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var binderResult = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.Null(binderResult);
+            Assert.NotNull(binderResult);
+            Assert.False(binderResult.IsModelSet);
+            Assert.Equal("foo", binderResult.Key);
+            Assert.Null(binderResult.Model);
+
+            Assert.Empty(bindingContext.ModelState); // No submitted data for "foo".
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CompositeModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CompositeModelBinderTest.cs
@@ -291,7 +291,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var modelBinder = new Mock<IModelBinder>();
             modelBinder
                 .Setup(mb => mb.BindModelAsync(It.IsAny<ModelBindingContext>()))
-                .Returns(Task.FromResult(new ModelBindingResult(null, "someName", true)));
+                .Returns(Task.FromResult(new ModelBindingResult(model: "some value", key: "someName", isModelSet: true)));
 
             var composite = CreateCompositeBinder(modelBinder.Object);
 
@@ -302,7 +302,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             Assert.NotNull(result);
             Assert.True(result.IsModelSet);
             Assert.Equal("someName", result.Key);
-            Assert.Null(result.Model);
+            Assert.Equal("some value", result.Model);
         }
 
         [Fact]
@@ -445,6 +445,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
                 .Returns(
                     delegate (ModelBindingContext context)
                     {
+                        // Note this ModelBindingResult is not valid.
                         return Task.FromResult(
                             new ModelBindingResult(model: 42, key: "someName", isModelSet: false));
                     });
@@ -455,7 +456,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            // The result is null because of issue #2473
             Assert.Null(result);
         }
 

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/FormValueProviderFactoryTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/FormValueProviderFactoryTests.cs
@@ -33,8 +33,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         [Theory]
         [InlineData("application/x-www-form-urlencoded")]
         [InlineData("application/x-www-form-urlencoded;charset=utf-8")]
-        [InlineData("multipart/form-data")]
-        [InlineData("multipart/form-data;charset=utf-8")]
+        [InlineData("multipart/form-data; boundary=----WebKitFormBoundarymx2fSWqWSd0OxQqq")]
+        [InlineData("multipart/form-data; boundary=----WebKitFormBoundarymx2fSWqWSd0OxQqq; charset=utf-8")]
         public void GetValueProvider_ReturnsValueProviderInstanceWithInvariantCulture(string contentType)
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/KeyValuePairModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/KeyValuePairModelBinderTest.cs
@@ -139,13 +139,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var innerBinder = new Mock<IModelBinder>();
             innerBinder
                 .Setup(o => o.BindModelAsync(It.IsAny<ModelBindingContext>()))
-                .Returns((ModelBindingContext mbc) =>
+                .Returns((ModelBindingContext context) =>
                 {
-                    Assert.Equal("someName.key", mbc.ModelName);
-                    return Task.FromResult(new ModelBindingResult(null, string.Empty, true));
+                    Assert.Equal("someName.key", context.ModelName);
+                    return Task.FromResult(new ModelBindingResult(model: "not int", key: string.Empty, isModelSet: true));
                 });
             var bindingContext = GetBindingContext(new SimpleHttpValueProvider(), innerBinder.Object);
-
 
             var binder = new KeyValuePairModelBinder<int, string>();
             var modelValidationNodeList = new List<ModelValidationNode>();
@@ -155,7 +154,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
 
             // Assert
             Assert.True(result.IsModelSet);
-            Assert.Null(result.Model);
+            Assert.Equal("not int", result.Model);
             Assert.Empty(bindingContext.ModelState);
         }
 

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ParameterBinding/ControllerActionArgumentBinderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ParameterBinding/ControllerActionArgumentBinderTests.cs
@@ -361,7 +361,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
             binder
                 .Setup(b => b.BindModelAsync(It.IsAny<ModelBindingContext>()))
                 .Returns(Task.FromResult(
-                    result: new ModelBindingResult(model: null, key: string.Empty, isModelSet: true)));
+                    result: new ModelBindingResult(model: null, key: string.Empty, isModelSet: false)));
             var actionBindingContext = new ActionBindingContext()
             {
                 ModelBinder = binder.Object,

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingTest.cs
@@ -778,7 +778,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 
             //Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal("\0", await response.Content.ReadAsStringAsync());
+            Assert.Equal(string.Empty, await response.Content.ReadAsStringAsync());
         }
 
         [Fact]
@@ -1462,7 +1462,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 
             };
             var url = "http://localhost/dealers/43/update-vehicle?dealer.name=TestCarDealer&dealer.location=NE";
-            
+
             // Act
             var response = await client.PostAsJsonAsync(url, postedContent);
 

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/ByteArrayModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/ByteArrayModelBinderIntegrationTest.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal(ModelValidationState.Valid, modelState[key].ValidationState); // Should be skipped. bug#2447
         }
 
-        [Fact(Skip = "ByteArrayModelBinder should return a non-null result #2456")]
+        [Fact]
         public async Task BindParameter_NoData_DoesNotGetBound()
         {
             // Arrange
@@ -92,8 +92,9 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 ParameterType = typeof(byte[])
             };
 
-            // No data is passed.
-            var operationContext = ModelBindingTestHelper.GetOperationBindingContext(httpContext => { });
+            // No data is passed. The ByteArrayModelBinder should ensure no later binders run.
+            var operationContext = ModelBindingTestHelper.GetOperationBindingContext(
+                updateOptions: ModelBindingTestHelper.UpdateOptionsToEnsureNothingFollows<ByteArrayModelBinder>);
             var modelState = new ModelStateDictionary();
 
             // Act
@@ -102,15 +103,11 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             // Assert
 
             // ModelBindingResult
-            Assert.NotNull(modelBindingResult);
+            Assert.Null(modelBindingResult);
 
             // ModelState
             Assert.True(modelState.IsValid);
             Assert.Empty(modelState.Keys);
-
-            Assert.Equal("CustomParameter", modelBindingResult.Key);
-            Assert.True(modelBindingResult.IsModelSet);
-            Assert.Equal(new byte[0], modelBindingResult.Model);
         }
 
         [Fact(Skip = "ModelState.Value not set due to #2445")]

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/FormCollectionModelBindingIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/FormCollectionModelBindingIntegrationTest.cs
@@ -128,8 +128,8 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Empty(modelState.Keys);
         }
 
-        [Fact(Skip = "FormCollection should not return null modelBindingResult for a type that matches. #2456")]
-        public async Task BindParameter_NoData_DoesNotGetBound()
+        [Fact]
+        public async Task BindParameter_NoData_BindsWithEmptyCollection()
         {
             // Arrange
             var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
@@ -144,10 +144,9 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 ParameterType = typeof(FormCollection)
             };
 
-            // No data is passed.
-            var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
-            {
-            });
+            // No data is passed. The FormCollectionModelBinder should ensure no later binders run.
+            var operationContext = ModelBindingTestHelper.GetOperationBindingContext(
+                updateOptions: ModelBindingTestHelper.UpdateOptionsToEnsureNothingFollows<FormCollectionModelBinder>);
 
             var modelState = new ModelStateDictionary();
 
@@ -158,11 +157,16 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             // ModelBindingResult
             Assert.NotNull(modelBindingResult);
-            Assert.Null(modelBindingResult.Model);
+            var collection = Assert.IsType<FormCollection>(modelBindingResult.Model);
 
             // ModelState
             Assert.True(modelState.IsValid);
             Assert.Empty(modelState.Keys);
+
+            // FormCollection
+            Assert.Empty(collection);
+            Assert.Empty(collection.Files);
+            Assert.Empty(collection.Keys);
         }
 
         private void UpdateRequest(HttpRequest request, string data, string name)
@@ -172,7 +176,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(data));
 
             request.Form = formCollection;
-            request.ContentType = "multipart/form-data";
+            request.ContentType = "multipart/form-data; boundary=----WebKitFormBoundarymx2fSWqWSd0OxQqq";
             request.Headers["Content-Disposition"] = "form-data; name=" + name + "; filename=text.txt";
             fileCollection.Add(new FormFile(memoryStream, 0, data.Length)
             {

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/FormFileModelBindingIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/FormFileModelBindingIntegrationTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -125,7 +126,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Empty(modelState.Keys);
         }
 
-        [Fact(Skip = "FormFile Should not return null modelBindingResult for a type that matches. #2456")]
+        [Fact]
         public async Task BindParameter_NoData_DoesNotGetBound()
         {
             // Arrange
@@ -141,11 +142,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 ParameterType = typeof(IFormFile)
             };
 
-            // No data is passed.
-            var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
-            {
-                request.ContentType = "multipart/form-data";
-            });
+            // No data is passed. The FormFileModelBinder should ensure no later binders run.
+            var operationContext = ModelBindingTestHelper.GetOperationBindingContext(
+                request => UpdateRequest(request, data: null, name: null),
+                ModelBindingTestHelper.UpdateOptionsToEnsureNothingFollows<FormFileModelBinder>);
 
             var modelState = new ModelStateDictionary();
 
@@ -154,9 +154,8 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             // Assert
 
-            // ModelBindingResult
-            Assert.NotNull(modelBindingResult); // Fails due to bug #2456
-            Assert.Null(modelBindingResult.Model);
+            // ModelBindingResult; expect null because binding failed.
+            Assert.Null(modelBindingResult);
 
             // ModelState
             Assert.True(modelState.IsValid);
@@ -167,11 +166,19 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
         {
             var fileCollection = new FormFileCollection();
             var formCollection = new FormCollection(new Dictionary<string, string[]>(), fileCollection);
-            var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(data));
 
             request.Form = formCollection;
-            request.ContentType = "multipart/form-data";
+            request.ContentType = "multipart/form-data; boundary=----WebKitFormBoundarymx2fSWqWSd0OxQqq";
+
+            if (string.IsNullOrEmpty(data) || string.IsNullOrEmpty(name))
+            {
+                // Leave the submission empty.
+                return;
+            }
+
             request.Headers["Content-Disposition"] = "form-data; name=" + name + "; filename=text.txt";
+
+            var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(data));
             fileCollection.Add(new FormFile(memoryStream, 0, data.Length)
             {
                 Headers = request.Headers

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/ModelBindingTestHelper.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/ModelBindingTestHelper.cs
@@ -2,12 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Internal;
 using Microsoft.AspNet.Mvc.ModelBinding;
 using Microsoft.AspNet.Mvc.ModelBinding.Validation;
 using Microsoft.AspNet.Routing;
 using Microsoft.Framework.DependencyInjection;
+using Xunit;
 
 namespace Microsoft.AspNet.Mvc.IntegrationTests
 {
@@ -67,6 +69,21 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                     metadataProvider);
         }
 
+        public static void UpdateOptionsToEnsureNothingFollows<TModelBinder>(MvcOptions options)
+        {
+            var index = 0;
+            for (; index < options.ModelBinders.Count; index++)
+            {
+                if (typeof(TModelBinder) == options.ModelBinders[index].GetType())
+                {
+                    options.ModelBinders.Insert(index + 1, new AssertIfCalledModelBinder());
+                    return;
+                }
+            }
+
+            Assert.False(true, $"Unable to find { typeof(TModelBinder).FullName } in { nameof(MvcOptions) }.");
+        }
+
         private static void InitializeServices(HttpContext httpContext, Action<MvcOptions> updateOptions = null)
         {
             var serviceCollection = new ServiceCollection();
@@ -109,6 +126,16 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 ModelBinder = new CompositeModelBinder(options.ModelBinders),
                 ValueProvider = valueProvider
             };
+        }
+
+        private class AssertIfCalledModelBinder : IModelBinder
+        {
+            public Task<ModelBindingResult> BindModelAsync(ModelBindingContext bindingContext)
+            {
+                Assert.False(true, "This model binder should never be used");
+
+                return Task.FromResult<ModelBindingResult>(result: null);
+            }
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/MutableObjectModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/MutableObjectModelBinderIntegrationTest.cs
@@ -2043,7 +2043,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(content));
 
             request.Form = formCollection;
-            request.ContentType = "multipart/form-data";
+            request.ContentType = "multipart/form-data; boundary=----WebKitFormBoundarymx2fSWqWSd0OxQqq";
             request.Headers["Content-Disposition"] = "form-data; name=" + name + "; filename=text.txt";
 
             fileCollection.Add(new FormFile(memoryStream, 0, memoryStream.Length)

--- a/test/WebSites/ModelBindingWebSite/Controllers/HomeController.cs
+++ b/test/WebSites/ModelBindingWebSite/Controllers/HomeController.cs
@@ -15,6 +15,11 @@ namespace ModelBindingWebSite.Controllers
         [HttpGet]
         public IActionResult Index(byte[] byteValues)
         {
+            if (byteValues == null)
+            {
+                return Content(content: null);
+            }
+
             return Content(System.Text.Encoding.UTF8.GetString(byteValues));
         }
 


### PR DESCRIPTION
- #2456
- visible behaviours now match MVC 5
- prevent `CollectionModelBinder` from converting no value to `byte[0]`
- prevent `TypeConverterModelBinder` from converting empty value to `byte[] { '\0' }`