### PR TITLE
Explicitly check if URI is file when checking for an absolute URI

### DIFF
--- a/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/FileVersionProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/FileVersionProvider.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
             }
 
             Uri uri;
-            if (Uri.TryCreate(resolvedPath, UriKind.Absolute, out uri))
+            if (Uri.TryCreate(resolvedPath, UriKind.Absolute, out uri) && !uri.IsFile)
             {
                 // Don't append version if the path is absolute.
                 return path;

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/HtmlGenerationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/HtmlGenerationTest.cs
@@ -59,12 +59,6 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         [InlineData("AttributesWithBooleanValues", null)]
         public async Task HtmlGenerationWebSite_GeneratesExpectedResults(string action, string antiforgeryPath)
         {
-            // This uses FileVersionProvider which uses Uri.TryCreate - https://github.com/aspnet/External/issues/21
-            if (TestPlatformHelper.IsMono && (action == "Link" || action == "Script" || action == "Image"))
-            {
-                return;
-            }
-
             // Arrange
             var server = TestHelper.CreateServer(_app, SiteName, _configureServices);
             var client = server.CreateClient();
@@ -124,12 +118,6 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         [InlineData("AttributesWithBooleanValues", null)]
         public async Task HtmlGenerationWebSite_GenerateEncodedResults(string action, string antiforgeryPath)
         {
-            // This uses FileVersionProvider which uses Uri.TryCreate - https://github.com/aspnet/External/issues/21
-            if (TestPlatformHelper.IsMono && (action == "Link" || action == "Script"))
-            {
-                return;
-            }
-
             // Arrange
             var server = TestHelper.CreateServer(_app, SiteName, services =>
             {

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ImageTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ImageTagHelperTest.cs
@@ -135,9 +135,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             }
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/21
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public void RendersImageTag_AddsFileVersion()
         {
             // Arrange
@@ -209,9 +207,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal("/images/test-image.png", srcAttribute.Value);
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/21
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public void RendersImageTag_AddsFileVersion_WithRequestPathBase()
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/Internal/FileVersionProviderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/Internal/FileVersionProviderTest.cs
@@ -17,9 +17,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
 {
     public class FileVersionProviderTest
     {
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/21
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Theory]
         [InlineData("/hello/world", "/hello/world?v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk")]
         [InlineData("/hello/world?q=test", "/hello/world?q=test&v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk")]
         [InlineData("/hello/world?q=foo&bar", "/hello/world?q=foo&bar&v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk")]
@@ -42,9 +40,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
         }
 
         // Verifies if the stream is closed after reading.
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/21
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public void AddsVersionToFiles_DoesNotLockFileAfterReading()
         {
             // Arrange
@@ -75,9 +71,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
             Assert.Throws<ObjectDisposedException>(() => fileVersionProvider.AddFileVersionToPath("/hello/world"));
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/21
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Theory]
         [InlineData("/testApp/hello/world", true, "/testApp")]
         [InlineData("/testApp/foo/bar/hello/world", true, "/testApp/foo/bar")]
         [InlineData("/test/testApp/hello/world", false, "/testApp")]
@@ -100,9 +94,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
             Assert.Equal(filePath + "?v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk", result);
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/21
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public void DoesNotAddVersion_IfFileNotFound()
         {
             // Arrange
@@ -120,9 +112,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
             Assert.Equal("http://contoso.com/hello/world", result);
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/21
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public void ReturnsValueFromCache()
         {
             // Arrange
@@ -140,9 +130,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
             Assert.Equal("FromCache", result);
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/21
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Theory]
         [InlineData("/hello/world", "/hello/world", null)]
         [InlineData("/testApp/hello/world", "/hello/world", "/testApp")]
         public void SetsValueInCache(string filePath, string watchPath, string requestPathBase)

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LinkTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LinkTagHelperTest.cs
@@ -678,9 +678,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 output.PostElement.GetContent());
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/21
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public void RendersLinkTags_AddsFileVersion()
         {
             // Arrange
@@ -720,9 +718,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal("/css/site.css?v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk", output.Attributes["href"].Value);
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/21
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public void RendersLinkTags_AddsFileVersion_WithRequestPathBase()
         {
             // Arrange
@@ -762,9 +758,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal("/bar/css/site.css?v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk", output.Attributes["href"].Value);
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/21
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public void RendersLinkTags_GlobbedHref_AddsFileVersion()
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ScriptTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ScriptTagHelperTest.cs
@@ -733,9 +733,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal("<script src=\"HtmlEncode[[/common.js]]\"></script>", output.PostElement.GetContent());
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/21
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task RenderScriptTags_WithFileVersion()
         {
             // Arrange
@@ -772,9 +770,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal("/js/site.js?v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk", output.Attributes["src"].Value);
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/21
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task RenderScriptTags_WithFileVersion_AndRequestPathBase()
         {
             // Arrange
@@ -811,9 +807,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal("/bar/js/site.js?v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk", output.Attributes["src"].Value);
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/21
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task RenderScriptTags_FallbackSrc_WithFileVersion()
         {
             // Arrange
@@ -857,9 +851,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 "<\\/script>\"));</script>", output.PostElement.GetContent());
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/21
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task RenderScriptTags_GlobbedSrc_WithFileVersion()
         {
             // Arrange


### PR DESCRIPTION
Parsing `/foo.css` as a URI on Linux results in `file:///foo.css`, because `/foo.css` is a legitimate absolute path to a file on the file system. This code needs to explicitly check if the resulting URI is that of a file. 

After fixing this, all the disabled tests relating to this feature actually work on Mono, and can be re-enabled. This means that https://github.com/aspnet/External/issues/21 (which I can't see because it's private, but it was referenced in the code) can be closed as it's not an actual issue.

#2979 
