### PR TITLE
Build break: React to aspnet/Razor@e722f90

### DIFF
--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TagHelperOutputExtensionsTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TagHelperOutputExtensionsTest.cs
@@ -620,11 +620,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             public int GetHashCode(IReadOnlyTagHelperAttribute attribute)
             {
-                return HashCodeCombiner
-                    .Start()
-                    .Add(attribute.Name, StringComparer.Ordinal)
-                    .Add(attribute.Value)
-                    .CombinedHash;
+                return attribute.GetHashCode();
             }
         }
     }


### PR DESCRIPTION
- aspnet/Razor@e722f90 removed `HashCodeCombiner` from `public` surface of Razor assembly
- not actually needed since `IReadOnlyTagHelperAttribute` implementations provide a solid `GetHashCode()`