### PR TITLE
Making TagBuilder implement IHtmlContent and removing ToHtmlContent.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.TagHelpers/FormTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/FormTagHelper.cs
@@ -163,7 +163,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 var antiforgeryTag = Generator.GenerateAntiforgery(ViewContext);
                 if (antiforgeryTag != null)
                 {
-                    output.PostContent.Append(antiforgeryTag.ToString());
+                    output.PostContent.Append(antiforgeryTag);
                 }
             }
         }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/InputTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/InputTagHelper.cs
@@ -248,14 +248,11 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 // <input type="hidden"/> into the output's Content.
                 output.Attributes.Clear();
                 output.TagName = null;
-
-                checkBoxTag.TagRenderMode = TagRenderMode.SelfClosing;
                 output.Content.Append(checkBoxTag);
 
                 var hiddenForCheckboxTag = Generator.GenerateHiddenForCheckbox(ViewContext, modelExplorer, For.Name);
                 if (hiddenForCheckboxTag != null)
                 {
-                    hiddenForCheckboxTag.TagRenderMode = TagRenderMode.SelfClosing;
                     output.Content.Append(hiddenForCheckboxTag);
                 }
             }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/InputTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/InputTagHelper.cs
@@ -236,25 +236,27 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 }
             }
 
-            var tagBuilder = Generator.GenerateCheckBox(
+            var checkBoxTag = Generator.GenerateCheckBox(
                 ViewContext,
                 modelExplorer,
                 For.Name,
                 isChecked: null,
                 htmlAttributes: htmlAttributes);
-            if (tagBuilder != null)
+            if (checkBoxTag != null)
             {
                 // Do not generate current element's attributes or tags. Instead put both <input type="checkbox"/> and
                 // <input type="hidden"/> into the output's Content.
                 output.Attributes.Clear();
                 output.TagName = null;
 
-                output.Content.Append(tagBuilder.ToHtmlContent(TagRenderMode.SelfClosing));
+                checkBoxTag.TagRenderMode = TagRenderMode.SelfClosing;
+                output.Content.Append(checkBoxTag);
 
-                tagBuilder = Generator.GenerateHiddenForCheckbox(ViewContext, modelExplorer, For.Name);
-                if (tagBuilder != null)
+                var hiddenForCheckboxTag = Generator.GenerateHiddenForCheckbox(ViewContext, modelExplorer, For.Name);
+                if (hiddenForCheckboxTag != null)
                 {
-                    output.Content.Append(tagBuilder.ToHtmlContent(TagRenderMode.SelfClosing));
+                    hiddenForCheckboxTag.TagRenderMode = TagRenderMode.SelfClosing;
+                    output.Content.Append(hiddenForCheckboxTag);
                 }
             }
         }

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/DefaultDisplayTemplates.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/DefaultDisplayTemplates.cs
@@ -256,16 +256,17 @@ namespace Microsoft.AspNet.Mvc.Rendering
                     readOnly: true,
                     additionalViewData: null);
 
+                var templateBuilderResult = templateBuilder.Build();
                 if (!propertyMetadata.HideSurroundingHtml)
                 {
-                    var containerDivTag = new TagBuilder("div");
-                    containerDivTag.AddCssClass("display-field");
-                    containerDivTag.InnerHtml = templateBuilder.Build();
-                    content.AppendLine(containerDivTag);
+                    var valueDivTag = new TagBuilder("div");
+                    valueDivTag.AddCssClass("display-field");
+                    valueDivTag.InnerHtml = templateBuilderResult;
+                    content.AppendLine(valueDivTag);
                 }
                 else
                 {
-                    content.Append(templateBuilder.Build());
+                    content.Append(templateBuilderResult);
                 }
             }
 

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/DefaultDisplayTemplates.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/DefaultDisplayTemplates.cs
@@ -41,7 +41,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 inputTag.Attributes["checked"] = "checked";
             }
 
-            return inputTag.ToHtmlContent(TagRenderMode.SelfClosing);
+            inputTag.TagRenderMode = TagRenderMode.SelfClosing;
+            return inputTag;
         }
 
         private static IHtmlContent BooleanTemplateDropDownList(IHtmlHelper htmlHelper, bool? value)
@@ -52,17 +53,13 @@ namespace Microsoft.AspNet.Mvc.Rendering
             selectTag.Attributes["disabled"] = "disabled";
 
             var content = new BufferedHtmlContent();
-            content.Append(selectTag.ToHtmlContent(TagRenderMode.StartTag));
-
             foreach (var item in TriStateValues(value))
             {
-                content.Append(
-                    DefaultHtmlGenerator.GenerateOption(item, item.Text)
-                        .ToHtmlContent(TagRenderMode.Normal));
+                content.Append(DefaultHtmlGenerator.GenerateOption(item, item.Text));
             }
 
-            content.Append(selectTag.ToHtmlContent(TagRenderMode.EndTag));
-            return content;
+            selectTag.InnerHtml = content;
+            return selectTag;
         }
 
         // Will soon need to be shared with the default editor templates implementations.
@@ -208,7 +205,6 @@ namespace Microsoft.AspNet.Mvc.Rendering
             var viewData = htmlHelper.ViewData;
             var templateInfo = viewData.TemplateInfo;
             var modelExplorer = viewData.ModelExplorer;
-            var content = new BufferedHtmlContent();
 
             if (modelExplorer.Model == null)
             {
@@ -229,6 +225,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             var serviceProvider = htmlHelper.ViewContext.HttpContext.RequestServices;
             var viewEngine = serviceProvider.GetRequiredService<ICompositeViewEngine>();
 
+            var content = new BufferedHtmlContent();
             foreach (var propertyExplorer in modelExplorer.Properties)
             {
                 var propertyMetadata = propertyExplorer.Metadata;
@@ -237,23 +234,16 @@ namespace Microsoft.AspNet.Mvc.Rendering
                     continue;
                 }
 
-                var divTag = new TagBuilder("div");
-
                 if (!propertyMetadata.HideSurroundingHtml)
                 {
                     var label = propertyMetadata.GetDisplayName();
                     if (!string.IsNullOrEmpty(label))
                     {
-                        divTag.SetInnerText(label);
-                        divTag.AddCssClass("display-label");
-                        content.AppendLine(divTag.ToHtmlContent(TagRenderMode.Normal));
-
-                        // Reset divTag for reuse.
-                        divTag.Attributes.Clear();
-                    }
-
-                    divTag.AddCssClass("display-field");
-                    content.Append(divTag.ToHtmlContent(TagRenderMode.StartTag));
+                        var labelTag = new TagBuilder("div");
+                        labelTag.SetInnerText(label);
+                        labelTag.AddCssClass("display-label");
+                        content.AppendLine(labelTag);
+                    } 
                 }
 
                 var templateBuilder = new TemplateBuilder(
@@ -266,11 +256,16 @@ namespace Microsoft.AspNet.Mvc.Rendering
                     readOnly: true,
                     additionalViewData: null);
 
-                content.Append(templateBuilder.Build());
-
                 if (!propertyMetadata.HideSurroundingHtml)
                 {
-                    content.AppendLine(divTag.ToHtmlContent(TagRenderMode.EndTag));
+                    var containerDivTag = new TagBuilder("div");
+                    containerDivTag.AddCssClass("display-field");
+                    containerDivTag.InnerHtml = templateBuilder.Build();
+                    content.AppendLine(containerDivTag);
+                }
+                else
+                {
+                    content.Append(templateBuilder.Build());
                 }
             }
 
@@ -312,8 +307,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             var hyperlinkTag = new TagBuilder("a");
             hyperlinkTag.MergeAttribute("href", uriString);
             hyperlinkTag.SetInnerText(linkedText);
-
-            return hyperlinkTag.ToHtmlContent(TagRenderMode.Normal);
+            return hyperlinkTag;
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/DefaultDisplayTemplates.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/DefaultDisplayTemplates.cs
@@ -234,18 +234,6 @@ namespace Microsoft.AspNet.Mvc.Rendering
                     continue;
                 }
 
-                if (!propertyMetadata.HideSurroundingHtml)
-                {
-                    var label = propertyMetadata.GetDisplayName();
-                    if (!string.IsNullOrEmpty(label))
-                    {
-                        var labelTag = new TagBuilder("div");
-                        labelTag.SetInnerText(label);
-                        labelTag.AddCssClass("display-label");
-                        content.AppendLine(labelTag);
-                    } 
-                }
-
                 var templateBuilder = new TemplateBuilder(
                     viewEngine,
                     htmlHelper.ViewContext,
@@ -259,6 +247,15 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 var templateBuilderResult = templateBuilder.Build();
                 if (!propertyMetadata.HideSurroundingHtml)
                 {
+                    var label = propertyMetadata.GetDisplayName();
+                    if (!string.IsNullOrEmpty(label))
+                    {
+                        var labelTag = new TagBuilder("div");
+                        labelTag.SetInnerText(label);
+                        labelTag.AddCssClass("display-label");
+                        content.AppendLine(labelTag);
+                    }
+
                     var valueDivTag = new TagBuilder("div");
                     valueDivTag.AddCssClass("display-field");
                     valueDivTag.InnerHtml = templateBuilderResult;

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/DefaultEditorTemplates.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/DefaultEditorTemplates.cs
@@ -264,10 +264,10 @@ namespace Microsoft.AspNet.Mvc.Rendering
                         htmlAttributes: null);
                     if (!string.IsNullOrEmpty(label.ToString()))
                     {
-                        var labelDivTag = new TagBuilder("div");
-                        labelDivTag.AddCssClass("editor-label");
-                        labelDivTag.InnerHtml = label; // already escaped
-                        content.AppendLine(labelDivTag);
+                        var labelTag = new TagBuilder("div");
+                        labelTag.AddCssClass("editor-label");
+                        labelTag.InnerHtml = label;
+                        content.AppendLine(labelTag);
                     }
                 }
 
@@ -281,26 +281,27 @@ namespace Microsoft.AspNet.Mvc.Rendering
                     readOnly: false,
                     additionalViewData: null);
 
+                var templateBuilderResult = templateBuilder.Build();
                 if (!propertyMetadata.HideSurroundingHtml)
                 {
-                    var divTag = new TagBuilder("div");
-                    divTag.AddCssClass("editor-field");
+                    var valueDivTag = new TagBuilder("div");
+                    valueDivTag.AddCssClass("editor-field");
 
                     var innerContent = new BufferedHtmlContent();
-                    innerContent.Append(templateBuilder.Build());
+                    innerContent.Append(templateBuilderResult);
                     innerContent.Append(" ");
                     innerContent.Append(htmlHelper.ValidationMessage(
                         propertyMetadata.PropertyName,
                         message: null,
                         htmlAttributes: null,
                         tag: null));
-                    divTag.InnerHtml = innerContent;
+                    valueDivTag.InnerHtml = innerContent;
 
-                    content.AppendLine(divTag);
+                    content.AppendLine(valueDivTag);
                 }
                 else
                 {
-                    content.Append(templateBuilder.Build());
+                    content.Append(templateBuilderResult);
                 }
             }
 

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/DefaultEditorTemplates.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/DefaultEditorTemplates.cs
@@ -256,21 +256,6 @@ namespace Microsoft.AspNet.Mvc.Rendering
                     continue;
                 }
 
-                if (!propertyMetadata.HideSurroundingHtml)
-                {
-                    var label = htmlHelper.Label(
-                        propertyMetadata.PropertyName,
-                        labelText: null,
-                        htmlAttributes: null);
-                    if (!string.IsNullOrEmpty(label.ToString()))
-                    {
-                        var labelTag = new TagBuilder("div");
-                        labelTag.AddCssClass("editor-label");
-                        labelTag.InnerHtml = label;
-                        content.AppendLine(labelTag);
-                    }
-                }
-
                 var templateBuilder = new TemplateBuilder(
                     viewEngine,
                     htmlHelper.ViewContext,
@@ -284,6 +269,15 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 var templateBuilderResult = templateBuilder.Build();
                 if (!propertyMetadata.HideSurroundingHtml)
                 {
+                    var label = htmlHelper.Label(propertyMetadata.PropertyName, labelText: null, htmlAttributes: null);
+                    if (!string.IsNullOrEmpty(label.ToString()))
+                    {
+                        var labelTag = new TagBuilder("div");
+                        labelTag.AddCssClass("editor-label");
+                        labelTag.InnerHtml = label;
+                        content.AppendLine(labelTag);
+                    }
+
                     var valueDivTag = new TagBuilder("div");
                     valueDivTag.AddCssClass("editor-field");
 

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/DefaultEditorTemplates.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/DefaultEditorTemplates.cs
@@ -256,8 +256,6 @@ namespace Microsoft.AspNet.Mvc.Rendering
                     continue;
                 }
 
-                var divTag = new TagBuilder("div");
-
                 if (!propertyMetadata.HideSurroundingHtml)
                 {
                     var label = htmlHelper.Label(
@@ -266,16 +264,11 @@ namespace Microsoft.AspNet.Mvc.Rendering
                         htmlAttributes: null);
                     if (!string.IsNullOrEmpty(label.ToString()))
                     {
-                        divTag.AddCssClass("editor-label");
-                        divTag.InnerHtml = label; // already escaped
-                        content.AppendLine(divTag.ToHtmlContent(TagRenderMode.Normal));
-
-                        // Reset divTag for reuse.
-                        divTag.Attributes.Clear();
+                        var labelDivTag = new TagBuilder("div");
+                        labelDivTag.AddCssClass("editor-label");
+                        labelDivTag.InnerHtml = label; // already escaped
+                        content.AppendLine(labelDivTag);
                     }
-
-                    divTag.AddCssClass("editor-field");
-                    content.Append(divTag.ToHtmlContent(TagRenderMode.StartTag));
                 }
 
                 var templateBuilder = new TemplateBuilder(
@@ -288,18 +281,26 @@ namespace Microsoft.AspNet.Mvc.Rendering
                     readOnly: false,
                     additionalViewData: null);
 
-                content.Append(templateBuilder.Build());
-
                 if (!propertyMetadata.HideSurroundingHtml)
                 {
-                    content.Append(" ");
-                    content.Append(htmlHelper.ValidationMessage(
+                    var divTag = new TagBuilder("div");
+                    divTag.AddCssClass("editor-field");
+
+                    var innerContent = new BufferedHtmlContent();
+                    innerContent.Append(templateBuilder.Build());
+                    innerContent.Append(" ");
+                    innerContent.Append(htmlHelper.ValidationMessage(
                         propertyMetadata.PropertyName,
                         message: null,
                         htmlAttributes: null,
                         tag: null));
+                    divTag.InnerHtml = innerContent;
 
-                    content.AppendLine(divTag.ToHtmlContent(TagRenderMode.EndTag));
+                    content.AppendLine(divTag);
+                }
+                else
+                {
+                    content.Append(templateBuilder.Build());
                 }
             }
 

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/DefaultHtmlGenerator.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/DefaultHtmlGenerator.cs
@@ -673,7 +673,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 }
                 var messageTag = new TagBuilder(headerTag);
                 messageTag.SetInnerText(message);
-                wrappedMessage.AppendLine(messageTag.ToHtmlContent(TagRenderMode.Normal));
+                wrappedMessage.AppendLine(messageTag);
             }
             else
             {
@@ -696,7 +696,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                     {
                         var listItem = new TagBuilder("li");
                         listItem.SetInnerText(errorText);
-                        htmlSummary.AppendLine(listItem.ToHtmlContent(TagRenderMode.Normal));
+                        htmlSummary.AppendLine(listItem);
                         isHtmlSummaryModified = true;
                     }
                 }
@@ -726,7 +726,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
             var innerContent = new BufferedHtmlContent();
             innerContent.Append(wrappedMessage);
-            innerContent.Append(unorderedList.ToHtmlContent(TagRenderMode.Normal));
+            innerContent.Append(unorderedList);
             tagBuilder.InnerHtml = innerContent;
 
             if (formContext != null && !excludePropertyErrors)
@@ -1302,12 +1302,26 @@ namespace Microsoft.AspNet.Mvc.Rendering
             foreach (var group in groupedSelectList)
             {
                 var optGroup = group.First().Group;
+                BufferedHtmlContent optGroupContent;
 
-                // Wrap if requested.
-                TagBuilder groupBuilder = null;
                 if (optGroup != null)
                 {
-                    groupBuilder = new TagBuilder("optgroup");
+                    optGroupContent = new BufferedHtmlContent();
+                    optGroupContent.Append(Environment.NewLine);
+                }
+                else
+                {
+                    optGroupContent = listItemBuilder;
+                }
+
+                foreach (var item in group)
+                {
+                    optGroupContent.AppendLine(GenerateOption(item));
+                }
+
+                if (optGroup != null)
+                {
+                    var groupBuilder = new TagBuilder("optgroup");
                     if (optGroup.Name != null)
                     {
                         groupBuilder.MergeAttribute("label", optGroup.Name);
@@ -1318,17 +1332,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
                         groupBuilder.MergeAttribute("disabled", "disabled");
                     }
 
-                    listItemBuilder.AppendLine(groupBuilder.ToHtmlContent(TagRenderMode.StartTag));
-                }
-
-                foreach (var item in group)
-                {
-                    listItemBuilder.AppendLine(GenerateOption(item));
-                }
-
-                if (optGroup != null)
-                {
-                    listItemBuilder.AppendLine(groupBuilder.ToHtmlContent(TagRenderMode.EndTag));
+                    groupBuilder.InnerHtml = optGroupContent;
+                    listItemBuilder.AppendLine(groupBuilder);
                 }
             }
 
@@ -1338,7 +1343,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         private IHtmlContent GenerateOption(SelectListItem item)
         {
             var tagBuilder = GenerateOption(item, item.Text);
-            return tagBuilder.ToHtmlContent(TagRenderMode.Normal);
+            return tagBuilder;
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/DefaultHtmlGenerator.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/DefaultHtmlGenerator.cs
@@ -157,6 +157,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             var tagBuilder = new TagBuilder("input");
             tagBuilder.MergeAttribute("type", GetInputTypeString(InputType.Hidden));
             tagBuilder.MergeAttribute("value", "false");
+            tagBuilder.TagRenderMode = TagRenderMode.SelfClosing;
 
             var fullName = GetFullHtmlFieldName(viewContext, expression);
             tagBuilder.MergeAttribute("name", fullName);
@@ -1015,6 +1016,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             }
 
             var tagBuilder = new TagBuilder("input");
+            tagBuilder.TagRenderMode = TagRenderMode.SelfClosing;
             tagBuilder.MergeAttributes(htmlAttributes);
             tagBuilder.MergeAttribute("type", GetInputTypeString(inputType));
             tagBuilder.MergeAttribute("name", fullName, replaceExisting: true);
@@ -1302,25 +1304,16 @@ namespace Microsoft.AspNet.Mvc.Rendering
             foreach (var group in groupedSelectList)
             {
                 var optGroup = group.First().Group;
-                BufferedHtmlContent optGroupContent;
-
                 if (optGroup != null)
                 {
-                    optGroupContent = new BufferedHtmlContent();
+                    var optGroupContent = new BufferedHtmlContent();
                     optGroupContent.Append(Environment.NewLine);
-                }
-                else
-                {
-                    optGroupContent = listItemBuilder;
-                }
 
-                foreach (var item in group)
-                {
-                    optGroupContent.AppendLine(GenerateOption(item));
-                }
+                    foreach (var item in group)
+                    {
+                        optGroupContent.AppendLine(GenerateOption(item));
+                    }
 
-                if (optGroup != null)
-                {
                     var groupBuilder = new TagBuilder("optgroup");
                     if (optGroup.Name != null)
                     {
@@ -1334,6 +1327,13 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
                     groupBuilder.InnerHtml = optGroupContent;
                     listItemBuilder.AppendLine(groupBuilder);
+                }
+                else
+                {
+                    foreach (var item in group)
+                    {
+                        listItemBuilder.AppendLine(GenerateOption(item));
+                    }
                 }
             }
 

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/HtmlHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/HtmlHelper.cs
@@ -214,7 +214,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 return HtmlString.Empty;
             }
 
-            return tagBuilder.ToHtmlContent(TagRenderMode.Normal);
+            return tagBuilder;
         }
 
         /// <inheritdoc />
@@ -542,7 +542,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 return HtmlString.Empty;
             }
 
-            return tagBuilder.ToHtmlContent(TagRenderMode.Normal);
+            return tagBuilder;
         }
 
         /// <inheritdoc />
@@ -644,8 +644,10 @@ namespace Microsoft.AspNet.Mvc.Rendering
             }
 
             var elements = new BufferedHtmlContent();
-            elements.Append(checkbox.ToHtmlContent(TagRenderMode.SelfClosing));
-            elements.Append(hidden.ToHtmlContent(TagRenderMode.SelfClosing));
+            checkbox.TagRenderMode = TagRenderMode.SelfClosing;
+            elements.Append(checkbox);
+            hidden.TagRenderMode = TagRenderMode.SelfClosing;
+            elements.Append(hidden);
 
             return elements;
         }
@@ -690,7 +692,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 return HtmlString.Empty;
             }
 
-            return tagBuilder.ToHtmlContent(TagRenderMode.Normal);
+            return tagBuilder;
         }
 
         protected virtual IHtmlContent GenerateEditor(
@@ -751,7 +753,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 htmlAttributes);
             if (tagBuilder != null)
             {
-                tagBuilder.ToHtmlContent(TagRenderMode.StartTag).WriteTo(ViewContext.Writer, _htmlEncoder);
+                tagBuilder.TagRenderMode = TagRenderMode.StartTag;
+                tagBuilder.WriteTo(ViewContext.Writer, _htmlEncoder);
             }
 
             return CreateForm();
@@ -793,7 +796,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 htmlAttributes);
             if (tagBuilder != null)
             {
-                tagBuilder.ToHtmlContent(TagRenderMode.StartTag).WriteTo(ViewContext.Writer, _htmlEncoder);
+                tagBuilder.TagRenderMode = TagRenderMode.StartTag;
+                tagBuilder.WriteTo(ViewContext.Writer, _htmlEncoder);
             }
 
             return CreateForm();
@@ -819,7 +823,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 return HtmlString.Empty;
             }
 
-            return tagBuilder.ToHtmlContent(TagRenderMode.SelfClosing);
+            tagBuilder.TagRenderMode = TagRenderMode.SelfClosing;
+            return tagBuilder;
         }
 
         protected virtual string GenerateId(string expression)
@@ -847,7 +852,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 return HtmlString.Empty;
             }
 
-            return tagBuilder.ToHtmlContent(TagRenderMode.Normal);
+            return tagBuilder;
         }
 
         protected IHtmlContent GenerateListBox(
@@ -869,7 +874,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 return HtmlString.Empty;
             }
 
-            return tagBuilder.ToHtmlContent(TagRenderMode.Normal);
+            return tagBuilder;
         }
 
         protected virtual string GenerateName(string expression)
@@ -895,7 +900,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 return HtmlString.Empty;
             }
 
-            return tagBuilder.ToHtmlContent(TagRenderMode.SelfClosing);
+            tagBuilder.TagRenderMode = TagRenderMode.SelfClosing;
+            return tagBuilder;
         }
 
         protected virtual IHtmlContent GenerateRadioButton(
@@ -917,7 +923,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 return HtmlString.Empty;
             }
 
-            return tagBuilder.ToHtmlContent(TagRenderMode.SelfClosing);
+            tagBuilder.TagRenderMode = TagRenderMode.SelfClosing;
+            return tagBuilder;
         }
 
         protected virtual IHtmlContent GenerateTextArea(
@@ -939,7 +946,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 return HtmlString.Empty;
             }
 
-            return tagBuilder.ToHtmlContent(TagRenderMode.Normal);
+            return tagBuilder;
         }
 
         protected virtual IHtmlContent GenerateTextBox(
@@ -961,7 +968,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 return HtmlString.Empty;
             }
 
-            return tagBuilder.ToHtmlContent(TagRenderMode.SelfClosing);
+            tagBuilder.TagRenderMode = TagRenderMode.SelfClosing;
+            return tagBuilder;
         }
 
         protected virtual IHtmlContent GenerateValidationMessage(
@@ -981,7 +989,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 return HtmlString.Empty;
             }
 
-            return tagBuilder.ToHtmlContent(TagRenderMode.Normal);
+            return tagBuilder;
         }
 
         protected virtual IHtmlContent GenerateValidationSummary(
@@ -1001,7 +1009,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 return HtmlString.Empty;
             }
 
-            return tagBuilder.ToHtmlContent(TagRenderMode.Normal);
+            return tagBuilder;
         }
 
         protected virtual string GenerateValue(string expression, object value, string format, bool useViewData)

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/HtmlHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/HtmlHelper.cs
@@ -643,13 +643,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 return HtmlString.Empty;
             }
 
-            var elements = new BufferedHtmlContent();
-            checkbox.TagRenderMode = TagRenderMode.SelfClosing;
-            elements.Append(checkbox);
-            hidden.TagRenderMode = TagRenderMode.SelfClosing;
-            elements.Append(hidden);
-
-            return elements;
+            return new BufferedHtmlContent().Append(checkbox).Append(hidden);
         }
 
         protected virtual string GenerateDisplayName([NotNull] ModelExplorer modelExplorer, string expression)
@@ -823,7 +817,6 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 return HtmlString.Empty;
             }
 
-            tagBuilder.TagRenderMode = TagRenderMode.SelfClosing;
             return tagBuilder;
         }
 
@@ -900,7 +893,6 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 return HtmlString.Empty;
             }
 
-            tagBuilder.TagRenderMode = TagRenderMode.SelfClosing;
             return tagBuilder;
         }
 
@@ -923,7 +915,6 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 return HtmlString.Empty;
             }
 
-            tagBuilder.TagRenderMode = TagRenderMode.SelfClosing;
             return tagBuilder;
         }
 
@@ -968,7 +959,6 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 return HtmlString.Empty;
             }
 
-            tagBuilder.TagRenderMode = TagRenderMode.SelfClosing;
             return tagBuilder;
         }
 

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TestableHtmlGenerator.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TestableHtmlGenerator.cs
@@ -83,7 +83,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 },
             };
 
-            return tagBuilder.ToHtmlContent(TagRenderMode.SelfClosing);
+            tagBuilder.TagRenderMode = TagRenderMode.SelfClosing;
+            return tagBuilder;
         }
 
         protected override IDictionary<string, object> GetValidationAttributes(

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/Rendering/TagBuilderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/Rendering/TagBuilderTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Mvc.TestCommon;
 using Microsoft.Framework.WebEncoders.Testing;
@@ -73,36 +74,22 @@ namespace Microsoft.AspNet.Mvc.Core.Rendering
 
         [Theory]
         [MemberData(nameof(RenderingTestingData))]
-        public void ToString_IgnoresIdAttributeCase(TagRenderMode renderingMode, string expectedOutput)
+        public void WriteTo_IgnoresIdAttributeCase(TagRenderMode renderingMode, string expectedOutput)
         {
             // Arrange
             var tagBuilder = new TagBuilder("p");
-
             // An empty value id attribute should not be rendered via ToString.
             tagBuilder.Attributes.Add("ID", string.Empty);
+            tagBuilder.TagRenderMode = renderingMode;
 
             // Act
-            var value = tagBuilder.ToHtmlContent(renderingMode);
+            using (var writer = new StringWriter())
+            {
+                tagBuilder.WriteTo(writer, new NullTestEncoder());
 
-            // Assert
-            Assert.Equal(expectedOutput, HtmlContentUtilities.HtmlContentToString(value, new NullTestEncoder()));
-        }
-
-        [Theory]
-        [MemberData(nameof(RenderingTestingData))]
-        public void ToHtmlString_IgnoresIdAttributeCase(TagRenderMode renderingMode, string expectedOutput)
-        {
-            // Arrange
-            var tagBuilder = new TagBuilder("p");
-
-            // An empty value id attribute should not be rendered via ToHtmlString.
-            tagBuilder.Attributes.Add("ID", string.Empty);
-
-            // Act
-            var value = tagBuilder.ToHtmlContent(renderingMode);
-
-            // Assert
-            Assert.Equal(expectedOutput, HtmlContentUtilities.HtmlContentToString(value, new NullTestEncoder()));
+                // Assert
+                Assert.Equal(expectedOutput, writer.ToString());
+            }
         }
 
         [Fact]

--- a/test/WebSites/ActivatorWebSite/TagHelpers/HiddenTagHelper.cs
+++ b/test/WebSites/ActivatorWebSite/TagHelpers/HiddenTagHelper.cs
@@ -30,7 +30,7 @@ namespace ActivatorWebSite.TagHelpers
 
             var content = await context.GetChildContentAsync();
 
-            output.Content.SetContent(HtmlHelper.Hidden(Name, content).ToString());
+            output.Content.SetContent(HtmlHelper.Hidden(Name, content));
         }
     }
 }

--- a/test/WebSites/ActivatorWebSite/TagHelpers/TitleTagHelper.cs
+++ b/test/WebSites/ActivatorWebSite/TagHelpers/TitleTagHelper.cs
@@ -28,7 +28,7 @@ namespace ActivatorWebSite.TagHelpers
             var builder = new TagBuilder("h2");
             var title = ViewContext.ViewBag.Title;
             builder.SetInnerText(title);
-            output.PreContent.SetContent(builder.ToHtmlContent(TagRenderMode.Normal));
+            output.PreContent.SetContent(builder);
         }
     }
 }


### PR DESCRIPTION
- Making `TagRenderMode` a property in `TagBuilder`.
- Modifying places where `TagBuilder` is used to suit the new model.
- This reduces space occupied by a normal application by 11.8%. (Tested over 1000 requests with 20 in parallel)