### PR TITLE
Go one less step when resolving `[ModelMetadataType]`

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Metadata/ModelAttributes.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Metadata/ModelAttributes.cs
@@ -77,9 +77,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 if (metadataProperty != null)
                 {
                     propertyAttributes = propertyAttributes.Concat(metadataProperty.GetCustomAttributes());
-
-                    var propertyMetadataType = metadataProperty.PropertyType;
-                    typeAttributes = typeAttributes.Concat(propertyMetadataType.GetTypeInfo().GetCustomAttributes());
                 }
             }
 

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/Metadata/ModelAttributesTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/Metadata/ModelAttributesTest.cs
@@ -165,19 +165,17 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var attributes = ModelAttributes.GetAttributesForProperty(typeof(MergedAttributes), property);
 
             // Assert
-            Assert.Equal(4, attributes.Attributes.Count);
+            Assert.Equal(3, attributes.Attributes.Count);
             Assert.IsType<RequiredAttribute>(attributes.Attributes[0]);
             Assert.IsType<RangeAttribute>(attributes.Attributes[1]);
             Assert.IsType<ClassValidator>(attributes.Attributes[2]);
-            Assert.IsType<BindAttribute>(attributes.Attributes[3]);
 
             Assert.Equal(2, attributes.PropertyAttributes.Count);
             Assert.IsType<RequiredAttribute>(attributes.PropertyAttributes[0]);
             Assert.IsType<RangeAttribute>(attributes.PropertyAttributes[1]);
 
-            Assert.Equal(2, attributes.TypeAttributes.Count);
-            Assert.IsType<ClassValidator>(attributes.TypeAttributes[0]);
-            Assert.IsType<BindAttribute>(attributes.TypeAttributes[1]);
+            var attribute = Assert.Single(attributes.TypeAttributes);
+            Assert.IsType<ClassValidator>(attribute);
         }
 
         [ClassValidator]
@@ -207,7 +205,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             [Range(10,100)]
             public override int VirtualProperty { get; set; }
-            
+
         }
 
         [ModelMetadataType(typeof(BaseModel))]


### PR DESCRIPTION
- #2610
- make MVC 6's attribute consistent with data annotation's `[MetadataType]`, used in MVC 5