### PR TITLE
Issue #2745 - ViewHierarchyUtility.GetHierarchicalPath does not handle root paths *nix file systems.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor.Host/ViewHierarchyUtility.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/ViewHierarchyUtility.cs
@@ -68,12 +68,6 @@ namespace Microsoft.AspNet.Mvc.Razor
                 relativePath = relativePath.Substring(1);
             }
 
-            if (Path.IsPathRooted(relativePath))
-            {
-                // If the path looks like it's not app relative, don't attempt to construct paths.
-                return Enumerable.Empty<string>();
-            }
-
             if (string.Equals(Path.GetFileName(relativePath), fileName, StringComparison.OrdinalIgnoreCase))
             {
                 // If the specified path is for the file hierarchy being constructed, then the first file that applies

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/ViewHierarchyUtilityTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/ViewHierarchyUtilityTest.cs
@@ -221,35 +221,5 @@ namespace Microsoft.AspNet.Mvc.Razor
             // Assert
             Assert.Empty(result);
         }
-
-        [ConditionalTheory]
-        // https://github.com/aspnet/Mvc/issues/2745
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
-        public void GetViewStartLocations_ReturnsEmptySequence_IfPathIsRooted()
-        {
-            // Arrange
-            var absolutePath = Path.Combine(Directory.GetCurrentDirectory(), "Index.cshtml");
-
-            // Act
-            var result = ViewHierarchyUtility.GetViewStartLocations(absolutePath);
-
-            // Assert
-            Assert.Empty(result);
-        }
-
-        [ConditionalTheory]
-        // https://github.com/aspnet/Mvc/issues/2745
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
-        public void GetViewImportsLocations_ReturnsEmptySequence_IfPathIsRooted()
-        {
-            // Arrange
-            var absolutePath = Path.Combine(Directory.GetCurrentDirectory(), "Index.cshtml");
-
-            // Act
-            var result = ViewHierarchyUtility.GetViewImportsLocations(absolutePath);
-
-            // Assert
-            Assert.Empty(result);
-        }
     }
 }


### PR DESCRIPTION
Fix: It is not necessary to check for root paths in this place because `GetHierarchicalPath` is always called with a relative path. Hence removing the check.