### PR TITLE
Make `string`-based expression evaluations behave consistently

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Extensions/ViewDataDictionary.cs
+++ b/src/Microsoft.AspNet.Mvc.Extensions/ViewDataDictionary.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Reflection;
 using Microsoft.AspNet.Mvc.Extensions;
 using Microsoft.AspNet.Mvc.ModelBinding;
 using Microsoft.AspNet.Mvc.Rendering.Expressions;
@@ -301,12 +300,37 @@ namespace Microsoft.AspNet.Mvc
             get { return _data; }
         }
 
+        /// <summary>
+        /// Gets value of named <paramref name="expression"/> in this <see cref="ViewDataDictionary"/>.
+        /// </summary>
+        /// <param name="expression">Expression name, relative to the current model.</param>
+        /// <returns>Value of named <paramref name="expression"/> in this <see cref="ViewDataDictionary"/>.</returns>
+        /// <remarks>
+        /// Looks up <paramref name="expression"/> in the dictionary first. Falls back to evaluating it against
+        /// <see cref="Model"/>.
+        /// </remarks>
         public object Eval(string expression)
         {
             var info = GetViewDataInfo(expression);
             return (info != null) ? info.Value : null;
         }
 
+        /// <summary>
+        /// Gets value of named <paramref name="expression"/> in this <see cref="ViewDataDictionary"/>, formatted
+        /// using given <paramref name="format"/>.
+        /// </summary>
+        /// <param name="expression">Expression name, relative to the current model.</param>
+        /// <param name="format">
+        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx).
+        /// </param>
+        /// <returns>
+        /// Value of named <paramref name="expression"/> in this <see cref="ViewDataDictionary"/>, formatted using
+        /// given <paramref name="format"/>.
+        /// </returns>
+        /// <remarks>
+        /// Looks up <paramref name="expression"/> in the dictionary first. Falls back to evaluating it against
+        /// <see cref="Model"/>.
+        /// </remarks>
         public string Eval(string expression, string format)
         {
             var value = Eval(expression);
@@ -330,14 +354,21 @@ namespace Microsoft.AspNet.Mvc
             }
         }
 
+        /// <summary>
+        /// Gets <see cref="ViewDataInfo"/> for named <paramref name="expression"/> in this
+        /// <see cref="ViewDataDictionary"/>.
+        /// </summary>
+        /// <param name="expression">Expression name, relative to the current model.</param>
+        /// <returns>
+        /// <see cref="ViewDataInfo"/> for named <paramref name="expression"/> in this
+        /// <see cref="ViewDataDictionary"/>.
+        /// </returns>
+        /// <remarks>
+        /// Looks up <paramref name="expression"/> in the dictionary first. Falls back to evaluating it against
+        /// <see cref="Model"/>.
+        /// </remarks>
         public ViewDataInfo GetViewDataInfo(string expression)
         {
-            if (string.IsNullOrEmpty(expression))
-            {
-                // Null or empty expression name means current model.
-                return new ViewDataInfo(container: null, value: Model);
-            }
-
             return ViewDataEvaluator.Eval(this, expression);
         }
 

--- a/test/Microsoft.AspNet.Mvc.Extensions.Test/Rendering/HtmlHelperCheckboxTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Extensions.Test/Rendering/HtmlHelperCheckboxTest.cs
@@ -225,7 +225,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             Assert.Equal(expected, html.ToString());
         }
 
-        [Fact(Skip = "#1485, unable to get Model value.")]
+        [Fact]
         public void CheckBoxInTemplate_GetsModelValue_IfModelStateAndViewDataEmpty()
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.Extensions.Test/Rendering/HtmlHelperDisplayTextTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Extensions.Test/Rendering/HtmlHelperDisplayTextTest.cs
@@ -248,7 +248,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         [Fact]
-        public void DisplayText_ReturnsModelStateEntry()
+        public void DisplayText_IgnoresModelStateEntry_ReturnsViewDataEntry()
         {
             // Arrange
             var model = new OverriddenToStringModel("Model value")
@@ -257,7 +257,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             };
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
             var viewData = helper.ViewData;
-            viewData["Name"] = "View data dictionary value";
+            viewData["FieldPrefix.Name"] = "View data dictionary value";
             viewData.TemplateInfo.HtmlFieldPrefix = "FieldPrefix";
 
             var modelState = new ModelState();

--- a/test/Microsoft.AspNet.Mvc.Extensions.Test/Rendering/HtmlHelperHiddenTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Extensions.Test/Rendering/HtmlHelperHiddenTest.cs
@@ -239,7 +239,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             Assert.Equal(expected, result.ToString());
         }
 
-        [Fact(Skip = "#1485, unable to get Model value.")]
+        [Fact]
         public void HiddenInTemplate_GetsModelValue_IfModelStateAndViewDataEmpty()
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.Extensions.Test/Rendering/HtmlHelperSelectTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Extensions.Test/Rendering/HtmlHelperSelectTest.cs
@@ -488,7 +488,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             Assert.Equal(expectedHtml, html.ToString());
         }
 
-        [Fact(Skip = "#1487, incorrectly matches Property1 entry (without prefix) in ViewData.")]
+        [Fact]
         public void DropDownListInTemplate_GetsViewDataEntry_IfModelStateEmpty()
         {
             // Arrange
@@ -516,7 +516,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             Assert.Equal(expectedHtml, html.ToString());
         }
 
-        [Fact(Skip = "#1487, incorrectly matches Property1 entry (without prefix) in ViewData.")]
+        [Fact]
         public void DropDownListInTemplate_GetsPropertyOfViewDataEntry_IfModelStateEmptyAndNoViewDataEntryWithPrefix()
         {
             // Arrange
@@ -899,7 +899,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             Assert.Equal(expectedHtml, html.ToString());
         }
 
-        [Fact(Skip = "#1487, incorrectly matches Property1 entry (without prefix) in ViewData.")]
+        [Fact]
         public void ListBoxInTemplate_GetsViewDataEntry_IfModelStateEmpty()
         {
             // Arrange
@@ -927,7 +927,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             Assert.Equal(expectedHtml, html.ToString());
         }
 
-        [Fact(Skip = "#1487, incorrectly matches Property1 entry (without prefix) in ViewData.")]
+        [Fact]
         public void ListBoxInTemplate_GetsPropertyOfViewDataEntry_IfModelStateEmptyAndNoViewDataEntryWithPrefix()
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.Extensions.Test/Rendering/HtmlHelperValueTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Extensions.Test/Rendering/HtmlHelperValueTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNet.Mvc.Core
             Assert.Equal("ViewDataValue", html);
         }
 
-        [Fact(Skip = "$1487, finds 'StringProperty' entry (without prefix) instead.")]
+        [Fact]
         public void ValueInTemplate_GetsValueFromPrefixedViewDataEntry()
         {
             // Arrange
@@ -59,7 +59,7 @@ namespace Microsoft.AspNet.Mvc.Core
             Assert.Equal("ContainedViewDataValue", html);
         }
 
-        [Fact(Skip = "$1487, finds 'StringProperty' entry (without prefix) instead.")]
+        [Fact]
         public void ValueInTemplate_GetsValueFromPropertyOfViewDataEntry()
         {
             // Arrange
@@ -117,7 +117,7 @@ namespace Microsoft.AspNet.Mvc.Core
             Assert.Empty(html);
         }
 
-        [Fact(Skip = "$1487, finds 'StringProperty' entry (without prefix) instead.")]
+        [Fact]
         public void ValueInTemplate_GetsValueFromViewData_EvenIfNull()
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.EmployeeList.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.EmployeeList.html
@@ -3,15 +3,13 @@
 <form action="/HtmlGeneration_Home/EmployeeList" method="post">
 <div>
     <label for="z0__Number">Number</label>
-    
-    <input data-val="true" data-val-range="The field Number must be between 1 and 100." data-val-range-max="100" data-val-range-min="1" data-val-required="The Number field is required." disabled="disabled" id="z0__Number" name="[0].Number" readonly="readonly" type="text" value="" />
+    <input data-val="true" data-val-range="The field Number must be between 1 and 100." data-val-range-max="100" data-val-range-min="1" data-val-required="The Number field is required." disabled="disabled" id="z0__Number" name="[0].Number" readonly="readonly" type="text" value="0" />
     <input class="form-control" type="number" id="z0__Number" name="[0].Number" value="0" />
 </div>
 <div>
     <label class="employee" for="z0__Name">Name</label>
-    
     <textarea id="z0__Name" name="[0].Name">
-Name value that should not be seen.</textarea>
+EmployeeName_0</textarea>
 </div>
 <div>
     <label class="employee" for="z0__PhoneNumber">PhoneNumber</label>
@@ -20,9 +18,7 @@ Name value that should not be seen.</textarea>
 <div>
 
     <label class="employee" for="z0__Gender">Gender</label>
-    
-    <input disabled="disabled" id="z0__Gender" name="[0].Gender" readonly="readonly" type="radio" value="Female" />
-    
+    <input data-val="true" data-val-required="The Gender field is required." disabled="disabled" id="z0__Gender" name="[0].Gender" readonly="readonly" type="radio" value="Female" />
     <select id="z0__Gender" name="[0].Gender"><option selected="selected">Male</option>
 <option>Female</option>
 </select>
@@ -40,15 +36,13 @@ Name value that should not be seen.</textarea>
 </div>
 <div>
     <label for="z1__Number">Number</label>
-    
-    <input data-val="true" data-val-range="The field Number must be between 1 and 100." data-val-range-max="100" data-val-range-min="1" data-val-required="The Number field is required." disabled="disabled" id="z1__Number" name="[1].Number" readonly="readonly" type="text" value="" />
+    <input data-val="true" data-val-range="The field Number must be between 1 and 100." data-val-range-max="100" data-val-range-min="1" data-val-required="The Number field is required." disabled="disabled" id="z1__Number" name="[1].Number" readonly="readonly" type="text" value="1" />
     <input class="form-control" type="number" id="z1__Number" name="[1].Number" value="1" />
 </div>
 <div>
     <label class="employee" for="z1__Name">Name</label>
-    
     <textarea id="z1__Name" name="[1].Name">
-Name value that should not be seen.</textarea>
+EmployeeName_1</textarea>
 </div>
 <div>
     <label class="employee" for="z1__PhoneNumber">PhoneNumber</label>
@@ -57,9 +51,7 @@ Name value that should not be seen.</textarea>
 <div>
 
     <label class="employee" for="z1__Gender">Gender</label>
-    
-    <input disabled="disabled" id="z1__Gender" name="[1].Gender" readonly="readonly" type="radio" value="Female" />
-    
+    <input checked="checked" data-val="true" data-val-required="The Gender field is required." disabled="disabled" id="z1__Gender" name="[1].Gender" readonly="readonly" type="radio" value="Female" />
     <select id="z1__Gender" name="[1].Gender"><option>Male</option>
 <option selected="selected">Female</option>
 </select>
@@ -77,15 +69,13 @@ Name value that should not be seen.</textarea>
 </div>
 <div>
     <label for="z2__Number">Number</label>
-    
-    <input data-val="true" data-val-range="The field Number must be between 1 and 100." data-val-range-max="100" data-val-range-min="1" data-val-required="The Number field is required." disabled="disabled" id="z2__Number" name="[2].Number" readonly="readonly" type="text" value="" />
+    <input data-val="true" data-val-range="The field Number must be between 1 and 100." data-val-range-max="100" data-val-range-min="1" data-val-required="The Number field is required." disabled="disabled" id="z2__Number" name="[2].Number" readonly="readonly" type="text" value="2" />
     <input class="form-control" type="number" id="z2__Number" name="[2].Number" value="2" />
 </div>
 <div>
     <label class="employee" for="z2__Name">Name</label>
-    
     <textarea id="z2__Name" name="[2].Name">
-Name value that should not be seen.</textarea>
+EmployeeName_2</textarea>
 </div>
 <div>
     <label class="employee" for="z2__PhoneNumber">PhoneNumber</label>
@@ -94,9 +84,7 @@ Name value that should not be seen.</textarea>
 <div>
 
     <label class="employee" for="z2__Gender">Gender</label>
-    
-    <input disabled="disabled" id="z2__Gender" name="[2].Gender" readonly="readonly" type="radio" value="Female" />
-    
+    <input data-val="true" data-val-required="The Gender field is required." disabled="disabled" id="z2__Gender" name="[2].Gender" readonly="readonly" type="radio" value="Female" />
     <select id="z2__Gender" name="[2].Gender"><option selected="selected">Male</option>
 <option>Female</option>
 </select>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.OrderUsingHtmlHelpers.Encoded.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.OrderUsingHtmlHelpers.Encoded.html
@@ -69,8 +69,7 @@
         <div>
             <label class="HtmlEncode[[order]]" for="HtmlEncode[[Customer_Gender]]">HtmlEncode[[Gender]]</label>
             <input data-val="HtmlEncode[[true]]" data-val-required="HtmlEncode[[The Gender field is required.]]" id="HtmlEncode[[Customer_Gender]]" name="HtmlEncode[[Customer.Gender]]" type="HtmlEncode[[radio]]" value="HtmlEncode[[Male]]" /> Male
-
-<input id="HtmlEncode[[Customer_Gender]]" name="HtmlEncode[[Customer.Gender]]" type="HtmlEncode[[radio]]" value="HtmlEncode[[Female]]" /> Female
+<input checked="HtmlEncode[[checked]]" id="HtmlEncode[[Customer_Gender]]" name="HtmlEncode[[Customer.Gender]]" type="HtmlEncode[[radio]]" value="HtmlEncode[[Female]]" /> Female
             <span class="HtmlEncode[[field-validation-valid]]" data-valmsg-for="HtmlEncode[[Customer.Gender]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
         </div>
         <div class="HtmlEncode[[validation-summary-valid order]]" data-valmsg-summary="HtmlEncode[[true]]"><ul><li style="display:none"></li>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.OrderUsingHtmlHelpers.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.OrderUsingHtmlHelpers.html
@@ -69,8 +69,7 @@
         <div>
             <label class="order" for="Customer_Gender">Gender</label>
             <input data-val="true" data-val-required="The Gender field is required." id="Customer_Gender" name="Customer.Gender" type="radio" value="Male" /> Male
-
-<input id="Customer_Gender" name="Customer.Gender" type="radio" value="Female" /> Female
+<input checked="checked" id="Customer_Gender" name="Customer.Gender" type="radio" value="Female" /> Female
             <span class="field-validation-valid" data-valmsg-for="Customer.Gender" data-valmsg-replace="true"></span>
         </div>
         <div class="validation-summary-valid order" data-valmsg-summary="true"><ul><li style="display:none"></li>

--- a/test/WebSites/HtmlGenerationWebSite/Controllers/HtmlGeneration_HomeController.cs
+++ b/test/WebSites/HtmlGenerationWebSite/Controllers/HtmlGeneration_HomeController.cs
@@ -124,8 +124,7 @@ namespace HtmlGenerationWebSite.Controllers
                 },
             };
 
-            // Extra data that should be ignored within a template. But #1487 currently affects RadioButton and
-            // TextArea as well as ModelMetadata for <select> tag helper.
+            // Extra data that should be ignored / not used within a template.
             ViewData[nameof(Employee.Gender)] = "Gender value that will not match.";
             ViewData[nameof(Employee.Name)] = "Name value that should not be seen.";
 

--- a/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/EditorTemplates/Employee.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/EditorTemplates/Employee.cshtml
@@ -4,13 +4,11 @@
 
 <div>
     @Html.LabelFor(m => m.Number)
-    @* Due to #1485, text box will be empty though all employees have Number values. *@
     @Html.TextBox(nameof(Model.Number), value: null, htmlAttributes: new { disabled = "disabled", @readonly = "readonly" })
     <input asp-for="Number" type="number" class="form-control" />
 </div>
 <div>
     <label asp-for="Name" class="employee"></label>
-    @* Due to #1487, text area will contain incorrect "Value that should not be seen." *@
     @Html.TextArea(nameof(Model.Name))
 </div>
 <div>
@@ -22,9 +20,7 @@
         var genders = new SelectList(new string[] { "Male", "Female" });
     }
     <label asp-for="Gender" class="employee"></label>
-    @* Due to #1487, radio button will not be checked. Employee is Female but incorrect information does not match. *@
     @Html.RadioButton(nameof(Model.Gender), "Female", htmlAttributes: new { disabled = "disabled", @readonly = "readonly" })
-    @* Due to #1487, <select> tag helper will not generate expected validation attributes. *@
     <select asp-for="Gender" asp-items="genders"></select>
 </div>
 <div>

--- a/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/EditorTemplates/GenderUsingHtmlHelpers.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/EditorTemplates/GenderUsingHtmlHelpers.cshtml
@@ -1,5 +1,4 @@
 ﻿@using HtmlGenerationWebSite.Models
 @model Gender
 @Html.RadioButtonFor(m => m, value: "Male") Male
-@* Due to #2662 radio button will not be checked because help ignores this expression." *@
 @Html.RadioButton(expression: string.Empty, value: "Female") Female


### PR DESCRIPTION
- #1485, #1487
 - handle `TemplateInfo.HtmlFieldPrefix` in `ViewDataEvaluator.Eval()`
  - attempt lookup in the `ViewDataDictionary` using full name then evaluate
    relative `expression` against `viewData.Model`
  - handle `null` or empty `expression` special case in this method (remove `throw`s)
 - always pass relative `expression` name into `Eval()`
  - remove `null` or empty `expression` handling from higher-level code
  - in a couple of cases, special-case returned `ViewDataInfo`
- #2662
 - remove incorrect guard from `DefaultHtmlGenerator.GenerateRadioButtion()`
- add doc comments for the core methods that have changed
- enable unit tests skipped due to one of above bugs
 - fix one (yeah, just one) other test with incorrect expectations
- remove functional test comments about the above bugs and update expectations

nits:
- move some comments describing `ViewDataEvaluator` methods above the methods