### PR TITLE
Add `srcset` to list of application relative resolvable URLs.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/TagHelpers/UrlResolutionTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/TagHelpers/UrlResolutionTagHelper.cs
@@ -31,6 +31,7 @@ namespace Microsoft.AspNet.Mvc.Razor.TagHelpers
     [TargetElement("html", Attributes = "manifest")]
     [TargetElement("iframe", Attributes = "src")]
     [TargetElement("img", Attributes = "src", TagStructure = TagStructure.WithoutEndTag)]
+    [TargetElement("img", Attributes = "srcset", TagStructure = TagStructure.WithoutEndTag)]
     [TargetElement("input", Attributes = "src", TagStructure = TagStructure.WithoutEndTag)]
     [TargetElement("input", Attributes = "formaction", TagStructure = TagStructure.WithoutEndTag)]
     [TargetElement("ins", Attributes = "cite")]
@@ -41,6 +42,7 @@ namespace Microsoft.AspNet.Mvc.Razor.TagHelpers
     [TargetElement("q", Attributes = "cite")]
     [TargetElement("script", Attributes = "src")]
     [TargetElement("source", Attributes = "src", TagStructure = TagStructure.WithoutEndTag)]
+    [TargetElement("source", Attributes = "srcset", TagStructure = TagStructure.WithoutEndTag)]
     [TargetElement("track", Attributes = "src", TagStructure = TagStructure.WithoutEndTag)]
     [TargetElement("video", Attributes = "src")]
     [TargetElement("video", Attributes = "poster")]
@@ -65,7 +67,7 @@ namespace Microsoft.AspNet.Mvc.Razor.TagHelpers
                 { "form", new[] { "action" } },
                 { "html", new[] { "manifest" } },
                 { "iframe", new[] { "src" } },
-                { "img", new[] { "src" } },
+                { "img", new[] { "src", "srcset" } },
                 { "input", new[] { "src", "formaction" } },
                 { "ins", new[] { "cite" } },
                 { "link", new[] { "href" } },
@@ -73,7 +75,7 @@ namespace Microsoft.AspNet.Mvc.Razor.TagHelpers
                 { "object", new[] { "archive", "data" } },
                 { "q", new[] { "cite" } },
                 { "script", new[] { "src" } },
-                { "source", new[] { "src" } },
+                { "source", new[] { "src", "srcset" } },
                 { "track", new[] { "src" } },
                 { "video", new[] { "poster", "src" } },
             };

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/RazorWebSite.UrlResolution.Index.Encoded.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/RazorWebSite.UrlResolution.Index.Encoded.html
@@ -9,12 +9,12 @@
     <link href="HtmlEncode[[/]]Person/HtmlEncode[[John Doe]]/CSS" rel="stylesheet">
     <video poster="HtmlEncode[[~/SomeUrl]]" src="HtmlEncode[[~/SomeUrl]]/HtmlEncode[[video]]" />
     <audio src="HtmlEncode[[~/SomeUrl]]">
-        <source src="HtmlEncode[[/]]Person">
+        <source src="HtmlEncode[[/]]Person" srcset="HtmlEncode[[/]]Person">
         <track src="HtmlEncode[[/]]emailHtmlEncode[[~/SomeUrl]]">
     </audio>
     <embed src="HtmlEncode[[/]]email@dyanmicUrl">
     <iframe src="HtmlEncode[[~/SomeUrl]]" />
-    <img src="HtmlEncode[[/]]HtmlEncode[[~/SomeUrl]]">
+    <img src="HtmlEncode[[/]]HtmlEncode[[John Doe]]" srcset="HtmlEncode[[/]]HtmlEncode[[John Doe]]">
     <script src="HtmlEncode[[/]]Person/HtmlEncode[[John Doe]]/JS"></script>
     <input src="HtmlEncode[[/]]/Person" itemscope itemid="HtmlEncode[[/]]Person" formaction="HtmlEncode[[~/SomeUrl]]">
     <button formaction="HtmlEncode[[/]]\Person" />

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/RazorWebSite.UrlResolution.Index.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/RazorWebSite.UrlResolution.Index.html
@@ -9,12 +9,12 @@
     <link href="/Person/John Doe/CSS" rel="stylesheet">
     <video poster="/SomeUrl" src="/SomeUrl/video" />
     <audio src="/SomeUrl">
-        <source src="/Person">
+        <source src="/Person" srcset="/Person">
         <track src="/email~/SomeUrl">
     </audio>
     <embed src="/email@dyanmicUrl">
     <iframe src="/SomeUrl" />
-    <img src="/~/SomeUrl">
+    <img src="/John Doe" srcset="/John Doe">
     <script src="/Person/John Doe/JS"></script>
     <input src="//Person" itemscope itemid="/Person" formaction="/SomeUrl">
     <button formaction="/\Person" />

--- a/test/WebSites/RazorWebSite/Views/UrlResolution/Index.cshtml
+++ b/test/WebSites/RazorWebSite/Views/UrlResolution/Index.cshtml
@@ -15,12 +15,12 @@
     <link href="~/Person/@Model.Name/CSS" rel="stylesheet">
     <video poster=@dynamicUrl src='@dynamicUrl/@("video")' />
     <audio src="@(dynamicUrl)">
-        <source src="~/Person">
+        <source src="~/Person" srcset="~/Person">
         <track src="~/email@(dynamicUrl)">
     </audio>
     <embed src="~/email@dyanmicUrl">
     <iframe src=@(dynamicUrl) />
-    <img src="~/@dynamicUrl">
+    <img src="~/@Model.Name" srcset="~/@Model.Name">
     <script src="~/Person/@Model.Name/JS"></script>
     <input src="~//Person" itemscope itemid="~/Person" formaction=@dynamicUrl>
     <button formaction="~/\Person" />


### PR DESCRIPTION
- Now allow the attribute to exist on `img` and `source` tags.
- Updated existing `UrlResolutionTagHelper` functional test to validate `srcset` attribute.

#2964