### PR TITLE
converted warningsAsErrors values to Boolean

### DIFF
--- a/test/Microsoft.AspNet.JsonPatch.Test/project.json
+++ b/test/Microsoft.AspNet.JsonPatch.Test/project.json
@@ -1,6 +1,6 @@
 {
     "compilationOptions": {
-        "warningsAsErrors": "true"
+        "warningsAsErrors": true
     },
     "dependencies": {
         "Microsoft.AspNet.Http.Extensions": "1.0.0-*",

--- a/test/Microsoft.AspNet.Mvc.Abstractions.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.Abstractions.Test/project.json
@@ -1,6 +1,6 @@
 {
   "compilationOptions": {
-    "warningsAsErrors": "true"
+    "warningsAsErrors": true
   },
   "dependencies": {
     "Microsoft.AspNet.Mvc" : "6.0.0-*",

--- a/test/Microsoft.AspNet.Mvc.ApiExplorer.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.ApiExplorer.Test/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "compilationOptions": {
-    "warningsAsErrors": "true"
+    "warningsAsErrors": true
   },
   "dependencies": {
     "Microsoft.AspNet.Mvc" : "6.0.0-*",

--- a/test/Microsoft.AspNet.Mvc.Core.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/project.json
@@ -1,6 +1,6 @@
 {
     "compilationOptions": {
-        "warningsAsErrors": "true"
+        "warningsAsErrors": true
     },
     "dependencies": {
         "Microsoft.AspNet.Mvc": "6.0.0-*",

--- a/test/Microsoft.AspNet.Mvc.Cors.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.Cors.Test/project.json
@@ -1,6 +1,6 @@
 ﻿{
     "compilationOptions": {
-        "warningsAsErrors": "true"
+        "warningsAsErrors": true
     },
     "dependencies": {
         "Microsoft.AspNet.Mvc": "6.0.0-*",

--- a/test/Microsoft.AspNet.Mvc.DataAnnotations.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.DataAnnotations.Test/project.json
@@ -1,6 +1,6 @@
 ﻿{
     "compilationOptions": {
-        "warningsAsErrors": "true"
+        "warningsAsErrors": true
     },
     "dependencies": {
         "Microsoft.AspNet.Mvc": "6.0.0-*",

--- a/test/Microsoft.AspNet.Mvc.Formatters.Json.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.Formatters.Json.Test/project.json
@@ -1,6 +1,6 @@
 ﻿{
     "compilationOptions": {
-        "warningsAsErrors": "true"
+        "warningsAsErrors": true
     },
     "dependencies": {
         "Microsoft.AspNet.Mvc": "6.0.0-*",

--- a/test/Microsoft.AspNet.Mvc.Formatters.Xml.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.Formatters.Xml.Test/project.json
@@ -1,6 +1,6 @@
 {
   "compilationOptions": {
-    "warningsAsErrors": "true"
+    "warningsAsErrors": true
   },
   "dependencies": {
     "Microsoft.AspNet.Mvc" : "6.0.0-*",

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/project.json
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/project.json
@@ -4,7 +4,7 @@
   ],
   "compilationOptions": {
     "define": [ "__RemoveThisBitTo__GENERATE_BASELINES" ],
-    "warningsAsErrors": "true"
+    "warningsAsErrors": true
   },
   "dependencies": {
     "ActionConstraintsWebSite": "1.0.0",

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/project.json
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/project.json
@@ -1,6 +1,6 @@
 {
     "compilationOptions": {
-        "warningsAsErrors": "true"
+        "warningsAsErrors": true
     },
     "dependencies": {
         "Microsoft.AspNet.Mvc": "6.0.0-*",

--- a/test/Microsoft.AspNet.Mvc.Localization.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.Localization.Test/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "compilationOptions": {
-    "warningsAsErrors": "true"
+    "warningsAsErrors": true
   },
   "dependencies": {
     "Microsoft.AspNet.Mvc": "6.0.0-*",

--- a/test/Microsoft.AspNet.Mvc.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.Test/project.json
@@ -1,6 +1,6 @@
 {
   "compilationOptions": {
-    "warningsAsErrors": "true"
+    "warningsAsErrors": true
   },
   "dependencies": {
     "Microsoft.AspNet.Mvc": "6.0.0-*",

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/project.json
@@ -1,6 +1,6 @@
 ﻿{
     "compilationOptions": {
-        "warningsAsErrors": "true"
+        "warningsAsErrors": true
     },
     "dependencies": {
         "Microsoft.AspNet.Mvc": "6.0.0-*",

--- a/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/project.json
+++ b/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/project.json
@@ -1,6 +1,6 @@
 {
     "compilationOptions": {
-        "warningsAsErrors": "false"
+        "warningsAsErrors": false
     },
     "dependencies": {
         "Microsoft.AspNet.Mvc.WebApiCompatShim": "6.0.0-*",


### PR DESCRIPTION
Some code editors and IDEs give schema validation over project.json (e.g. VS Code) and gives warnings on some `warningsAsErrors` fileds under `compilationOptions` object inside project.json files as they had the values as `string` rather than `Boolean`. This PR converts them to Boolean values.