### PR TITLE
Use stable locale when testing date/time formats

### DIFF
--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/HtmlHelperOptionsTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/HtmlHelperOptionsTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
+using Microsoft.AspNet.Testing;
 using Microsoft.Framework.DependencyInjection;
 using RazorWebSite;
 using Xunit;
@@ -50,6 +51,7 @@ False";
         }
 
         [Fact]
+        [ReplaceCulture]
         public async Task OverrideAppWideDefaultsInViewAndPartialView()
         {
             // Arrange
@@ -60,7 +62,7 @@ False";
 <ValidationInView class=""field-validation-error"" data-valmsg-for=""Error"" data-valmsg-replace=""true"">An error occurred.</ValidationInView>
 <input id=""Prefix!Property1"" name=""Prefix.Property1"" type=""text"" value="""" />
 <div class=""editor-label""><label for=""MyDate"">MyDate</label></div>
-<div class=""editor-field""><input class=""text-box single-line"" data-val=""true"" data-val-required=""The MyDate field is required."" id=""MyDate"" name=""MyDate"" type=""datetime"" value=""1/2/2000 3:04:05 AM &#x2B;00:00"" /> <ValidationInView class=""field-validation-valid"" data-valmsg-for=""MyDate"" data-valmsg-replace=""true""></ValidationInView></div>
+<div class=""editor-field""><input class=""text-box single-line"" data-val=""true"" data-val-required=""The MyDate field is required."" id=""MyDate"" name=""MyDate"" type=""datetime"" value=""02/01/2000 03:04:05 &#x2B;00:00"" /> <ValidationInView class=""field-validation-valid"" data-valmsg-for=""MyDate"" data-valmsg-replace=""true""></ValidationInView></div>
 
 True
 
@@ -70,7 +72,7 @@ True
 <ValidationInPartialView class=""field-validation-error"" data-valmsg-for=""Error"" data-valmsg-replace=""true"">An error occurred.</ValidationInPartialView>
 <input id=""Prefix!Property1"" name=""Prefix.Property1"" type=""text"" value="""" />
 <div class=""editor-label""><label for=""MyDate"">MyDate</label></div>
-<div class=""editor-field""><input class=""text-box single-line"" id=""MyDate"" name=""MyDate"" type=""datetime"" value=""1/2/2000 3:04:05 AM &#x2B;00:00"" /> <ValidationInPartialView class=""field-validation-valid"" data-valmsg-for=""MyDate"" data-valmsg-replace=""true""></ValidationInPartialView></div>
+<div class=""editor-field""><input class=""text-box single-line"" id=""MyDate"" name=""MyDate"" type=""datetime"" value=""02/01/2000 03:04:05 &#x2B;00:00"" /> <ValidationInPartialView class=""field-validation-valid"" data-valmsg-for=""MyDate"" data-valmsg-replace=""true""></ValidationInPartialView></div>
 
 True";
 

--- a/test/WebSites/RazorWebSite/Startup.cs
+++ b/test/WebSites/RazorWebSite/Startup.cs
@@ -37,8 +37,6 @@ namespace RazorWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.UseCultureReplacer();
-
             app.UseRequestLocalization();
 
             // Add MVC to the request pipeline


### PR DESCRIPTION
- `CultureReplacerMiddleware` no longer helping `RazorWebSite`
 - likely regressed with @30d11a8