### PR TITLE
Fix #2837 - Make it easier to get ParameterInfo/PropertyInfo

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Abstractions/ParameterDescriptor.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/ParameterDescriptor.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.AspNet.Mvc.ModelBinding;
-using Microsoft.AspNet.Mvc.ModelBinding.Metadata;
 
 namespace Microsoft.AspNet.Mvc
 {

--- a/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/ParameterModel.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ApplicationModels/ParameterModel.cs
@@ -1,12 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using Microsoft.AspNet.Mvc.ModelBinding;
-using Microsoft.AspNet.Mvc.ModelBinding.Metadata;
 using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Mvc.ApplicationModels

--- a/src/Microsoft.AspNet.Mvc.Core/ControllerActionDescriptorBuilder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ControllerActionDescriptorBuilder.cs
@@ -281,11 +281,12 @@ namespace Microsoft.AspNet.Mvc
 
         private static ParameterDescriptor CreateParameterDescriptor(ParameterModel parameterModel)
         {
-            var parameterDescriptor = new ParameterDescriptor()
+            var parameterDescriptor = new ControllerParameterDescriptor()
             {
                 Name = parameterModel.ParameterName,
                 ParameterType = parameterModel.ParameterInfo.ParameterType,
-                BindingInfo = parameterModel.BindingInfo
+                BindingInfo = parameterModel.BindingInfo,
+                ParameterInfo = parameterModel.ParameterInfo,
             };
 
             return parameterDescriptor;
@@ -293,11 +294,12 @@ namespace Microsoft.AspNet.Mvc
 
         private static ParameterDescriptor CreateParameterDescriptor(PropertyModel propertyModel)
         {
-            var parameterDescriptor = new ParameterDescriptor()
+            var parameterDescriptor = new ControllerBoundPropertyDescriptor()
             {
                 BindingInfo = propertyModel.BindingInfo,
                 Name = propertyModel.PropertyName,
                 ParameterType = propertyModel.PropertyInfo.PropertyType,
+                PropertyInfo = propertyModel.PropertyInfo,
             };
 
             return parameterDescriptor;

--- a/src/Microsoft.AspNet.Mvc.Core/ControllerBoundPropertyDescriptor.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ControllerBoundPropertyDescriptor.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+
+namespace Microsoft.AspNet.Mvc
+{
+    /// <summary>
+    /// A descriptor for model bound properties of a controller.
+    /// </summary>
+    public class ControllerBoundPropertyDescriptor : ParameterDescriptor
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="PropertyInfo"/> for this property.
+        /// </summary>
+        public PropertyInfo PropertyInfo { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Core/ControllerParameterDescriptor.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ControllerParameterDescriptor.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+
+namespace Microsoft.AspNet.Mvc
+{
+    /// <summary>
+    /// A descriptor for method parameters of an action method.
+    /// </summary>
+    public class ControllerParameterDescriptor : ParameterDescriptor
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="ParameterInfo"/>.
+        /// </summary>
+        public ParameterInfo ParameterInfo { get; set; }
+    }
+}

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ControllerActionDescriptorBuilderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ControllerActionDescriptorBuilderTest.cs
@@ -17,11 +17,14 @@ namespace Microsoft.AspNet.Mvc
         {
             // Arrange
             var applicationModel = new ApplicationModel();
-            var controller = new ControllerModel(typeof(TestController).GetTypeInfo(),
-                                                 new List<object>() { });
+            var controller = new ControllerModel(
+                typeof(TestController).GetTypeInfo(),
+                new List<object>() { });
+
+            var propertyInfo = controller.ControllerType.GetProperty("BoundProperty");
             controller.ControllerProperties.Add(
                 new PropertyModel(
-                    controller.ControllerType.GetProperty("BoundProperty"),
+                    propertyInfo,
                     new List<object>() { })
                 {
                     BindingInfo = BindingInfo.GetBindingInfo(new object[] { new FromQueryAttribute() }),
@@ -43,8 +46,12 @@ namespace Microsoft.AspNet.Mvc
             var descriptors = ControllerActionDescriptorBuilder.Build(applicationModel);
 
             // Assert
-            var property = Assert.Single(descriptors.Single().BoundProperties);
+            var controllerDescriptor = Assert.Single(descriptors);
+
+            var parameter = Assert.Single(controllerDescriptor.BoundProperties);
+            var property = Assert.IsType<ControllerBoundPropertyDescriptor>(parameter);
             Assert.Equal("BoundProperty", property.Name);
+            Assert.Equal(propertyInfo, property.PropertyInfo);
             Assert.Equal(typeof(string), property.ParameterType);
             Assert.Equal(BindingSource.Query, property.BindingInfo.BindingSource);
         }


### PR DESCRIPTION
For a typical configuration, it's now possible to cast a parameter
descriptor to ControllerParameterDescriptor or
ControllerBoundPropertyDescriptor to access the corresponding reflection
type.