### PR TITLE
[quick fixes] Cleanup a few things StyleCop found ages ago

### DIFF
--- a/src/Microsoft.AspNet.JsonPatch/Exceptions/JsonPatchException.cs
+++ b/src/Microsoft.AspNet.JsonPatch/Exceptions/JsonPatchException.cs
@@ -11,7 +11,8 @@ namespace Microsoft.AspNet.JsonPatch.Exceptions
         public Operation<TModel> FailedOperation { get; private set; }
         public new TModel AffectedObject { get; private set; }
 
-        private string _message = "";
+        private string _message = string.Empty;
+
         public override string Message
         {
             get

--- a/src/Microsoft.AspNet.JsonPatch/Exceptions/JsonPatchExceptionBase.cs
+++ b/src/Microsoft.AspNet.JsonPatch/Exceptions/JsonPatchExceptionBase.cs
@@ -11,19 +11,18 @@ namespace Microsoft.AspNet.JsonPatch.Exceptions
 
         public object AffectedObject { get; private set; }
 
-        private string _message = "";
+        private string _message = string.Empty;
+
         public override string Message
         {
             get
             {
                 return _message;
             }
-
         }
 
         public JsonPatchException()
         {
-
         }
 
         public JsonPatchException(string message, Exception innerException)

--- a/src/Microsoft.AspNet.JsonPatch/Helpers/ExpressionHelpers.cs
+++ b/src/Microsoft.AspNet.JsonPatch/Helpers/ExpressionHelpers.cs
@@ -59,9 +59,9 @@ namespace Microsoft.AspNet.JsonPatch.Helpers
                     }
                 case ExpressionType.Parameter:
                     // Fits "x => x" (the whole document which is "" as JSON pointer)
-                    return firstTime ? "" : null;
+                    return firstTime ? string.Empty : null;
                 default:
-                    return "";
+                    return string.Empty;
             }
         }
 

--- a/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/Validation/ModelValidationContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/Validation/ModelValidationContext.cs
@@ -11,10 +11,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             [NotNull] ModelBindingContext bindingContext,
             [NotNull] ModelExplorer modelExplorer)
             : this(
-                 bindingContext.BindingSource,
-                 bindingContext.OperationBindingContext.ValidatorProvider,
-                 bindingContext.ModelState,
-                 modelExplorer)
+                  bindingContext.BindingSource,
+                  bindingContext.OperationBindingContext.ValidatorProvider,
+                  bindingContext.ModelState,
+                  modelExplorer)
         {
         }
 
@@ -35,9 +35,13 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         /// <paramref name="parentContext" /> and <paramref name="modelExplorer"/>.
         /// </summary>
         /// <param name="parentContext">Existing <see cref="ModelValidationContext"/>.</param>
-        /// <param name="modelExplorer"><see cref="ModelExplorer"/> associated with the new 
-        /// <see cref="ModelValidationContext"/>.</param>
-        /// <returns></returns>
+        /// <param name="modelExplorer">
+        /// <see cref="ModelExplorer"/> associated with the new <see cref="ModelValidationContext"/>.
+        /// </param>
+        /// <returns>
+        /// A new instance of the <see cref="ModelValidationContext"/> class using the
+        /// <paramref name="parentContext" /> and <paramref name="modelExplorer"/>.
+        /// </returns>
         public static ModelValidationContext GetChildValidationContext(
             [NotNull] ModelValidationContext parentContext,
             [NotNull] ModelExplorer modelExplorer)

--- a/src/Microsoft.AspNet.Mvc.ApiExplorer/DefaultApiDescriptionProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.ApiExplorer/DefaultApiDescriptionProvider.cs
@@ -275,7 +275,7 @@ namespace Microsoft.AspNet.Mvc.ApiExplorer
 
             foreach (var segment in parsedTemplate.Segments)
             {
-                var currentSegment = "";
+                var currentSegment = string.Empty;
                 foreach (var part in segment.Parts)
                 {
                     if (part.IsLiteral)

--- a/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/AttributeRouteModel.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/AttributeRouteModel.cs
@@ -177,7 +177,7 @@ namespace Microsoft.AspNet.Mvc.ApplicationModels
             // We are in the case where the string is "/" or "~/"
             if (startIndex == result.Length)
             {
-                return "";
+                return string.Empty;
             }
 
             var subStringLength = result.Length - startIndex;

--- a/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/DefaultApplicationModelProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/DefaultApplicationModelProvider.cs
@@ -427,8 +427,8 @@ namespace Microsoft.AspNet.Mvc.ApplicationModels
         /// <summary>
         /// Returns <c>true</c> if the <paramref name="methodInfo"/> is an action. Otherwise <c>false</c>.
         /// </summary>
-        /// <param name="methodInfo">The <see cref="MethodInfo"/>.</param>
         /// <param name="typeInfo">The <see cref="TypeInfo"/>.</param>
+        /// <param name="methodInfo">The <see cref="MethodInfo"/>.</param>
         /// <returns><c>true</c> if the <paramref name="methodInfo"/> is an action. Otherwise <c>false</c>.</returns>
         /// <remarks>
         /// Override this method to provide custom logic to determine which methods are considered actions.

--- a/src/Microsoft.AspNet.Mvc.Core/Internal/MvcServicesHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Internal/MvcServicesHelper.cs
@@ -16,7 +16,6 @@ namespace Microsoft.AspNet.Mvc.Internal
         /// in the list of services.
         /// </summary>
         /// <param name="services">The list of services.</param>
-        /// <param name="serviceType">The type of service which needs to be searched for.</param>
         public static void ThrowIfMvcNotRegistered(IServiceProvider services)
         {
             if (services.GetService(typeof(MvcMarkerService)) == null)

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/CollectionModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/CollectionModelBinder.cs
@@ -168,7 +168,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             else
             {
                 indexNamesIsFinite = false;
-                indexNames = Enumerable.Range(0, Int32.MaxValue)
+                indexNames = Enumerable.Range(0, int.MaxValue)
                                        .Select(i => i.ToString(CultureInfo.InvariantCulture));
             }
 

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/ModelMetadataProviderExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/ModelMetadataProviderExtensions.cs
@@ -19,7 +19,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// <param name="provider">The <see cref="IModelMetadataProvider"/>.</param>
         /// <param name="modelType">The declared <see cref="Type"/> of the model object.</param>
         /// <param name="model">The model object.</param>
-        /// <returns></returns>
+        /// <returns>
+        /// A <see cref="ModelExplorer"/> for the <paramref name="modelType"/> and <paramref name="model"/>.
+        /// </returns>
         public static ModelExplorer GetModelExplorerForType(
             [NotNull] this IModelMetadataProvider provider,
             [NotNull] Type modelType,

--- a/src/Microsoft.AspNet.Mvc.Core/Routing/AttributeRoutePrecedence.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Routing/AttributeRoutePrecedence.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNet.Mvc.Routing
                 var digit = ComputeDigit(segment);
                 Debug.Assert(digit >= 0 && digit < 10);
 
-                precedence += Decimal.Divide(digit, (decimal)Math.Pow(10, i));
+                precedence += decimal.Divide(digit, (decimal)Math.Pow(10, i));
             }
 
             return precedence;

--- a/src/Microsoft.AspNet.Mvc.Extensions/AntiForgery/AntiForgeryTokenProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Extensions/AntiForgery/AntiForgeryTokenProvider.cs
@@ -132,7 +132,7 @@ namespace Microsoft.AspNet.Mvc
                 currentUsername.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
                 currentUsername.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
 
-            if (!String.Equals(fieldToken.Username,
+            if (!string.Equals(fieldToken.Username,
                                 currentUsername,
                                 (useCaseSensitiveUsernameComparison) ?
                                                  StringComparison.Ordinal :

--- a/src/Microsoft.AspNet.Mvc.Extensions/AntiForgery/DefaultClaimUidExtractor.cs
+++ b/src/Microsoft.AspNet.Mvc.Extensions/AntiForgery/DefaultClaimUidExtractor.cs
@@ -31,9 +31,8 @@ namespace Microsoft.AspNet.Mvc
 
         internal static IEnumerable<string> GetUniqueIdentifierParameters(ClaimsIdentity claimsIdentity)
         {
-            var nameIdentifierClaim = claimsIdentity.FindFirst(claim =>
-                                                            String.Equals(ClaimTypes.NameIdentifier,
-                                                                        claim.Type, StringComparison.Ordinal));
+            var nameIdentifierClaim = claimsIdentity.FindFirst(
+                claim => string.Equals(ClaimTypes.NameIdentifier, claim.Type, StringComparison.Ordinal));
             if (nameIdentifierClaim != null && !string.IsNullOrEmpty(nameIdentifierClaim.Value))
             {
                 return new string[]

--- a/src/Microsoft.AspNet.Mvc.Extensions/Authorization/AuthorizeFilter.cs
+++ b/src/Microsoft.AspNet.Mvc.Extensions/Authorization/AuthorizeFilter.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNet.Mvc
         /// <summary>
         /// Authorize filter for a specific policy.
         /// </summary>
-        /// <param name="policy"></param>
+        /// <param name="policy">Authorization policy to be used.</param>
         public AuthorizeFilter([NotNull] AuthorizationPolicy policy)
         {
             Policy = policy;

--- a/src/Microsoft.AspNet.Mvc.Extensions/Cors/CorsAuthorizationFilterFactory.cs
+++ b/src/Microsoft.AspNet.Mvc.Extensions/Cors/CorsAuthorizationFilterFactory.cs
@@ -2,12 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNet.Cors.Core;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.WebUtilities;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.Internal;
 
@@ -21,9 +15,9 @@ namespace Microsoft.AspNet.Mvc
         private readonly string _policyName;
 
         /// <summary>
-        /// Creates a new insntace of <see cref="CorsAuthorizationFilterFactory"/>.
+        /// Creates a new instance of <see cref="CorsAuthorizationFilterFactory"/>.
         /// </summary>
-        /// <param name="policyName"></param>
+        /// <param name="policyName">Name used to fetch a CORS policy.</param>
         public CorsAuthorizationFilterFactory(string policyName)
         {
             _policyName = policyName;

--- a/src/Microsoft.AspNet.Mvc.Extensions/Filters/FormatFilterAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.Extensions/Filters/FormatFilterAttribute.cs
@@ -8,17 +8,17 @@ using Microsoft.Framework.Internal;
 namespace Microsoft.AspNet.Mvc
 {
     /// <summary>
-    /// A filter which will use the format value in the route data or query string to set the content type on an 
+    /// A filter which will use the format value in the route data or query string to set the content type on an
     /// <see cref="ObjectResult" /> returned from an action.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public class FormatFilterAttribute : Attribute, IFilterFactory
     {
         /// <summary>
-        /// Creates an instance of <see cref="FormatFilter"/>
+        /// Creates an instance of <see cref="FormatFilter"/>.
         /// </summary>
-        /// <param name="serviceProvider">The <see cref="IServiceProvider "/></param>
-        /// <returns>An instance of <see cref="FormatFilter"/></returns>
+        /// <param name="serviceProvider">The <see cref="IServiceProvider"/>.</param>
+        /// <returns>An instance of <see cref="FormatFilter"/>.</returns>
         public IFilter CreateInstance([NotNull] IServiceProvider serviceProvider)
         {
             return serviceProvider.GetRequiredService<FormatFilter>();

--- a/src/Microsoft.AspNet.Mvc.Extensions/Rendering/Html/DefaultHtmlGenerator.cs
+++ b/src/Microsoft.AspNet.Mvc.Extensions/Rendering/Html/DefaultHtmlGenerator.cs
@@ -117,7 +117,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 if (modelExplorer.Model != null)
                 {
                     bool modelChecked;
-                    if (Boolean.TryParse(modelExplorer.Model.ToString(), out modelChecked))
+                    if (bool.TryParse(modelExplorer.Model.ToString(), out modelChecked))
                     {
                         isChecked = modelChecked;
                     }

--- a/src/Microsoft.AspNet.Mvc.Extensions/Rendering/HtmlHelperPartialExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Extensions/Rendering/HtmlHelperPartialExtensions.cs
@@ -139,6 +139,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <summary>
         /// Returns HTML markup for the specified partial view.
         /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="partialViewName">
         /// The name of the partial view used to create the HTML markup. Must not be <c>null</c>.
         /// </param>

--- a/src/Microsoft.AspNet.Mvc.Extensions/Rendering/HtmlString.cs
+++ b/src/Microsoft.AspNet.Mvc.Extensions/Rendering/HtmlString.cs
@@ -21,7 +21,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <summary>
         /// Initializes a new instance of <see cref="HtmlString"/> that is backed by <paramref name="writer"/>.
         /// </summary>
-        /// <param name="writer"></param>
+        /// <param name="writer">
+        /// A <see cref="StringCollectionTextWriter"/> instance to back this <see cref="HtmlString"/>.
+        /// </param>
         public HtmlString([NotNull] StringCollectionTextWriter writer)
         {
             _writer = writer;
@@ -36,7 +38,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <summary>
-        /// Writes the value in this instance of <see cref="HtmlString"/> to the target <paramref name="targetWriter"/>.
+        /// Writes the value in this instance of <see cref="HtmlString"/> to the target
+        /// <paramref name="targetWriter"/>.
         /// </summary>
         /// <param name="targetWriter">The <see cref="TextWriter"/> to write contents to.</param>
         public void WriteTo(TextWriter targetWriter)

--- a/src/Microsoft.AspNet.Mvc.Extensions/Rendering/ViewEngine/IViewEngine.cs
+++ b/src/Microsoft.AspNet.Mvc.Extensions/Rendering/ViewEngine/IViewEngine.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// Finds the specified partial view by using the specified action context.
         /// </summary>
         /// <param name="context">The action context.</param>
-        /// <param name="viewName">The name or full path to the view.</param>
+        /// <param name="partialViewName">The name or full path to the view.</param>
         /// <returns>A result representing the result of locating the view.</returns>
         ViewEngineResult FindPartialView(ActionContext context, string partialViewName);
     }

--- a/src/Microsoft.AspNet.Mvc.Extensions/ViewComponents/ContentViewComponentResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Extensions/ViewComponents/ContentViewComponentResult.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNet.Mvc
         /// <summary>
         /// Initializes a new <see cref="ContentViewComponentResult"/>.
         /// </summary>
-        /// <param name="content">
+        /// <param name="encodedContent">
         /// Content to write. The content is treated as already HTML encoded, and no further encoding
         /// will be performed.
         /// </param>

--- a/src/Microsoft.AspNet.Mvc.Razor.Host/Directives/SetBaseTypeChunkMerger.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/Directives/SetBaseTypeChunkMerger.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNet.Mvc.Razor.Directives
         /// <summary>
         /// Initializes a new instance of <see cref="SetBaseTypeChunkMerger"/>.
         /// </summary>
-        /// <param name="defaultModelType">The type name of the model used by default.</param>
+        /// <param name="modelType">The type name of the model used by default.</param>
         public SetBaseTypeChunkMerger(string modelType)
         {
             _modelType = "<" + modelType + ">";

--- a/src/Microsoft.AspNet.Mvc.Razor/Compilation/RoslynCompilationService.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Compilation/RoslynCompilationService.cs
@@ -43,8 +43,13 @@ namespace Microsoft.AspNet.Mvc.Razor.Compilation
         /// Initalizes a new instance of the <see cref="RoslynCompilationService"/> class.
         /// </summary>
         /// <param name="environment">The environment for the executing application.</param>
-        /// <param name="loaderEngine">The loader used to load compiled assemblies.</param>
+        /// <param name="loaderAccessor">
+        /// The accessor for the <see cref="IAssemblyLoadContext"/> used to load compiled assemblies.
+        /// </param>
         /// <param name="libraryManager">The library manager that provides export and reference information.</param>
+        /// <param name="compilerOptionsProvider">
+        /// The <see cref="ICompilerOptionsProvider"/> that provides Roslyn compilation settings.
+        /// </param>
         /// <param name="host">The <see cref="IMvcRazorHost"/> that was used to generate the code.</param>
         public RoslynCompilationService(IApplicationEnvironment environment,
                                         IAssemblyLoadContextAccessor loaderAccessor,

--- a/src/Microsoft.AspNet.Mvc.Razor/IRazorViewEngine.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/IRazorViewEngine.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         /// <see cref="IViewEngine.FindPartialView(ActionContext, string)"/>.
         /// </summary>
         /// <param name="context">The <see cref="ActionContext"/>.</param>
-        /// <param name="viewName">The name or full path to the view.</param>
+        /// <param name="page">The name or full path to the view.</param>
         /// <returns>A result representing the result of locating the <see cref="IRazorPage"/>.</returns>
         RazorPageResult FindPage(ActionContext context, string page);
     }

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
@@ -506,6 +506,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         /// <summary>
         /// Writes the specified <paramref name="value"/> without HTML encoding to <see cref="Output"/>.
         /// </summary>
+        /// <param name="writer">The <see cref="TextWriter"/> instance to write to.</param>
         /// <param name="value">The <see cref="string"/> to write.</param>
         public virtual void WriteLiteralTo([NotNull] TextWriter writer, string value)
         {

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorPageResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorPageResult.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         /// Initializes a new instance of <see cref="RazorPageResult"/> for an unsuccessful discovery.
         /// </summary>
         /// <param name="name">The name of the page that was located.</param>
-        /// <param name="page">The locations that were searched.</param>
+        /// <param name="searchedLocations">The locations that were searched.</param>
         public RazorPageResult([NotNull] string name, [NotNull] IEnumerable<string> searchedLocations)
         {
             Name = name;

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/JavaScriptStringArrayEncoder.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/JavaScriptStringArrayEncoder.cs
@@ -8,7 +8,7 @@ using Microsoft.Framework.WebEncoders;
 namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
 {
     /// <summary>
-    /// Methods for encoding <see cref="IEnumerable{String}"/> for use as a JavaScript array literal.
+    /// Methods for encoding <see cref="IEnumerable{string}"/> for use as a JavaScript array literal.
     /// </summary>
     public static class JavaScriptStringArrayEncoder
     {
@@ -22,7 +22,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
             var firstAdded = false;
 
             writer.Write('[');
-            
+
             foreach (var value in values)
             {
                 if (firstAdded)

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/ActionResults/ExceptionResult.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/ActionResults/ExceptionResult.cs
@@ -18,9 +18,6 @@ namespace System.Web.Http
         /// <param name="includeErrorDetail">
         /// <see langword="true"/> if the error should include exception messages; otherwise, <see langword="false"/>.
         /// </param>
-        /// <param name="contentNegotiator">The content negotiator to handle content negotiation.</param>
-        /// <param name="request">The request message which led to this result.</param>
-        /// <param name="formatters">The formatters to use to negotiate and format the content.</param>
         public ExceptionResult(Exception exception, bool includeErrorDetail)
             : base(new HttpError(exception, includeErrorDetail))
         {

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/ActionResults/OkNegotiatedContentResult.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/ActionResults/OkNegotiatedContentResult.cs
@@ -19,7 +19,6 @@ namespace System.Web.Http
         /// provided.
         /// </summary>
         /// <param name="content">The content value to negotiate and format in the entity body.</param>
-        /// <param name="formatters">The formatters to use to negotiate and format the content.</param>
         public OkNegotiatedContentResult([NotNull] T content)
             : base(HttpStatusCode.OK, content)
         {

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/ApiController.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/ApiController.cs
@@ -180,7 +180,7 @@ namespace System.Web.Http
         /// <summary>
         /// Creates a <see cref="CreatedResult"/> (201 Created) with the specified values.
         /// </summary>
-        /// <param name="location">The location at which the content has been created.</param>
+        /// <param name="uri">The location at which the content has been created.</param>
         /// <param name="content">The content value to format in the entity body.</param>
         /// <returns>A <see cref="CreatedResult"/> with the specified values.</returns>
         [NonAction]

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/ContentNegotiator/FormattingUtilities.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/ContentNegotiator/FormattingUtilities.cs
@@ -138,7 +138,7 @@ namespace System.Net.Http
             HttpContentHeaders contentHeaders = null;
             try
             {
-                tempContent = new StringContent(String.Empty);
+                tempContent = new StringContent(string.Empty);
                 contentHeaders = tempContent.Headers;
                 contentHeaders.Clear();
             }
@@ -155,9 +155,9 @@ namespace System.Net.Http
         }
 
         /// <summary>
-        /// Create a default reader quotas with a default depth quota of 1K
+        /// Create a default reader quotas with a default depth quota of 1K.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>A default <see cref="XmlDictionaryReaderQuotas"/> with a default depth quota of 1K.</returns>
         public static XmlDictionaryReaderQuotas CreateDefaultReaderQuotas()
         {
             // MaxDepth is a DOS mitigation. We don't support MaxDepth in portable libraries because it is strictly
@@ -167,11 +167,11 @@ namespace System.Net.Http
 #else
             return new XmlDictionaryReaderQuotas()
             {
-                MaxArrayLength = Int32.MaxValue,
-                MaxBytesPerRead = Int32.MaxValue,
+                MaxArrayLength = int.MaxValue,
+                MaxBytesPerRead = int.MaxValue,
                 MaxDepth = DefaultMaxDepth,
-                MaxNameTableCharCount = Int32.MaxValue,
-                MaxStringContentLength = Int32.MaxValue
+                MaxNameTableCharCount = int.MaxValue,
+                MaxStringContentLength = int.MaxValue
             };
 #endif
         }
@@ -183,7 +183,7 @@ namespace System.Net.Http
         /// <returns>Unquoted token.</returns>
         public static string UnquoteToken(string token)
         {
-            if (String.IsNullOrWhiteSpace(token))
+            if (string.IsNullOrWhiteSpace(token))
             {
                 return token;
             }
@@ -237,7 +237,7 @@ namespace System.Net.Http
         /// <returns>True if value was valid; false otherwise.</returns>
         public static bool TryParseInt32(string value, out int result)
         {
-            return Int32.TryParse(value, NumberStyles.None, NumberFormatInfo.InvariantInfo, out result);
+            return int.TryParse(value, NumberStyles.None, NumberFormatInfo.InvariantInfo, out result);
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/ContentNegotiator/MediaTypeWithQualityHeaderComparer.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/ContentNegotiator/MediaTypeWithQualityHeaderComparer.cs
@@ -37,13 +37,17 @@ namespace System.Net.Http.Formatting
         /// </summary>
         /// <param name="mediaType1">The first <see cref="MediaTypeWithQualityHeaderValue"/> to compare.</param>
         /// <param name="mediaType2">The second <see cref="MediaTypeWithQualityHeaderValue"/> to compare.</param>
-        /// <returns></returns>
+        /// <returns>
+        /// <c>0</c> if <paramref name="mediaType1"/> and <paramref name="mediaType2"/> are considered equal.
+        /// <c>1</c> if <paramref name="mediaType1"/> is considered greater than <paramref name="mediaType2"/>.
+        /// <c>-1</c> otherwise (<paramref name="mediaType1"/> is considered less than <paramref name="mediaType2"/>).
+        /// </returns>
         public int Compare(MediaTypeWithQualityHeaderValue mediaType1, MediaTypeWithQualityHeaderValue mediaType2)
         {
             Debug.Assert(mediaType1 != null, "The 'mediaType1' parameter should not be null.");
             Debug.Assert(mediaType2 != null, "The 'mediaType2' parameter should not be null.");
 
-            if (Object.ReferenceEquals(mediaType1, mediaType2))
+            if (ReferenceEquals(mediaType1, mediaType2))
             {
                 return 0;
             }

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/ContentNegotiator/StringWithQualityHeaderValueComparer.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/ContentNegotiator/StringWithQualityHeaderValueComparer.cs
@@ -60,11 +60,11 @@ namespace System.Net.Http.Formatting
 
             if (!string.Equals(stringWithQuality1.Value, stringWithQuality2.Value, StringComparison.OrdinalIgnoreCase))
             {
-                if (String.Equals(stringWithQuality1.Value, "*", StringComparison.Ordinal))
+                if (string.Equals(stringWithQuality1.Value, "*", StringComparison.Ordinal))
                 {
                     return -1;
                 }
-                else if (String.Equals(stringWithQuality2.Value, "*", StringComparison.Ordinal))
+                else if (string.Equals(stringWithQuality2.Value, "*", StringComparison.Ordinal))
                 {
                     return 1;
                 }

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/HttpError.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/HttpError.cs
@@ -117,7 +117,7 @@ namespace System.Web.Http
         /// </summary>
         public string Message
         {
-            get { return GetPropertyValue<String>(HttpErrorKeys.MessageKey); }
+            get { return GetPropertyValue<string>(HttpErrorKeys.MessageKey); }
             set { this[HttpErrorKeys.MessageKey] = value; }
         }
 
@@ -145,7 +145,7 @@ namespace System.Web.Http
         /// </remarks>
         public string MessageDetail
         {
-            get { return GetPropertyValue<String>(HttpErrorKeys.MessageDetailKey); }
+            get { return GetPropertyValue<string>(HttpErrorKeys.MessageDetailKey); }
             set { this[HttpErrorKeys.MessageDetailKey] = value; }
         }
 
@@ -159,7 +159,7 @@ namespace System.Web.Http
         /// </remarks>
         public string ExceptionMessage
         {
-            get { return GetPropertyValue<String>(HttpErrorKeys.ExceptionMessageKey); }
+            get { return GetPropertyValue<string>(HttpErrorKeys.ExceptionMessageKey); }
             set { this[HttpErrorKeys.ExceptionMessageKey] = value; }
         }
 
@@ -173,7 +173,7 @@ namespace System.Web.Http
         /// </remarks>
         public string ExceptionType
         {
-            get { return GetPropertyValue<String>(HttpErrorKeys.ExceptionTypeKey); }
+            get { return GetPropertyValue<string>(HttpErrorKeys.ExceptionTypeKey); }
             set { this[HttpErrorKeys.ExceptionTypeKey] = value; }
         }
 
@@ -187,7 +187,7 @@ namespace System.Web.Http
         /// </remarks>
         public string StackTrace
         {
-            get { return GetPropertyValue<String>(HttpErrorKeys.StackTraceKey); }
+            get { return GetPropertyValue<string>(HttpErrorKeys.StackTraceKey); }
             set { this[HttpErrorKeys.StackTraceKey] = value; }
         }
 

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/HttpRequestMessage/HttpRequestMessageExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/HttpRequestMessage/HttpRequestMessageExtensions.cs
@@ -230,7 +230,7 @@ namespace System.Net.Http
         /// <param name="request">The request.</param>
         /// <param name="statusCode">The status code of the created response.</param>
         /// <param name="value">The value to wrap. Can be <c>null</c>.</param>
-        /// <param name="configuration">The configuration to use. Can be <c>null</c>.</param>
+        /// <param name="formatters">The set of <see cref="MediaTypeFormatter"/> objects from which to choose.</param>
         /// <returns>A response wrapping <paramref name="value"/> with <paramref name="statusCode"/>.</returns>
         public static HttpResponseMessage CreateResponse<T>(
             [NotNull] this HttpRequestMessage request,

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/OverloadActionConstraint.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/OverloadActionConstraint.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShim
 {
     public class OverloadActionConstraint : IActionConstraint
     {
-        public int Order { get; } = Int32.MaxValue;
+        public int Order { get; } = int.MaxValue;
 
         public bool Accept(ActionConstraintContext context)
         {

--- a/src/Microsoft.AspNet.Mvc.Xml/SerializableErrorWrapperProviderFactory.cs
+++ b/src/Microsoft.AspNet.Mvc.Xml/SerializableErrorWrapperProviderFactory.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using Microsoft.AspNet.Mvc;
 using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Mvc.Xml
@@ -14,11 +12,15 @@ namespace Microsoft.AspNet.Mvc.Xml
     {
         /// <summary>
         /// Creates an instance of <see cref="SerializableErrorWrapperProvider"/> if the provided
-        /// declared type is <see cref="Microsoft.AspNet.Mvc.SerializableError"/>.
+        /// <paramref name="context"/>'s <see cref="WrapperProviderContext.DeclaredType"/> is
+        /// <see cref="Microsoft.AspNet.Mvc.SerializableError"/>.
         /// </summary>
-        /// <param name="context"></param>
-        /// <returns>An instance of <see cref="SerializableErrorWrapperProvider"/> if the provided 
-        /// declared type is <see cref="Microsoft.AspNet.Mvc.SerializableError"/>, else <c>null</c>.</returns>
+        /// <param name="context">The <see cref="WrapperProviderContext"/>.</param>
+        /// <returns>
+        /// An instance of <see cref="SerializableErrorWrapperProvider"/> if the provided <paramref name="context"/>'s
+        /// <see cref="WrapperProviderContext.DeclaredType"/> is
+        /// <see cref="Microsoft.AspNet.Mvc.SerializableError"/>; otherwise <c>null</c>.
+        /// </returns>
         public IWrapperProvider GetProvider([NotNull] WrapperProviderContext context)
         {
             if (context.DeclaredType == typeof(SerializableError))


### PR DESCRIPTION
- was trying out rules matching frequest PR comments (then)
 - did a manual scan to find new instances of same issues
- "" -> `string.Empty`
- `String` -> `string` and similar
- fill empty XML doc elements
 - ignored `JsonPatchDocument<TModel>`; just too many empty elements
- corrected missing / extra / out-of-order `<param>` descriptions
 - `xml-docs-test` detects incorrect external references but not these local issues