### PR TITLE
Tweak lifetimes for a few commonly resolved services

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/DefaultControllerFactory.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/DefaultControllerFactory.cs
@@ -2,13 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNet.Mvc.Core;
-using Microsoft.AspNet.Mvc.ModelBinding;
-using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Mvc

--- a/src/Microsoft.AspNet.Mvc.Core/DefaultFilterProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/DefaultFilterProvider.cs
@@ -10,17 +10,10 @@ namespace Microsoft.AspNet.Mvc.Filters
 {
     public class DefaultFilterProvider : IFilterProvider
     {
-        public DefaultFilterProvider(IServiceProvider serviceProvider)
-        {
-            ServiceProvider = serviceProvider;
-        }
-
         public int Order
         {
             get { return DefaultOrder.DefaultFrameworkSortOrder; }
         }
-
-        protected IServiceProvider ServiceProvider { get; private set; }
 
         /// <inheritdoc />
         public void OnProvidersExecuting([NotNull] FilterProviderContext context)
@@ -55,7 +48,8 @@ namespace Microsoft.AspNet.Mvc.Filters
             }
             else
             {
-                filterItem.Filter = filterFactory.CreateInstance(ServiceProvider);
+                var services = context.ActionContext.HttpContext.RequestServices;
+                filterItem.Filter = filterFactory.CreateInstance(services);
 
                 if (filterItem.Filter == null)
                 {

--- a/src/Microsoft.AspNet.Mvc.Core/MvcCoreServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/MvcCoreServiceCollectionExtensions.cs
@@ -78,24 +78,28 @@ namespace Microsoft.Framework.DependencyInjection
                 services,
                 ServiceDescriptor.Transient<IActionConstraintProvider, DefaultActionConstraintProvider>());
 
-            // Action Invoker
+            // Controller Factory
             //
             // This has a cache, so it needs to be a singleton
             services.TryAdd(ServiceDescriptor.Singleton<IControllerFactory, DefaultControllerFactory>());
+            // These will be cached by the controller factory
             services.TryAdd(ServiceDescriptor.Transient<IControllerActivator, DefaultControllerActivator>());
-            // This accesses per-request services
-            services.TryAdd(ServiceDescriptor.Transient<IActionInvokerFactory, ActionInvokerFactory>());
-            services.TryAdd(ServiceDescriptor
-                .Transient<IControllerActionArgumentBinder, DefaultControllerActionArgumentBinder>());
-            TryAddMultiRegistrationService(
-                services,
-                ServiceDescriptor.Transient<IActionInvokerProvider, ControllerActionInvokerProvider>());
-            TryAddMultiRegistrationService(
-                services,
-                ServiceDescriptor.Transient<IFilterProvider, DefaultFilterProvider>());
             TryAddMultiRegistrationService(
                 services,
                 ServiceDescriptor.Transient<IControllerPropertyActivator, DefaultControllerPropertyActivator>());
+
+            // Action Invoker
+            //
+            // These two access per-request services
+            services.TryAdd(ServiceDescriptor.Transient<IActionInvokerFactory, ActionInvokerFactory>());
+            TryAddMultiRegistrationService(
+                services,
+                ServiceDescriptor.Transient<IActionInvokerProvider, ControllerActionInvokerProvider>());
+            // Stateless
+            services.TryAddSingleton<IControllerActionArgumentBinder, DefaultControllerActionArgumentBinder>();
+            TryAddMultiRegistrationService(
+                services,
+                ServiceDescriptor.Singleton<IFilterProvider, DefaultFilterProvider>());
 
             // ModelBinding, Validation and Formatting
             //
@@ -106,7 +110,7 @@ namespace Microsoft.Framework.DependencyInjection
                 var options = serviceProvider.GetRequiredService<IOptions<MvcOptions>>().Options;
                 return new DefaultCompositeMetadataDetailsProvider(options.ModelMetadataDetailsProviders);
             }));
-            services.TryAdd(ServiceDescriptor.Transient<IObjectModelValidator>(serviceProvider =>
+            services.TryAdd(ServiceDescriptor.Singleton<IObjectModelValidator>(serviceProvider =>
             {
                 var options = serviceProvider.GetRequiredService<IOptions<MvcOptions>>().Options;
                 var modelMetadataProvider = serviceProvider.GetRequiredService<IModelMetadataProvider>();
@@ -121,7 +125,7 @@ namespace Microsoft.Framework.DependencyInjection
 
             // Random Infrastructure
             //
-            services.TryAdd(ServiceDescriptor.Transient<MvcMarkerService, MvcMarkerService>());
+            services.TryAdd(ServiceDescriptor.Singleton<MvcMarkerService, MvcMarkerService>());
             services.TryAdd((ServiceDescriptor.Singleton<ITypeActivatorCache, DefaultTypeActivatorCache>()));
             services.TryAdd(ServiceDescriptor.Scoped(typeof(IScopedInstance<>), typeof(ScopedInstance<>)));
             services.TryAdd(ServiceDescriptor.Scoped<IUrlHelper, UrlHelper>());

--- a/src/Microsoft.AspNet.Mvc/MvcServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc/MvcServiceCollectionExtensions.cs
@@ -230,7 +230,7 @@ namespace Microsoft.Framework.DependencyInjection
             // View and rendering helpers
             services.TryAdd(ServiceDescriptor.Transient<IHtmlHelper, HtmlHelper>());
             services.TryAdd(ServiceDescriptor.Transient(typeof(IHtmlHelper<>), typeof(HtmlHelper<>)));
-            services.TryAdd(ServiceDescriptor.Transient<IJsonHelper, JsonHelper>());
+            services.TryAdd(ServiceDescriptor.Singleton<IJsonHelper, JsonHelper>());
 
             // Only want one ITagHelperActivator so it can cache Type activation information. Types won't conflict.
             services.TryAdd(ServiceDescriptor.Singleton<ITagHelperActivator, DefaultTagHelperActivator>());
@@ -238,9 +238,9 @@ namespace Microsoft.Framework.DependencyInjection
             // Consumed by the Cache tag helper to cache results across the lifetime of the application.
             services.TryAdd(ServiceDescriptor.Singleton<IMemoryCache, MemoryCache>());
 
-            // DefaultHtmlGenerator is pretty much stateless but depends on Scoped services such as IUrlHelper and
-            // IActionBindingContextProvider. Therefore it too is scoped.
-            services.TryAdd(ServiceDescriptor.Transient<IHtmlGenerator, DefaultHtmlGenerator>());
+            // DefaultHtmlGenerator is pretty much stateless but depends on IUrlHelper, which is scoped.
+            // Therefore it too is scoped.
+            services.TryAdd(ServiceDescriptor.Scoped<IHtmlGenerator, DefaultHtmlGenerator>());
 
             // These do caching so they should stay singleton
             services.TryAdd(ServiceDescriptor.Singleton<IViewComponentSelector, DefaultViewComponentSelector>());
@@ -252,7 +252,7 @@ namespace Microsoft.Framework.DependencyInjection
             services.TryAdd(ServiceDescriptor
                 .Transient<IViewComponentDescriptorProvider, DefaultViewComponentDescriptorProvider>());
             services.TryAdd(ServiceDescriptor
-                .Transient<IViewComponentInvokerFactory, DefaultViewComponentInvokerFactory>());
+                .Singleton<IViewComponentInvokerFactory, DefaultViewComponentInvokerFactory>());
             services.TryAdd(ServiceDescriptor.Transient<IViewComponentHelper, DefaultViewComponentHelper>());
 
             // Security and Authorization
@@ -261,7 +261,7 @@ namespace Microsoft.Framework.DependencyInjection
             services.TryAdd(ServiceDescriptor
                 .Singleton<IAntiForgeryAdditionalDataProvider, DefaultAntiForgeryAdditionalDataProvider>());
 
-            // Api Description
+            // Api Description 
             services.TryAdd(ServiceDescriptor
                 .Singleton<IApiDescriptionGroupCollectionProvider, ApiDescriptionGroupCollectionProvider>());
             TryAddMultiRegistrationService(


### PR DESCRIPTION
This is some low hanging fruit for reducing the number of resolves we have
per request.

DefaultHtmlGenerator: Lots of these are created by RazorPage. It needs
IUrlHelper, so scoped is the best we can do for now. For an example, on
the front page of our sample, 48 of these are created for each request.
48! This takes it down to 1-per-request.

JsonResult: Again, multiple created per request (12 for the sample). This
class is totally stateless, so we can get down to 0-per-request.

DefaultViewComponentInvokerFactory: Same story as JsonResult.

DefaultObjectValidator/MvcMarkerService these are stateless and pretty
much guaranteed to be used by every request. Getting them off the table.