### PR TITLE
RequireHttpsAttribute - Returning a 405 Method Not Allowed Response

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/RequireHttpsAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/RequireHttpsAttribute.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.Mvc
             // body correctly.
             if (!string.Equals(filterContext.HttpContext.Request.Method, "GET", StringComparison.OrdinalIgnoreCase))
             {
-                filterContext.Result = new HttpStatusCodeResult(StatusCodes.Status403Forbidden);
+                filterContext.Result = new HttpStatusCodeResult(StatusCodes.Status405MethodNotAllowed);
             }
             else
             {

--- a/test/Microsoft.AspNet.Mvc.Core.Test/RequireHttpsAttributeTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/RequireHttpsAttributeTests.cs
@@ -120,7 +120,7 @@ namespace Microsoft.AspNet.Mvc
             // Assert
             Assert.NotNull(authContext.Result);
             var result = Assert.IsType<HttpStatusCodeResult>(authContext.Result);
-            Assert.Equal(StatusCodes.Status403Forbidden, result.StatusCode);
+            Assert.Equal(StatusCodes.Status405MethodNotAllowed, result.StatusCode);
         }
 
         [Fact]


### PR DESCRIPTION
Returning a 405 Method Not Allowed response is the more appropriate status code when you only want to allow GET requests.