### PR TITLE
Expose locations of `_ViewImports.cshtml` that affect a given Razor file.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor.Host/Directives/ChunkInheritanceUtility.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/Directives/ChunkInheritanceUtility.cs
@@ -40,17 +40,18 @@ namespace Microsoft.AspNet.Mvc.Razor.Directives
         }
 
         /// <summary>
-        /// Gets an ordered <see cref="IReadOnlyList{T}"/> of parsed <see cref="ChunkTree"/> for each
-        /// <c>_ViewImports</c> that is applicable to the page located at <paramref name="pagePath"/>. The list is
-        /// ordered so that the <see cref="ChunkTree"/> for the <c>_ViewImports</c> closest to the
+        /// Gets an ordered <see cref="IReadOnlyList{ChunkTreeResult}"/> of parsed <see cref="ChunkTree"/>s and
+        /// file paths for each <c>_ViewImports</c> that is applicable to the page located at
+        /// <paramref name="pagePath"/>. The list is ordered so that the <see cref="ChunkTreeResult"/>'s
+        /// <see cref="ChunkTreeResult.ChunkTree"/> for the <c>_ViewImports</c> closest to the
         /// <paramref name="pagePath"/> in the file system appears first.
         /// </summary>
         /// <param name="pagePath">The path of the page to locate inherited chunks for.</param>
-        /// <returns>A <see cref="IReadOnlyList{ChunkTree}"/> of parsed <c>_ViewImports</c>
-        /// <see cref="ChunkTree"/>s.</returns>
-        public virtual IReadOnlyList<ChunkTree> GetInheritedChunkTrees([NotNull] string pagePath)
+        /// <returns>A <see cref="IReadOnlyList{ChunkTreeResult}"/> of parsed <c>_ViewImports</c>
+        /// <see cref="ChunkTree"/>s and their file paths.</returns>
+        public virtual IReadOnlyList<ChunkTreeResult> GetInheritedChunkTreeResults([NotNull] string pagePath)
         {
-            var inheritedChunkTrees = new List<ChunkTree>();
+            var inheritedChunkTreeResults = new List<ChunkTreeResult>();
             var templateEngine = new RazorTemplateEngine(_razorHost);
             foreach (var viewImportsPath in ViewHierarchyUtility.GetViewImportsLocations(pagePath))
             {
@@ -67,11 +68,12 @@ namespace Microsoft.AspNet.Mvc.Razor.Directives
 
                 if (chunkTree != null)
                 {
-                    inheritedChunkTrees.Add(chunkTree);
+                    var result = new ChunkTreeResult(chunkTree, viewImportsPath);
+                    inheritedChunkTreeResults.Add(result);
                 }
             }
 
-            return inheritedChunkTrees;
+            return inheritedChunkTreeResults;
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Mvc.Razor.Host/Directives/ChunkTreeResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/Directives/ChunkTreeResult.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Razor.Chunks;
+using Microsoft.Framework.Internal;
+
+namespace Microsoft.AspNet.Mvc.Razor.Directives
+{
+    /// <summary>
+    /// Contains <see cref="AspNet.Razor.Chunks.ChunkTree"/> information.
+    /// </summary>
+    public class ChunkTreeResult
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="ChunkTreeResult"/>.
+        /// </summary>
+        /// <param name="chunkTree">The <see cref="AspNet.Razor.Chunks.ChunkTree"/> generated from the file at the
+        /// given <paramref name="filePath"/>.</param>
+        /// <param name="filePath">The path to the file that generated the given <paramref name="chunkTree"/>.</param>
+        public ChunkTreeResult([NotNull] ChunkTree chunkTree, [NotNull] string filePath)
+        {
+            ChunkTree = chunkTree;
+            FilePath = filePath;
+        }
+
+        /// <summary>
+        /// The <see cref="AspNet.Razor.Chunks.ChunkTree"/> generated from the file at <see cref="FilePath"/>.
+        /// </summary>
+        public ChunkTree ChunkTree { get; }
+
+        /// <summary>
+        /// The path to the file that generated the <see cref="ChunkTree"/>.
+        /// </summary>
+        public string FilePath { get; }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Razor.Host/Directives/DefaultChunkTreeCache.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/Directives/DefaultChunkTreeCache.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNet.Mvc.Razor.Directives
             ChunkTree chunkTree;
             if (!_chunkTreeCache.TryGetValue(pagePath, out chunkTree))
             {
-                // GetOrAdd is invoked for each _GlobalImport that might potentially exist in the path.
+                // GetOrAdd is invoked for each _ViewImport that might potentially exist in the path.
                 // We can avoid performing file system lookups for files that do not exist by caching
                 // negative results and adding a Watch for that file.
 
@@ -57,7 +57,6 @@ namespace Microsoft.AspNet.Mvc.Razor.Directives
 
                 var file = _fileProvider.GetFileInfo(pagePath);
                 chunkTree = file.Exists ? getChunkTree(file) : null;
-
 
                 _chunkTreeCache.Set(pagePath, chunkTree, options);
             }

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/Directives/ChunkInheritanceUtilityTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/Directives/ChunkInheritanceUtilityTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNet.Razor.Chunks;
-using Microsoft.AspNet.Testing;
 using Xunit;
 
 namespace Microsoft.AspNet.Mvc.Razor.Directives
@@ -36,14 +35,15 @@ namespace Microsoft.AspNet.Mvc.Razor.Directives
             var utility = new ChunkInheritanceUtility(host, cache, defaultChunks);
 
             // Act
-            var chunkTrees = utility.GetInheritedChunkTrees(PlatformNormalizer.NormalizePath(@"Views\home\Index.cshtml"));
+            var chunkTreeResults = utility.GetInheritedChunkTreeResults(
+                PlatformNormalizer.NormalizePath(@"Views\home\Index.cshtml"));
 
             // Assert
-            Assert.Collection(chunkTrees,
-                chunkTree =>
+            Assert.Collection(chunkTreeResults,
+                chunkTreeResult =>
                 {
                     var viewImportsPath = PlatformNormalizer.NormalizePath(@"Views\home\_ViewImports.cshtml");
-                    Assert.Collection(chunkTree.Chunks,
+                    Assert.Collection(chunkTreeResult.ChunkTree.Chunks,
                         chunk =>
                         {
                             Assert.IsType<LiteralChunk>(chunk);
@@ -60,11 +60,12 @@ namespace Microsoft.AspNet.Mvc.Razor.Directives
                             Assert.IsType<LiteralChunk>(chunk);
                             Assert.Equal(viewImportsPath, chunk.Start.FilePath);
                         });
+                    Assert.Equal(viewImportsPath, chunkTreeResult.FilePath);
                 },
-                chunkTree =>
+                chunkTreeResult =>
                 {
                     var viewImportsPath = PlatformNormalizer.NormalizePath(@"Views\_ViewImports.cshtml");
-                    Assert.Collection(chunkTree.Chunks,
+                    Assert.Collection(chunkTreeResult.ChunkTree.Chunks,
                         chunk =>
                         {
                             Assert.IsType<LiteralChunk>(chunk);
@@ -104,6 +105,7 @@ namespace Microsoft.AspNet.Mvc.Razor.Directives
                             Assert.IsType<LiteralChunk>(chunk);
                             Assert.Equal(viewImportsPath, chunk.Start.FilePath);
                         });
+                    Assert.Equal(viewImportsPath, chunkTreeResult.FilePath);
                 });
         }
 
@@ -125,7 +127,7 @@ namespace Microsoft.AspNet.Mvc.Razor.Directives
             var utility = new ChunkInheritanceUtility(host, cache, defaultChunks);
 
             // Act
-            var chunkTrees = utility.GetInheritedChunkTrees(PlatformNormalizer.NormalizePath(@"Views\home\Index.cshtml"));
+            var chunkTrees = utility.GetInheritedChunkTreeResults(PlatformNormalizer.NormalizePath(@"Views\home\Index.cshtml"));
 
             // Assert
             Assert.Empty(chunkTrees);
@@ -168,9 +170,7 @@ namespace Microsoft.AspNet.Mvc.Razor.Directives
             var chunkTree = new ChunkTree();
 
             // Act
-            utility.MergeInheritedChunkTrees(chunkTree,
-                                            inheritedChunkTrees,
-                                            "dynamic");
+            utility.MergeInheritedChunkTrees(chunkTree, inheritedChunkTrees, "dynamic");
 
             // Assert
             Assert.Equal(3, chunkTree.Chunks.Count);

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/MvcRazorHostTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/MvcRazorHostTest.cs
@@ -486,11 +486,11 @@ namespace Microsoft.AspNet.Mvc.Razor
 
             public string InheritedChunkTreePagePath { get; private set; }
 
-            public override IReadOnlyList<ChunkTree> GetInheritedChunkTrees([NotNull] string pagePath)
+            public override IReadOnlyList<ChunkTreeResult> GetInheritedChunkTreeResults([NotNull] string pagePath)
             {
                 InheritedChunkTreePagePath = pagePath;
 
-                return new ChunkTree[0];
+                return new ChunkTreeResult[0];
             }
         }
 
@@ -533,7 +533,7 @@ namespace Microsoft.AspNet.Mvc.Razor
 
                 protected override CSharpCodeWriter CreateCodeWriter()
                 {
-                    // We normalize newlines so no matter what platform we're on 
+                    // We normalize newlines so no matter what platform we're on
                     // they're consistent (for code generation tests).
                     var codeWriter = base.CreateCodeWriter();
                     codeWriter.NewLine = "\r\n";


### PR DESCRIPTION
- Added `ChunkTreeResult` to associate inherited chunks with a specific source file.

#2256