### PR TITLE
Add `ModelBindingContext.IsFirstChanceBinding` and `IsTopLevelObject`

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/ModelBindingContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/ModelBindingContext.cs
@@ -174,7 +174,30 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// Gets or sets a value that indicates whether the binder should use an empty prefix to look up
         /// values in <see cref="IValueProvider"/> when no values are found using the <see cref="ModelName"/> prefix.
         /// </summary>
+        /// <remarks>
+        /// Passed into the model binding system. Should not be <c>true</c> when <see cref="IsTopLevelObject"/> is
+        /// <c>false</c>.
+        /// </remarks>
         public bool FallbackToEmptyPrefix { get; set; }
+
+        /// <summary>
+        /// Gets or sets an indication that the current binder is handling the top-level object.
+        /// </summary>
+        /// <remarks>Passed into the model binding system.</remarks>
+        public bool IsTopLevelObject { get; set; }
+
+        /// <summary>
+        /// Gets or sets an indication that a parent binder will make another binding attempt (e.g. fall back to the
+        /// empty prefix) after this one.
+        /// </summary>
+        /// <remarks>
+        /// Not passed into the model binding system but instead set by the top-level binder. With built-in binders,
+        /// <c>true</c> only in binders called directly from a
+        /// <c>Microsoft.AspNet.Mvc.ModelBinding.CompositeModelBinder</c> that was passed a
+        /// <see cref="ModelBindingContext"/> with <see cref="FallbackToEmptyPrefix"/> <c>true</c>. <c>false</c>
+        /// otherwise.
+        /// </remarks>
+        public bool IsFirstChanceBinding { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="IValueProvider"/> associated with this context.

--- a/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/ModelBindingContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/ModelBindingContext.cs
@@ -187,8 +187,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         public bool IsTopLevelObject { get; set; }
 
         /// <summary>
-        /// Gets or sets an indication that a parent binder will make another binding attempt (e.g. fall back to the
-        /// empty prefix) after this one.
+        /// Gets or sets an indication that the model binding system will make another binding attempt (e.g. fall back
+        /// to the empty prefix) after this one.
         /// </summary>
         /// <remarks>
         /// Not passed into the model binding system but instead set by the top-level binder. With built-in binders,

--- a/src/Microsoft.AspNet.Mvc.Core/DefaultControllerActionArgumentBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/DefaultControllerActionArgumentBinder.cs
@@ -196,6 +196,7 @@ namespace Microsoft.AspNet.Mvc
                 bindingInfo,
                 parameterName);
 
+            modelBindingContext.IsTopLevelObject = true;
             modelBindingContext.ModelState = modelState;
             modelBindingContext.ValueProvider = operationBindingContext.ValueProvider;
             modelBindingContext.OperationBindingContext = operationBindingContext;

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/BodyModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/BodyModelBinder.cs
@@ -30,8 +30,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             // For compatibility with MVC 5.0 for top level object we want to consider an empty key instead of
             // the parameter name/a custom name. In all other cases (like when binding body to a property) we
             // consider the entire ModelName as a prefix.
-            var isTopLevelObject = bindingContext.ModelMetadata.ContainerType == null;
-            var modelBindingKey = isTopLevelObject ? string.Empty : bindingContext.ModelName;
+            var modelBindingKey = bindingContext.IsTopLevelObject ? string.Empty : bindingContext.ModelName;
 
             var httpContext = bindingContext.OperationBindingContext.HttpContext;
 

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/CollectionModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/CollectionModelBinder.cs
@@ -27,12 +27,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             if (!await bindingContext.ValueProvider.ContainsPrefixAsync(bindingContext.ModelName))
             {
-                // If this is the fallback case, and we failed to find data as a top-level model, then generate a
+                // If this is the fallback case and we failed to find data for a top-level model, then generate a
                 // default 'empty' model and return it.
-                var isTopLevelObject = bindingContext.ModelMetadata.ContainerType == null;
-                var hasExplicitAlias = bindingContext.BinderModelName != null;
-
-                if (isTopLevelObject && (hasExplicitAlias || bindingContext.ModelName == string.Empty))
+                if (!bindingContext.IsFirstChanceBinding && bindingContext.IsTopLevelObject)
                 {
                     model = CreateEmptyCollection();
 

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/KeyValuePairModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/KeyValuePairModelBinder.cs
@@ -62,12 +62,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             }
             else
             {
-                // If this is the fallback case, and we failed to find data as a top-level model, then generate a
+                // If this is the fallback case and we failed to find data for a top-level model, then generate a
                 // default 'empty' model and return it.
-                var isTopLevelObject = bindingContext.ModelMetadata.ContainerType == null;
-                var hasExplicitAlias = bindingContext.BinderModelName != null;
-
-                if (isTopLevelObject && (hasExplicitAlias || bindingContext.ModelName == string.Empty))
+                if (!bindingContext.IsFirstChanceBinding && bindingContext.IsTopLevelObject)
                 {
                     var model = new KeyValuePair<TKey, TValue>();
 

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBindingHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBindingHelper.cs
@@ -303,8 +303,9 @@ namespace Microsoft.AspNet.Mvc
                 ModelState = modelState,
                 ValueProvider = valueProvider,
                 FallbackToEmptyPrefix = true,
+                IsTopLevelObject = true,
                 OperationBindingContext = operationBindingContext,
-                PropertyFilter = predicate
+                PropertyFilter = predicate,
             };
 
             var modelBindingResult = await modelBinder.BindModelAsync(modelBindingContext);

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBindingHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBindingHelper.cs
@@ -2,10 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/ArrayModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/ArrayModelBinderTest.cs
@@ -37,13 +37,18 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         }
 
         [Fact]
-        public async Task ArrayModelBinder_DoesNotCreateCollection_ForTopLevelModel_OnFirstPass()
+        public async Task ArrayModelBinder_DoesNotCreateCollection_IfIsTopLevelObjectAndIsFirstChanceBinding()
         {
             // Arrange
             var binder = new ArrayModelBinder<string>();
 
             var context = CreateContext();
-            context.ModelName = "param";
+            context.IsFirstChanceBinding = true;
+            context.IsTopLevelObject = true;
+
+            // Explicit prefix and empty model name both ignored.
+            context.BinderModelName = "prefix";
+            context.ModelName = string.Empty;
 
             var metadataProvider = context.OperationBindingContext.MetadataProvider;
             context.ModelMetadata = metadataProvider.GetMetadataForType(typeof(string[]));
@@ -58,13 +63,16 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         }
 
         [Fact]
-        public async Task ArrayModelBinder_CreatesEmptyCollection_ForTopLevelModel_OnFallback()
+        public async Task ArrayModelBinder_CreatesEmptyCollection_IfIsTopLevelObjectAndNotIsFirstChanceBinding()
         {
             // Arrange
             var binder = new ArrayModelBinder<string>();
 
             var context = CreateContext();
-            context.ModelName = string.Empty;
+            context.IsTopLevelObject = true;
+
+            // Lack of prefix and non-empty model name both ignored.
+            context.ModelName = "modelName";
 
             var metadataProvider = context.OperationBindingContext.MetadataProvider;
             context.ModelMetadata = metadataProvider.GetMetadataForType(typeof(string[]));
@@ -78,37 +86,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             Assert.NotNull(result);
 
             Assert.Empty(Assert.IsType<string[]>(result.Model));
-            Assert.Equal(string.Empty, result.Key);
-            Assert.True(result.IsModelSet);
-
-            Assert.Same(result.ValidationNode.Model, result.Model);
-            Assert.Same(result.ValidationNode.Key, result.Key);
-            Assert.Same(result.ValidationNode.ModelMetadata, context.ModelMetadata);
-        }
-
-        [Fact]
-        public async Task ArrayModelBinder_CreatesEmptyCollection_ForTopLevelModel_WithExplicitPrefix()
-        {
-            // Arrange
-            var binder = new ArrayModelBinder<string>();
-
-            var context = CreateContext();
-            context.ModelName = "prefix";
-            context.BinderModelName = "prefix";
-
-            var metadataProvider = context.OperationBindingContext.MetadataProvider;
-            context.ModelMetadata = metadataProvider.GetMetadataForType(typeof(string[]));
-
-            context.ValueProvider = new TestValueProvider(new Dictionary<string, object>());
-
-            // Act
-            var result = await binder.BindModelAsync(context);
-
-            // Assert
-            Assert.NotNull(result);
-
-            Assert.Empty(Assert.IsType<string[]>(result.Model));
-            Assert.Equal("prefix", result.Key);
+            Assert.Equal("modelName", result.Key);
             Assert.True(result.IsModelSet);
 
             Assert.Same(result.ValidationNode.Model, result.Model);
@@ -119,7 +97,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         [Theory]
         [InlineData("")]
         [InlineData("param")]
-        public async Task ArrayModelBinder_DoesNotCreateCollection_ForNonTopLevelModel(string prefix)
+        public async Task ArrayModelBinder_DoesNotCreateCollection_IfNotIsTopLevelObject(string prefix)
         {
             // Arrange
             var binder = new ArrayModelBinder<string>();

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BodyModelBinderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BodyModelBinderTests.cs
@@ -279,6 +279,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             var bindingContext = new ModelBindingContext
             {
+                IsTopLevelObject = true,
                 ModelMetadata = metadataProvider.GetMetadataForType(modelType),
                 ModelName = "someName",
                 ValueProvider = Mock.Of<IValueProvider>(),

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BodyModelBinderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BodyModelBinderTests.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Internal;
 using Microsoft.AspNet.Routing;
-using Microsoft.Framework.DependencyInjection;
 using Microsoft.Net.Http.Headers;
 using Moq;
 using Xunit;

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/DictionaryModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/DictionaryModelBinderTest.cs
@@ -65,13 +65,18 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         }
 
         [Fact]
-        public async Task DictionaryModelBinder_DoesNotCreateCollection_ForTopLevelModel_OnFirstPass()
+        public async Task DictionaryModelBinder_DoesNotCreateCollection_IfIsTopLevelObjectAndIsFirstChanceBinding()
         {
             // Arrange
             var binder = new DictionaryModelBinder<string, string>();
 
             var context = CreateContext();
-            context.ModelName = "param";
+            context.IsTopLevelObject = true;
+            context.IsFirstChanceBinding = true;
+
+            // Explicit prefix and empty model name both ignored.
+            context.BinderModelName = "prefix";
+            context.ModelName = string.Empty;
 
             var metadataProvider = context.OperationBindingContext.MetadataProvider;
             context.ModelMetadata = metadataProvider.GetMetadataForType(typeof(Dictionary<string, string>));
@@ -86,13 +91,16 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         }
 
         [Fact]
-        public async Task DictionaryModelBinder_CreatesEmptyCollection_ForTopLevelModel_OnFallback()
+        public async Task DictionaryModelBinder_CreatesEmptyCollection_IfIsTopLevelObjectAndNotIsFirstChanceBinding()
         {
             // Arrange
             var binder = new DictionaryModelBinder<string, string>();
 
             var context = CreateContext();
-            context.ModelName = string.Empty;
+            context.IsTopLevelObject = true;
+
+            // Lack of prefix and non-empty model name both ignored.
+            context.ModelName = "modelName";
 
             var metadataProvider = context.OperationBindingContext.MetadataProvider;
             context.ModelMetadata = metadataProvider.GetMetadataForType(typeof(Dictionary<string, string>));
@@ -106,37 +114,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             Assert.NotNull(result);
 
             Assert.Empty(Assert.IsType<Dictionary<string, string>>(result.Model));
-            Assert.Equal(string.Empty, result.Key);
-            Assert.True(result.IsModelSet);
-
-            Assert.Same(result.ValidationNode.Model, result.Model);
-            Assert.Same(result.ValidationNode.Key, result.Key);
-            Assert.Same(result.ValidationNode.ModelMetadata, context.ModelMetadata);
-        }
-
-        [Fact]
-        public async Task DictionaryModelBinder_CreatesEmptyCollection_ForTopLevelModel_WithExplicitPrefix()
-        {
-            // Arrange
-            var binder = new DictionaryModelBinder<string, string>();
-
-            var context = CreateContext();
-            context.ModelName = "prefix";
-            context.BinderModelName = "prefix";
-
-            var metadataProvider = context.OperationBindingContext.MetadataProvider;
-            context.ModelMetadata = metadataProvider.GetMetadataForType(typeof(Dictionary<string, string>));
-
-            context.ValueProvider = new TestValueProvider(new Dictionary<string, object>());
-
-            // Act
-            var result = await binder.BindModelAsync(context);
-
-            // Assert
-            Assert.NotNull(result);
-
-            Assert.Empty(Assert.IsType<Dictionary<string, string>>(result.Model));
-            Assert.Equal("prefix", result.Key);
+            Assert.Equal("modelName", result.Key);
             Assert.True(result.IsModelSet);
 
             Assert.Same(result.ValidationNode.Model, result.Model);
@@ -147,7 +125,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         [Theory]
         [InlineData("")]
         [InlineData("param")]
-        public async Task DictionaryModelBinder_DoesNotCreateCollection_ForNonTopLevelModel(string prefix)
+        public async Task DictionaryModelBinder_DoesNotCreateCollection_IfNotIsTopLevelObject(string prefix)
         {
             // Arrange
             var binder = new DictionaryModelBinder<string, string>();

--- a/test/Microsoft.AspNet.Mvc.Extensions.Test/Rendering/DefaultHtmlGeneratorTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Extensions.Test/Rendering/DefaultHtmlGeneratorTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using Microsoft.AspNet.DataProtection;

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/GenericModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/GenericModelBinderIntegrationTest.cs
@@ -181,10 +181,9 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             };
 
             // Need to have a key here so that the GenericModelBinder will recurse to bind elements.
-            var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
-            {
-                request.QueryString = new QueryString("?parameter.index=0");
-            });
+            var operationContext = ModelBindingTestHelper.GetOperationBindingContext(
+                request => request.QueryString = new QueryString("?parameter.index=0"),
+                options => options.ModelBinders.Add(new AddressBinder()));
 
             var modelState = new ModelStateDictionary();
 
@@ -198,6 +197,41 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Address[]>(modelBindingResult.Model);
             Assert.Equal(1, model.Length);
             Assert.NotNull(model[0]);
+
+            Assert.Equal(0, modelState.Count);
+            Assert.Equal(0, modelState.ErrorCount);
+            Assert.True(modelState.IsValid);
+        }
+
+        // Similar to the GenericModelBinder_BindsCollection_ElementTypeUsesGreedyModelBinder_WithPrefix_Success
+        // scenario but mis-configured. Model using a BindingSource for which no ModelBinder is enabled.
+        [Fact]
+        public async Task GenericModelBinder_BindsCollection_ElementTypeUsesGreedyBindingSource_WithPrefix_NullElement()
+        {
+            // Arrange
+            var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
+            var parameter = new ParameterDescriptor()
+            {
+                Name = "parameter",
+                ParameterType = typeof(Address[])
+            };
+
+            // Need to have a key here so that the GenericModelBinder will recurse to bind elements.
+            var operationContext = ModelBindingTestHelper.GetOperationBindingContext(
+                request => request.QueryString = new QueryString("?parameter.index=0"));
+
+            var modelState = new ModelStateDictionary();
+
+            // Act
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+
+            // Assert
+            Assert.NotNull(modelBindingResult);
+            Assert.True(modelBindingResult.IsModelSet);
+
+            var model = Assert.IsType<Address[]>(modelBindingResult.Model);
+            Assert.Equal(1, model.Length);
+            Assert.Null(model[0]);
 
             Assert.Equal(0, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/ValidationIntegrationTests.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/ValidationIntegrationTests.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Http;


### PR DESCRIPTION
- cleanup duplicate code now that #2445 is fixed
- update unit tests using old `ModelBindingContext` setups
- fix (just) one integration test where `MutableObjectModelBinder` incorrectly calculated
  `isTopLevelObject` and returned a non-`null` model

nits:
- combine tests that are now duplicates
- beef up coverage of some `MutableObjectModelBinderTest` cases