### PR TITLE
Remove a VS build warning

### DIFF
--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/MutableObjectModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/MutableObjectModelBinderTest.cs
@@ -1804,7 +1804,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
         private class PersonWithNoProperties
         {
-            public string name;
+            public string name = null;
         }
 
         private class PersonWithBindExclusion

--- a/test/Microsoft.AspNet.Mvc.Localization.Test/Microsoft.AspNet.Mvc.Localization.Test.xproj
+++ b/test/Microsoft.AspNet.Mvc.Localization.Test/Microsoft.AspNet.Mvc.Localization.Test.xproj
@@ -4,7 +4,6 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>8fc726b5-e766-44e0-8b38-1313b6d8d9a7</ProjectGuid>
@@ -12,9 +11,11 @@
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>


### PR DESCRIPTION
- was "CS0649: Field is never assigned to, and will always have its default value `null'"
 - visible only in VS builds due to aspnet/dnx#2284

nit: let VS do its thing with Microsoft.AspNet.Mvc.Localization.xproj