### PR TITLE
packExclue > publishEclude and removed xproj and kproj exludes

### DIFF
--- a/samples/MvcMinimalSample.Web/project.json
+++ b/samples/MvcMinimalSample.Web/project.json
@@ -20,9 +20,6 @@
   },
 
   "publishExclude": [
-    "node_modules",
-    "bower_components",
-    "**.xproj",
     "**.user",
     "**.vspscc"
   ],

--- a/samples/MvcSample.Web/project.json
+++ b/samples/MvcSample.Web/project.json
@@ -36,10 +36,7 @@
         "node_modules",
         "bower_components"
     ],
-    "packExclude": [
-        "node_modules",
-        "bower_components",
-        "**.kproj",
+    "publishExclude": [
         "**.user",
         "**.vspscc"
     ],

--- a/samples/TagHelperSample.Web/project.json
+++ b/samples/TagHelperSample.Web/project.json
@@ -28,10 +28,7 @@
     "node_modules",
     "bower_components"
   ],
-  "packExclude": [
-    "node_modules",
-    "bower_components",
-    "**.kproj",
+  "publishExclude": [
     "**.user",
     "**.vspscc"
   ],

--- a/src/Microsoft.AspNet.Mvc.Localization/project.json
+++ b/src/Microsoft.AspNet.Mvc.Localization/project.json
@@ -20,12 +20,5 @@
     "wwwroot",
     "node_modules",
     "bower_components"
-  ],
-  "packExclude": [
-    "node_modules",
-    "bower_components",
-    "**.kproj",
-    "**.user",
-    "**.vspscc"
   ]
 }

--- a/src/Microsoft.AspNet.Mvc.Razor.Host/project.json
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/project.json
@@ -36,12 +36,5 @@
     "wwwroot",
     "node_modules",
     "bower_components"
-  ],
-  "packExclude": [
-    "node_modules",
-    "bower_components",
-    "**.kproj",
-    "**.user",
-    "**.vspscc"
   ]
 }

--- a/src/Microsoft.AspNet.Mvc.Razor/project.json
+++ b/src/Microsoft.AspNet.Mvc.Razor/project.json
@@ -38,12 +38,5 @@
     "wwwroot",
     "node_modules",
     "bower_components"
-  ],
-  "packExclude": [
-    "node_modules",
-    "bower_components",
-    "**.kproj",
-    "**.user",
-    "**.vspscc"
   ]
 }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/project.json
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/project.json
@@ -28,12 +28,5 @@
     "wwwroot",
     "node_modules",
     "bower_components"
-  ],
-  "packExclude": [
-    "node_modules",
-    "bower_components",
-    "**.kproj",
-    "**.user",
-    "**.vspscc"
   ]
 }

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/project.json
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/project.json
@@ -79,12 +79,5 @@
     "wwwroot",
     "node_modules",
     "bower_components"
-  ],
-  "packExclude": [
-    "node_modules",
-    "bower_components",
-    "**.kproj",
-    "**.user",
-    "**.vspscc"
   ]
 }

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/project.json
@@ -27,12 +27,5 @@
     "wwwroot",
     "node_modules",
     "bower_components"
-  ],
-  "packExclude": [
-    "node_modules",
-    "bower_components",
-    "**.kproj",
-    "**.user",
-    "**.vspscc"
   ]
 }

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/project.json
@@ -32,12 +32,5 @@
         "wwwroot",
         "node_modules",
         "bower_components"
-    ],
-    "packExclude": [
-        "node_modules",
-        "bower_components",
-        "**.kproj",
-        "**.user",
-        "**.vspscc"
     ]
 }

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/project.json
@@ -26,12 +26,5 @@
     "wwwroot",
     "node_modules",
     "bower_components"
-  ],
-  "packExclude": [
-    "node_modules",
-    "bower_components",
-    "**.kproj",
-    "**.user",
-    "**.vspscc"
   ]
 }

--- a/test/WebSites/ValidationWebSite/project.json
+++ b/test/WebSites/ValidationWebSite/project.json
@@ -20,10 +20,7 @@
         "node_modules",
         "bower_components"
     ],
-    "packExclude": [
-        "node_modules",
-        "bower_components",
-        "**.kproj",
+    "publishExclude": [
         "**.user",
         "**.vspscc"
     ],


### PR DESCRIPTION
 - removed `packExclude` from unnecessary project where the publish is not necessary.
 - renamed `packExclude` > `publishExclude`.
 - removed xproj and kproj excludes as xproj is being excluded by default and kproj has been renamed to xproj.