### PR TITLE
Make `CompositeValueProvider` consistent with `IBindingSourceValueProvider` contract

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/CompositeValueProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/CompositeValueProvider.cs
@@ -137,6 +137,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 }
             }
 
+            if (filteredValueProviders.Count == 0)
+            {
+                // Do not create an empty CompositeValueProvider.
+                return null;
+            }
+
             if (filteredValueProviders.Count == Count)
             {
                 // No need for a new CompositeValueProvider.

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/MutableObjectModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/MutableObjectModelBinder.cs
@@ -115,7 +115,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
         private async Task<bool> CanValueBindAnyModelProperties(MutableObjectBinderContext context)
         {
-            // If there are no properties on the model, there is nothing to bind. We are here means this is not a top 
+            // If there are no properties on the model, there is nothing to bind. We are here means this is not a top
             // level object. So we return false.
             if (context.PropertyMetadata == null || context.PropertyMetadata.Count == 0)
             {
@@ -196,6 +196,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 if (rootValueProvider != null)
                 {
                     valueProvider = rootValueProvider.Filter(bindingSource);
+                    if (valueProvider == null)
+                    {
+                        // Unable to find a value provider for this binding source. Binding will fail.
+                        return false;
+                    }
                 }
             }
 

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CompositeValueProviderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CompositeValueProviderTest.cs
@@ -28,14 +28,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             return new CompositeValueProvider(new[] { emptyValueProvider, valueProvider });
         }
 
-        protected override void CheckFilterExcludeResult(IValueProvider result)
-        {
-            // CompositeValueProvider returns an empty instance rather than null. CompositeModelBinder and
-            // MutableObjectModelBinder depend on this empty instance.
-            var compositeProvider = Assert.IsType<CompositeValueProvider>(result);
-            Assert.Empty(compositeProvider);
-        }
-
 #if DNX451
         [Fact]
         public async Task GetKeysFromPrefixAsync_ReturnsResultFromFirstValueProviderThatReturnsValues()

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/EnumerableValueProviderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/EnumerableValueProviderTest.cs
@@ -273,11 +273,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var result = provider.Filter(bindingSource);
 
             // Assert
-            CheckFilterExcludeResult(result);
-        }
-
-        protected virtual void CheckFilterExcludeResult(IValueProvider result)
-        {
             Assert.Null(result);
         }
 


### PR DESCRIPTION
- #2907
- return `null` if `Filter()` finds no matching value provider in collection
- fix lack of defensiveness in model binders' use of `IBindingSourceValueProvider` implementations
- remove test workaround for unusual `CompositeValueProvider` behaviour