### PR TITLE
Fix for #2739

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Properties/Resources.Designer.cs
@@ -363,22 +363,6 @@ namespace Microsoft.AspNet.Mvc.Core
         }
 
         /// <summary>
-        /// No encoding found for output formatter '{0}'. There must be at least one supported encoding registered in order for the output formatter to write content.
-        /// </summary>
-        internal static string OutputFormatterNoEncoding
-        {
-            get { return GetString("OutputFormatterNoEncoding"); }
-        }
-
-        /// <summary>
-        /// No encoding found for output formatter '{0}'. There must be at least one supported encoding registered in order for the output formatter to write content.
-        /// </summary>
-        internal static string FormatOutputFormatterNoEncoding(object p0)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("OutputFormatterNoEncoding"), p0);
-        }
-
-        /// <summary>
         /// No encoding found for input formatter '{0}'. There must be at least one supported encoding registered in order for the formatter to read content.
         /// </summary>
         internal static string InputFormatterNoEncoding

--- a/src/Microsoft.AspNet.Mvc.Core/Resources.resx
+++ b/src/Microsoft.AspNet.Mvc.Core/Resources.resx
@@ -183,9 +183,6 @@
   <data name="TypeMustDeriveFromType" xml:space="preserve">
     <value>The type '{0}' must derive from '{1}'.</value>
   </data>
-  <data name="OutputFormatterNoEncoding" xml:space="preserve">
-    <value>No encoding found for output formatter '{0}'. There must be at least one supported encoding registered in order for the output formatter to write content.</value>
-  </data>
   <data name="InputFormatterNoEncoding" xml:space="preserve">
     <value>No encoding found for input formatter '{0}'. There must be at least one supported encoding registered in order for the formatter to read content.</value>
   </data>


### PR DESCRIPTION
This change removes the validation that forces an OutputFormatter to set
an encoding, so that you can use the OutputFormatter base class for
non-text.

The check that we had would pretty much only be hit when you
didn't have any SupportedEncodings. If you have anything in
SupportedEncodings, then one of them will be picked as a default. So
removing the check is to do, because for a text-based formatter you'd
never run into this issue in the first place.