### PR TITLE
Order `ModelMetadata.Properties` by `Order` then by `PropertyName`

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Metadata/DefaultModelMetadata.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Metadata/DefaultModelMetadata.cs
@@ -442,7 +442,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
                 if (_properties == null)
                 {
                     var properties = _provider.GetMetadataForProperties(ModelType);
-                    properties = properties.OrderBy(p => p.Order);
+                    properties = properties.OrderBy(p => p.Order).ThenBy(p => p.PropertyName);
                     _properties = new ModelPropertyCollection(properties);
                 }
 

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/Metadata/DefaultModelMetadataTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/Metadata/DefaultModelMetadataTest.cs
@@ -218,7 +218,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
 
             // Act
             var isBindingRequired = metadata.IsBindingRequired;
-            
+
             // Assert
             Assert.False(isBindingRequired);
         }
@@ -316,7 +316,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         {
             get
             {
-                // ModelMetadata does not reorder properties the provider returns without an Order override.
+                // ModelMetadata reorders properties the provider returns (without an Order override) by PropertyName.
                 return new TheoryData<IEnumerable<string>, IEnumerable<string>>
                 {
                     {
@@ -325,15 +325,15 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
                     },
                     {
                         new List<string> { "Property4", "Property3", "Property2", "Property1", },
-                        new List<string> { "Property4", "Property3", "Property2", "Property1", }
+                        new List<string> { "Property1", "Property2", "Property3", "Property4", }
                     },
                     {
                         new List<string> { "Delta", "Bravo", "Charlie", "Alpha", },
-                        new List<string> { "Delta", "Bravo", "Charlie", "Alpha", }
+                        new List<string> { "Alpha", "Bravo", "Charlie", "Delta", }
                     },
                     {
                         new List<string> { "John", "Jonathan", "Jon", "Joan", },
-                        new List<string> { "John", "Jonathan", "Jon", "Joan", }
+                        new List<string> { "Joan", "John", "Jon", "Jonathan", }
                     },
                 };
             }
@@ -341,7 +341,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
 
         [Theory]
         [MemberData(nameof(PropertyNamesTheoryData))]
-        public void PropertiesProperty_WithDefaultOrder_OrdersPropertyNamesAsProvided(
+        public void PropertiesProperty_WithDefaultOrder_OrdersPropertyNamesAlphbetically(
             IEnumerable<string> originalNames,
             IEnumerable<string> expectedNames)
         {
@@ -395,7 +395,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
                         },
                         new List<string> { "Property1", "Property2", "Property3", "Property4", }
                     },
-                    // Same order if already ordered using Order.
+                    // Same order if all ordered using Order.
                     {
                         new List<KeyValuePair<string, int>>
                         {
@@ -405,6 +405,17 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
                             new KeyValuePair<string, int>("Property1", 26),
                         },
                         new List<string> { "Property4", "Property3", "Property2", "Property1", }
+                    },
+                    // Alphabetic order if all have same Order.
+                    {
+                        new List<KeyValuePair<string, int>>
+                        {
+                            new KeyValuePair<string, int>("Property4", 23),
+                            new KeyValuePair<string, int>("Property3", 23),
+                            new KeyValuePair<string, int>("Property2", 23),
+                            new KeyValuePair<string, int>("Property1", 23),
+                        },
+                        new List<string> { "Property1", "Property2", "Property3", "Property4", }
                     },
                     // Rest of the orderings get updated within ModelMetadata.
                     {
@@ -427,7 +438,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
                         },
                         new List<string> { "Charlie", "Bravo", "Delta", "Alpha", }
                     },
-                    // Jonathan and Jon will not be reordered.
                     {
                         new List<KeyValuePair<string, int>>
                         {
@@ -436,7 +446,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
                             new KeyValuePair<string, int>("Jon", 0),
                             new KeyValuePair<string, int>("John", -1),
                         },
-                        new List<string> { "John", "Jonathan", "Jon", "Joan", }
+                        new List<string> { "John", "Jon", "Jonathan", "Joan", }
                     },
                 };
             }
@@ -444,7 +454,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
 
         [Theory]
         [MemberData(nameof(PropertyNamesAndOrdersTheoryData))]
-        public void PropertiesProperty_OrdersPropertyNamesUsingOrder_ThenAsProvided(
+        public void PropertiesProperty_OrdersPropertyNamesUsingOrder_ThenByName(
             IEnumerable<KeyValuePair<string, int>> originalNamesAndOrders,
             IEnumerable<string> expectedNames)
         {

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/MutableObjectModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/MutableObjectModelBinderTest.cs
@@ -275,7 +275,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         [InlineData(typeof(TypeWithUnmarkedAndBinderMetadataMarkedProperties), false)]
         [InlineData(typeof(TypeWithUnmarkedAndBinderMetadataMarkedProperties), true)]
         public void CanCreateModel_CreatesModelForValueProviderBasedBinderMetadatas_IfAValueProviderProvidesValue(
-            Type modelType, 
+            Type modelType,
             bool valueProviderProvidesValue)
         {
             var mockValueProvider = new Mock<IValueProvider>();
@@ -655,13 +655,13 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             {
                 nameof(Person.DateOfBirth),
                 nameof(Person.DateOfDeath),
-                nameof(Person.ValueTypeRequired),
-                nameof(Person.ValueTypeRequiredWithDefaultValue),
                 nameof(Person.FirstName),
                 nameof(Person.LastName),
                 nameof(Person.PropertyWithDefaultValue),
                 nameof(Person.PropertyWithInitializedValue),
                 nameof(Person.PropertyWithInitializedValueAndDefault),
+                nameof(Person.ValueTypeRequired),
+                nameof(Person.ValueTypeRequiredWithDefaultValue),
             };
             var bindingContext = new ModelBindingContext
             {

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/Rendering/DefaultDisplayTemplatesTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/Rendering/DefaultDisplayTemplatesTest.cs
@@ -174,12 +174,13 @@ namespace Microsoft.AspNet.Mvc.Core
             var html = DefaultTemplatesUtilities.GetHtmlHelper(model);
             var expectedProperties = new List<string>
             {
-                "OrderedProperty3",
-                "OrderedProperty2",
                 "OrderedProperty1",
-                "Property3",
+                "OrderedProperty2",
+                "OrderedProperty3",
+                // Next three properties come between explicitly ordered ones because DefaultOrder is 10000.
                 "Property1",
                 "Property2",
+                "Property3",
                 "LastProperty",
             };
 
@@ -361,7 +362,7 @@ namespace Microsoft.AspNet.Mvc.Core
             var viewEngine = new Mock<ICompositeViewEngine>(MockBehavior.Strict);
 
             viewEngine
-                .Setup(v => v.FindPartialView(It.IsAny<ActionContext>(), 
+                .Setup(v => v.FindPartialView(It.IsAny<ActionContext>(),
                                               It.Is<string>(view => view.Equals("DisplayTemplates/String"))))
                 .Returns(ViewEngineResult.Found(string.Empty, new Mock<IView>().Object))
                 .Verifiable();

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/Rendering/DefaultEditorTemplatesTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/Rendering/DefaultEditorTemplatesTest.cs
@@ -238,12 +238,13 @@ Environment.NewLine;
             var html = DefaultTemplatesUtilities.GetHtmlHelper(model);
             var expectedProperties = new List<string>
             {
-                "OrderedProperty3",
-                "OrderedProperty2",
                 "OrderedProperty1",
-                "Property3",
+                "OrderedProperty2",
+                "OrderedProperty3",
+                // Next three properties come between explicitly ordered ones because DefaultOrder is 10000.
                 "Property1",
                 "Property2",
+                "Property3",
                 "LastProperty",
             };
 
@@ -596,7 +597,7 @@ Environment.NewLine;
                 "<input class=\"HtmlEncode[[text-box single-line]]\" data-val=\"HtmlEncode[[true]]\" " +
                 "data-val-required=\"HtmlEncode[[The DateTimeOffset field is required.]]\" id=\"HtmlEncode[[FieldPrefix]]\" " +
                 "name=\"HtmlEncode[[FieldPrefix]]\" type=\"HtmlEncode[[" +
-                dataTypeName + 
+                dataTypeName +
                 "]]\" value=\"HtmlEncode[[" + expected + "]]\" />");
 
             var offset = TimeSpan.FromHours(0);
@@ -649,7 +650,7 @@ Environment.NewLine;
                 "<input class=\"HtmlEncode[[text-box single-line]]\" data-val=\"HtmlEncode[[true]]\" " +
                 "data-val-required=\"HtmlEncode[[The DateTimeOffset field is required.]]\" id=\"HtmlEncode[[FieldPrefix]]\" " +
                 "name=\"HtmlEncode[[FieldPrefix]]\" type=\"HtmlEncode[[" +
-                dataTypeName + 
+                dataTypeName +
                 "]]\" value=\"HtmlEncode[[" + expected + "]]\" />");
 
             // Place DateTime-local value in current timezone.
@@ -707,7 +708,7 @@ Environment.NewLine;
                 "<input class=\"HtmlEncode[[text-box single-line]]\" data-val=\"HtmlEncode[[true]]\" " +
                 "data-val-required=\"HtmlEncode[[The DateTimeOffset field is required.]]\" id=\"HtmlEncode[[FieldPrefix]]\" " +
                 "name=\"HtmlEncode[[FieldPrefix]]\" type=\"HtmlEncode[[" +
-                dataTypeName + 
+                dataTypeName +
                 "]]\" value=\"HtmlEncode[[Formatted as 2000-01-02T03:04:05.0600000+00:00]]\" />");
 
             var offset = TimeSpan.FromHours(0);
@@ -844,8 +845,8 @@ Environment.NewLine;
             // Arrange
             var viewEngine = new Mock<ICompositeViewEngine>(MockBehavior.Strict);
             viewEngine
-                .Setup(v => v.FindPartialView(It.IsAny<ActionContext>(), 
-                                              It.Is<string>(view => String.Equals(view, 
+                .Setup(v => v.FindPartialView(It.IsAny<ActionContext>(),
+                                              It.Is<string>(view => String.Equals(view,
                                                                                   "EditorTemplates/String"))))
                 .Returns(ViewEngineResult.Found(string.Empty, new Mock<IView>().Object))
                 .Verifiable();


### PR DESCRIPTION
- #1888
- add `PropertyName` to make order not only stable but predictable
  - slight breaking change from MVC 5 which uses only `Order` and what `System.Reflection` provides