### PR TITLE
Update ApiController tests with StatusCodes class constants

### DIFF
--- a/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/ApiControllerTest.cs
+++ b/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/ApiControllerTest.cs
@@ -277,7 +277,7 @@ namespace System.Web.Http
             var result = controller.NotFound();
 
             // Assert
-            Assert.Equal(404, Assert.IsType<HttpNotFoundResult>(result).StatusCode);
+            Assert.Equal(StatusCodes.Status404NotFound, Assert.IsType<HttpNotFoundResult>(result).StatusCode);
         }
 
         [Fact]
@@ -290,7 +290,7 @@ namespace System.Web.Http
             var result = controller.Ok();
 
             // Assert
-            Assert.Equal(200, Assert.IsType<HttpOkResult>(result).StatusCode);
+            Assert.Equal(StatusCodes.Status200OK, Assert.IsType<HttpOkResult>(result).StatusCode);
         }
 
 


### PR DESCRIPTION
Few of the ApiController test methods contain checks for certain status code that is being returned from controller (i.e. Ok, NotFound status).

The current commit updates assertion of few of the test methods to have constants instead of hard-coded status code (i.e. StatusCodes.Status200OK instead of 200).