### PR TITLE
Get tets working with `core.autocrlf=false`

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/Compilation/RazorCompilationService.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Compilation/RazorCompilationService.cs
@@ -22,9 +22,18 @@ namespace Microsoft.AspNet.Mvc.Razor.Compilation
         private readonly IMvcRazorHost _razorHost;
         private readonly IFileProvider _fileProvider;
 
-        public RazorCompilationService(ICompilationService compilationService,
-                                       IMvcRazorHost razorHost,
-                                       IOptions<RazorViewEngineOptions> viewEngineOptions)
+        /// <summary>
+        /// Instantiates a new instance of the <see cref="RazorCompilationService"/> class.
+        /// </summary>
+        /// <param name="compilationService">The <see cref="ICompilationService"/> to compile generated code.</param>
+        /// <param name="razorHost">The <see cref="IMvcRazorHost"/> to generate code from Razor files.</param>
+        /// <param name="viewEngineOptions">
+        /// The <see cref="IFileProvider"/> to read Razor files referenced in error messages.
+        /// </param>
+        public RazorCompilationService(
+            ICompilationService compilationService,
+            IMvcRazorHost razorHost,
+            IOptions<RazorViewEngineOptions> viewEngineOptions)
         {
             _compilationService = compilationService;
             _razorHost = razorHost;
@@ -37,7 +46,7 @@ namespace Microsoft.AspNet.Mvc.Razor.Compilation
             GeneratorResults results;
             using (var inputStream = file.FileInfo.CreateReadStream())
             {
-                results = _razorHost.GenerateCode(file.RelativePath, inputStream);
+                results = GenerateCode(file.RelativePath, inputStream);
             }
 
             if (!results.Success)
@@ -46,6 +55,21 @@ namespace Microsoft.AspNet.Mvc.Razor.Compilation
             }
 
             return _compilationService.Compile(file, results.GeneratedCode);
+        }
+
+        /// <summary>
+        /// Generate code for the Razor file at <paramref name="relativePath"/> with content
+        /// <paramref name="inputStream"/>.
+        /// </summary>
+        /// <param name="relativePath">
+        /// The path of the Razor file relative to the root of the application. Used to generate line pragmas and
+        /// calculate the class name of the generated type.
+        /// </param>
+        /// <param name="inputStream">A <see cref="Stream"/> that contains the Razor content.</param>
+        /// <returns>A <see cref="GeneratorResults"/> instance containing results of code generation.</returns>
+        protected virtual GeneratorResults GenerateCode(string relativePath, Stream inputStream)
+        {
+            return _razorHost.GenerateCode(relativePath, inputStream);
         }
 
         // Internal for unit testing

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ActivatorTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ActivatorTests.cs
@@ -156,7 +156,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var expected = "<body><h2>Activation Test</h2>" +
                            Environment.NewLine +
                            "<div>FakeFakeFake</div>" +
-                           Environment.NewLine + 
+                           Environment.NewLine +
                            "<span>" +
                            "<input id=\"foo\" name=\"foo\" type=\"hidden\" value=\"test content\" />" +
                            "</span>" +
@@ -168,7 +168,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var body = await client.GetStringAsync("http://localhost/View/UseTagHelper");
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/BasicTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/BasicTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(_resourcesAssembly, outputFile, expectedContent, responseContent);
 #else
-            Assert.Equal(expectedContent, responseContent);
+            Assert.Equal(expectedContent, responseContent, ignoreLineEndingDifferences: true);
 #endif
         }
 
@@ -82,7 +82,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(_resourcesAssembly, outputFile, expectedContent, responseContent);
 #else
-            Assert.Equal(expectedContent, responseContent);
+            Assert.Equal(expectedContent, responseContent, ignoreLineEndingDifferences: true);
 #endif
         }
 
@@ -106,7 +106,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(_resourcesAssembly, outputFile, expectedContent, responseContent);
 #else
-            Assert.Equal(expectedContent, responseContent);
+            Assert.Equal(expectedContent, responseContent, ignoreLineEndingDifferences: true);
 #endif
         }
 
@@ -258,9 +258,11 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
                 Name = "John <b>Smith</b>"
             });
 
-            var expectedBody = string.Format(@"<script type=""text/javascript"">" + Environment.NewLine +
-                                             @"    var json = {0};" + Environment.NewLine +
-                                             @"</script>", json);
+            var expectedBody = string.Format(
+                @"<script type=""text/javascript"">
+    var json = {0};
+</script>",
+                json);
 
             // Act
             var response = await client.GetAsync("https://localhost/Home/JsonHelperInView");
@@ -270,7 +272,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("text/html", response.Content.Headers.ContentType.MediaType);
 
             var actualBody = await response.Content.ReadAsStringAsync();
-            Assert.Equal(expectedBody, actualBody);
+            Assert.Equal(expectedBody, actualBody, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -286,9 +288,11 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
                 Name = "John <b>Smith</b>"
             }, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
 
-            var expectedBody = string.Format(@"<script type=""text/javascript"">" + Environment.NewLine +
-                                             @"    var json = {0};" + Environment.NewLine +
-                                             @"</script>", json);
+            var expectedBody = string.Format(
+                @"<script type=""text/javascript"">
+    var json = {0};
+</script>",
+                json);
 
             // Act
             var response = await client.GetAsync("https://localhost/Home/JsonHelperWithSettingsInView");
@@ -298,7 +302,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("text/html", response.Content.Headers.ContentType.MediaType);
 
             var actualBody = await response.Content.ReadAsStringAsync();
-            Assert.Equal(expectedBody, actualBody);
+            Assert.Equal(expectedBody, actualBody, ignoreLineEndingDifferences: true);
         }
 
         public static IEnumerable<object[]> HtmlHelperLinkGenerationData

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/BestEffortLinkGenerationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/BestEffortLinkGenerationTest.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal(ExpectedOutput, content);
+            Assert.Equal(ExpectedOutput, content, ignoreLineEndingDifferences: true);
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/CompilationOptionsTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/CompilationOptionsTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 
 This method is only defined in DNX451";
 #elif DNXCORE50
-            var expected = 
+            var expected =
 @"This method is running from DNXCORE50
 
 This method is only defined in DNXCORE50";
@@ -40,7 +40,7 @@ This method is only defined in DNXCORE50";
             var body = await client.GetStringAsync("http://localhost/ViewsConsumingCompilationOptions/");
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ContentNegotiationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ContentNegotiationTest.cs
@@ -169,17 +169,29 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         }
 
         [Theory]
-        [InlineData("ContactInfoUsingV3Format", "text/vcard; version=v3.0; charset=utf-8", "BEGIN:VCARD#FN:John Williams#END:VCARD#")]
-        [InlineData("ContactInfoUsingV4Format", "text/vcard; version=v4.0; charset=utf-8", "BEGIN:VCARD#FN:John Williams#GENDER:M#END:VCARD#")]
+        [InlineData(
+            "ContactInfoUsingV3Format",
+            "text/vcard; version=v3.0; charset=utf-8",
+            @"BEGIN:VCARD
+FN:John Williams
+END:VCARD
+")]
+        [InlineData(
+            "ContactInfoUsingV4Format",
+            "text/vcard; version=v4.0; charset=utf-8",
+            @"BEGIN:VCARD
+FN:John Williams
+GENDER:M
+END:VCARD
+")]
         public async Task ProducesAttribute_WithMediaTypeHavingParameters_IsCaseInsensitiveMatch(
-                                                                                            string action,
-                                                                                            string expectedMediaType,
-                                                                                            string expectedResponseBody)
+            string action,
+            string expectedMediaType,
+            string expectedResponseBody)
         {
             // Arrange
             var server = TestHelper.CreateServer(_app, SiteName, _configureServices);
             var client = server.CreateClient();
-            expectedResponseBody = expectedResponseBody.Replace("#", Environment.NewLine);
 
             // Act
             var response = await client.GetAsync("http://localhost/ProducesWithMediaTypeParameters/" + action);
@@ -192,7 +204,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal(expectedMediaType, contentType.ToString());
 
             var actualResponseBody = await response.Content.ReadAsStringAsync();
-            Assert.Equal(expectedResponseBody, actualResponseBody);
+            Assert.Equal(expectedResponseBody, actualResponseBody, ignoreLineEndingDifferences: true);
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/FlushPointTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/FlushPointTest.cs
@@ -74,14 +74,17 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             waitService.WaitForServer();
 
             // Assert - 4
-            Assert.Equal(@"After flush inside partial
+            Assert.Equal(
+                @"After flush inside partial
 <form action=""/FlushPoint/PageWithoutLayout"" method=""post""><input id=""Name1"" name=""Name1"" type=""text"" value="""" />",
-            GetTrimmedString(stream));
+                GetTrimmedString(stream),
+                ignoreLineEndingDifferences: true);
             waitService.WaitForServer();
 
             // Assert - 5
-            Assert.Equal(@"<input id=""Name2"" name=""Name2"" type=""text"" value="""" /></form>",
-                        GetTrimmedString(stream));
+            Assert.Equal(
+                @"<input id=""Name2"" name=""Name2"" type=""text"" value="""" /></form>",
+                GetTrimmedString(stream));
         }
 
         [Theory]
@@ -102,28 +105,32 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var stream = await client.GetStreamAsync("http://localhost/FlushPoint/" + action);
 
             // Assert - 1
-            Assert.Equal(string.Join(Environment.NewLine,
-                                     "<title>" + title + "</title>",
-                                     "",
-                                     "RenderBody content"), GetTrimmedString(stream));
+            Assert.Equal(
+                $@"<title>{ title }</title>
+
+RenderBody content",
+                GetTrimmedString(stream),
+                ignoreLineEndingDifferences: true);
             waitService.WaitForServer();
 
             // Assert - 2
-            Assert.Equal(string.Join(
-                Environment.NewLine,
-                "partial-content",
-                "",
-                "Value from TaskReturningString",
-                "<p>section-content</p>"), GetTrimmedString(stream));
+            Assert.Equal(
+                @"partial-content
+
+Value from TaskReturningString
+<p>section-content</p>",
+                GetTrimmedString(stream),
+                ignoreLineEndingDifferences: true);
             waitService.WaitForServer();
 
             // Assert - 3
-            Assert.Equal(string.Join(
-                Environment.NewLine,
-                "component-content",
-                "    <span>Content that takes time to produce</span>",
-                "",
-                "More content from layout"), GetTrimmedString(stream));
+            Assert.Equal(
+                @"component-content
+    <span>Content that takes time to produce</span>
+
+More content from layout",
+                GetTrimmedString(stream),
+                ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -143,10 +150,12 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var stream = await client.GetStreamAsync("http://localhost/FlushPoint/PageWithNestedLayout");
 
             // Assert - 1
-            Assert.Equal(@"Inside Nested Layout
+            Assert.Equal(
+                @"Inside Nested Layout
 
 <title>Nested Page With Layout</title>",
-                GetTrimmedString(stream));
+                GetTrimmedString(stream),
+                ignoreLineEndingDifferences: true);
             waitService.WaitForServer();
 
             // Assert - 2

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/HtmlGenerationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/HtmlGenerationTest.cs
@@ -77,7 +77,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #if GENERATE_BASELINES
                 ResourceFile.UpdateFile(_resourcesAssembly, outputFile, expectedContent, responseContent);
 #else
-                Assert.Equal(expectedContent.Trim(), responseContent);
+                Assert.Equal(expectedContent.Trim(), responseContent, ignoreLineEndingDifferences: true);
 #endif
             }
             else
@@ -89,7 +89,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
                 ResourceFile.UpdateFile(_resourcesAssembly, outputFile, expectedContent, responseContent);
 #else
                 expectedContent = string.Format(expectedContent, forgeryToken);
-                Assert.Equal(expectedContent.Trim(), responseContent);
+                Assert.Equal(expectedContent.Trim(), responseContent, ignoreLineEndingDifferences: true);
 #endif
             }
         }
@@ -133,7 +133,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #if GENERATE_BASELINES
                 ResourceFile.UpdateFile(_resourcesAssembly, outputFile, expectedContent, responseContent);
 #else
-                Assert.Equal(expectedContent.Trim(), responseContent);
+                Assert.Equal(expectedContent.Trim(), responseContent, ignoreLineEndingDifferences: true);
 #endif
             }
             else
@@ -145,7 +145,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
                 ResourceFile.UpdateFile(_resourcesAssembly, outputFile, expectedContent, responseContent);
 #else
                 expectedContent = string.Format(expectedContent, forgeryToken);
-                Assert.Equal(expectedContent.Trim(), responseContent);
+                Assert.Equal(expectedContent.Trim(), responseContent, ignoreLineEndingDifferences: true);
 #endif
             }
         }
@@ -188,7 +188,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             ResourceFile.UpdateFile(_resourcesAssembly, outputFile, expectedContent, responseContent);
 #else
             expectedContent = string.Format(expectedContent, forgeryToken);
-            Assert.Equal(expectedContent.Trim(), responseContent);
+            Assert.Equal(expectedContent.Trim(), responseContent, ignoreLineEndingDifferences: true);
 #endif
         }
 
@@ -223,8 +223,8 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(_resourcesAssembly, outputFile1, expected1, response1.Trim());
 #else
-            Assert.Equal(expected1, response1.Trim());
-            Assert.Equal(expected1, response2.Trim());
+            Assert.Equal(expected1, response1.Trim(), ignoreLineEndingDifferences: true);
+            Assert.Equal(expected1, response2.Trim(), ignoreLineEndingDifferences: true);
 #endif
 
             // Act - 2
@@ -237,8 +237,8 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(_resourcesAssembly, outputFile2, expected2, response3.Trim());
 #else
-            Assert.Equal(expected2, response3.Trim());
-            Assert.Equal(expected2, response4.Trim());
+            Assert.Equal(expected2, response3.Trim(), ignoreLineEndingDifferences: true);
+            Assert.Equal(expected2, response4.Trim(), ignoreLineEndingDifferences: true);
 #endif
 
             // Act - 3
@@ -254,8 +254,8 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(_resourcesAssembly, outputFile3, expected3, response5.Trim());
 #else
-            Assert.Equal(expected3, response5.Trim());
-            Assert.Equal(expected3, response6.Trim());
+            Assert.Equal(expected3, response5.Trim(), ignoreLineEndingDifferences: true);
+            Assert.Equal(expected3, response6.Trim(), ignoreLineEndingDifferences: true);
 #endif
         }
 
@@ -413,7 +413,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var expected1 =
 @"Category: Books
 Products: Book1, Book2 (1)";
-            Assert.Equal(expected1, response1.Trim());
+            Assert.Equal(expected1, response1.Trim(), ignoreLineEndingDifferences: true);
 
             // Act - 2
             var response2 = await client.GetStringAsync("/categories/Electronics?correlationId=2");
@@ -422,7 +422,7 @@ Products: Book1, Book2 (1)";
             var expected2 =
 @"Category: Electronics
 Products: Book1, Book2 (1)";
-            Assert.Equal(expected2, response2.Trim());
+            Assert.Equal(expected2, response2.Trim(), ignoreLineEndingDifferences: true);
 
             // Act - 3
             // Trigger an expiration
@@ -435,7 +435,7 @@ Products: Book1, Book2 (1)";
             var expected3 =
 @"Category: Electronics
 Products: Laptops (3)";
-            Assert.Equal(expected3, response4.Trim());
+            Assert.Equal(expected3, response4.Trim(), ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -503,7 +503,7 @@ Products: Laptops (3)";
             ResourceFile.UpdateFile(_resourcesAssembly, outputFile, expectedContent, responseContent);
 #else
             expectedContent = string.Format(expectedContent, forgeryTokens);
-            Assert.Equal(expectedContent.Trim(), responseContent);
+            Assert.Equal(expectedContent.Trim(), responseContent, ignoreLineEndingDifferences: true);
 #endif
         }
     }

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/HtmlHelperOptionsTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/HtmlHelperOptionsTest.cs
@@ -47,7 +47,7 @@ False";
             var body = await client.GetStringAsync("http://localhost/HtmlHelperOptions/HtmlHelperOptionsDefaultsInView");
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -83,7 +83,7 @@ True";
             var body = await client.GetStringAsync("http://localhost/HtmlHelperOptions/OverrideAppWideDefaultsInView");
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/LinkGenerationTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/LinkGenerationTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(_resourcesAssembly, outputFile, expectedContent, responseContent);
 #else
-            Assert.Equal(expectedContent, responseContent);
+            Assert.Equal(expectedContent, responseContent, ignoreLineEndingDifferences: true);
 #endif
         }
     }

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/LocalizationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/LocalizationTest.cs
@@ -69,7 +69,7 @@ mypartial
             var body = await client.GetStringAsync("http://localhost/");
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingTest.cs
@@ -1406,7 +1406,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(_assembly, outputFile, expectedContent, responseContent);
 #else
-            Assert.Equal(expectedContent, responseContent);
+            Assert.Equal(expectedContent, responseContent, ignoreLineEndingDifferences: true);
 #endif
         }
 
@@ -1442,7 +1442,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(_assembly, outputFile, expectedContent, responseContent);
 #else
-            Assert.Equal(expectedContent, responseContent);
+            Assert.Equal(expectedContent, responseContent, ignoreLineEndingDifferences: true);
 #endif
         }
 
@@ -1478,7 +1478,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(_assembly, outputFile, expectedContent, responseContent);
 #else
-            Assert.Equal(expectedContent, responseContent);
+            Assert.Equal(expectedContent, responseContent, ignoreLineEndingDifferences: true);
 #endif
         }
 
@@ -1629,7 +1629,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(_assembly, outputFile, expectedContent, responseContent);
 #else
-            Assert.Equal(expectedContent, responseContent);
+            Assert.Equal(expectedContent, responseContent, ignoreLineEndingDifferences: true);
 #endif
         }
 
@@ -1653,7 +1653,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(_assembly, outputFile, expectedContent, responseContent);
 #else
-            Assert.Equal(expectedContent, responseContent);
+            Assert.Equal(expectedContent, responseContent, ignoreLineEndingDifferences: true);
 #endif
         }
 
@@ -1696,7 +1696,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(_assembly, outputFile, expectedContent, responseContent);
 #else
-            Assert.Equal(expectedContent, responseContent);
+            Assert.Equal(expectedContent, responseContent, ignoreLineEndingDifferences: true);
 #endif
         }
 

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/PrecompilationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/PrecompilationTest.cs
@@ -8,7 +8,6 @@ using System.Net;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Mvc.Razor;
 using Microsoft.AspNet.Mvc.Razor.Precompilation;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.Runtime;
@@ -236,7 +235,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         {
             // Arrange
             var assemblyNamePrefix = GetAssemblyNamePrefix();
-            var expected = 
+            var expected =
                 @"<root data-root=""true""><input class=""form-control"" type=""number"" data-val=""true""" +
                 @" data-val-range=""The field Age must be between 10 and 100."" data-val-range-max=""100"" "+
                 @"data-val-range-min=""10"" data-val-required=""The Age field is required."" " +
@@ -248,7 +247,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var response = await client.GetStringAsync("http://localhost/TagHelpers/Add");
 
             // Assert
-            var responseLines = response.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            var responseLines = response.Split(new[] { "\n", "\r" }, StringSplitOptions.RemoveEmptyEntries);
             Assert.StartsWith(assemblyNamePrefix, responseLines[0]);
             Assert.Equal(expected, responseLines[1]);
         }
@@ -266,7 +265,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var response = await client.GetStringAsync("http://localhost/TagHelpers/Remove");
 
             // Assert
-            var responseLines = response.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            var responseLines = response.Split(new[] { "\n", "\r" }, StringSplitOptions.RemoveEmptyEntries);
             Assert.StartsWith(assemblyNamePrefix, responseLines[0]);
             Assert.Equal(expected, responseLines[1]);
         }
@@ -291,10 +290,10 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         {
             public ParsedResponse(string responseContent)
             {
-                var results = responseContent.Split(new[] { Environment.NewLine },
-                                                    StringSplitOptions.RemoveEmptyEntries)
-                                             .Select(s => s.Trim())
-                                             .ToArray();
+                var results = responseContent
+                    .Split(new[] { "\n", "\r" }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(s => s.Trim())
+                    .ToArray();
 
                 Assert.True(results[0].StartsWith("Layout:"));
                 Layout = results[0].Substring("Layout:".Length);

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/RazorPageExecutionInstrumentationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/RazorPageExecutionInstrumentationTest.cs
@@ -21,72 +21,70 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         {
             get
             {
-                var expected = string.Join(Environment.NewLine,
-                                           @"<div>",
-                                           @"2147483647",
-                                           "",
-                                           @"viewstart-content",
-                                           @"<p class=""Hello world"">",
-                                           @"page-content",
-                                           @"</p>",
-                                           @"</div>");
+                var expected = @"<div>
+2147483647
+
+viewstart-content
+<p class=""Hello world"">
+page-content
+</p>
+</div>";
 
                 var expectedLineMappings = new[]
                 {
-                    Tuple.Create(93, 2, true),
-                    Tuple.Create(96, 16, false),
-                    Tuple.Create(112, 2, true),
+                    Tuple.Create(90, 1, true),
+                    Tuple.Create(92, 16, false),
+                    Tuple.Create(108, 1, true),
                     Tuple.Create(0, 2, true),
                     Tuple.Create(2, 8, true),
                     Tuple.Create(10, 16, false),
                     Tuple.Create(26, 1, true),
-                    Tuple.Create(27, 21, true),
-                    Tuple.Create(0, 7, true),
-                    Tuple.Create(8, 12, false),
-                    Tuple.Create(20, 2, true),
-                    Tuple.Create(23, 12, false),
-                    Tuple.Create(35, 8, true),
+                    Tuple.Create(27, 19, true),
+                    Tuple.Create(0, 6, true),
+                    Tuple.Create(7, 12, false),
+                    Tuple.Create(19, 1, true),
+                    Tuple.Create(21, 12, false),
+                    Tuple.Create(33, 7, true),
                 };
 
                 yield return new object[] { "FullPath", expected, expectedLineMappings };
                 yield return new object[] { "ViewDiscoveryPath", expected, expectedLineMappings };
 
-                var expected2 = string.Join(Environment.NewLine,
-                                            "<div>",
-                                            "2147483647",
-                                            "",
-                                            "viewstart-content",
-                                            "view-with-partial-content",
-                                            "",
-                                            @"<p class=""class"">partial-content</p>",
-                                            "",
-                                            @"<p class=""class"">partial-content</p>",
-                                            "</div>");
+                var expected2 = @"<div>
+2147483647
+
+viewstart-content
+view-with-partial-content
+
+<p class=""class"">partial-content</p>
+
+<p class=""class"">partial-content</p>
+</div>";
                 var expectedLineMappings2 = new[]
                 {
-                    Tuple.Create(93, 2, true),
-                    Tuple.Create(96, 16, false),
-                    Tuple.Create(112, 2, true),
-                    Tuple.Create(0, 27, true),
-                    Tuple.Create(28, 39, false),
+                    Tuple.Create(90, 1, true),
+                    Tuple.Create(92, 16, false),
+                    Tuple.Create(108, 1, true),
+                    Tuple.Create(0, 26, true),
+                    Tuple.Create(27, 39, false),
                     // Html.PartialAsync()
-                    Tuple.Create(29, 4, true),
-                    Tuple.Create(33, 8, true),
-                    Tuple.Create(41, 4, false),
-                    Tuple.Create(45, 1, true),
-                    Tuple.Create(46, 20, true),
-                    Tuple.Create(67, 2, true),
+                    Tuple.Create(27, 3, true),
+                    Tuple.Create(30, 8, true),
+                    Tuple.Create(38, 4, false),
+                    Tuple.Create(42, 1, true),
+                    Tuple.Create(43, 20, true),
+                    Tuple.Create(66, 1, true),
                     // Html.RenderPartial()
-                    Tuple.Create(29, 4, true),
-                    Tuple.Create(33, 8, true),
-                    Tuple.Create(41, 4, false),
-                    Tuple.Create(45, 1, true),
-                    Tuple.Create(46, 20, true),
-                    Tuple.Create(0, 7, true),
-                    Tuple.Create(8, 12, false),
-                    Tuple.Create(20, 2, true),
-                    Tuple.Create(23, 12, false),
-                    Tuple.Create(35, 8, true)
+                    Tuple.Create(27, 3, true),
+                    Tuple.Create(30, 8, true),
+                    Tuple.Create(38, 4, false),
+                    Tuple.Create(42, 1, true),
+                    Tuple.Create(43, 20, true),
+                    Tuple.Create(0, 6, true),
+                    Tuple.Create(7, 12, false),
+                    Tuple.Create(19, 1, true),
+                    Tuple.Create(21, 12, false),
+                    Tuple.Create(33, 7, true)
                 };
                 yield return new object[] { "ViewWithPartial", expected2, expectedLineMappings2 };
             }
@@ -97,7 +95,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         public async Task ViewsAreServedWithoutInstrumentationByDefault(
             string actionName,
             string expected,
-            IEnumerable<Tuple<int, int, bool>> expectedLineMappings)
+            IEnumerable<Tuple<int, int, bool>> ignored)
         {
             // Arrange
             var context = new TestPageExecutionContext();
@@ -112,7 +110,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var body = await client.GetStringAsync("http://localhost/Home/" + actionName);
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
             Assert.Empty(context.Values);
         }
 
@@ -137,7 +135,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var body = await client.GetStringAsync("http://localhost/Home/" + actionName);
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
             Assert.Equal(expectedLineMappings, context.Values);
         }
 
@@ -161,7 +159,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var body = await client.GetStringAsync("http://localhost/Home/" + actionName);
 
             // Assert - 1
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
             Assert.Empty(context.Values);
 
             // Arrange - 2
@@ -171,7 +169,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             body = await client.GetStringAsync("http://localhost/Home/" + actionName);
 
             // Assert - 2
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
             Assert.Equal(expectedLineMappings, context.Values);
         }
 
@@ -181,19 +179,19 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             // Arrange - 1
             var expectedLineMappings = new[]
             {
-                Tuple.Create(93, 2, true),
-                Tuple.Create(96, 16, false),
-                Tuple.Create(112, 2, true),
+                Tuple.Create(90, 1, true),
+                Tuple.Create(92, 16, false),
+                Tuple.Create(108, 1, true),
                 Tuple.Create(0, 2, true),
                 Tuple.Create(2, 8, true),
                 Tuple.Create(10, 16, false),
                 Tuple.Create(26, 1, true),
-                Tuple.Create(27, 21, true),
-                Tuple.Create(0, 7, true),
-                Tuple.Create(8, 12, false),
-                Tuple.Create(20, 2, true),
-                Tuple.Create(23, 12, false),
-                Tuple.Create(35, 8, true),
+                Tuple.Create(27, 19, true),
+                Tuple.Create(0, 6, true),
+                Tuple.Create(7, 12, false),
+                Tuple.Create(19, 1, true),
+                Tuple.Create(21, 12, false),
+                Tuple.Create(33, 7, true),
             };
             var context = new TestPageExecutionContext();
             var server = TestHelper.CreateServer(_app, SiteName, services =>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/RazorViewLocationSpecificationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/RazorViewLocationSpecificationTest.cs
@@ -35,7 +35,7 @@ _ViewStart that specifies partial Layout
             var body = await client.GetStringAsync(BaseUrl + action);
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
 
         [Theory]
@@ -56,7 +56,7 @@ Layout specified in page
             var body = await client.GetStringAsync(BaseUrl + actionName);
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
 
         [Theory]
@@ -75,7 +75,7 @@ Page With Non Partial Layout
             var body = await client.GetStringAsync(BaseUrl + actionName);
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
 
         [Theory]
@@ -97,7 +97,7 @@ Non Shared Partial
             var body = await client.GetStringAsync(BaseUrl + actionName);
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/RemoteAttributeValidationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/RemoteAttributeValidationTest.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(_resourcesAssembly, outputFile, expectedContent, responseContent);
 #else
-            Assert.Equal(expectedContent, responseContent);
+            Assert.Equal(expectedContent, responseContent, ignoreLineEndingDifferences: true);
 #endif
         }
 

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/TagHelpersTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/TagHelpersTest.cs
@@ -15,7 +15,7 @@ using Xunit;
 
 namespace Microsoft.AspNet.Mvc.FunctionalTests
 {
-    public class TagHelpersTests
+    public class TagHelpersTest
     {
         private const string SiteName = nameof(TagHelpersWebSite);
 
@@ -23,7 +23,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         // so they require a reference to the assembly on which the resources are located, in order to
         // make the tests less verbose, we get a reference to the assembly with the resources and we
         // use it on all the rest of the tests.
-        private static readonly Assembly _resourcesAssembly = typeof(TagHelpersTests).GetTypeInfo().Assembly;
+        private static readonly Assembly _resourcesAssembly = typeof(TagHelpersTest).GetTypeInfo().Assembly;
 
         private readonly Action<IApplicationBuilder> _app = new Startup().Configure;
         private readonly Action<IServiceCollection> _configureServices = new Startup().ConfigureServices;
@@ -54,7 +54,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(_resourcesAssembly, outputFile, expectedContent, responseContent);
 #else
-            Assert.Equal(expectedContent, responseContent);
+            Assert.Equal(expectedContent, responseContent, ignoreLineEndingDifferences: true);
 #endif
         }
 
@@ -67,45 +67,55 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
                 {
                     {
                         "NestedViewImportsTagHelper",
-                        string.Format(
-                            "<root>root-content</root>{0}{0}{0}<nested>nested-content</nested>",
-                            Environment.NewLine)
+                        @"<root>root-content</root>
+
+
+<nested>nested-content</nested>"
                     },
                     {
                         "ViewWithLayoutAndNestedTagHelper",
-                        string.Format(
-                            "layout:<root>root-content</root>{0}{0}{0}<nested>nested-content</nested>",
-                            Environment.NewLine)
+                        @"layout:<root>root-content</root>
+
+
+<nested>nested-content</nested>"
                     },
                     {
                         "ViewWithInheritedRemoveTagHelper",
-                        string.Format(
-                            "layout:<root>root-content</root>{0}{0}{0}page:<root/>{0}<nested>nested-content</nested>",
-                            Environment.NewLine)
+                        @"layout:<root>root-content</root>
+
+
+page:<root/>
+<nested>nested-content</nested>"
                     },
                     {
                         "ViewWithInheritedTagHelperPrefix",
-                        string.Format(
-                            "layout:<root>root-content</root>{0}{0}{0}page:<root>root-content</root>",
-                            Environment.NewLine)
+                        @"layout:<root>root-content</root>
+
+
+page:<root>root-content</root>"
                     },
                     {
                         "ViewWithOverriddenTagHelperPrefix",
-                        string.Format(
-                            "layout:<root>root-content</root>{0}{0}{0}{0}page:<root>root-content</root>",
-                            Environment.NewLine)
+                        @"layout:<root>root-content</root>
+
+
+
+page:<root>root-content</root>"
                     },
                     {
                         "ViewWithNestedInheritedTagHelperPrefix",
-                        string.Format(
-                            "layout:<root>root-content</root>{0}{0}{0}page:<root>root-content</root>",
-                            Environment.NewLine)
+                        @"layout:<root>root-content</root>
+
+
+page:<root>root-content</root>"
                     },
                     {
                         "ViewWithNestedOverriddenTagHelperPrefix",
-                        string.Format(
-                            "layout:<root>root-content</root>{0}{0}{0}{0}page:<root>root-content</root>",
-                            Environment.NewLine)
+                        @"layout:<root>root-content</root>
+
+
+
+page:<root>root-content</root>"
                     },
                 };
             }
@@ -123,7 +133,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var result = await client.GetStringAsync("http://localhost/Home/" + action);
 
             // Assert
-            Assert.Equal(expected, result.Trim());
+            Assert.Equal(expected, result.Trim(), ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -146,7 +156,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(_resourcesAssembly, outputFile, expectedContent, responseContent);
 #else
-            Assert.Equal(expectedContent, responseContent);
+            Assert.Equal(expectedContent, responseContent, ignoreLineEndingDifferences: true);
 #endif
         }
 
@@ -180,7 +190,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(_resourcesAssembly, outputFile, expectedContent, responseContent);
 #else
-            Assert.Equal(expectedContent, responseContent);
+            Assert.Equal(expectedContent, responseContent, ignoreLineEndingDifferences: true);
 #endif
         }
 
@@ -214,7 +224,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(_resourcesAssembly, outputFile, expectedContent, responseContent);
 #else
-            Assert.Equal(expectedContent, responseContent);
+            Assert.Equal(expectedContent, responseContent, ignoreLineEndingDifferences: true);
 #endif
         }
     }

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ViewComponentTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ViewComponentTests.cs
@@ -24,17 +24,15 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
                 yield return new[]
                 {
                     "ViewWithAsyncComponents",
-                    string.Join(Environment.NewLine,
-                                       "<test-component>value-from-component value-from-view</test-component>",
-                                        "ViewWithAsyncComponents InvokeAsync: hello from viewdatacomponent")
+                    @"<test-component>value-from-component value-from-view</test-component>
+ViewWithAsyncComponents InvokeAsync: hello from viewdatacomponent"
                 };
 
                 yield return new[]
                 {
                     "ViewWithSyncComponents",
-                    string.Join(Environment.NewLine,
-                                       "<test-component>value-from-component value-from-view</test-component>",
-                                        "ViewWithSyncComponents Invoke: hello from viewdatacomponent")
+                    @"<test-component>value-from-component value-from-view</test-component>
+ViewWithSyncComponents Invoke: hello from viewdatacomponent"
                 };
             }
         }
@@ -50,7 +48,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var body = await client.GetStringAsync("http://localhost/Home/" + actionName);
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ViewEngineTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ViewEngineTests.cs
@@ -74,20 +74,19 @@ ViewWithNestedLayout-Content
             var body = await client.GetStringAsync("http://localhost/ViewEngine/" + actionName);
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
 
         [Fact]
         public async Task RazorView_ExecutesPartialPagesWithCorrectContext()
         {
-            var expected = string.Join(Environment.NewLine,
-                                       "<partial>98052",
-                                       "",
-                                       "</partial>",
-                                       "<partial2>98052",
-                                       "",
-                                       "</partial2>",
-                                       "test-value");
+            var expected = @"<partial>98052
+
+</partial>
+<partial2>98052
+
+</partial2>
+test-value";
             var server = TestHelper.CreateServer(_app, SiteName, _configureServices);
             var client = server.CreateClient();
 
@@ -95,7 +94,7 @@ ViewWithNestedLayout-Content
             var body = await client.GetStringAsync("http://localhost/ViewEngine/ViewWithPartial");
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -129,26 +128,23 @@ component-content";
             var body = await client.GetStringAsync("http://localhost/ViewEngine/ViewPassesViewDataToLayout");
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
 
         public static IEnumerable<object[]> RazorViewEngine_UsesAllExpandedPathsToLookForViewsData
         {
             get
             {
-                var expected1 = string.Join(Environment.NewLine,
-                                            "expander-index",
-                                            "gb-partial");
+                var expected1 = @"expander-index
+gb-partial";
                 yield return new[] { "en-GB", expected1 };
 
-                var expected2 = string.Join(Environment.NewLine,
-                                            "fr-index",
-                                            "fr-partial");
+                var expected2 = @"fr-index
+fr-partial";
                 yield return new[] { "fr", expected2 };
 
-                var expected3 = string.Join(Environment.NewLine,
-                                            "expander-index",
-                                            "expander-partial");
+                var expected3 = @"expander-index
+expander-partial";
                 yield return new[] { "na", expected3 };
             }
         }
@@ -169,7 +165,7 @@ component-content";
             var body = await client.GetStringAsync("http://localhost/TemplateExpander");
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
 
         public static TheoryData ViewLocationExpanders_PassesInIsPartialToViewLocationExpanderContextData
@@ -241,10 +237,10 @@ ViewWithNestedLayout-Content
                 };
                 yield return new[]
                 {
-                    "PartialWithModel", string.Join(Environment.NewLine,
-                                                    "my name is judge",
-                                                    "<partial>98052",
-                                                    "</partial>")
+                    "PartialWithModel",
+                    @"my name is judge
+<partial>98052
+</partial>"
                 };
             }
         }
@@ -261,18 +257,17 @@ ViewWithNestedLayout-Content
             var body = await client.GetStringAsync("http://localhost/PartialViewEngine/" + actionName);
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
 
         [Fact]
         public async Task LayoutValueIsPassedBetweenNestedViewStarts()
         {
             // Arrange
-            var expected = string.Join(Environment.NewLine,
-                                       "<title>viewstart-value</title>",
-                                       "",
-                                       "~/Views/NestedViewStarts/NestedViewStarts/Layout.cshtml",
-                                       "index-content");
+            var expected = @"<title>viewstart-value</title>
+
+~/Views/NestedViewStarts/NestedViewStarts/Layout.cshtml
+index-content";
             var server = TestHelper.CreateServer(_app, SiteName, _configureServices);
             var client = server.CreateClient();
 
@@ -280,7 +275,7 @@ ViewWithNestedLayout-Content
             var body = await client.GetStringAsync("http://localhost/NestedViewStarts");
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
 
         public static IEnumerable<object[]> RazorViewEngine_UsesExpandersForLayoutsData
@@ -320,7 +315,7 @@ View With Layout
             var body = await client.GetStringAsync("http://localhost/TemplateExpander/ViewWithLayout");
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -338,7 +333,7 @@ View With Layout
             var body = await client.GetStringAsync(target);
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -359,7 +354,7 @@ Component With Layout</component-body>";
             var body = await client.GetStringAsync("http://localhost/ViewEngine/ViewWithComponentThatHasLayout");
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -408,7 +403,7 @@ Partial that specifies Layout
             var body = await client.GetStringAsync("http://localhost/PartialsWithLayout/PartialsRenderedViaRenderPartial");
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -428,7 +423,7 @@ Partial that does not specify Layout
             var body = await client.GetStringAsync("http://localhost/PartialsWithLayout/PartialsRenderedViaPartialAsync");
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -448,7 +443,7 @@ Partial that does not specify Layout
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(_assembly, outputFile, expectedContent, responseContent);
 #else
-            Assert.Equal(expectedContent, responseContent);
+            Assert.Equal(expectedContent, responseContent, ignoreLineEndingDifferences: true);
 #endif
         }
     }

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/MvcRazorHostTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/MvcRazorHostTest.cs
@@ -3,10 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+#if GENERATE_BASELINES
 using System.IO;
 using System.Linq;
+#endif
 using System.Reflection;
+#if GENERATE_BASELINES
 using System.Text;
+#endif
 using Microsoft.AspNet.Mvc.Razor.Directives;
 using Microsoft.AspNet.Mvc.Razor.Internal;
 using Microsoft.AspNet.Razor;
@@ -110,29 +114,32 @@ namespace Microsoft.AspNet.Mvc.Razor
             };
             var expectedLineMappings = new List<LineMapping>
             {
-                BuildLineMapping(documentAbsoluteIndex: 7,
-                                 documentLineIndex: 0,
-                                 documentCharacterIndex: 7,
-                                 generatedAbsoluteIndex: 444,
-                                 generatedLineIndex: 12,
-                                 generatedCharacterIndex: 7,
-                                 contentLength: 8),
-                BuildLineMapping(documentAbsoluteIndex: 33,
-                                 documentLineIndex: 2,
-                                 documentCharacterIndex: 14,
-                                 generatedAbsoluteIndex: 823,
-                                 generatedLineIndex: 25,
-                                 generatedCharacterIndex: 14,
-                                 contentLength: 85),
-                BuildLineMapping(documentAbsoluteIndex: 139,
-                                 documentLineIndex: 4,
-                                 documentCharacterIndex: 17,
-                                 generatedAbsoluteIndex: 2313,
-                                 generatedLineIndex: 55,
-                                 generatedCharacterIndex: 95,
-                                 contentLength: 3),
                 BuildLineMapping(
-                    documentAbsoluteIndex: 166,
+                    documentAbsoluteIndex: 7,
+                    documentLineIndex: 0,
+                    documentCharacterIndex: 7,
+                    generatedAbsoluteIndex: 444,
+                    generatedLineIndex: 12,
+                    generatedCharacterIndex: 7,
+                    contentLength: 8),
+                BuildLineMapping(
+                    documentAbsoluteIndex: 31,
+                    documentLineIndex: 2,
+                    documentCharacterIndex: 14,
+                    generatedAbsoluteIndex: 823,
+                    generatedLineIndex: 25,
+                    generatedCharacterIndex: 14,
+                    contentLength: 85),
+                BuildLineMapping(
+                    documentAbsoluteIndex: 135,
+                    documentLineIndex: 4,
+                    documentCharacterIndex: 17,
+                    generatedAbsoluteIndex: 2313,
+                    generatedLineIndex: 55,
+                    generatedCharacterIndex: 95,
+                    contentLength: 3),
+                BuildLineMapping(
+                    documentAbsoluteIndex: 161,
                     documentLineIndex: 5,
                     documentCharacterIndex: 18,
                     generatedAbsoluteIndex: 2626,
@@ -185,7 +192,7 @@ namespace Microsoft.AspNet.Mvc.Razor
                     generatedCharacterIndex: 13,
                     contentLength: 4),
                 BuildLineMapping(
-                    documentAbsoluteIndex: 43,
+                    documentAbsoluteIndex: 41,
                     documentLineIndex: 2,
                     documentCharacterIndex: 5,
                     generatedAbsoluteIndex: 1353,
@@ -210,8 +217,22 @@ namespace Microsoft.AspNet.Mvc.Razor
             host.NamespaceImports.Clear();
             var expectedLineMappings = new List<LineMapping>
             {
-                BuildLineMapping(1, 0, 1, 59, 3, 0, 17),
-                BuildLineMapping(28, 1, 8, 706, 26, 8, 20)
+                BuildLineMapping(
+                    documentAbsoluteIndex: 1,
+                    documentLineIndex: 0,
+                    documentCharacterIndex: 1,
+                    generatedAbsoluteIndex: 59,
+                    generatedLineIndex: 3,
+                    generatedCharacterIndex: 0,
+                    contentLength: 17),
+                BuildLineMapping(
+                    documentAbsoluteIndex: 27,
+                    documentLineIndex: 1,
+                    documentCharacterIndex: 8,
+                    generatedAbsoluteIndex: 706,
+                    generatedLineIndex: 26,
+                    generatedCharacterIndex: 8,
+                    contentLength: 20),
             };
 
             // Act and Assert
@@ -230,9 +251,30 @@ namespace Microsoft.AspNet.Mvc.Razor
             host.NamespaceImports.Clear();
             var expectedLineMappings = new[]
             {
-                BuildLineMapping(7, 0, 7, 214, 6, 7, 7),
-                BuildLineMapping(24, 1, 8, 731, 26, 8, 20),
-                BuildLineMapping(54, 2, 8, 957, 34, 8, 23)
+                BuildLineMapping(
+                    documentAbsoluteIndex: 7,
+                    documentLineIndex: 0,
+                    documentCharacterIndex: 7,
+                    generatedAbsoluteIndex: 214,
+                    generatedLineIndex: 6,
+                    generatedCharacterIndex: 7,
+                    contentLength: 7),
+                BuildLineMapping(
+                    documentAbsoluteIndex: 23,
+                    documentLineIndex: 1,
+                    documentCharacterIndex: 8,
+                    generatedAbsoluteIndex: 731,
+                    generatedLineIndex: 26,
+                    generatedCharacterIndex: 8,
+                    contentLength: 20),
+                BuildLineMapping(
+                    documentAbsoluteIndex: 52,
+                    documentLineIndex: 2,
+                    documentCharacterIndex: 8,
+                    generatedAbsoluteIndex: 957,
+                    generatedLineIndex: 34,
+                    generatedCharacterIndex: 8,
+                    contentLength: 23),
             };
 
             // Act and Assert
@@ -251,11 +293,46 @@ namespace Microsoft.AspNet.Mvc.Razor
             host.NamespaceImports.Clear();
             var expectedLineMappings = new[]
             {
-                BuildLineMapping(7, 0, 7, 222, 6, 7, 7),
-                BuildLineMapping(24, 1, 8, 747, 26, 8, 20),
-                BuildLineMapping(58, 2, 8, 977, 34, 8, 23),
-                BuildLineMapping(93, 3, 8, 1210, 42, 8, 21),
-                BuildLineMapping(129, 4, 8, 1441, 50, 8, 24),
+                BuildLineMapping(
+                    documentAbsoluteIndex: 7,
+                    documentLineIndex: 0,
+                    documentCharacterIndex: 7,
+                    generatedAbsoluteIndex: 222,
+                    generatedLineIndex: 6,
+                    generatedCharacterIndex: 7,
+                    contentLength: 7),
+                BuildLineMapping(
+                    documentAbsoluteIndex: 23,
+                    documentLineIndex: 1,
+                    documentCharacterIndex: 8,
+                    generatedAbsoluteIndex: 747,
+                    generatedLineIndex: 26,
+                    generatedCharacterIndex: 8,
+                    contentLength: 20),
+                BuildLineMapping(
+                    documentAbsoluteIndex: 56,
+                    documentLineIndex: 2,
+                    documentCharacterIndex: 8,
+                    generatedAbsoluteIndex: 977,
+                    generatedLineIndex: 34,
+                    generatedCharacterIndex: 8,
+                    contentLength: 23),
+                BuildLineMapping(
+                    documentAbsoluteIndex: 90,
+                    documentLineIndex: 3,
+                    documentCharacterIndex: 8,
+                    generatedAbsoluteIndex: 1210,
+                    generatedLineIndex: 42,
+                    generatedCharacterIndex: 8,
+                    contentLength: 21),
+                BuildLineMapping(
+                    documentAbsoluteIndex: 125,
+                    documentLineIndex: 4,
+                    documentCharacterIndex: 8,
+                    generatedAbsoluteIndex: 1441,
+                    generatedLineIndex: 50,
+                    generatedCharacterIndex: 8,
+                    contentLength: 24),
             };
 
             // Act and Assert
@@ -302,7 +379,7 @@ namespace Microsoft.AspNet.Mvc.Razor
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(_assembly, outputFile, expectedCode, results.GeneratedCode);
 #else
-            Assert.Equal(expectedCode, results.GeneratedCode);
+            Assert.Equal(expectedCode, results.GeneratedCode, ignoreLineEndingDifferences: true);
 #endif
         }
 
@@ -362,7 +439,7 @@ namespace Microsoft.AspNet.Mvc.Razor
                 ResourceFile.UpdateFile(_assembly, lineMappingFile, previousContent: null, content: lineMappings.ToString());
             }
 #else
-            Assert.Equal(expectedCode, results.GeneratedCode);
+            Assert.Equal(expectedCode, results.GeneratedCode, ignoreLineEndingDifferences: true);
             Assert.Equal(expectedLineMappings, results.DesignTimeLineMappings);
 #endif
         }

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/Basic.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/Basic.cs
@@ -1,4 +1,4 @@
-#pragma checksum "TestFiles/Input/Basic.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "63d2634be31f68aa89a0c1561d67c73cc446f3d4"
+#pragma checksum "TestFiles/Input/Basic.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "4901c9b2325c62315b9048c930cac987201ccbab"
 namespace Asp
 {
     using System;
@@ -34,18 +34,18 @@ namespace Asp
             EndContext();
             WriteAttribute("class", Tuple.Create(" class=\"", 4), Tuple.Create("\"", 17), 
             Tuple.Create(Tuple.Create("", 12), Tuple.Create<System.Object, System.Int32>(logo, 12), false));
-            BeginContext(18, 24, true);
-            WriteLiteral(">\r\n    Hello world\r\n    ");
+            BeginContext(18, 22, true);
+            WriteLiteral(">\n    Hello world\n    ");
             EndContext();
-            BeginContext(43, 21, false);
+            BeginContext(41, 21, false);
 #line 3 "TestFiles/Input/Basic.cshtml"
 Write(Html.Input("SomeKey"));
 
 #line default
 #line hidden
             EndContext();
-            BeginContext(64, 8, true);
-            WriteLiteral("\r\n</div>");
+            BeginContext(62, 7, true);
+            WriteLiteral("\n</div>");
             EndContext();
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/Inject.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/Inject.cs
@@ -1,4 +1,4 @@
-#pragma checksum "TestFiles/Input/Inject.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "424b7fe9f12352c59210b5fa8c74ca8c9c67de81"
+#pragma checksum "TestFiles/Input/Inject.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "1b6d0816c4801cc45d2f51f612298d2e978b8dac"
 namespace Asp
 {
 #line 1 "TestFiles/Input/Inject.cshtml"

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/InjectWithModel.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/InjectWithModel.cs
@@ -1,4 +1,4 @@
-#pragma checksum "TestFiles/Input/InjectWithModel.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "0c0e10d3fd8f5bf30eabc22ca0ee91355a13426d"
+#pragma checksum "TestFiles/Input/InjectWithModel.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "a3c84d50826508cf6aab272b5b403b41f22eb058"
 namespace Asp
 {
     using System;

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/InjectWithSemicolon.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/InjectWithSemicolon.cs
@@ -1,4 +1,4 @@
-#pragma checksum "TestFiles/Input/InjectWithSemicolon.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "b753615982659a9805e6213ceced76ba06782038"
+#pragma checksum "TestFiles/Input/InjectWithSemicolon.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "76a79c64a24a4b239eaa7f70aa9a708c5794e050"
 namespace Asp
 {
     using System;

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/Model.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/Model.cs
@@ -1,4 +1,4 @@
-#pragma checksum "TestFiles/Input/Model.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "2c1e88396568d309c236020e59bf2abacfadd612"
+#pragma checksum "TestFiles/Input/Model.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "dbb4c96d18dd379f760a081c6ff84ed9fd31b82b"
 namespace Asp
 {
     using System;

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/ModelExpressionTagHelper.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/ModelExpressionTagHelper.cs
@@ -1,4 +1,4 @@
-#pragma checksum "TestFiles/Input/ModelExpressionTagHelper.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "3b1d4af116a70f83c556ece1980f2e9364e6baa7"
+#pragma checksum "TestFiles/Input/ModelExpressionTagHelper.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "a866c3c5622349399a04557339d06e12178fb260"
 namespace Asp
 {
     using Microsoft.AspNet.Razor.Runtime.TagHelpers;
@@ -45,8 +45,8 @@ namespace Asp
         public override async Task ExecuteAsync()
         {
             __tagHelperRunner = __tagHelperRunner ?? new Microsoft.AspNet.Razor.Runtime.TagHelpers.TagHelperRunner();
-            BeginContext(120, 2, true);
-            WriteLiteral("\r\n");
+            BeginContext(117, 1, true);
+            WriteLiteral("\n");
             EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input-test", true, "test", async() => {
             }
@@ -60,12 +60,12 @@ __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For = CreateModelExpression(__mo
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("for", __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For);
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
-            BeginContext(122, 24, false);
+            BeginContext(118, 24, false);
             await WriteTagHelperAsync(__tagHelperExecutionContext);
             EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            BeginContext(146, 2, true);
-            WriteLiteral("\r\n");
+            BeginContext(142, 1, true);
+            WriteLiteral("\n");
             EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input-test", true, "test", async() => {
             }
@@ -79,7 +79,7 @@ __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For = CreateModelExpression(__mo
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("for", __Microsoft_AspNet_Mvc_Razor_InputTestTagHelper.For);
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
-            BeginContext(148, 27, false);
+            BeginContext(143, 27, false);
             await WriteTagHelperAsync(__tagHelperExecutionContext);
             EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.End();

--- a/test/Microsoft.AspNet.Mvc.TestCommon/ResourceFile.cs
+++ b/test/Microsoft.AspNet.Mvc.TestCommon/ResourceFile.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -62,7 +63,26 @@ namespace Microsoft.AspNet.Mvc
                 return null;
             }
 
-            return assembly.GetManifestResourceStream(fullName);
+            var stream = assembly.GetManifestResourceStream(fullName);
+            if (sourceFile)
+            {
+                // Normalize line endings to '\n' (LF). This removes core.autocrlf, core.eol, core.safecrlf, and
+                // .gitattributes from the equation and treats "\r\n", "\r", and "\n" as equivalent. Does not handle
+                // some obscure line endings (e.g. "\n\r") but otherwise ensures checksums and line mappings are
+                // consistent.
+                string text;
+                using (var streamReader = new StreamReader(stream))
+                {
+                    text = streamReader.ReadToEnd()
+                        .Replace("\r\n", "\n")  // Windows line endings
+                        .Replace("\r", "\n");   // Older Mac OS line endings
+                }
+
+                var bytes = Encoding.UTF8.GetBytes(text);
+                stream = new MemoryStream(bytes);
+            }
+
+            return stream;
         }
 
         /// <summary>
@@ -101,13 +121,7 @@ namespace Microsoft.AspNet.Mvc
 
                 using (var streamReader = new StreamReader(stream))
                 {
-                    var content = await streamReader.ReadToEndAsync();
-
-                    // Normalize line endings to Environment.NewLine. This removes core.autocrlf, core.eol,
-                    // core.safecrlf, and .gitattributes from the equation and matches what MVC returns.
-                    return content
-                        .Replace("\r", string.Empty)
-                        .Replace("\n", Environment.NewLine);
+                    return await streamReader.ReadToEndAsync();
                 }
             }
         }
@@ -147,13 +161,7 @@ namespace Microsoft.AspNet.Mvc
 
                 using (var streamReader = new StreamReader(stream))
                 {
-                    var content = streamReader.ReadToEnd();
-
-                    // Normalize line endings to Environment.NewLine. This removes core.autocrlf, core.eol,
-                    // core.safecrlf, and .gitattributes from the equation and matches what MVC returns.
-                    return content
-                        .Replace("\r", string.Empty)
-                        .Replace("\n", Environment.NewLine);
+                    return streamReader.ReadToEnd();
                 }
             }
         }
@@ -178,10 +186,19 @@ namespace Microsoft.AspNet.Mvc
         [Conditional("GENERATE_BASELINES")]
         public static void UpdateFile(Assembly assembly, string resourceName, string previousContent, string content)
         {
-            if (!string.Equals(previousContent, content, StringComparison.Ordinal))
+            // Normalize line endings to '\n' for comparison. This removes Environment.NewLine from the equation. Not
+            // worth updating files just because we generate baselines on a different system.
+            var normalizedPreviousContent = previousContent
+                ?.Replace("\r\n", "\n")
+                .Replace("\r", "\n");
+            var normalizedContent = content
+                .Replace("\r\n", "\n")
+                .Replace("\r", "\n");
+
+            if (!string.Equals(normalizedPreviousContent, normalizedContent, StringComparison.Ordinal))
             {
-                // The DNX runtime compiles every file under the resources folder as a resource available at runtime with
-                // the same name as the file name. Need to update this file on disc.
+                // The DNX runtime compiles every file under the resources folder as a resource available at runtime
+                // with the same name as the file name. Need to update this file on disc.
                 var projectName = assembly.GetName().Name;
                 var projectPath = GetProjectPath(projectName);
                 var fullPath = Path.Combine(projectPath, resourceName);

--- a/test/WebSites/RazorPageExecutionInstrumentationWebSite/Startup.cs
+++ b/test/WebSites/RazorPageExecutionInstrumentationWebSite/Startup.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Http;
+using Microsoft.AspNet.Mvc.Razor.Compilation;
 using Microsoft.AspNet.PageExecutionInstrumentation;
 using Microsoft.Framework.DependencyInjection;
 
@@ -15,6 +16,9 @@ namespace RazorPageExecutionInstrumentationWebSite
         // Set up application services
         public void ConfigureServices(IServiceCollection services)
         {
+            // Normalize line endings to avoid changes in instrumentation locations between systems.
+            services.TryAdd(ServiceDescriptor.Transient<IRazorCompilationService, TestRazorCompilationService>());
+
             // Add MVC services to the services container
             services.AddMvc();
         }

--- a/test/WebSites/RazorPageExecutionInstrumentationWebSite/TestRazorCompilationService.cs
+++ b/test/WebSites/RazorPageExecutionInstrumentationWebSite/TestRazorCompilationService.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Text;
+using Microsoft.AspNet.Mvc.Razor;
+using Microsoft.AspNet.Mvc.Razor.Compilation;
+using Microsoft.AspNet.Razor.CodeGenerators;
+using Microsoft.Framework.OptionsModel;
+
+namespace RazorPageExecutionInstrumentationWebSite
+{
+    public class TestRazorCompilationService : RazorCompilationService
+    {
+        public TestRazorCompilationService(
+            ICompilationService compilationService,
+            IMvcRazorHost razorHost,
+            IOptions<RazorViewEngineOptions> viewEngineOptions)
+            : base(compilationService, razorHost, viewEngineOptions)
+        {
+        }
+
+        protected override GeneratorResults GenerateCode(string relativePath, Stream inputStream)
+        {
+            // Normalize line endings to '\n' (LF). This removes core.autocrlf, core.eol, core.safecrlf, and
+            // .gitattributes from the equation and treats "\r\n", "\r", and "\n" as equivalent. Does not handle
+            // some obscure line endings (e.g. "\n\r") but otherwise ensures instrumentation locations are
+            // consistent.
+            string text;
+            using (var streamReader = new StreamReader(inputStream))
+            {
+                text = streamReader.ReadToEnd()
+                    .Replace("\r\n", "\n")  // Windows line endings
+                    .Replace("\r", "\n");   // Older Mac OS line endings
+            }
+
+            var bytes = Encoding.UTF8.GetBytes(text);
+            inputStream = new MemoryStream(bytes);
+
+            return base.GenerateCode(relativePath, inputStream);
+        }
+    }
+}


### PR DESCRIPTION
- #1514
- refactor `RazorCompilationService` to allow a test subclass that normalizes Razor file line endings
 - add `TestRazorCompilationService` to `RazorPageExecutionInstrumentationWebSite`
 - adjust line endings to match in `RazorPageExecutionInstrumentationTest`
- add `ignoreLineEndingDifferences: true` to `Assert.Equal()` calls
 - responses on Windows can have a mix of line endings
  - `git config` setting affects line endings in .cshtml (and baseline) files
  - however MVC and Razor mix `Environment.NewLine`s into HTTP responses
- update `PrecompilationTest` to split response regardless of line endings
- update `ResourceFile` to normalize all source file streams to LF only
 - ensures consistent checksums and line mappings
 - change `MvcRazorHostTest` to expect new line mappings
 - recreate baseline files to expect new checksums and literal line endings
- use verbatim strings in affected tests
 - careful use of `Environment.NewLine` in expectations is now just noise

nits:
- add doc comments in `RazorCompilationService`
- correct `TagHelpersTest` name to match containing file
- avoid incorrect `using` removal when `GENERATE_BASELINES` is not defined
- remove unnecessary `ResourceFile` normalization of output files