### PR TITLE
Make validation in `TryUpdateModelAsync()` consistent with model binding elsewhere

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ModelBindingHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBindingHelper.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -313,9 +312,16 @@ namespace Microsoft.AspNet.Mvc
                 var modelValidationContext = new ModelValidationContext(modelBindingContext, modelExplorer);
 
                 var validationNode = modelBindingResult.ValidationNode;
-                Debug.Assert(
-                    validationNode != null,
-                    "ValidationNode should never be null in a successful ModelBindingResult.");
+                if (validationNode == null)
+                {
+                    validationNode = new ModelValidationNode(
+                        modelBindingResult.Key,
+                        modelMetadata,
+                        modelBindingResult.Model)
+                    {
+                        ValidateAllProperties = true,
+                    };
+                }
 
                 objectModelValidator.Validate(modelValidationContext, validationNode);
 

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBindingHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBindingHelperTest.cs
@@ -17,15 +17,29 @@ namespace Microsoft.AspNet.Mvc.Test
 {
     public class ModelBindingHelperTest
     {
-        [Fact]
-        public async Task TryUpdateModel_ReturnsFalse_IfBinderReturnsNull()
+        public static TheoryData<ModelBindingResult> UnsuccessfulModelBindingData
+        {
+            get
+            {
+                return new TheoryData<ModelBindingResult>
+                {
+                    null,
+                    new ModelBindingResult("someKey"), // IsFatalError true as well as IsModelSet false.
+                    new ModelBindingResult(model: null, key: "someKey", isModelSet: false),
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(UnsuccessfulModelBindingData))]
+        public async Task TryUpdateModel_ReturnsFalse_IfBinderIsUnsuccessful(ModelBindingResult binderResult)
         {
             // Arrange
             var metadataProvider = new EmptyModelMetadataProvider();
-
             var binder = new Mock<IModelBinder>();
-            binder.Setup(b => b.BindModelAsync(It.IsAny<ModelBindingContext>()))
-                  .Returns(Task.FromResult<ModelBindingResult>(null));
+            binder
+                .Setup(b => b.BindModelAsync(It.IsAny<ModelBindingContext>()))
+                .Returns(Task.FromResult<ModelBindingResult>(binderResult));
             var model = new MyModel();
 
             // Act
@@ -126,18 +140,20 @@ namespace Microsoft.AspNet.Mvc.Test
             Assert.Equal("MyPropertyValue", model.MyProperty);
         }
 
-        [Fact]
-        public async Task TryUpdateModel_UsingIncludePredicateOverload_ReturnsFalse_IfBinderReturnsNull()
+        [Theory]
+        [MemberData(nameof(UnsuccessfulModelBindingData))]
+        public async Task TryUpdateModel_UsingIncludePredicateOverload_ReturnsFalse_IfBinderIsUnsuccessful(
+            ModelBindingResult binderResult)
         {
             // Arrange
             var metadataProvider = new EmptyModelMetadataProvider();
-
             var binder = new Mock<IModelBinder>();
-            binder.Setup(b => b.BindModelAsync(It.IsAny<ModelBindingContext>()))
-                  .Returns(Task.FromResult<ModelBindingResult>(null));
+            binder
+                .Setup(b => b.BindModelAsync(It.IsAny<ModelBindingContext>()))
+                .Returns(Task.FromResult<ModelBindingResult>(binderResult));
             var model = new MyModel();
-            Func<ModelBindingContext, string, bool> includePredicate =
-               (context, propertyName) => true;
+            Func<ModelBindingContext, string, bool> includePredicate = (context, propertyName) => true;
+
             // Act
             var result = await ModelBindingHelper.TryUpdateModelAsync(
                 model,
@@ -214,15 +230,17 @@ namespace Microsoft.AspNet.Mvc.Test
             Assert.Equal("Old-ExcludedPropertyValue", model.ExcludedProperty);
         }
 
-        [Fact]
-        public async Task TryUpdateModel_UsingIncludeExpressionOverload_ReturnsFalse_IfBinderReturnsNull()
+        [Theory]
+        [MemberData(nameof(UnsuccessfulModelBindingData))]
+        public async Task TryUpdateModel_UsingIncludeExpressionOverload_ReturnsFalse_IfBinderIsUnsuccessful(
+            ModelBindingResult binderResult)
         {
             // Arrange
             var metadataProvider = new EmptyModelMetadataProvider();
-
             var binder = new Mock<IModelBinder>();
-            binder.Setup(b => b.BindModelAsync(It.IsAny<ModelBindingContext>()))
-                  .Returns(Task.FromResult<ModelBindingResult>(null));
+            binder
+                .Setup(b => b.BindModelAsync(It.IsAny<ModelBindingContext>()))
+                .Returns(Task.FromResult<ModelBindingResult>(binderResult));
             var model = new MyModel();
 
             // Act
@@ -468,17 +486,20 @@ namespace Microsoft.AspNet.Mvc.Test
                          ex.Message);
         }
 
-        [Fact]
-        public async Task TryUpdateModelNonGeneric_PredicateOverload_ReturnsFalse_IfBinderReturnsNull()
+        [Theory]
+        [MemberData(nameof(UnsuccessfulModelBindingData))]
+        public async Task TryUpdateModelNonGeneric_PredicateOverload_ReturnsFalse_IfBinderIsUnsuccessful(
+            ModelBindingResult binderResult)
         {
             // Arrange
             var metadataProvider = new EmptyModelMetadataProvider();
             var binder = new Mock<IModelBinder>();
-            binder.Setup(b => b.BindModelAsync(It.IsAny<ModelBindingContext>()))
-                  .Returns(Task.FromResult<ModelBindingResult>(null));
+            binder
+                .Setup(b => b.BindModelAsync(It.IsAny<ModelBindingContext>()))
+                .Returns(Task.FromResult<ModelBindingResult>(binderResult));
             var model = new MyModel();
-            Func<ModelBindingContext, string, bool> includePredicate =
-               (context, propertyName) => true;
+            Func<ModelBindingContext, string, bool> includePredicate = (context, propertyName) => true;
+
             // Act
             var result = await ModelBindingHelper.TryUpdateModelAsync(
                                                     model,
@@ -560,15 +581,17 @@ namespace Microsoft.AspNet.Mvc.Test
             Assert.Equal("Old-ExcludedPropertyValue", model.ExcludedProperty);
         }
 
-        [Fact]
-        public async Task TryUpdateModelNonGeneric_ModelTypeOverload_ReturnsFalse_IfBinderReturnsNull()
+        [Theory]
+        [MemberData(nameof(UnsuccessfulModelBindingData))]
+        public async Task TryUpdateModelNonGeneric_ModelTypeOverload_ReturnsFalse_IfBinderIsUnsuccessful(
+            ModelBindingResult binderResult)
         {
             // Arrange
             var metadataProvider = new EmptyModelMetadataProvider();
-
             var binder = new Mock<IModelBinder>();
-            binder.Setup(b => b.BindModelAsync(It.IsAny<ModelBindingContext>()))
-                  .Returns(Task.FromResult<ModelBindingResult>(null));
+            binder
+                .Setup(b => b.BindModelAsync(It.IsAny<ModelBindingContext>()))
+                .Returns(Task.FromResult<ModelBindingResult>(binderResult));
             var model = new MyModel();
 
             // Act

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBindingHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBindingHelperTest.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNet.Mvc.Test
                 GetCompositeBinder(binder.Object),
                 Mock.Of<IValueProvider>(),
                 new List<IInputFormatter>(),
-                new DefaultObjectValidator(new IExcludeTypeValidationFilter[0], metadataProvider),
+                new Mock<IObjectModelValidator>(MockBehavior.Strict).Object,
                 Mock.Of<IModelValidatorProvider>());
 
             // Assert
@@ -164,7 +164,7 @@ namespace Microsoft.AspNet.Mvc.Test
                 GetCompositeBinder(binder.Object),
                 Mock.Of<IValueProvider>(),
                 new List<IInputFormatter>(),
-                Mock.Of<IObjectModelValidator>(),
+                new Mock<IObjectModelValidator>(MockBehavior.Strict).Object,
                 Mock.Of<IModelValidatorProvider>(),
                 includePredicate);
 
@@ -245,17 +245,17 @@ namespace Microsoft.AspNet.Mvc.Test
 
             // Act
             var result = await ModelBindingHelper.TryUpdateModelAsync(
-                                                    model,
-                                                    null,
-                                                    Mock.Of<HttpContext>(),
-                                                    new ModelStateDictionary(),
-                                                    metadataProvider,
-                                                    GetCompositeBinder(binder.Object),
-                                                    Mock.Of<IValueProvider>(),
-                                                    new List<IInputFormatter>(),
-                                                    Mock.Of<IObjectModelValidator>(),
-                                                    Mock.Of<IModelValidatorProvider>(),
-                                                    m => m.IncludedProperty );
+                model,
+                null,
+                Mock.Of<HttpContext>(),
+                new ModelStateDictionary(),
+                metadataProvider,
+                GetCompositeBinder(binder.Object),
+                Mock.Of<IValueProvider>(),
+                new List<IInputFormatter>(),
+                new Mock<IObjectModelValidator>(MockBehavior.Strict).Object,
+                Mock.Of<IModelValidatorProvider>(),
+                m => m.IncludedProperty );
 
             // Assert
             Assert.False(result);
@@ -502,18 +502,18 @@ namespace Microsoft.AspNet.Mvc.Test
 
             // Act
             var result = await ModelBindingHelper.TryUpdateModelAsync(
-                                                    model,
-                                                    model.GetType(),
-                                                    prefix: null,
-                                                    httpContext: Mock.Of<HttpContext>(),
-                                                    modelState: new ModelStateDictionary(),
-                                                    metadataProvider: metadataProvider,
-                                                    modelBinder: GetCompositeBinder(binder.Object),
-                                                    valueProvider: Mock.Of<IValueProvider>(),
-                                                    inputFormatters: new List<IInputFormatter>(),
-                                                    objectModelValidator: Mock.Of<IObjectModelValidator>(),
-                                                    validatorProvider: Mock.Of<IModelValidatorProvider>(),
-                                                    predicate: includePredicate);
+                model,
+                model.GetType(),
+                prefix: null,
+                httpContext: Mock.Of<HttpContext>(),
+                modelState: new ModelStateDictionary(),
+                metadataProvider: metadataProvider,
+                modelBinder: GetCompositeBinder(binder.Object),
+                valueProvider: Mock.Of<IValueProvider>(),
+                inputFormatters: new List<IInputFormatter>(),
+                objectModelValidator: new Mock<IObjectModelValidator>(MockBehavior.Strict).Object,
+                validatorProvider: Mock.Of<IModelValidatorProvider>(),
+                predicate: includePredicate);
 
             // Assert
             Assert.False(result);
@@ -596,17 +596,17 @@ namespace Microsoft.AspNet.Mvc.Test
 
             // Act
             var result = await ModelBindingHelper.TryUpdateModelAsync(
-                                                    model,
-                                                    modelType: model.GetType(),
-                                                    prefix: null,
-                                                    httpContext: Mock.Of<HttpContext>(),
-                                                    modelState: new ModelStateDictionary(),
-                                                    metadataProvider: metadataProvider,
-                                                    modelBinder: GetCompositeBinder(binder.Object),
-                                                    valueProvider: Mock.Of<IValueProvider>(),
-                                                    inputFormatters: new List<IInputFormatter>(),
-                                                    objectModelValidator: Mock.Of<IObjectModelValidator>(),
-                                                    validatorProvider: Mock.Of<IModelValidatorProvider>());
+                model,
+                modelType: model.GetType(),
+                prefix: null,
+                httpContext: Mock.Of<HttpContext>(),
+                modelState: new ModelStateDictionary(),
+                metadataProvider: metadataProvider,
+                modelBinder: GetCompositeBinder(binder.Object),
+                valueProvider: Mock.Of<IValueProvider>(),
+                inputFormatters: new List<IInputFormatter>(),
+                objectModelValidator: new Mock<IObjectModelValidator>(MockBehavior.Strict).Object,
+                validatorProvider: Mock.Of<IModelValidatorProvider>());
 
             // Assert
             Assert.False(result);


### PR DESCRIPTION
- #2941
- honor `ModelBindingResult.IsModelSet` and use `ModelBindingResult.ValidationNode`
  - enable correct validation of collections or after model binding falls back to the empty prefix
  - code previously matched `Controller.TryValidateModel()`; less context available in that case