### PR TITLE
Fix: asp-append-version ignored for urls containing fragment

### DIFF
--- a/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/FileVersionProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/FileVersionProvider.cs
@@ -49,10 +49,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
         {
             var resolvedPath = path;
 
-            var queryStringStartIndex = path.IndexOf('?');
-            if (queryStringStartIndex != -1)
+            var queryStringOrFragmentStartIndex = path.IndexOfAny(new char[] { '?', '#' });
+            if (queryStringOrFragmentStartIndex != -1)
             {
-                resolvedPath = path.Substring(0, queryStringStartIndex);
+                resolvedPath = path.Substring(0, queryStringOrFragmentStartIndex);
             }
 
             Uri uri;

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Image.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Image.html
@@ -26,6 +26,9 @@
     <!-- Plain image tag with file version and path containing query string -->
     <img alt="Path with query string" src="/images/red.png?abc=def&amp;v=W2F5D366_nQ2fQqUk3URdgWy2ZekXjHzHJaY5yaiOOk" />
 
+    <!-- Plain image tag with file version and path containing fragment -->
+    <img alt="Path with query string" src="/images/red.png?v=W2F5D366_nQ2fQqUk3URdgWy2ZekXjHzHJaY5yaiOOk#abc" />
+
     <!-- Plain image tag with file version and path linking to some action -->
     <img alt="Path linking to some action" src="/controller/action" />
 </body>

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ImageTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ImageTagHelperTest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 attributes: new TagHelperAttributeList
                 {
                     { "alt", new HtmlString("alt text") },
-                    { "data-extra", new HtmlString("something") },                    
+                    { "data-extra", new HtmlString("something") },
                     { "title", new HtmlString("Image title") },
                     { "src", "testimage.png" },
                     { "asp-append-version", "true" }
@@ -42,7 +42,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 attributes: new TagHelperAttributeList
                 {
                     { "alt", new HtmlString("alt text") },
-                    { "data-extra", new HtmlString("something") },                    
+                    { "data-extra", new HtmlString("something") },
                     { "title", new HtmlString("Image title") },
                 });
 
@@ -68,10 +68,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Act
             helper.Process(context, output);
 
-            // Assert            
+            // Assert
             Assert.Equal(expectedOutput.TagName, output.TagName);
             Assert.Equal(4, output.Attributes.Count);
-            
+
             for(int i=0; i < expectedOutput.Attributes.Count; i++)
             {
                 var expectedAtribute = expectedOutput.Attributes[i];

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/Internal/FileVersionProviderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/Internal/FileVersionProviderTest.cs
@@ -23,6 +23,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
         [InlineData("/hello/world", "/hello/world?v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk")]
         [InlineData("/hello/world?q=test", "/hello/world?q=test&v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk")]
         [InlineData("/hello/world?q=foo&bar", "/hello/world?q=foo&bar&v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk")]
+        [InlineData("/hello/world?q=foo&bar#abc", "/hello/world?q=foo&bar&v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk#abc")]
+        [InlineData("/hello/world#somefragment", "/hello/world?v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk#somefragment")]
         public void AddsVersionToFiles_WhenCacheIsAbsent(string filePath, string expected)
         {
             // Arrange

--- a/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Image.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Image.cshtml
@@ -28,6 +28,9 @@
     <!-- Plain image tag with file version and path containing query string -->
     <img src="~/images/red.png?abc=def" alt="Path with query string" asp-append-version="true" />
 
+    <!-- Plain image tag with file version and path containing fragment -->
+    <img src="~/images/red.png#abc" alt="Path with query string" asp-append-version="true" />
+
     <!-- Plain image tag with file version and path linking to some action -->
     <img src="/controller/action" alt="Path linking to some action" asp-append-version="true" />
 </body>


### PR DESCRIPTION
Issue - #2862 
@dougbu 

unrelated nit: Removed some unnecessary whitespace in `ImageTagHelperTest`.