### PR TITLE
Modify `TypeConverterModelBinder`'s `ModelBindingResult.IsModelSet` to be false when model value is `null`.

### DIFF
--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/TypeConverterModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/TypeConverterModelBinderTest.cs
@@ -67,6 +67,35 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             Assert.NotNull(retVal);
         }
 
+        [Theory]
+        [InlineData(typeof(byte))]
+        [InlineData(typeof(short))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(long))]
+        [InlineData(typeof(Guid))]
+        [InlineData(typeof(double))]
+        [InlineData(typeof(DayOfWeek))]
+        public async Task BindModel_CreatesError_WhenTypeConversionIsNull(Type destinationType)
+        {
+            // Arrange
+            var bindingContext = GetBindingContext(destinationType);
+            bindingContext.ValueProvider = new SimpleHttpValueProvider
+            {
+                { "theModelName", string.Empty }
+            };
+            var binder = new TypeConverterModelBinder();
+
+            // Act
+            var result = await binder.BindModelAsync(bindingContext);
+
+            // Assert
+            Assert.False(result.IsModelSet);
+            Assert.NotNull(result.ValidationNode);
+            var error = Assert.Single(bindingContext.ModelState["theModelName"].Errors);
+            Assert.Equal(error.ErrorMessage, "The value '' is invalid.", StringComparer.Ordinal);
+            Assert.Null(error.Exception);
+        }
+
         [Fact]
         public async Task BindModel_Error_FormatExceptionsTurnedIntoStringsInModelState()
         {
@@ -113,7 +142,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var bindingContext = GetBindingContext(typeof(string));
             bindingContext.ValueProvider = new SimpleHttpValueProvider
             {
-                { "theModelName", "" }
+                { "theModelName", string.Empty }
             };
 
             var binder = new TypeConverterModelBinder();
@@ -144,7 +173,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
 
             // Assert
             Assert.NotNull(retVal);
-            Assert.Equal(42, retVal.Model);;
+            Assert.Equal(42, retVal.Model);
             Assert.True(bindingContext.ModelState.ContainsKey("theModelName"));
         }
 

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Customer.Index.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Customer.Index.html
@@ -30,7 +30,8 @@
             <input type="radio" value="Female" id="Gender" name="Gender" /> Female
             <span class="field-validation-valid" data-valmsg-for="Gender" data-valmsg-replace="true"></span>
         </div>
-        <div class="order validation-summary-errors" data-valmsg-summary="true"><ul><li>The Password field is required.</li>
+        <div class="order validation-summary-errors" data-valmsg-summary="true"><ul><li>The value &#x27;&#x27; is invalid.</li>
+<li>The Password field is required.</li>
 </ul></div>
         <div class="order validation-summary-errors"><ul><li style="display:none"></li>
 </ul></div>

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/TypeConverterModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/TypeConverterModelBinderIntegrationTest.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Mvc.ModelBinding;
@@ -162,6 +164,92 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.Equal("someValue", modelState[key].Value.RawValue);
             Assert.Empty(modelState[key].Errors);
             Assert.Equal(ModelValidationState.Valid, modelState[key].ValidationState);
+        }
+
+        [Theory]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(bool))]
+        public async Task BindParameter_WithEmptyData_DoesNotBind(Type parameterType)
+        {
+            // Arrange
+            var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
+            var parameter = new ParameterDescriptor
+            {
+                Name = "Parameter1",
+                BindingInfo = new BindingInfo(),
+
+                ParameterType = parameterType
+            };
+            var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
+            {
+                request.QueryString = QueryString.Create("Parameter1", string.Empty);
+            });
+            var modelState = new ModelStateDictionary();
+
+            // Act
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+
+            // Assert
+
+            // ModelBindingResult
+            Assert.NotNull(modelBindingResult);
+            Assert.False(modelBindingResult.IsModelSet);
+
+            // Model
+            Assert.Null(modelBindingResult.Model);
+
+            // ModelState
+            Assert.False(modelState.IsValid);
+            var key = Assert.Single(modelState.Keys);
+            Assert.Equal("Parameter1", key);
+            Assert.Equal(string.Empty, modelState[key].Value.AttemptedValue);
+            Assert.Equal(string.Empty, modelState[key].Value.RawValue);
+            var error = Assert.Single(modelState[key].Errors);
+            Assert.Equal(error.ErrorMessage, "The value '' is invalid.", StringComparer.Ordinal);
+            Assert.Null(error.Exception);
+        }
+
+        [InlineData(typeof(int?))]
+        [InlineData(typeof(bool?))]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(IEnumerable))]
+        public async Task BindParameter_WithEmptyData_BindsMutableAndNullableObjects(Type parameterType)
+        {
+            // Arrange
+            var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
+            var parameter = new ParameterDescriptor
+            {
+                Name = "Parameter1",
+                BindingInfo = new BindingInfo(),
+
+                ParameterType = parameterType
+            };
+            var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
+            {
+                request.QueryString = QueryString.Create("Parameter1", string.Empty);
+            });
+            var modelState = new ModelStateDictionary();
+
+            // Act
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+
+            // Assert
+
+            // ModelBindingResult
+            Assert.NotNull(modelBindingResult);
+            Assert.True(modelBindingResult.IsModelSet);
+
+            // Model
+            Assert.Null(modelBindingResult.Model);
+
+            // ModelState
+            Assert.True(modelState.IsValid);
+            var key = Assert.Single(modelState.Keys);
+            Assert.Equal("Parameter1", key);
+            Assert.Equal(string.Empty, modelState[key].Value.AttemptedValue);
+            Assert.Equal(string.Empty, modelState[key].Value.RawValue);
+            Assert.Empty(modelState[key].Errors);
         }
 
         [Fact]


### PR DESCRIPTION
- Previously `ModelBindingResult.IsModelSet` would be set to true if type conversions resulted in empty => `null` values. This resulted in improper usage of `ModelBindingResult`s creating null ref exceptions in certain cases.
- Updated existing functional test to account for new behavior. Previously it was handling the null ref exception by stating that errors were simply invalid; now we can provide a more distinct error.
- Added unit test to validate `TypeConverterModelBinder` does what it's supposed to when conversions result in null values.

https://github.com/aspnet/Mvc/issues/2720