### PR TITLE
Change Script, Link and Image `TagHelper`s to work better with other `TagHelper`s.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ImageTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ImageTagHelper.cs
@@ -75,22 +75,19 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         /// <inheritdoc />
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
+            output.CopyHtmlAttribute(SrcAttributeName, context);
+            ProcessUrlAttribute(SrcAttributeName, output);
+
             if (AppendVersion)
             {
                 EnsureFileVersionProvider();
 
-                string resolvedUrl;
-                if (TryResolveUrl(Src, encodeWebRoot: false, resolvedUrl: out resolvedUrl))
-                {
-                    Src = resolvedUrl;
-                }
+                // Retrieve the TagHelperOutput variation of the "src" attribute in case other TagHelpers in the
+                // pipeline have touched the value. If the value is already encoded this ImageTagHelper may
+                // not function properly.
+                Src = output.Attributes[SrcAttributeName].Value as string;
+
                 output.Attributes[SrcAttributeName] = _fileVersionProvider.AddFileVersionToPath(Src);
-            }
-            else
-            {
-                // Pass through attribute that is also a well-known HTML attribute.
-                output.CopyHtmlAttribute(SrcAttributeName, context);
-                ProcessUrlAttribute(SrcAttributeName, output);
             }
         }
 

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/LinkTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/LinkTagHelper.cs
@@ -211,15 +211,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             if (Href != null)
             {
                 output.CopyHtmlAttribute(HrefAttributeName, context);
-
-                // Resolve any application relative URLs (~/) now so they can be used in comparisons later.
-                if (TryResolveUrl(Href, encodeWebRoot: false, resolvedUrl: out resolvedUrl))
-                {
-                    Href = resolvedUrl;
-                }
-
-                ProcessUrlAttribute(HrefAttributeName, output);
             }
+
+            // If there's no "href" attribute in output.Attributes this will noop.
+            ProcessUrlAttribute(HrefAttributeName, output);
+
+            // Retrieve the TagHelperOutput variation of the "href" attribute in case other TagHelpers in the
+            // pipeline have touched the value. If the value is already encoded this LinkTagHelper may
+            // not function properly.
+            Href = output.Attributes[HrefAttributeName]?.Value as string;
 
             var modeResult = AttributeMatcher.DetermineMode(context, ModeDetails);
 
@@ -238,11 +238,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 EnsureFileVersionProvider();
 
-                var attributeStringValue = output.Attributes[HrefAttributeName]?.Value as string;
-                if (attributeStringValue != null)
+                if (Href != null)
                 {
-                    output.Attributes[HrefAttributeName].Value =
-                        _fileVersionProvider.AddFileVersionToPath(attributeStringValue);
+                    output.Attributes[HrefAttributeName].Value = _fileVersionProvider.AddFileVersionToPath(Href);
                 }
             }
 

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ScriptTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ScriptTagHelper.cs
@@ -179,14 +179,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             if (Src != null)
             {
                 output.CopyHtmlAttribute(SrcAttributeName, context);
-
-                if (TryResolveUrl(Src, encodeWebRoot: false, resolvedUrl: out resolvedUrl))
-                {
-                    Src = resolvedUrl;
-                }
-
-                ProcessUrlAttribute(SrcAttributeName, output);
             }
+
+            // If there's no "src" attribute in output.Attributes this will noop.
+            ProcessUrlAttribute(SrcAttributeName, output);
+
+            // Retrieve the TagHelperOutput variation of the "src" attribute in case other TagHelpers in the
+            // pipeline have touched the value. If the value is already encoded this ScriptTagHelper may
+            // not function properly.
+            Src = output.Attributes[SrcAttributeName]?.Value as string;
 
             var modeResult = AttributeMatcher.DetermineMode(context, ModeDetails);
 
@@ -205,11 +206,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 EnsureFileVersionProvider();
 
-                var attributeStringValue = output.Attributes[SrcAttributeName]?.Value as string;
-                if (attributeStringValue != null)
+                if (Src != null)
                 {
-                    output.Attributes[SrcAttributeName].Value =
-                        _fileVersionProvider.AddFileVersionToPath(attributeStringValue);
+                    output.Attributes[SrcAttributeName].Value = _fileVersionProvider.AddFileVersionToPath(Src);
                 }
             }
 

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Image.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Image.html
@@ -12,24 +12,24 @@
     <img src="/images/red.png" alt="Red block" title="&lt;the title>">
 
     <!-- Plain image tag with file version -->
-    <img alt="Red versioned" title="Red versioned" src="/images/red.png?v=W2F5D366_nQ2fQqUk3URdgWy2ZekXjHzHJaY5yaiOOk" />
+    <img src="/images/red.png?v=W2F5D366_nQ2fQqUk3URdgWy2ZekXjHzHJaY5yaiOOk" alt="Red versioned" title="Red versioned" />
 
     <!-- Plain image tag with file version set to false -->
     <img src="/images/red.png" alt="Red explicitly not versioned" title="Red versioned">
 
     <!-- Plain image tag with absolute path and file version -->
-    <img alt="Absolute path versioned" src="http://contoso.com/hello/world">
+    <img src="http://contoso.com/hello/world" alt="Absolute path versioned">
 
     <!-- Plain image tag with file version and path to file that does not exist -->
-    <img alt="Path to non existing file" src="/images/fake.png" />
+    <img src="/images/fake.png" alt="Path to non existing file" />
 
     <!-- Plain image tag with file version and path containing query string -->
-    <img alt="Path with query string" src="/images/red.png?abc=def&amp;v=W2F5D366_nQ2fQqUk3URdgWy2ZekXjHzHJaY5yaiOOk">
+    <img src="/images/red.png?abc=def&amp;v=W2F5D366_nQ2fQqUk3URdgWy2ZekXjHzHJaY5yaiOOk" alt="Path with query string">
 
     <!-- Plain image tag with file version and path containing fragment -->
-    <img alt="Path with query string" src="/images/red.png?v=W2F5D366_nQ2fQqUk3URdgWy2ZekXjHzHJaY5yaiOOk#abc" />
+    <img src="/images/red.png?v=W2F5D366_nQ2fQqUk3URdgWy2ZekXjHzHJaY5yaiOOk#abc" alt="Path with query string" />
 
     <!-- Plain image tag with file version and path linking to some action -->
-    <img alt="Path linking to some action" src="/controller/action">
+    <img src="/controller/action" alt="Path linking to some action">
 </body>
 </html>


### PR DESCRIPTION
- `ScriptTagHelper`, `LinkTagHelper` and `ImageTagHelper` now default to using `output.Attributes["href|src"]` if it's present when they run. This enables other `TagHelper`s to run prior and add those attributes.
- Added unit tests to validate this behavior.
- Updated `ImageTagHelper` functional test resources. Now that we're always defaulting to `output.Attributes["src"]` for `ImageTagHelper.Src` we're properly copying attributes back into the `output.Attributes` collection in the correct order (isntead of appending to the end).

#2902