### PR TITLE
Added missing `HtmlAttributeNotBound` to `ViewContext` property.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ImageTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ImageTagHelper.cs
@@ -56,6 +56,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
         protected IHostingEnvironment HostingEnvironment { get; }
 
+        [HtmlAttributeNotBound]
         [ViewContext]
         public ViewContext ViewContext { get; set; }
 


### PR DESCRIPTION
- Did not add a test to validate the behavior. None of the other `TagHelper`s validate that a property is not visible/bound.

#2901