### PR TITLE
Add `Encode()` and `Raw()` overrides to `IHtmlHelper<TModel>`

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Extensions/Rendering/IHtmlHelperOfT.cs
+++ b/src/Microsoft.AspNet.Mvc.Extensions/Rendering/IHtmlHelperOfT.cs
@@ -171,6 +171,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
             string htmlFieldName,
             object additionalViewData);
 
+        /// <inheritdoc cref="IHtmlHelper.Encode(object)"/>
+        new string Encode(object value);
+
+        /// <inheritdoc cref="IHtmlHelper.Encode(string)"/>
+        new string Encode(string value);
+
         /// <summary>
         /// Returns an &lt;input&gt; element of type "hidden" for the specified <paramref name="expression"/>.
         /// </summary>
@@ -332,6 +338,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
             [NotNull] Expression<Func<TModel, TResult>> expression,
             [NotNull] object value,
             object htmlAttributes);
+
+        /// <inheritdoc cref="IHtmlHelper.Raw(object)"/>
+        new HtmlString Raw(object value);
+
+        /// <inheritdoc cref="IHtmlHelper.Raw(string)"/>
+        new HtmlString Raw(string value);
 
         /// <summary>
         /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>.

--- a/test/Microsoft.AspNet.Mvc.Extensions.Test/Rendering/HtmlHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Extensions.Test/Rendering/HtmlHelperTest.cs
@@ -42,6 +42,98 @@ namespace Microsoft.AspNet.Mvc.Rendering
             }
         }
 
+        // value, expectedString
+        public static TheoryData<object, string> EncodeDynamicTestData
+        {
+            get
+            {
+                var data = new TheoryData<object, string>
+                {
+                    { null, string.Empty },
+                    // Dynamic implementation calls the string overload when possible.
+                    { string.Empty, string.Empty },
+                    { "<\">", "HtmlEncode[[<\">]]" },
+                    { "<br />", "HtmlEncode[[<br />]]" },
+                    { "<b>bold</b>", "HtmlEncode[[<b>bold</b>]]" },
+                    { new ObjectWithToStringOverride(), "HtmlEncode[[<b>boldFromObject</b>]]" },
+                };
+
+                return data;
+            }
+        }
+
+        // value, expectedString
+        public static TheoryData<object, string> EncodeObjectTestData
+        {
+            get
+            {
+                var data = new TheoryData<object, string>
+                {
+                    { null, string.Empty },
+                    // Object overload does not special case the empty string.
+                    { string.Empty, "HtmlEncode[[]]" },
+                    { "<\">", "HtmlEncode[[<\">]]" },
+                    { "<br />", "HtmlEncode[[<br />]]" },
+                    { "<b>bold</b>", "HtmlEncode[[<b>bold</b>]]" },
+                    { new ObjectWithToStringOverride(), "HtmlEncode[[<b>boldFromObject</b>]]" },
+                };
+
+                return data;
+            }
+        }
+
+        // value, expectedString
+        public static TheoryData<string, string> EncodeStringTestData
+        {
+            get
+            {
+                return new TheoryData<string, string>
+                {
+                    { null, string.Empty },
+                    // String overload does not encode the empty string.
+                    { string.Empty, string.Empty },
+                    { "<\">", "HtmlEncode[[<\">]]" },
+                    { "<br />", "HtmlEncode[[<br />]]" },
+                    { "<b>bold</b>", "HtmlEncode[[<b>bold</b>]]" },
+                };
+            }
+        }
+
+        // value, expectedString
+        public static TheoryData<object, string> RawObjectTestData
+        {
+            get
+            {
+                var data = new TheoryData<object, string>
+                {
+                    { new ObjectWithToStringOverride(), "<b>boldFromObject</b>" },
+                };
+
+                foreach (var item in RawStringTestData)
+                {
+                    data.Add(item[0], (string)item[1]);
+                }
+
+                return data;
+            }
+        }
+
+        // value, expectedString
+        public static TheoryData<string, string> RawStringTestData
+        {
+            get
+            {
+                return new TheoryData<string, string>
+                {
+                    { null, null },
+                    { string.Empty, string.Empty },
+                    { "<\">", "<\">" },
+                    { "<br />", "<br />" },
+                    { "<b>bold</b>", "<b>bold</b>" },
+                };
+            }
+        }
+
         [Theory]
         [MemberData(nameof(IgnoreCaseTestData))]
         public void AnonymousObjectToHtmlAttributes_IgnoresPropertyCase(object htmlAttributeObject,
@@ -53,6 +145,136 @@ namespace Microsoft.AspNet.Mvc.Rendering
             // Assert
             var entry = Assert.Single(result);
             Assert.Equal(expectedEntry, entry);
+        }
+
+        [Theory]
+        [MemberData(nameof(EncodeDynamicTestData))]
+        public void EncodeDynamic_ReturnsExpectedString(object value, string expectedString)
+        {
+            // Arrange
+            dynamic dynamicValue = value;
+            IHtmlHelper<DefaultTemplatesUtilities.ObjectTemplateModel> helper =
+                DefaultTemplatesUtilities.GetHtmlHelper();
+
+            // Act
+            var result = helper.Encode(dynamicValue);
+
+            // Assert
+            Assert.Equal(expectedString, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(EncodeDynamicTestData))]
+        public void EncodeDynamic_ReturnsExpectedString_WithBaseHelper(object value, string expectedString)
+        {
+            // Arrange
+            dynamic dynamicValue = value;
+            IHtmlHelper helper = DefaultTemplatesUtilities.GetHtmlHelper();
+
+            // Act
+            var result = helper.Encode(dynamicValue);
+
+            // Assert
+            Assert.Equal(expectedString, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(EncodeObjectTestData))]
+        public void EncodeObject_ReturnsExpectedString(object value, string expectedString)
+        {
+            // Arrange
+            IHtmlHelper<DefaultTemplatesUtilities.ObjectTemplateModel> helper =
+                DefaultTemplatesUtilities.GetHtmlHelper();
+
+            // Act
+            var result = helper.Encode(value);
+
+            // Assert
+            Assert.Equal(expectedString, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(EncodeStringTestData))]
+        public void EncodeString_ReturnsExpectedString(string value, string expectedString)
+        {
+            // Arrange
+            IHtmlHelper<DefaultTemplatesUtilities.ObjectTemplateModel> helper =
+                DefaultTemplatesUtilities.GetHtmlHelper();
+
+            // Act
+            var result = helper.Encode(value);
+
+            // Assert
+            Assert.Equal(expectedString, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(RawObjectTestData))]
+        public void RawDynamic_ReturnsExpectedString(object value, string expectedString)
+        {
+            // Arrange
+            dynamic dynamicValue = value;
+            IHtmlHelper<DefaultTemplatesUtilities.ObjectTemplateModel> helper =
+                DefaultTemplatesUtilities.GetHtmlHelper();
+
+            // Act
+            var result = helper.Raw(dynamicValue);
+
+            // Assert
+            Assert.Equal(expectedString, result.ToString());
+        }
+
+        [Theory]
+        [MemberData(nameof(RawObjectTestData))]
+        public void RawDynamic_ReturnsExpectedString_WithBaseHelper(object value, string expectedString)
+        {
+            // Arrange
+            dynamic dynamicValue = value;
+            IHtmlHelper helper = DefaultTemplatesUtilities.GetHtmlHelper();
+
+            // Act
+            var result = helper.Raw(dynamicValue);
+
+            // Assert
+            Assert.Equal(expectedString, result.ToString());
+        }
+
+        [Theory]
+        [MemberData(nameof(RawObjectTestData))]
+        public void RawObject_ReturnsExpectedString(object value, string expectedString)
+        {
+            // Arrange
+            IHtmlHelper<DefaultTemplatesUtilities.ObjectTemplateModel> helper =
+                DefaultTemplatesUtilities.GetHtmlHelper();
+
+            // Act
+            var result = helper.Raw(value);
+
+            // Assert
+            Assert.Equal(expectedString, result.ToString());
+        }
+
+        [Theory]
+        [MemberData(nameof(RawStringTestData))]
+        public void RawString_ReturnsExpectedString(string value, string expectedString)
+        {
+            // Arrange
+            IHtmlHelper<DefaultTemplatesUtilities.ObjectTemplateModel> helper =
+                DefaultTemplatesUtilities.GetHtmlHelper();
+
+            // Act
+            var result = helper.Raw(value);
+
+            // Assert
+            Assert.Equal(expectedString, result.ToString());
+        }
+
+        private class ObjectWithToStringOverride
+        {
+            public override string ToString()
+            {
+                return "<b>boldFromObject</b>";
+            }
         }
     }
 }


### PR DESCRIPTION
- #2392
- `dynamic` does not work correctly when inherited from a base `interface`