### PR TITLE
Add support for model binding dictionaries from `prefix[name]=value` entries

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/DictionaryModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/DictionaryModelBinder.cs
@@ -2,7 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Mvc.ModelBinding
 {
@@ -14,14 +17,86 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
     public class DictionaryModelBinder<TKey, TValue> : CollectionModelBinder<KeyValuePair<TKey, TValue>>
     {
         /// <inheritdoc />
+        public override async Task<ModelBindingResult> BindModelAsync([NotNull] ModelBindingContext bindingContext)
+        {
+            var result = await base.BindModelAsync(bindingContext);
+            if (result == null || !result.IsModelSet)
+            {
+                // No match for the prefix at all.
+                return result;
+            }
+
+            var model = result.Model as Dictionary<TKey, TValue>;
+            Debug.Assert(model != null);
+            if (model.Count != 0)
+            {
+                // ICollection<KeyValuePair<TKey, TValue>> approach was successful.
+                return result;
+            }
+
+            var enumerableValueProvider = bindingContext.ValueProvider as IEnumerableValueProvider;
+            if (enumerableValueProvider == null)
+            {
+                // No IEnumerableValueProvider available for the fallback approach.
+                return result;
+            }
+
+            // Attempt to bind dictionary from a set of prefix[key]=value entries. Get the short and long keys first.
+            var keys = await enumerableValueProvider.GetKeysFromPrefixAsync(bindingContext.ModelName);
+            if (!keys.Any())
+            {
+                // No entries with the expected keys.
+                return result;
+            }
+
+            // Update the existing successful but empty ModelBindingResult.
+            var metadataProvider = bindingContext.OperationBindingContext.MetadataProvider;
+            var valueMetadata = metadataProvider.GetMetadataForType(typeof(TValue));
+            var valueBindingContext = ModelBindingContext.GetChildModelBindingContext(
+                bindingContext,
+                bindingContext.ModelName,
+                valueMetadata);
+
+            var modelBinder = bindingContext.OperationBindingContext.ModelBinder;
+            var validationNode = result.ValidationNode;
+
+            foreach (var key in keys)
+            {
+                var dictionaryKey = ConvertFromString(key.Key);
+                valueBindingContext.ModelName = key.Value;
+
+                var valueResult = await modelBinder.BindModelAsync(valueBindingContext);
+
+                // Always add an entry to the dictionary but validate only if binding was successful.
+                model[dictionaryKey] = ModelBindingHelper.CastOrDefault<TValue>(valueResult?.Model);
+                if (valueResult != null && valueResult.IsModelSet)
+                {
+                    validationNode.ChildNodes.Add(valueResult.ValidationNode);
+                }
+            }
+
+            return result;
+        }
+
+        /// <inheritdoc />
         protected override object GetModel(IEnumerable<KeyValuePair<TKey, TValue>> newCollection)
         {
             return newCollection?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
 
+        /// <inheritdoc />
         protected override object CreateEmptyCollection()
         {
             return new Dictionary<TKey, TValue>();
+        }
+
+        private static TKey ConvertFromString(string keyString)
+        {
+            // Use InvariantCulture to convert string since ExpressionHelper.GetExpressionText() used that culture.
+            var keyResult = new ValueProviderResult(keyString);
+            var keyObject = keyResult.ConvertTo(typeof(TKey));
+
+            return ModelBindingHelper.CastOrDefault<TKey>(keyObject);
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/DictionaryModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/DictionaryModelBinder.cs
@@ -26,8 +26,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 return result;
             }
 
-            var model = result.Model as Dictionary<TKey, TValue>;
-            Debug.Assert(model != null);
+            Debug.Assert(result.Model != null);
+            var model = (Dictionary<TKey, TValue>)result.Model;
             if (model.Count != 0)
             {
                 // ICollection<KeyValuePair<TKey, TValue>> approach was successful.
@@ -37,7 +37,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var enumerableValueProvider = bindingContext.ValueProvider as IEnumerableValueProvider;
             if (enumerableValueProvider == null)
             {
-                // No IEnumerableValueProvider available for the fallback approach.
+                // No IEnumerableValueProvider available for the fallback approach. For example the user may have
+                // replaced the ValueProvider with something other than a CompositeValueProvider.
                 return result;
             }
 

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/RoundTripTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/RoundTripTests.cs
@@ -101,13 +101,19 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             // Arrange
             var server = TestHelper.CreateServer(_app, SiteName, _configureServices);
             var client = server.CreateClient();
+            var expected = "6 feet";
 
             // Act
             var expression = await client.GetStringAsync("http://localhost/RoundTrip/GetPersonParentHeightAttribute");
+            var keyValuePairs = new[]
+            {
+                new KeyValuePair<string, string>(expression, expected),
+            };
+            var result = await GetPerson(client, keyValuePairs);
 
             // Assert
             Assert.Equal("Parent.Attributes[height]", expression);
-            // TODO: https://github.com/aspnet/Mvc/issues/1418 Requires resolution in model binding
+            Assert.Equal(expected, result.Parent.Attributes["height"]);
         }
 
         // Uses the expression p => p.Dependents[0].Dependents[0].Name

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/DictionaryModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/DictionaryModelBinderIntegrationTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Mvc.ModelBinding;
@@ -14,7 +13,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
     public class DictionaryModelBinderIntegrationTest
     {
         [Fact]
-        public async Task DictionaryModelBinder_BindsDictionaryOfSimpleType_WithPrefix_Success()
+        public async Task DictionaryModelBinder_BindsDictionaryOfSimpleType_WithPrefixAndKVP_Success()
         {
             // Arrange
             var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
@@ -55,7 +54,48 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
         }
 
         [Fact]
-        public async Task DictionaryModelBinder_BindsDictionaryOfSimpleType_WithExplicitPrefix_Success()
+        public async Task DictionaryModelBinder_BindsDictionaryOfSimpleType_WithPrefixAndItem_Success()
+        {
+            // Arrange
+            var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
+            var parameter = new ParameterDescriptor()
+            {
+                Name = "parameter",
+                ParameterType = typeof(Dictionary<string, int>)
+            };
+
+            var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
+            {
+                request.QueryString = new QueryString("?parameter[key0]=10");
+            });
+
+            var modelState = new ModelStateDictionary();
+
+            // Act
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+
+            // Assert
+            Assert.NotNull(modelBindingResult);
+            Assert.True(modelBindingResult.IsModelSet);
+
+            var model = Assert.IsType<Dictionary<string, int>>(modelBindingResult.Model);
+            Assert.Equal(new Dictionary<string, int>() { { "key0", 10 } }, model);
+
+            Assert.Equal(0, modelState.ErrorCount);
+            Assert.True(modelState.IsValid);
+
+            var kvp = Assert.Single(modelState);
+            Assert.Equal("parameter[key0]", kvp.Key);
+            var entry = kvp.Value;
+            Assert.Equal("10", entry.Value.AttemptedValue);
+            Assert.Equal("10", entry.Value.RawValue);
+        }
+
+        [Theory]
+        [InlineData("?prefix[key0]=10")]
+        [InlineData("?prefix[0].Key=key0&prefix[0].Value=10")]
+        public async Task DictionaryModelBinder_BindsDictionaryOfSimpleType_WithExplicitPrefix_Success(
+            string queryString)
         {
             // Arrange
             var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
@@ -71,7 +111,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
             {
-                request.QueryString = new QueryString("?prefix[0].Key=key0&prefix[0].Value=10");
+                request.QueryString = new QueryString(queryString);
             });
 
             var modelState = new ModelStateDictionary();
@@ -86,21 +126,15 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Dictionary<string, int>>(modelBindingResult.Model);
             Assert.Equal(new Dictionary<string, int>() { { "key0", 10 }, }, model);
 
-            Assert.Equal(2, modelState.Count);
+            Assert.NotEmpty(modelState);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
-
-            var entry = Assert.Single(modelState, kvp => kvp.Key == "prefix[0].Key").Value;
-            Assert.Equal("key0", entry.Value.AttemptedValue);
-            Assert.Equal("key0", entry.Value.RawValue);
-
-            entry = Assert.Single(modelState, kvp => kvp.Key == "prefix[0].Value").Value;
-            Assert.Equal("10", entry.Value.AttemptedValue);
-            Assert.Equal("10", entry.Value.RawValue);
         }
 
-        [Fact]
-        public async Task DictionaryModelBinder_BindsDictionaryOfSimpleType_EmptyPrefix_Success()
+        [Theory]
+        [InlineData("?[key0]=10")]
+        [InlineData("?[0].Key=key0&[0].Value=10")]
+        public async Task DictionaryModelBinder_BindsDictionaryOfSimpleType_EmptyPrefix_Success(string queryString)
         {
             // Arrange
             var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
@@ -112,7 +146,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
             {
-                request.QueryString = new QueryString("?[0].Key=key0&[0].Value=10");
+                request.QueryString = new QueryString(queryString);
             });
 
             var modelState = new ModelStateDictionary();
@@ -127,17 +161,9 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var model = Assert.IsType<Dictionary<string, int>>(modelBindingResult.Model);
             Assert.Equal(new Dictionary<string, int>() { { "key0", 10 }, }, model);
 
-            Assert.Equal(2, modelState.Count);
+            Assert.NotEmpty(modelState);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
-
-            var entry = Assert.Single(modelState, kvp => kvp.Key == "[0].Key").Value;
-            Assert.Equal("key0", entry.Value.AttemptedValue);
-            Assert.Equal("key0", entry.Value.RawValue);
-
-            entry = Assert.Single(modelState, kvp => kvp.Key == "[0].Value").Value;
-            Assert.Equal("10", entry.Value.AttemptedValue);
-            Assert.Equal("10", entry.Value.RawValue);
         }
 
         [Fact]
@@ -164,9 +190,11 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             // Assert
             Assert.NotNull(modelBindingResult);
             Assert.True(modelBindingResult.IsModelSet);
-            Assert.Empty(Assert.IsType<Dictionary<string, int>>(modelBindingResult.Model));
 
-            Assert.Equal(0, modelState.Count);
+            var model = Assert.IsType<Dictionary<string, int>>(modelBindingResult.Model);
+            Assert.Empty(model);
+
+            Assert.Empty(modelState);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
         }
@@ -174,10 +202,29 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
         private class Person
         {
             public int Id { get; set; }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as Person;
+
+                return other != null && Id == other.Id;
+            }
+
+            public override int GetHashCode()
+            {
+                return Id.GetHashCode();
+            }
+
+            public override string ToString()
+            {
+                return $"{{ { Id } }}";
+            }
         }
 
-        [Fact]
-        public async Task DictionaryModelBinder_BindsDictionaryOfComplexType_WithPrefix_Success()
+        [Theory]
+        [InlineData("?parameter[key0].Id=10")]
+        [InlineData("?parameter[0].Key=key0&parameter[0].Value.Id=10")]
+        public async Task DictionaryModelBinder_BindsDictionaryOfComplexType_WithPrefix_Success(string queryString)
         {
             // Arrange
             var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
@@ -189,7 +236,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
             {
-                request.QueryString = new QueryString("?parameter[0].Key=key0&parameter[0].Value.Id=10");
+                request.QueryString = new QueryString(queryString);
             });
 
             var modelState = new ModelStateDictionary();
@@ -202,25 +249,18 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.True(modelBindingResult.IsModelSet);
 
             var model = Assert.IsType<Dictionary<string, Person>>(modelBindingResult.Model);
-            Assert.Equal(1, model.Count);
-            Assert.Equal("key0", model.Keys.First());
-            Assert.Equal(model.Values, model.Values);
+            Assert.Equal(new Dictionary<string, Person> { { "key0", new Person { Id = 10 } }, }, model);
 
-            Assert.Equal(2, modelState.Count);
+            Assert.NotEmpty(modelState);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
-
-            var entry = Assert.Single(modelState, kvp => kvp.Key == "parameter[0].Key").Value;
-            Assert.Equal("key0", entry.Value.AttemptedValue);
-            Assert.Equal("key0", entry.Value.RawValue);
-
-            entry = Assert.Single(modelState, kvp => kvp.Key == "parameter[0].Value.Id").Value;
-            Assert.Equal("10", entry.Value.AttemptedValue);
-            Assert.Equal("10", entry.Value.RawValue);
         }
 
-        [Fact]
-        public async Task DictionaryModelBinder_BindsDictionaryOfComplexType_WithExplicitPrefix_Success()
+        [Theory]
+        [InlineData("?prefix[key0].Id=10")]
+        [InlineData("?prefix[0].Key=key0&prefix[0].Value.Id=10")]
+        public async Task DictionaryModelBinder_BindsDictionaryOfComplexType_WithExplicitPrefix_Success(
+            string queryString)
         {
             // Arrange
             var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
@@ -236,7 +276,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
             {
-                request.QueryString = new QueryString("?prefix[0].Key=key0&prefix[0].Value.Id=10");
+                request.QueryString = new QueryString(queryString);
             });
 
             var modelState = new ModelStateDictionary();
@@ -249,25 +289,17 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.True(modelBindingResult.IsModelSet);
 
             var model = Assert.IsType<Dictionary<string, Person>>(modelBindingResult.Model);
-            Assert.Equal(1, model.Count);
-            Assert.Equal("key0", model.Keys.First());
-            Assert.Equal(model.Values, model.Values);
+            Assert.Equal(new Dictionary<string, Person> { { "key0", new Person { Id = 10 } }, }, model);
 
-            Assert.Equal(2, modelState.Count);
+            Assert.NotEmpty(modelState);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
-
-            var entry = Assert.Single(modelState, kvp => kvp.Key == "prefix[0].Key").Value;
-            Assert.Equal("key0", entry.Value.AttemptedValue);
-            Assert.Equal("key0", entry.Value.RawValue);
-
-            entry = Assert.Single(modelState, kvp => kvp.Key == "prefix[0].Value.Id").Value;
-            Assert.Equal("10", entry.Value.AttemptedValue);
-            Assert.Equal("10", entry.Value.RawValue);
         }
 
-        [Fact]
-        public async Task DictionaryModelBinder_BindsDictionaryOfComplexType_EmptyPrefix_Success()
+        [Theory]
+        [InlineData("?[key0].Id=10")]
+        [InlineData("?[0].Key=key0&[0].Value.Id=10")]
+        public async Task DictionaryModelBinder_BindsDictionaryOfComplexType_EmptyPrefix_Success(string queryString)
         {
             // Arrange
             var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
@@ -279,7 +311,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
             {
-                request.QueryString = new QueryString("?[0].Key=key0&[0].Value.Id=10");
+                request.QueryString = new QueryString(queryString);
             });
 
             var modelState = new ModelStateDictionary();
@@ -292,21 +324,11 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.True(modelBindingResult.IsModelSet);
 
             var model = Assert.IsType<Dictionary<string, Person>>(modelBindingResult.Model);
-            Assert.Equal(1, model.Count);
-            Assert.Equal("key0", model.Keys.First());
-            Assert.Equal(model.Values, model.Values);
+            Assert.Equal(new Dictionary<string, Person> { { "key0", new Person { Id = 10 } }, }, model);
 
-            Assert.Equal(2, modelState.Count);
+            Assert.NotEmpty(modelState);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
-
-            var entry = Assert.Single(modelState, kvp => kvp.Key == "[0].Key").Value;
-            Assert.Equal("key0", entry.Value.AttemptedValue);
-            Assert.Equal("key0", entry.Value.RawValue);
-
-            entry = Assert.Single(modelState, kvp => kvp.Key == "[0].Value.Id").Value;
-            Assert.Equal("10", entry.Value.AttemptedValue);
-            Assert.Equal("10", entry.Value.RawValue);
         }
 
         [Fact]
@@ -333,9 +355,11 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             // Assert
             Assert.NotNull(modelBindingResult);
             Assert.True(modelBindingResult.IsModelSet);
-            Assert.Empty(Assert.IsType<Dictionary<string, Person>>(modelBindingResult.Model));
 
-            Assert.Equal(0, modelState.Count);
+            var model = Assert.IsType<Dictionary<string, Person>>(modelBindingResult.Model);
+            Assert.Empty(model);
+
+            Assert.Empty(modelState);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
         }


### PR DESCRIPTION
- #1418
- add new fallback binding in `DictionaryModelBinder`
 - similar to MVC 5 approach but more explicit and with better key conversion support
- fix bugs in `PrefixContainer` encountered while adding new tests of #1418 scenarios
 - did not handle entries like "[key]" or "prefix.key[index]" correctly
 - refactor part of `GetKeyFromEmptyPrefix()` into `IndexOfDelimiter()`; share with `GetKeyFromNonEmptyPrefix()`
 - extend `ReadableStringCollectionValueProviderTest` to cover bracketed key segments

nits:
- remove use of "foo", "bar", and "baz" in affected test classes
- `""` -> `string.Empty`
- `vpResult` -> `result`