### PR TITLE
#2664: Add `ModelMetadata.ElementMetadata`

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/ModelMetadata.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/ModelMetadata.cs
@@ -5,7 +5,9 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
+#if DNXCORE50
 using System.Reflection;
+#endif
 using Microsoft.AspNet.Mvc.ModelBinding.Metadata;
 using Microsoft.Framework.Internal;
 
@@ -79,7 +81,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         public abstract string BinderModelName { get; }
 
         /// <summary>
-        /// Gets the <see cref="Type"/> of an <see cref="IModelBinder"/> of a model if specified explicitly using 
+        /// Gets the <see cref="Type"/> of an <see cref="IModelBinder"/> of a model if specified explicitly using
         /// <see cref="IBinderTypeProviderMetadata"/>.
         /// </summary>
         public abstract Type BinderType { get; }
@@ -123,6 +125,18 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// http://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to edit the model.
         /// </summary>
         public abstract string EditFormatString { get; }
+
+        /// <summary>
+        /// Gets the <see cref="ModelMetadata"/> for elements of <see cref="ModelType"/> if that <see cref="Type"/>
+        /// implements <see cref="IEnumerable"/>.
+        /// </summary>
+        /// <value>
+        /// <see cref="ModelMetadata"/> for <c>T</c> if <see cref="ModelType"/> implements
+        /// <see cref="IEnumerable{T}"/>. <see cref="ModelMetadata"/> for <c>object</c> if <see cref="ModelType"/>
+        /// implements <see cref="IEnumerable"/> but not <see cref="IEnumerable{T}"/>. <c>null</c> otherwise i.e. when
+        /// <see cref="IsCollectionType"/> is <c>false</c>.
+        /// </value>
+        public abstract ModelMetadata ElementMetadata { get; }
 
         /// <summary>
         /// Gets the ordered display names and values of all <see cref="Enum"/> values in <see cref="ModelType"/> or
@@ -330,6 +344,16 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         }
 
         /// <summary>
+        /// Gets or sets a property getter delegate to get the property value from a model object.
+        /// </summary>
+        public abstract Func<object, object> PropertyGetter { get; }
+
+        /// <summary>
+        /// Gets or sets a property setter delegate to set the property value on a model object.
+        /// </summary>
+        public abstract Action<object, object> PropertySetter { get; }
+
+        /// <summary>
         /// Gets a display name for the model.
         /// </summary>
         /// <remarks>
@@ -341,15 +365,5 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         {
             return DisplayName ?? PropertyName ?? ModelType.Name;
         }
-
-        /// <summary>
-        /// Gets or sets a property getter delegate to get the property value from a model object.
-        /// </summary>
-        public abstract Func<object, object> PropertyGetter { get; }
-
-        /// <summary>
-        /// Gets or sets a property setter delegate to set the property value on a model object.
-        /// </summary>
-        public abstract Action<object, object> PropertySetter { get; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Metadata/DefaultModelMetadata.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Metadata/DefaultModelMetadata.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Linq;
 #if DNXCORE50
 using System.Reflection;
@@ -233,13 +234,13 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
             {
                 if (!_haveCalculatedElementMetadata)
                 {
-                    // Short-circuit checks below. As in IsCollectionType, do not consider string a collection.
-                    _haveCalculatedElementMetadata = ModelType == typeof(string);
-                }
-
-                if (!_haveCalculatedElementMetadata)
-                {
                     _haveCalculatedElementMetadata = true;
+                    if (!IsCollectionType)
+                    {
+                        // Short-circuit checks below. If not IsCollectionType, ElementMetadata is null.
+                        // For example, as in IsCollectionType, do not consider strings collections.
+                        return null;
+                    }
 
                     Type elementType = null;
                     if (ModelType.IsArray)
@@ -257,11 +258,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
                         }
                     }
 
-                    if (elementType != null)
-                    {
-                        // Success
-                        _elementMetadata = _provider.GetMetadataForType(elementType);
-                    }
+                    Debug.Assert(
+                        elementType != null,
+                        $"Unable to find element type for '{ ModelType.FullName }' though IsCollectionType is true.");
+
+                    // Success
+                    _elementMetadata = _provider.GetMetadataForType(elementType);
                 }
 
                 return _elementMetadata;

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Validation/DefaultObjectValidator.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Validation/DefaultObjectValidator.cs
@@ -169,11 +169,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             ExpandValidationNode(validationContext, modelExplorer);
 
             IList<IModelValidator> validators = null;
-            if (modelExplorer.Metadata.IsCollectionType && modelExplorer.Model != null)
+            if (modelExplorer.Metadata.IsCollectionType)
             {
-                var enumerableModel = (IEnumerable)modelExplorer.Model;
-                var elementType = GetElementType(enumerableModel.GetType());
-                var elementMetadata = _modelMetadataProvider.GetMetadataForType(elementType);
+                var elementMetadata = modelExplorer.Metadata.ElementMetadata;
                 validators = GetValidators(validationContext.ModelValidationContext.ValidatorProvider, elementMetadata);
             }
 
@@ -299,9 +297,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             }
             else
             {
+                var elementMetadata = modelExplorer.Metadata.ElementMetadata;
                 var enumerableModel = (IEnumerable)modelExplorer.Model;
-                var elementType = GetElementType(enumerableModel.GetType());
-                var elementMetadata = _modelMetadataProvider.GetMetadataForType(elementType);
 
                 // An integer index is incorrect in scenarios where there is a custom index provided by the user.
                 // However those scenarios are supported by createing a ModelValidationNode with the right keys.
@@ -319,26 +316,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
                     index++;
                 }
             }
-        }
-
-        private static Type GetElementType(Type type)
-        {
-            Debug.Assert(typeof(IEnumerable).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()));
-            if (type.IsArray)
-            {
-                return type.GetElementType();
-            }
-
-            foreach (var implementedInterface in type.GetInterfaces())
-            {
-                if (implementedInterface.GetTypeInfo().IsGenericType &&
-                    implementedInterface.GetGenericTypeDefinition() == typeof(IEnumerable<>))
-                {
-                    return implementedInterface.GetGenericArguments()[0];
-                }
-            }
-
-            return typeof(object);
         }
 
         private class ValidationContext

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Validation/DefaultObjectValidator.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Validation/DefaultObjectValidator.cs
@@ -169,9 +169,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             ExpandValidationNode(validationContext, modelExplorer);
 
             IList<IModelValidator> validators = null;
-            if (modelExplorer.Metadata.IsCollectionType)
+            var elementMetadata = modelExplorer.Metadata.ElementMetadata;
+            if (elementMetadata != null)
             {
-                var elementMetadata = modelExplorer.Metadata.ElementMetadata;
                 validators = GetValidators(validationContext.ModelValidationContext.ValidatorProvider, elementMetadata);
             }
 
@@ -281,7 +281,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
                 return;
             }
 
-            if (!modelExplorer.Metadata.IsCollectionType)
+            var elementMetadata = modelExplorer.Metadata.ElementMetadata;
+            if (elementMetadata == null)
             {
                 foreach (var property in validationNode.ModelMetadata.Properties)
                 {
@@ -297,7 +298,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             }
             else
             {
-                var elementMetadata = modelExplorer.Metadata.ElementMetadata;
                 var enumerableModel = (IEnumerable)modelExplorer.Model;
 
                 // An integer index is incorrect in scenarios where there is a custom index provided by the user.

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBindingHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBindingHelper.cs
@@ -369,7 +369,7 @@ namespace Microsoft.AspNet.Mvc
         /// <param name="expressions">Expressions identifying the properties to allow for binding.</param>
         /// <returns>An expression which can be used with <see cref="IPropertyBindingPredicateProvider"/>.</returns>
         public static Expression<Func<ModelBindingContext, string, bool>> GetIncludePredicateExpression<TModel>(
-            string prefix, 
+            string prefix,
             Expression<Func<TModel, object>>[] expressions)
         {
             if (expressions.Length == 0)
@@ -417,15 +417,14 @@ namespace Microsoft.AspNet.Mvc
         {
             // If modelkey is empty, we need to iterate through properties (obtained from ModelMetadata) and
             // clear validation state for all entries in ModelStateDictionary that start with each property name.
-            // If modelkey is non-empty, clear validation state for all entries in ModelStateDictionary 
+            // If modelkey is non-empty, clear validation state for all entries in ModelStateDictionary
             // that start with modelKey
             if (string.IsNullOrEmpty(modelKey))
             {
                 var modelMetadata = metadataProvider.GetMetadataForType(modelType);
                 if (modelMetadata.IsCollectionType)
                 {
-                    var elementType = GetElementType(modelMetadata.ModelType);
-                    modelMetadata = metadataProvider.GetMetadataForType(elementType);
+                    modelMetadata = modelMetadata.ElementMetadata;
                 }
 
                 foreach (var property in modelMetadata.Properties)
@@ -439,27 +438,6 @@ namespace Microsoft.AspNet.Mvc
                 modelstate.ClearValidationState(modelKey);
             }
         }
-
-        private static Type GetElementType(Type type)
-        {
-            Debug.Assert(typeof(IEnumerable).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()));
-            if (type.IsArray)
-            {
-                return type.GetElementType();
-            }
-
-            foreach (var implementedInterface in type.GetInterfaces())
-            {
-                if (implementedInterface.GetTypeInfo().IsGenericType &&
-                    implementedInterface.GetGenericTypeDefinition() == typeof(IEnumerable<>))
-                {
-                    return implementedInterface.GetGenericArguments()[0];
-                }
-            }
-
-            return typeof(object);
-        }
-
 
         internal static void ValidateBindingContext([NotNull] ModelBindingContext bindingContext)
         {

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBindingHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBindingHelper.cs
@@ -422,9 +422,10 @@ namespace Microsoft.AspNet.Mvc
             if (string.IsNullOrEmpty(modelKey))
             {
                 var modelMetadata = metadataProvider.GetMetadataForType(modelType);
-                if (modelMetadata.IsCollectionType)
+                var elementMetadata = modelMetadata.ElementMetadata;
+                if (elementMetadata != null)
                 {
-                    modelMetadata = modelMetadata.ElementMetadata;
+                    modelMetadata = elementMetadata;
                 }
 
                 foreach (var property in modelMetadata.Properties)

--- a/src/Microsoft.AspNet.Mvc.Extensions/Rendering/Html/DefaultDisplayTemplates.cs
+++ b/src/Microsoft.AspNet.Mvc.Extensions/Rendering/Html/DefaultDisplayTemplates.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using Microsoft.AspNet.Mvc.Extensions;
@@ -106,40 +107,42 @@ namespace Microsoft.AspNet.Mvc.Rendering
                     "Collection", model.GetType().FullName, typeof(IEnumerable).FullName));
             }
 
-            var typeInCollection = typeof(string);
-            var genericEnumerableType = ClosedGenericMatcher.ExtractGenericInterface(
-                collection.GetType(),
-                typeof(IEnumerable<>));
-            if (genericEnumerableType != null)
+            var elementMetadata = htmlHelper.ViewData.ModelMetadata.ElementMetadata;
+            Debug.Assert(elementMetadata != null);
+            var typeInCollectionIsNullableValueType = elementMetadata.IsNullableValueType;
+
+            var serviceProvider = htmlHelper.ViewContext.HttpContext.RequestServices;
+            var metadataProvider = serviceProvider.GetRequiredService<IModelMetadataProvider>();
+
+            // Use typeof(string) instead of typeof(object) for IEnumerable collections. Neither type is Nullable<T>.
+            if (elementMetadata.ModelType == typeof(object))
             {
-                typeInCollection = genericEnumerableType.GenericTypeArguments[0];
+                elementMetadata = metadataProvider.GetMetadataForType(typeof(string));
             }
 
-            var typeInCollectionIsNullableValueType = TypeHelper.IsNullableValueType(typeInCollection);
-
             var oldPrefix = htmlHelper.ViewData.TemplateInfo.HtmlFieldPrefix;
-
             try
             {
                 htmlHelper.ViewData.TemplateInfo.HtmlFieldPrefix = string.Empty;
 
                 var fieldNameBase = oldPrefix;
                 var result = new StringBuilder();
-
-                var serviceProvider = htmlHelper.ViewContext.HttpContext.RequestServices;
-                var metadataProvider = serviceProvider.GetRequiredService<IModelMetadataProvider>();
                 var viewEngine = serviceProvider.GetRequiredService<ICompositeViewEngine>();
 
                 var index = 0;
                 foreach (var item in collection)
                 {
-                    var itemType = typeInCollection;
+                    var itemMetadata = elementMetadata;
                     if (item != null && !typeInCollectionIsNullableValueType)
                     {
-                        itemType = item.GetType();
+                        itemMetadata = metadataProvider.GetMetadataForType(item.GetType());
                     }
 
-                    var modelExplorer = metadataProvider.GetModelExplorerForType(itemType, item);
+                    var modelExplorer = new ModelExplorer(
+                        metadataProvider,
+                        container: htmlHelper.ViewData.ModelExplorer,
+                        metadata: itemMetadata,
+                        model: item);
                     var fieldName = string.Format(CultureInfo.InvariantCulture, "{0}[{1}]", fieldNameBase, index++);
 
                     var templateBuilder = new TemplateBuilder(

--- a/test/Microsoft.AspNet.Mvc.Abstractions.Test/ModelBinding/ModelMetadataTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Abstractions.Test/ModelBinding/ModelMetadataTest.cs
@@ -269,6 +269,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 }
             }
 
+            public override ModelMetadata ElementMetadata
+            {
+                get
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
             public override IEnumerable<KeyValuePair<string, string>> EnumDisplayNamesAndValues
             {
                 get

--- a/test/Microsoft.AspNet.Mvc.Extensions.Test/Rendering/HtmlHelperSelectTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Extensions.Test/Rendering/HtmlHelperSelectTest.cs
@@ -874,7 +874,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             Assert.Equal(expectedHtml, html.ToString());
         }
 
-        [Fact(Skip = "#2664, throws ArgumentNullException")]
+        [Fact]
         public void ListBoxNotInTemplate_GetsViewDataEntry_IfModelStateEmpty()
         {
             // Arrange
@@ -899,7 +899,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             Assert.Equal(expectedHtml, html.ToString());
         }
 
-        [Fact(Skip = "#2664, throws ArgumentNullException")]
+        [Fact(Skip = "#1487, incorrectly matches Property1 entry (without prefix) in ViewData.")]
         public void ListBoxInTemplate_GetsViewDataEntry_IfModelStateEmpty()
         {
             // Arrange
@@ -927,7 +927,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             Assert.Equal(expectedHtml, html.ToString());
         }
 
-        [Fact(Skip = "#2664, throws ArgumentNullException")]
+        [Fact(Skip = "#1487, incorrectly matches Property1 entry (without prefix) in ViewData.")]
         public void ListBoxInTemplate_GetsPropertyOfViewDataEntry_IfModelStateEmptyAndNoViewDataEntryWithPrefix()
         {
             // Arrange
@@ -954,7 +954,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             Assert.Equal(expectedHtml, html.ToString());
         }
 
-        [Fact(Skip = "#2664, throws ArgumentNullException")]
+        [Fact]
         public void ListBoxNotInTemplate_GetsPropertyOfModel_IfModelStateAndViewDataEmpty()
         {
             // Arrange
@@ -970,7 +970,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             Assert.Equal(expectedHtml, html.ToString());
         }
 
-        [Fact(Skip = "#2664, throws ArgumentNullException")]
+        [Fact]
         public void ListBoxInTemplate_GetsPropertyOfModel_IfModelStateAndViewDataEmpty()
         {
             // Arrange


### PR DESCRIPTION
- builds on dougbu/testing.1485.1487.2662.2664 branch, unblocking some #1487 tests
- use new property to correctly determine `isTargetEnum` in `GetCurrentValues()`
 - avoid `ArgumentNullException` in all cases where raw values are `enum` but target is not
- also use new property instead of private `GetElementType()` methods where possible

nits:
- move properties above methods in `ModelMetadata`
- avoid accidentally-incorrect "Remove Unnecessary Usings"