### PR TITLE
Change in-box tag helpers to use `DefaultFrameworkSortOrder`

### DIFF
--- a/src/Microsoft.AspNet.Mvc.TagHelpers/AnchorTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/AnchorTagHelper.cs
@@ -41,6 +41,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Generator = generator;
         }
 
+        /// <inheritdoc />
+        public override int Order
+        {
+            get
+            {
+                return DefaultOrder.DefaultFrameworkSortOrder;
+            }
+        }
+
         protected IHtmlGenerator Generator { get; }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/CacheTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/CacheTagHelper.cs
@@ -45,6 +45,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             MemoryCache = memoryCache;
         }
 
+        /// <inheritdoc />
+        public override int Order
+        {
+            get
+            {
+                return DefaultOrder.DefaultFrameworkSortOrder;
+            }
+        }
+
         /// <summary>
         /// Gets the <see cref="IMemoryCache"/> instance used to cache entries.
         /// </summary>

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/EnvironmentTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/EnvironmentTagHelper.cs
@@ -25,6 +25,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             HostingEnvironment = hostingEnvironment;
         }
 
+        /// <inheritdoc />
+        public override int Order
+        {
+            get
+            {
+                return DefaultOrder.DefaultFrameworkSortOrder;
+            }
+        }
+
         /// <summary>
         /// A comma separated list of environment names in which the content should be rendered.
         /// </summary>

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/FormTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/FormTagHelper.cs
@@ -37,6 +37,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Generator = generator;
         }
 
+        /// <inheritdoc />
+        public override int Order
+        {
+            get
+            {
+                return DefaultOrder.DefaultFrameworkSortOrder;
+            }
+        }
+
         [HtmlAttributeNotBound]
         [ViewContext]
         public ViewContext ViewContext { get; set; }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ImageTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ImageTagHelper.cs
@@ -46,6 +46,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Cache = cache;
         }
 
+        /// <inheritdoc />
+        public override int Order
+        {
+            get
+            {
+                return DefaultOrder.DefaultFrameworkSortOrder;
+            }
+        }
+
         /// <summary>
         /// Source of the image.
         /// </summary>

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/InputTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/InputTagHelper.cs
@@ -71,6 +71,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Generator = generator;
         }
 
+        /// <inheritdoc />
+        public override int Order
+        {
+            get
+            {
+                return DefaultOrder.DefaultFrameworkSortOrder;
+            }
+        }
+
         protected IHtmlGenerator Generator { get; }
 
         [HtmlAttributeNotBound]

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/LabelTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/LabelTagHelper.cs
@@ -24,6 +24,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Generator = generator;
         }
 
+        /// <inheritdoc />
+        public override int Order
+        {
+            get
+            {
+                return DefaultOrder.DefaultFrameworkSortOrder;
+            }
+        }
+
         [HtmlAttributeNotBound]
         [ViewContext]
         public ViewContext ViewContext { get; set; }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/LinkTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/LinkTagHelper.cs
@@ -107,6 +107,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             JavaScriptEncoder = javaScriptEncoder;
         }
 
+        /// <inheritdoc />
+        public override int Order
+        {
+            get
+            {
+                return DefaultOrder.DefaultFrameworkSortOrder;
+            }
+        }
+
         /// <summary>
         /// Address of the linked resource.
         /// </summary>

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/OptionTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/OptionTagHelper.cs
@@ -13,8 +13,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     /// <see cref="ITagHelper"/> implementation targeting &lt;option&gt; elements.
     /// </summary>
     /// <remarks>
-    /// This <see cref="ITagHelper"/> works in conjunction with <see cref="SelectTagHelper"/>. It reads elements 
-    /// content but does not modify that content. The only modification it makes is to add a <c>selected</c> attribute 
+    /// This <see cref="ITagHelper"/> works in conjunction with <see cref="SelectTagHelper"/>. It reads elements
+    /// content but does not modify that content. The only modification it makes is to add a <c>selected</c> attribute
     /// in some cases.
     /// </remarks>
     public class OptionTagHelper : TagHelper
@@ -26,6 +26,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         public OptionTagHelper(IHtmlGenerator generator)
         {
             Generator = generator;
+        }
+
+        /// <inheritdoc />
+        public override int Order
+        {
+            get
+            {
+                return DefaultOrder.DefaultFrameworkSortOrder;
+            }
         }
 
         protected IHtmlGenerator Generator { get; }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ScriptTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ScriptTagHelper.cs
@@ -93,6 +93,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             JavaScriptEncoder = javaScriptEncoder;
         }
 
+        /// <inheritdoc />
+        public override int Order
+        {
+            get
+            {
+                return DefaultOrder.DefaultFrameworkSortOrder;
+            }
+        }
+
         /// <summary>
         /// Address of the external script to use.
         /// </summary>

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/SelectTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/SelectTagHelper.cs
@@ -40,6 +40,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Generator = generator;
         }
 
+        /// <inheritdoc />
+        public override int Order
+        {
+            get
+            {
+                return DefaultOrder.DefaultFrameworkSortOrder;
+            }
+        }
+
         protected IHtmlGenerator Generator { get; }
 
         [HtmlAttributeNotBound]

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/TextAreaTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/TextAreaTagHelper.cs
@@ -23,6 +23,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Generator = generator;
         }
 
+        /// <inheritdoc />
+        public override int Order
+        {
+            get
+            {
+                return DefaultOrder.DefaultFrameworkSortOrder;
+            }
+        }
+
         protected IHtmlGenerator Generator { get; }
 
         [HtmlAttributeNotBound]

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationMessageTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationMessageTagHelper.cs
@@ -25,6 +25,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Generator = generator;
         }
 
+        /// <inheritdoc />
+        public override int Order
+        {
+            get
+            {
+                return DefaultOrder.DefaultFrameworkSortOrder;
+            }
+        }
+
         [HtmlAttributeNotBound]
         [ViewContext]
         public ViewContext ViewContext { get; set; }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationSummaryTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationSummaryTagHelper.cs
@@ -26,6 +26,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Generator = generator;
         }
 
+        /// <inheritdoc />
+        public override int Order
+        {
+            get
+            {
+                return DefaultOrder.DefaultFrameworkSortOrder;
+            }
+        }
+
         [HtmlAttributeNotBound]
         [ViewContext]
         public ViewContext ViewContext { get; set; }


### PR DESCRIPTION
- #2905
- override `Order` implementation inherited from `TagHelper`
- only exception is `UrlResolutionTagHelper` which already overrides `Order` to execute much earlier