### PR TITLE
Fix #2527 - Remove FormCollection use

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/AuthorizationFilterAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/AuthorizationFilterAttribute.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNet.WebUtilities;
 using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Mvc

--- a/src/Microsoft.AspNet.Mvc.Core/project.json
+++ b/src/Microsoft.AspNet.Mvc.Core/project.json
@@ -12,7 +12,6 @@
         "Microsoft.AspNet.Authorization": "1.0.0-*",
         "Microsoft.AspNet.FileProviders.Abstractions": "1.0.0-*",
         "Microsoft.AspNet.Hosting.Abstractions": "1.0.0-*",
-        "Microsoft.AspNet.Http": "1.0.0-*",
         "Microsoft.AspNet.Mvc.Abstractions": "6.0.0-*",
         "Microsoft.Dnx.Runtime.Abstractions": "1.0.0-*",
         "Microsoft.Framework.ClosedGenericMatcher.Sources": { "version": "1.0.0-*", "type": "build" },

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/project.json
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/project.json
@@ -1,20 +1,27 @@
 {
-    "description": "Provides compatibility in ASP.NET MVC with ASP.NET Web API 2 to simplify migration of existing Web API implementations.",
-    "version": "6.0.0-*",
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/aspnet/mvc"
+  "description": "Provides compatibility in ASP.NET MVC with ASP.NET Web API 2 to simplify migration of existing Web API implementations.",
+  "version": "6.0.0-*",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/aspnet/mvc"
+  },
+  "compilationOptions": {
+    "warningsAsErrors": false
+  },
+  "dependencies": {
+    "Microsoft.AspNet.WebUtilities": "1.0.0-*",
+    "Microsoft.AspNet.Mvc.Core": "6.0.0-*",
+    "Microsoft.AspNet.Mvc.Formatters.Json": "6.0.0-*",
+    "Microsoft.AspNet.WebApi.Client": "5.2.2",
+    "Microsoft.Framework.PropertyHelper.Sources": {
+      "version": "1.0.0-*",
+      "type": "build"
     },
-    "compilationOptions": {
-        "warningsAsErrors": false
-    },
-    "dependencies": {
-        "Microsoft.AspNet.Mvc.Core": "6.0.0-*",
-        "Microsoft.AspNet.Mvc.Formatters.Json": "6.0.0-*",
-        "Microsoft.AspNet.WebApi.Client": "5.2.2",
-        "Microsoft.Framework.PropertyHelper.Sources": { "version": "1.0.0-*", "type": "build" },
-        "Microsoft.Framework.NotNullAttribute.Sources": { "version": "1.0.0-*", "type": "build" }
-    },
+    "Microsoft.Framework.NotNullAttribute.Sources": {
+      "version": "1.0.0-*",
+      "type": "build"
+    }
+  },
     "frameworks": {
         "dnx451": {
             "frameworkAssemblies": {

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/FormCollectionModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/FormCollectionModelBinderTest.cs
@@ -77,8 +77,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             // Assert
             Assert.NotNull(result);
-            Assert.IsType(typeof(FormCollection), result.Model);
-            Assert.Empty((FormCollection)result.Model);
+            Assert.IsType(typeof(IFormCollection), result.Model);
+            Assert.Empty((IFormCollection)result.Model);
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/FormCollectionModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/FormCollectionModelBinderTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 { "field2", new string[] { "value2" } }
             });
             var httpContext = GetMockHttpContext(formCollection);
-            var bindingContext = GetBindingContext(typeof(FormCollection), httpContext);
+            var bindingContext = GetBindingContext(typeof(IFormCollection), httpContext);
             var binder = new FormCollectionModelBinder();
 
             // Act
@@ -64,6 +64,27 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             Assert.Null(result);
         }
 
+        // We only support IFormCollection here. Using the concrete type won't work.
+        [Fact]
+        public async Task FormCollectionModelBinder_FormCollectionConcreteType_BindFails()
+        {
+            // Arrange
+            var formCollection = new FormCollection(new Dictionary<string, string[]>
+            {
+                { "field1", new string[] { "value1" } },
+                { "field2", new string[] { "value2" } }
+            });
+            var httpContext = GetMockHttpContext(formCollection);
+            var bindingContext = GetBindingContext(typeof(FormCollection), httpContext);
+            var binder = new FormCollectionModelBinder();
+
+            // Act
+            var result = await binder.BindModelAsync(bindingContext);
+
+            // Assert
+            Assert.Null(result);
+        }
+
         [Fact]
         public async Task FormCollectionModelBinder_NoForm_BindSuccessful_ReturnsEmptyFormCollection()
         {
@@ -77,32 +98,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             // Assert
             Assert.NotNull(result);
-            Assert.IsType(typeof(IFormCollection), result.Model);
-            Assert.Empty((IFormCollection)result.Model);
-        }
-
-        [Fact]
-        public async Task FormCollectionModelBinder_CustomFormCollection_BindSuccessful()
-        {
-            // Arrange
-            var formCollection = new MyFormCollection(new Dictionary<string, string[]>
-            {
-                { "field1", new string[] { "value1" } },
-                { "field2", new string[] { "value2" } }
-            });
-            var httpContext = GetMockHttpContext(formCollection);
-            var bindingContext = GetBindingContext(typeof(FormCollection), httpContext);
-            var binder = new FormCollectionModelBinder();
-
-            // Act
-            var result = await binder.BindModelAsync(bindingContext);
-
-            // Assert
-            Assert.NotNull(result);
             var form = Assert.IsAssignableFrom<IFormCollection>(result.Model);
-            Assert.Equal(2, form.Count);
-            Assert.Equal("value1", form["field1"]);
-            Assert.Equal("value2", form["field2"]);
+            Assert.Empty(form);
         }
 
         private static HttpContext GetMockHttpContext(IFormCollection formCollection, bool hasForm = true)

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/FormCollectionModelBindingIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/FormCollectionModelBindingIntegrationTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
         {
             public int Zip { get; set; }
 
-            public FormCollection FileCollection { get; set; }
+            public IFormCollection FileCollection { get; set; }
         }
 
         [Fact]
@@ -61,7 +61,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             // Model
             var boundPerson = Assert.IsType<Person>(modelBindingResult.Model);
             Assert.NotNull(boundPerson.Address);
-            var formCollection = Assert.IsAssignableFrom<FormCollection>(boundPerson.Address.FileCollection);
+            var formCollection = Assert.IsAssignableFrom<IFormCollection>(boundPerson.Address.FileCollection);
             var file = Assert.Single(formCollection.Files);
             Assert.Equal("form-data; name=Address.File; filename=text.txt", file.ContentDisposition);
             var reader = new StreamReader(file.OpenReadStream());
@@ -88,7 +88,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                     // Setting a custom parameter prevents it from falling back to an empty prefix.
                     BinderModelName = "CustomParameter",
                 },
-                ParameterType = typeof(FormCollection)
+                ParameterType = typeof(IFormCollection)
             };
 
             var data = "Some Data Is Better Than No Data.";
@@ -109,7 +109,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             Assert.True(modelBindingResult.IsModelSet);
 
             // Model
-            var formCollection = Assert.IsType<FormCollection>(modelBindingResult.Model);
+            var formCollection = Assert.IsAssignableFrom<IFormCollection>(modelBindingResult.Model);
             var file = Assert.Single(formCollection.Files);
             Assert.NotNull(file);
             Assert.Equal("form-data; name=CustomParameter; filename=text.txt", file.ContentDisposition);
@@ -133,7 +133,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 {
                     BinderModelName = "CustomParameter",
                 },
-                ParameterType = typeof(FormCollection)
+                ParameterType = typeof(IFormCollection)
             };
 
             // No data is passed.
@@ -148,7 +148,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             // ModelBindingResult
             Assert.NotNull(modelBindingResult);
-            var collection = Assert.IsType<FormCollection>(modelBindingResult.Model);
+            var collection = Assert.IsAssignableFrom<IFormCollection>(modelBindingResult.Model);
 
             // ModelState
             Assert.True(modelState.IsValid);

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/project.json
@@ -1,23 +1,24 @@
 {
-    "compile": [
-        "../Microsoft.AspNet.Mvc.Razor.Host.Test/TestFileProvider.cs",
-        "../Microsoft.AspNet.Mvc.Razor.Host.Test/TestFileInfo.cs",
-        "../Microsoft.AspNet.Mvc.Razor.Host.Test/TestFileTrigger.cs"
-    ],
-    "dependencies": {
-        "Microsoft.AspNet.Mvc.DataAnnotations": "6.0.0-*",
-        "Microsoft.AspNet.Mvc.Formatters.Xml": "6.0.0-*",
-        "Microsoft.AspNet.Mvc.Razor": "6.0.0-*",
-        "Microsoft.AspNet.Mvc.TestCommon": {
-            "version": "6.0.0-*",
-            "type": "build"
-        },
-        "Microsoft.AspNet.Testing": "1.0.0-*",
-        "Microsoft.Framework.DependencyInjection": "1.0.0-*",
-        "Microsoft.Framework.WebEncoders.Testing": "1.0.0-*",
-        "Microsoft.Dnx.Runtime": "1.0.0-*",
-        "xunit.runner.aspnet": "2.0.0-aspnet-*"
+  "compile": [
+    "../Microsoft.AspNet.Mvc.Razor.Host.Test/TestFileProvider.cs",
+    "../Microsoft.AspNet.Mvc.Razor.Host.Test/TestFileInfo.cs",
+    "../Microsoft.AspNet.Mvc.Razor.Host.Test/TestFileTrigger.cs"
+  ],
+  "dependencies": {
+    "Microsoft.AspNet.Http": "1.0.0-*",
+    "Microsoft.AspNet.Mvc.DataAnnotations": "6.0.0-*",
+    "Microsoft.AspNet.Mvc.Formatters.Xml": "6.0.0-*",
+    "Microsoft.AspNet.Mvc.Razor": "6.0.0-*",
+    "Microsoft.AspNet.Mvc.TestCommon": {
+      "version": "6.0.0-*",
+      "type": "build"
     },
+    "Microsoft.AspNet.Testing": "1.0.0-*",
+    "Microsoft.Framework.DependencyInjection": "1.0.0-*",
+    "Microsoft.Framework.WebEncoders.Testing": "1.0.0-*",
+    "Microsoft.Dnx.Runtime": "1.0.0-*",
+    "xunit.runner.aspnet": "2.0.0-aspnet-*"
+  },
     "commands": {
         "test": "xunit.runner.aspnet"
     },

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/project.json
@@ -1,17 +1,18 @@
 {
-    "dependencies": {
-        "Microsoft.AspNet.Mvc.DataAnnotations": "6.0.0-*",
-        "Microsoft.AspNet.Mvc.Formatters.Xml": "6.0.0-*",
-        "Microsoft.AspNet.Mvc.TagHelpers": "6.0.0-*",
-        "Microsoft.AspNet.Mvc.TestCommon": {
-            "version": "6.0.0-*",
-            "type": "build"
-        },
-        "Microsoft.AspNet.Testing": "1.0.0-*",
-        "Microsoft.Framework.Logging.Abstractions": "1.0.0-*",
-        "Microsoft.Framework.WebEncoders.Testing": "1.0.0-*",
-        "xunit.runner.aspnet": "2.0.0-aspnet-*"
+  "dependencies": {
+    "Microsoft.AspNet.Http": "1.0.0-*",
+    "Microsoft.AspNet.Mvc.DataAnnotations": "6.0.0-*",
+    "Microsoft.AspNet.Mvc.Formatters.Xml": "6.0.0-*",
+    "Microsoft.AspNet.Mvc.TagHelpers": "6.0.0-*",
+    "Microsoft.AspNet.Mvc.TestCommon": {
+      "version": "6.0.0-*",
+      "type": "build"
     },
+    "Microsoft.AspNet.Testing": "1.0.0-*",
+    "Microsoft.Framework.Logging.Abstractions": "1.0.0-*",
+    "Microsoft.Framework.WebEncoders.Testing": "1.0.0-*",
+    "xunit.runner.aspnet": "2.0.0-aspnet-*"
+  },
   "commands": {
     "test": "xunit.runner.aspnet"
   },

--- a/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/project.json
+++ b/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/project.json
@@ -1,13 +1,14 @@
 {
-    "compilationOptions": {
-        "warningsAsErrors": "false"
-    },
-    "dependencies": {
-        "Microsoft.AspNet.Mvc.WebApiCompatShim": "6.0.0-*",
-        "Microsoft.AspNet.Testing": "1.0.0-*",
-        "Microsoft.Framework.Logging.Testing": "1.0.0-*",
-        "xunit.runner.aspnet": "2.0.0-aspnet-*"
-    },
+  "compilationOptions": {
+    "warningsAsErrors": "false"
+  },
+  "dependencies": {
+    "Microsoft.AspNet.Http": "1.0.0-*",
+    "Microsoft.AspNet.Mvc.WebApiCompatShim": "6.0.0-*",
+    "Microsoft.AspNet.Testing": "1.0.0-*",
+    "Microsoft.Framework.Logging.Testing": "1.0.0-*",
+    "xunit.runner.aspnet": "2.0.0-aspnet-*"
+  },
     "commands": {
         "test": "xunit.runner.aspnet"
     },


### PR DESCRIPTION
This removes the dependency on Microsoft.AspNet.Http from the Mvc.Core
code. Added the reference back to tests where needed (DefaultHttpContext).