### PR TITLE
Add FieldName to model binding context

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/DefaultControllerActionArgumentBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/DefaultControllerActionArgumentBinder.cs
@@ -73,12 +73,12 @@ namespace Microsoft.AspNet.Mvc
             [NotNull] OperationBindingContext operationContext)
         {
             var metadata = _modelMetadataProvider.GetMetadataForType(parameter.ParameterType);
-            var modelBindingContext = GetModelBindingContext(
-                parameter.Name,
+            var modelBindingContext = ModelBindingContext.CreateBindingContext(
+                operationContext,
+                modelState,
                 metadata,
                 parameter.BindingInfo,
-                modelState,
-                operationContext);
+                parameter.Name);
 
             var modelBindingResult = await operationContext.ModelBinder.BindModelAsync(modelBindingContext);
             if (modelBindingResult != null &&
@@ -185,26 +185,6 @@ namespace Microsoft.AspNet.Mvc
                     arguments[parameter.Name] = modelBindingResult.Model;
                 }
             }
-        }
-
-        private static ModelBindingContext GetModelBindingContext(
-            string parameterName,
-            ModelMetadata metadata,
-            BindingInfo bindingInfo,
-            ModelStateDictionary modelState,
-            OperationBindingContext operationBindingContext)
-        {
-            var modelBindingContext = ModelBindingContext.GetModelBindingContext(
-                metadata,
-                bindingInfo,
-                parameterName);
-
-            modelBindingContext.IsTopLevelObject = true;
-            modelBindingContext.ModelState = modelState;
-            modelBindingContext.ValueProvider = operationBindingContext.ValueProvider;
-            modelBindingContext.OperationBindingContext = operationBindingContext;
-
-            return modelBindingContext;
         }
 
         private OperationBindingContext GetOperationBindingContext(

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/CollectionModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/CollectionModelBinder.cs
@@ -149,12 +149,16 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 bindingContext.ModelName,
                 bindingContext.ModelMetadata,
                 boundCollection);
+
+            var innerBindingContext = ModelBindingContext.CreateChildBindingContext(
+                bindingContext,
+                elementMetadata,
+                fieldName: bindingContext.FieldName,
+                modelName: bindingContext.ModelName,
+                model: null);
+
             foreach (var value in values)
             {
-                var innerBindingContext = ModelBindingContext.GetChildModelBindingContext(
-                    bindingContext,
-                    bindingContext.ModelName,
-                    elementMetadata);
                 innerBindingContext.ValueProvider = new CompositeValueProvider
                 {
                     // our temporary provider goes at the front of the list
@@ -222,10 +226,13 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             foreach (var indexName in indexNames)
             {
                 var fullChildName = ModelNames.CreateIndexModelName(bindingContext.ModelName, indexName);
-                var childBindingContext = ModelBindingContext.GetChildModelBindingContext(
+                var childBindingContext = ModelBindingContext.CreateChildBindingContext(
                     bindingContext,
-                    fullChildName,
-                    elementMetadata);
+                    elementMetadata,
+                    fieldName: indexName,
+                    modelName: fullChildName,
+                    model: null);
+
 
                 var didBind = false;
                 object boundValue = null;

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/CompositeModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/CompositeModelBinder.cs
@@ -148,6 +148,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 Model = oldBindingContext.Model,
                 ModelMetadata = oldBindingContext.ModelMetadata,
                 ModelName = modelName,
+                FieldName = oldBindingContext.FieldName,
                 ModelState = oldBindingContext.ModelState,
                 ValueProvider = oldBindingContext.ValueProvider,
                 OperationBindingContext = oldBindingContext.OperationBindingContext,

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/DictionaryModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/DictionaryModelBinder.cs
@@ -57,10 +57,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             // Update the existing successful but empty ModelBindingResult.
             var metadataProvider = bindingContext.OperationBindingContext.MetadataProvider;
             var valueMetadata = metadataProvider.GetMetadataForType(typeof(TValue));
-            var valueBindingContext = ModelBindingContext.GetChildModelBindingContext(
+            var valueBindingContext = ModelBindingContext.CreateChildBindingContext(
                 bindingContext,
-                bindingContext.ModelName,
-                valueMetadata);
+                valueMetadata,
+                fieldName: bindingContext.FieldName,
+                modelName: bindingContext.ModelName,
+                model: null);
 
             var modelBinder = bindingContext.OperationBindingContext.ModelBinder;
             var validationNode = result.ValidationNode;

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/HeaderModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/HeaderModelBinder.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var modelMetadata = bindingContext.ModelMetadata;
 
             // Property name can be null if the model metadata represents a type (rather than a property or parameter).
-            var headerName = bindingContext.BinderModelName ?? modelMetadata.PropertyName ?? bindingContext.ModelName;
+            var headerName = bindingContext.FieldName;
             object model = null;
             if (bindingContext.ModelType == typeof(string))
             {

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/KeyValuePairModelBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/KeyValuePairModelBinder.cs
@@ -93,11 +93,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 parentBindingContext.OperationBindingContext.MetadataProvider.GetMetadataForType(typeof(TModel));
             var propertyModelName =
                 ModelNames.CreatePropertyModelName(parentBindingContext.ModelName, propertyName);
-            var propertyBindingContext = ModelBindingContext.GetChildModelBindingContext(
+            var propertyBindingContext = ModelBindingContext.CreateChildBindingContext(
                 parentBindingContext,
+                propertyModelMetadata,
+                propertyName,
                 propertyModelName,
-                propertyModelMetadata);
-            propertyBindingContext.BinderModelName = propertyModelMetadata.BinderModelName;
+                model: null);
 
             var modelBindingResult = await propertyBindingContext.OperationBindingContext.ModelBinder.BindModelAsync(
                 propertyBindingContext);

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBindingHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBindingHelper.cs
@@ -293,21 +293,18 @@ namespace Microsoft.AspNet.Mvc
                 ModelBinder = modelBinder,
                 ValidatorProvider = validatorProvider,
                 MetadataProvider = metadataProvider,
-                HttpContext = httpContext
+                HttpContext = httpContext,
+                ValueProvider = valueProvider,
             };
 
-            var modelBindingContext = new ModelBindingContext
-            {
-                Model = model,
-                ModelMetadata = modelMetadata,
-                ModelName = prefix,
-                ModelState = modelState,
-                ValueProvider = valueProvider,
-                FallbackToEmptyPrefix = true,
-                IsTopLevelObject = true,
-                OperationBindingContext = operationBindingContext,
-                PropertyFilter = predicate,
-            };
+            var modelBindingContext = ModelBindingContext.CreateBindingContext(
+                operationBindingContext,
+                modelState,
+                modelMetadata,
+                bindingInfo: null,
+                modelName: prefix ?? string.Empty);
+            modelBindingContext.Model = model;
+            modelBindingContext.PropertyFilter = predicate;
 
             var modelBindingResult = await modelBinder.BindModelAsync(modelBindingContext);
             if (modelBindingResult != null && modelBindingResult.IsModelSet)

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/ArrayModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/ArrayModelBinderTest.cs
@@ -222,11 +222,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             {
                 ModelMetadata = modelMetadata,
                 ModelName = "someName",
+                ModelState = new ModelStateDictionary(),
                 ValueProvider = valueProvider,
                 OperationBindingContext = new OperationBindingContext
                 {
                     ModelBinder = CreateIntBinder(),
-                    MetadataProvider = metadataProvider
+                    MetadataProvider = metadataProvider,
                 },
             };
             return bindingContext;

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/ByteArrayModelBinderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/ByteArrayModelBinderTests.cs
@@ -129,10 +129,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             {
                 ModelMetadata = metadataProvider.GetMetadataForType(modelType),
                 ModelName = "foo",
+                ModelState = new ModelStateDictionary(),
                 ValueProvider = valueProvider,
                 OperationBindingContext  = new OperationBindingContext
                 {
-                    MetadataProvider = metadataProvider
+                    MetadataProvider = metadataProvider,
                 }
             };
             return bindingContext;

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CollectionModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CollectionModelBinderTest.cs
@@ -419,6 +419,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             {
                 ModelMetadata = metadataProvider.GetMetadataForType(typeof(IList<int>)),
                 ModelName = "someName",
+                ModelState = new ModelStateDictionary(),
                 ValueProvider = valueProvider,
                 OperationBindingContext = new OperationBindingContext
                 {

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CompositeModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CompositeModelBinderTest.cs
@@ -24,14 +24,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
                 ModelMetadata = new EmptyModelMetadataProvider().GetMetadataForType(typeof(int)),
                 ModelName = "someName",
                 ModelState = new ModelStateDictionary(),
+                OperationBindingContext = new OperationBindingContext(),
                 ValueProvider = new SimpleValueProvider
                 {
                     { "someName", "dummyValue" }
                 },
-                OperationBindingContext = new OperationBindingContext
-                {
-                    ValidatorProvider = GetValidatorProvider()
-                }
             };
 
             var mockIntBinder = new Mock<IModelBinder>();
@@ -71,14 +68,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
                 ModelMetadata = new EmptyModelMetadataProvider().GetMetadataForType(typeof(List<int>)),
                 ModelName = "someName",
                 ModelState = new ModelStateDictionary(),
+                OperationBindingContext = new OperationBindingContext(),
                 ValueProvider = new SimpleValueProvider
                 {
                     { "someOtherName", "dummyValue" }
                 },
-                OperationBindingContext = new OperationBindingContext
-                {
-                    ValidatorProvider = GetValidatorProvider()
-                }
             };
 
             var mockIntBinder = new Mock<IModelBinder>();
@@ -121,14 +115,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
                 ModelMetadata = new EmptyModelMetadataProvider().GetMetadataForType(typeof(List<int>)),
                 ModelName = "someName",
                 ModelState = new ModelStateDictionary(),
+                OperationBindingContext = new OperationBindingContext(),
                 ValueProvider = new SimpleValueProvider
                 {
                     { "someOtherName", "dummyValue" }
                 },
-                OperationBindingContext = new OperationBindingContext
-                {
-                    ValidatorProvider = GetValidatorProvider()
-                }
             };
 
             var modelBinder = new Mock<IModelBinder>();
@@ -155,14 +146,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
                 ModelMetadata = new EmptyModelMetadataProvider().GetMetadataForType(typeof(List<int>)),
                 ModelName = "someName",
                 ModelState = new ModelStateDictionary(),
+                OperationBindingContext = new OperationBindingContext(),
                 ValueProvider = new SimpleValueProvider
                 {
                     { "someOtherName", "dummyValue" }
                 },
-                OperationBindingContext = new OperationBindingContext
-                {
-                    ValidatorProvider = GetValidatorProvider()
-                }
             };
 
             var count = 0;
@@ -201,14 +189,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
                 ModelMetadata = new EmptyModelMetadataProvider().GetMetadataForType(typeof(List<int>)),
                 ModelName = "someName",
                 ModelState = new ModelStateDictionary(),
+                OperationBindingContext = new OperationBindingContext(),
                 ValueProvider = new SimpleValueProvider
                 {
                     { "someOtherName", "dummyValue" }
                 },
-                OperationBindingContext = new OperationBindingContext
-                {
-                    ValidatorProvider = GetValidatorProvider()
-                }
             };
 
             var modelBinder = new Mock<IModelBinder>();
@@ -238,14 +223,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
                 ModelMetadata = new EmptyModelMetadataProvider().GetMetadataForType(typeof(List<int>)),
                 ModelName = "someName",
                 ModelState = new ModelStateDictionary(),
+                OperationBindingContext = new OperationBindingContext(),
                 ValueProvider = new SimpleValueProvider
                 {
                     { "someOtherName", "dummyValue" }
                 },
-                OperationBindingContext = new OperationBindingContext
-                {
-                    ValidatorProvider = GetValidatorProvider()
-                }
             };
 
             var modelBinder = new Mock<IModelBinder>();
@@ -276,14 +258,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
                 ModelMetadata = new EmptyModelMetadataProvider().GetMetadataForType(typeof(List<int>)),
                 ModelName = "someName",
                 ModelState = new ModelStateDictionary(),
+                OperationBindingContext = new OperationBindingContext(),
                 ValueProvider = new SimpleValueProvider
                 {
                     { "someOtherName", "dummyValue" }
                 },
-                OperationBindingContext = new OperationBindingContext
-                {
-                    ValidatorProvider = GetValidatorProvider()
-                }
             };
 
             var modelBinder = new Mock<IModelBinder>();
@@ -318,6 +297,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             {
                 FallbackToEmptyPrefix = false,
                 ModelMetadata = new EmptyModelMetadataProvider().GetMetadataForType(typeof(List<int>)),
+                ModelState = new ModelStateDictionary(),
             };
 
             // Act
@@ -341,7 +321,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
                 FallbackToEmptyPrefix = true,
                 ModelMetadata = new EmptyModelMetadataProvider().GetMetadataForType(typeof(int)),
                 ModelState = new ModelStateDictionary(),
-                OperationBindingContext = Mock.Of<OperationBindingContext>(),
+                OperationBindingContext = new OperationBindingContext(),
             };
 
             // Act
@@ -504,24 +484,23 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             Assert.Same(validationNode, result.ValidationNode);
         }
 
-        private static ModelBindingContext CreateBindingContext(IModelBinder binder,
-                                                                IValueProvider valueProvider,
-                                                                Type type,
-                                                                IModelValidatorProvider validatorProvider = null)
+        private static ModelBindingContext CreateBindingContext(
+            IModelBinder binder,
+            IValueProvider valueProvider,
+            Type type)
         {
-            validatorProvider = validatorProvider ?? GetValidatorProvider();
             var metadataProvider = TestModelMetadataProvider.CreateDefaultProvider();
             var bindingContext = new ModelBindingContext
             {
                 FallbackToEmptyPrefix = true,
                 ModelMetadata = metadataProvider.GetMetadataForType(type),
+                ModelName = "parameter",
                 ModelState = new ModelStateDictionary(),
                 ValueProvider = valueProvider,
                 OperationBindingContext = new OperationBindingContext
                 {
                     MetadataProvider = metadataProvider,
                     ModelBinder = binder,
-                    ValidatorProvider = validatorProvider
                 }
             };
             return bindingContext;
@@ -547,26 +526,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             return shimBinder;
         }
 
-        private static IModelValidatorProvider GetValidatorProvider(params IModelValidator[] validators)
-        {
-            var provider = new Mock<IModelValidatorProvider>();
-            provider
-                .Setup(v => v.GetValidators(It.IsAny<ModelValidatorProviderContext>()))
-                .Callback<ModelValidatorProviderContext>(c =>
-                {
-                    if (validators == null)
-                    {
-                        return;
-                    }
-
-                    foreach (var validator in validators)
-                    {
-                        c.Validators.Add(validator);
-                    }
-                });
-
-            return provider.Object;
-        }
 
         private class SimplePropertiesModel
         {

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/DictionaryModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/DictionaryModelBinderTest.cs
@@ -429,6 +429,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         {
             var modelBindingContext = new ModelBindingContext()
             {
+                ModelState = new ModelStateDictionary(),
                 OperationBindingContext = new OperationBindingContext()
                 {
                     HttpContext = new DefaultHttpContext(),
@@ -510,6 +511,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             {
                 ModelMetadata = metadataProvider.GetMetadataForType(typeof(IDictionary<int, string>)),
                 ModelName = "someName",
+                ModelState = new ModelStateDictionary(),
                 OperationBindingContext = new OperationBindingContext
                 {
                     ModelBinder = binder.Object,

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/FormFileModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/FormFileModelBinderTest.cs
@@ -159,6 +159,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             {
                 ModelMetadata = metadataProvider.GetMetadataForType(modelType),
                 ModelName = "file",
+                ModelState = new ModelStateDictionary(),
                 OperationBindingContext = new OperationBindingContext
                 {
                     ModelBinder = new FormFileModelBinder(),

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/HeaderModelBinderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/HeaderModelBinderTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var binder = new HeaderModelBinder();
             var modelBindingContext = GetBindingContext(type);
 
-            modelBindingContext.ModelName = header;
+            modelBindingContext.FieldName = header;
             modelBindingContext.OperationBindingContext.HttpContext.Request.Headers.Add(header, new[] { headerValue });
 
             // Act
@@ -61,7 +61,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var binder = new HeaderModelBinder();
             var modelBindingContext = GetBindingContext(type);
 
-            modelBindingContext.ModelName = header;
+            modelBindingContext.FieldName = header;
             modelBindingContext.OperationBindingContext.HttpContext.Request.Headers.Add(header, new[] { headerValue });
 
             // Act
@@ -81,6 +81,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             {
                 ModelMetadata = modelMetadata,
                 ModelName = "modelName",
+                FieldName = "modelName",
+                ModelState = new ModelStateDictionary(),
                 OperationBindingContext = new OperationBindingContext
                 {
                     ModelBinder = new HeaderModelBinder(),

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/KeyValuePairModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/KeyValuePairModelBinderTest.cs
@@ -255,6 +255,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             {
                 ModelMetadata = metataProvider.GetMetadataForType(keyValuePairType ?? typeof(KeyValuePair<int, string>)),
                 ModelName = "someName",
+                ModelState = new ModelStateDictionary(),
                 ValueProvider = valueProvider,
                 OperationBindingContext = new OperationBindingContext
                 {

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/ModelBindingContextTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/ModelBindingContextTest.cs
@@ -10,14 +10,15 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
     public class ModelBindingContextTest
     {
         [Fact]
-        public void GetChildModelBindingContext()
+        public void CreateChildBindingContext_CopiesProperties()
         {
             // Arrange
             var originalBindingContext = new ModelBindingContext
             {
+                Model = new object(),
                 ModelMetadata = new TestModelMetadataProvider().GetMetadataForType(typeof(object)),
                 ModelName = "theName",
-                ModelState = new ModelStateDictionary(),
+                OperationBindingContext = new OperationBindingContext(),
                 ValueProvider = new SimpleValueProvider()
             };
 
@@ -32,19 +33,27 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var newModelMetadata = metadataProvider.GetMetadataForType(typeof(object));
             
             // Act
-            var newBindingContext = ModelBindingContext.GetChildModelBindingContext(
+            var newBindingContext = ModelBindingContext.CreateChildBindingContext(
                 originalBindingContext,
-                string.Empty,
-                newModelMetadata);
+                newModelMetadata,
+                fieldName: "fieldName",
+                modelName: "modelprefix.fieldName",
+                model: null);
 
             // Assert
-            Assert.Same(newModelMetadata, newBindingContext.ModelMetadata);
-            Assert.Same(newModelMetadata.BindingSource, newBindingContext.BindingSource);
             Assert.Same(newModelMetadata.BinderModelName, newBindingContext.BinderModelName);
             Assert.Same(newModelMetadata.BinderType, newBindingContext.BinderType);
-            Assert.Equal("", newBindingContext.ModelName);
-            Assert.Equal(originalBindingContext.ModelState, newBindingContext.ModelState);
-            Assert.Equal(originalBindingContext.ValueProvider, newBindingContext.ValueProvider);
+            Assert.Same(newModelMetadata.BindingSource, newBindingContext.BindingSource);
+            Assert.False(newBindingContext.FallbackToEmptyPrefix);
+            Assert.Equal("fieldName", newBindingContext.FieldName);
+            Assert.False(newBindingContext.IsFirstChanceBinding);
+            Assert.False(newBindingContext.IsTopLevelObject);
+            Assert.Null(newBindingContext.Model);
+            Assert.Same(newModelMetadata, newBindingContext.ModelMetadata);
+            Assert.Equal("modelprefix.fieldName", newBindingContext.ModelName);
+            Assert.Same(originalBindingContext.ModelState, newBindingContext.ModelState);
+            Assert.Same(originalBindingContext.OperationBindingContext, newBindingContext.OperationBindingContext);
+            Assert.Same(originalBindingContext.ValueProvider, newBindingContext.ValueProvider);
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/MutableObjectModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/MutableObjectModelBinderTest.cs
@@ -796,6 +796,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 Model = model,
                 ModelMetadata = containerMetadata,
                 ModelName = "theModel",
+                ModelState = new ModelStateDictionary(),
                 OperationBindingContext = new OperationBindingContext
                 {
                     MetadataProvider = TestModelMetadataProvider.CreateDefaultProvider(),
@@ -846,6 +847,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 Model = model,
                 ModelMetadata = containerMetadata,
                 ModelName = "theModel",
+                ModelState = new ModelStateDictionary(),
                 OperationBindingContext = new OperationBindingContext
                 {
                     MetadataProvider = TestModelMetadataProvider.CreateDefaultProvider(),
@@ -1649,9 +1651,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             return new ModelBindingContext
             {
                 Model = model,
-                ModelState = new ModelStateDictionary(),
                 ModelMetadata = metadata,
                 ModelName = "theModel",
+                ModelState = new ModelStateDictionary(),
                 OperationBindingContext = new OperationBindingContext
                 {
                     MetadataProvider = TestModelMetadataProvider.CreateDefaultProvider(),

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/SimpleTypeModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/SimpleTypeModelBinderTest.cs
@@ -185,6 +185,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             {
                 ModelMetadata = new EmptyModelMetadataProvider().GetMetadataForType(modelType),
                 ModelName = "theModelName",
+                ModelState = new ModelStateDictionary(),
                 ValueProvider = new SimpleValueProvider() // empty
             };
         }


### PR DESCRIPTION
Adds a new property, FieldName, to ModelBindingContext. The FieldName is
the name of whatever code-element is being bound, regardless of what
model-prefix is in use.

This is needed for cases like the Header model binder. We always want to
use the property/parameter name and we don't care about model prefixes.