### PR TITLE
Test Cleanup: Fix Assert.NotNulls with ModelBindingResult

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/ModelBindingResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/ModelBindingResult.cs
@@ -162,6 +162,23 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 object.Equals(Model, other.Model);
         }
 
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            if (Key == null)
+            {
+                return "No Result";
+            }
+            else if (IsModelSet)
+            {
+                return $"Success {Key} -> {Model}";
+            }
+            else
+            {
+                return $"Failed {Key}";
+            }
+        }
+
         /// <summary>
         /// Compares <see cref="ModelBindingResult"/> objects for equality.
         /// </summary>

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/ArrayModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/ArrayModelBinderTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
 
             var array = Assert.IsType<int[]>(result.Model);
             Assert.Equal(new[] { 42, 84 }, array);
@@ -57,7 +57,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(context);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
 
             Assert.Empty(Assert.IsType<string[]>(result.Model));
             Assert.Equal("modelName", result.Key);
@@ -150,7 +150,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.True(result.IsModelSet);
             Assert.Same(model, result.Model);
 

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BindingSourceModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BindingSourceModelBinderTest.cs
@@ -35,8 +35,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         public async Task BindingSourceModelBinder_ReturnsNull_WithNoSource()
         {
             // Arrange
-            var context = new ModelBindingContext();
-            context.ModelMetadata = new EmptyModelMetadataProvider().GetMetadataForType(typeof(string));
+            var context = new ModelBindingContext()
+            {
+                ModelMetadata = new EmptyModelMetadataProvider().GetMetadataForType(typeof(string)),
+                ModelName = "model",
+            };
 
             var binder = new TestableBindingSourceModelBinder(BindingSource.Body, isModelSet: false);
 
@@ -55,8 +58,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var provider = new TestModelMetadataProvider();
             provider.ForType<string>().BindingDetails(d => d.BindingSource = BindingSource.Query);
 
-            var context = new ModelBindingContext();
-            context.ModelMetadata = provider.GetMetadataForType(typeof(string));
+            var context = new ModelBindingContext()
+            {
+                ModelMetadata = new EmptyModelMetadataProvider().GetMetadataForType(typeof(string)),
+                ModelName = "model",
+            };
 
             var binder = new TestableBindingSourceModelBinder(BindingSource.Body, isModelSet: false);
 
@@ -71,7 +77,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public async Task BindingSourceModelBinder_ReturnsNonNull_MatchingSource(bool isModelSet)
+        public async Task BindingSourceModelBinder_ReturnsNonEmptyResult_MatchingSource(bool isModelSet)
         {
             // Arrange
             var provider = new TestModelMetadataProvider();
@@ -79,9 +85,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var modelMetadata = provider.GetMetadataForType(typeof(string));
             var context = new ModelBindingContext()
             {
-                ModelMetadata = modelMetadata,
+                BinderModelName = modelMetadata.BinderModelName,
                 BindingSource = modelMetadata.BindingSource,
-                BinderModelName = modelMetadata.BinderModelName
+                ModelMetadata = modelMetadata,
+                ModelName = "model",
             };
 
             var binder = new TestableBindingSourceModelBinder(BindingSource.Body, isModelSet);
@@ -90,7 +97,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var result = await binder.BindModelAsync(context);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.Equal(isModelSet, result.IsModelSet);
             Assert.Null(result.Model);
             Assert.True(binder.WasBindModelCoreCalled);

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CancellationTokenModelBinderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CancellationTokenModelBinderTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
     public class CancellationTokenModelBinderTests
     {
         [Fact]
-        public async Task CancellationTokenModelBinder_ReturnsNotNull_ForCancellationTokenType()
+        public async Task CancellationTokenModelBinder_ReturnsNonEmptyResult_ForCancellationTokenType()
         {
             // Arrange
             var bindingContext = GetBindingContext(typeof(CancellationToken));
@@ -22,7 +22,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.True(result.IsModelSet);
             Assert.Equal(bindingContext.OperationBindingContext.HttpContext.RequestAborted, result.Model);
             Assert.NotNull(result.ValidationNode);

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CollectionModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CollectionModelBinderTest.cs
@@ -85,7 +85,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.True(result.IsModelSet);
 
             var list = Assert.IsAssignableFrom<IList<int>>(result.Model);
@@ -117,7 +117,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.True(result.IsModelSet);
 
             Assert.Same(list, result.Model);
@@ -144,7 +144,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.True(result.IsModelSet);
 
             var list = Assert.IsAssignableFrom<IList<int>>(result.Model);
@@ -171,7 +171,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.True(result.IsModelSet);
 
             Assert.Same(list, result.Model);
@@ -194,7 +194,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.True(result.IsModelSet);
             Assert.NotNull(result.Model);
             Assert.NotNull(result.ValidationNode);
@@ -247,7 +247,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(context);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
 
             Assert.Empty(Assert.IsType<List<string>>(result.Model));
             Assert.Equal("modelName", result.Key);
@@ -284,7 +284,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(context);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
 
             Assert.Same(list, result.Model);
             Assert.Empty(list);

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CompositeModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CompositeModelBinderTest.cs
@@ -48,7 +48,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await shimBinder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.True(result.IsModelSet);
             Assert.Equal(42, result.Model);
         }
@@ -97,14 +97,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await shimBinder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.True(result.IsModelSet);
             Assert.Equal(string.Empty, result.Key);
             Assert.Equal(expectedModel, result.Model);
         }
 
         [Fact]
-        public async Task ModelBinder_ReturnsNull_IfBinderMatchesButDoesNotSetModel()
+        public async Task ModelBinder_ReturnsNoResult_IfBinderMatchesButDoesNotSetModel()
         {
             // Arrange
             var bindingContext = new ModelBindingContext
@@ -204,7 +204,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         }
 
         [Fact]
-        public async Task ModelBinder_ReturnsNotNull_SetsNullValue_SetsModelStateKey()
+        public async Task ModelBinder_ReturnsNonEmptyResult_SetsNullValue_SetsModelStateKey()
         {
             // Arrange
             var bindingContext = new ModelBindingContext
@@ -231,14 +231,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await composite.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.True(result.IsModelSet);
             Assert.Equal("someName", result.Key);
             Assert.Null(result.Model);
         }
 
         [Fact]
-        public async Task BindModel_UnsuccessfulBind_BinderFails_ReturnsNull()
+        public async Task BindModel_UnsuccessfulBind_BinderFails_ReturnsNoResult()
         {
             // Arrange
             var mockListBinder = new Mock<IModelBinder>();
@@ -265,7 +265,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         }
 
         [Fact]
-        public async Task BindModel_UnsuccessfulBind_SimpleTypeNoFallback_ReturnsNull()
+        public async Task BindModel_UnsuccessfulBind_SimpleTypeNoFallback_ReturnsNoResult()
         {
             // Arrange
             var innerBinder = Mock.Of<IModelBinder>();
@@ -304,7 +304,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             var model = Assert.IsType<SimplePropertiesModel>(result.Model);
             Assert.Equal("firstName-value", model.FirstName);
             Assert.Equal("lastName-value", model.LastName);
@@ -354,7 +354,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             var model = Assert.IsType<Person>(result.Model);
             Assert.Equal("firstName-value", model.FirstName);
             Assert.Equal("lastName-value", model.LastName);
@@ -392,7 +392,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         }
 
         [Fact]
-        public async Task BindModel_DoesNotAddAValidationNode_IfModelBindingResultIsNull()
+        public async Task BindModel_DoesNotAddAValidationNode_IfModelBindingResultIsNoResult()
         {
             // Arrange
             var mockBinder = new Mock<IModelBinder>();
@@ -433,7 +433,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.True(result.IsModelSet);
             Assert.Same(validationNode, result.ValidationNode);
         }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/DictionaryModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/DictionaryModelBinderTest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.True(result.IsModelSet);
             var dictionary = Assert.IsAssignableFrom<IDictionary<int, string>>(result.Model);
             Assert.True(modelState.IsValid);
@@ -69,7 +69,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.True(result.IsModelSet);
             Assert.Same(dictionary, result.Model);
             Assert.True(modelState.IsValid);
@@ -132,7 +132,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(context);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.True(result.IsModelSet);
             Assert.Equal(modelName, result.Key);
             Assert.NotNull(result.ValidationNode);
@@ -169,7 +169,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(context);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.True(result.IsModelSet);
             Assert.Equal("prefix", result.Key);
             Assert.NotNull(result.ValidationNode);
@@ -220,7 +220,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(context);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.True(result.IsModelSet);
             Assert.Equal("prefix", result.Key);
             Assert.NotNull(result.ValidationNode);
@@ -261,7 +261,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(context);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.True(result.IsModelSet);
             Assert.Equal("prefix", result.Key);
             Assert.NotNull(result.ValidationNode);
@@ -295,7 +295,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(context);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.True(result.IsModelSet);
             Assert.Equal(modelName, result.Key);
             Assert.NotNull(result.ValidationNode);
@@ -325,7 +325,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(context);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
 
             Assert.Empty(Assert.IsType<Dictionary<string, string>>(result.Model));
             Assert.Equal("modelName", result.Key);

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/ElementalValueProviderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/ElementalValueProviderTests.cs
@@ -82,7 +82,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var result =  valueProvider.GetValue(name);
 
             // Assert
-            Assert.NotNull(result);
             Assert.Equal("hi", (string)result);
             Assert.Equal(culture, result.Culture);
         }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/FormCollectionModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/FormCollectionModelBinderTest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.True(result.IsModelSet);
             Assert.NotNull(result.ValidationNode);
             Assert.True(result.ValidationNode.SuppressValidation);
@@ -98,7 +98,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             var form = Assert.IsAssignableFrom<IFormCollection>(result.Model);
             Assert.Empty(form);
         }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/FormFileModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/FormFileModelBinderTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.True(result.IsModelSet);
             Assert.NotNull(result.ValidationNode);
             Assert.True(result.ValidationNode.SuppressValidation);
@@ -56,7 +56,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             var files = Assert.IsAssignableFrom<IList<IFormFile>>(result.Model);
             Assert.Equal(2, files.Count);
         }
@@ -76,14 +76,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             var file = Assert.IsAssignableFrom<IFormFile>(result.Model);
             Assert.Equal("form-data; name=file; filename=file1.txt",
                          file.ContentDisposition);
         }
 
         [Fact]
-        public async Task FormFileModelBinder_ReturnsNull_WhenNoFilePosted()
+        public async Task FormFileModelBinder_ReturnsNoResult_WhenNoFilePosted()
         {
             // Arrange
             var formFiles = new FormFileCollection();
@@ -95,12 +95,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.Null(result.Model);
         }
 
         [Fact]
-        public async Task FormFileModelBinder_ReturnsNull_WhenNamesDontMatch()
+        public async Task FormFileModelBinder_ReturnsNoResult_WhenNamesDontMatch()
         {
             // Arrange
             var formFiles = new FormFileCollection();
@@ -113,7 +113,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.Null(result.Model);
         }
 
@@ -139,7 +139,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.True(result.IsModelSet);
             var file = Assert.IsAssignableFrom<IFormFile>(result.Model);
             
@@ -149,7 +149,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         }
 
         [Fact]
-        public async Task FormFileModelBinder_ReturnsNull_WithEmptyContentDisposition()
+        public async Task FormFileModelBinder_ReturnsNoResult_WithEmptyContentDisposition()
         {
             // Arrange
             var formFiles = new FormFileCollection();
@@ -162,12 +162,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.Null(result.Model);
         }
 
         [Fact]
-        public async Task FormFileModelBinder_ReturnsNull_WithNoFileNameAndZeroLength()
+        public async Task FormFileModelBinder_ReturnsNoResult_WithNoFileNameAndZeroLength()
         {
             // Arrange
             var formFiles = new FormFileCollection();
@@ -180,7 +180,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.Null(result.Model);
         }
 

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/HeaderModelBinderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/HeaderModelBinderTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
         [InlineData(typeof(int))]
         [InlineData(typeof(int[]))]
         [InlineData(typeof(BindingSource))]
-        public async Task BindModelAsync_ReturnsNotNull_ForAllTypes(Type type)
+        public async Task BindModelAsync_ReturnsNonEmptyResult_ForAllTypes_WithHeaderBindingSource(Type type)
         {
             // Arrange
             var binder = new HeaderModelBinder();
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(modelBindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
         }
 
         [Fact]
@@ -47,7 +47,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(modelBindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.Equal(headerValue.Split(','), result.Model);
         }
 
@@ -68,7 +68,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(modelBindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.Equal(headerValue, result.Model);
         }
 

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/KeyValuePairModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/KeyValuePairModelBinderTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.Null(result.Model);
             Assert.False(bindingContext.ModelState.IsValid);
             Assert.Null(result.ValidationNode);
@@ -97,7 +97,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.Equal(new KeyValuePair<int, string>(42, "some-value"), result.Model);
             Assert.NotNull(result.ValidationNode);
             Assert.Equal(new KeyValuePair<int, string>(42, "some-value"), result.ValidationNode.Model);
@@ -175,7 +175,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(context);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
 
             Assert.Equal(default(KeyValuePair<string, string>), Assert.IsType<KeyValuePair<string, string>>(result.Model));
             Assert.Equal("modelName", result.Key);

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/SimpleTypeModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/SimpleTypeModelBinderTest.cs
@@ -116,7 +116,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.Null(result.Model);
             Assert.False(bindingContext.ModelState.IsValid);
             var error = Assert.Single(bindingContext.ModelState["theModelName"].Errors);

--- a/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/HttpRequestMessage/HttpRequestMessageModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/HttpRequestMessage/HttpRequestMessageModelBinderTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShim
     public class HttpRequestMessageModelBinderTest
     {
         [Fact]
-        public async Task BindModelAsync_ReturnsNotNull_ForHttpRequestMessageType()
+        public async Task BindModelAsync_ReturnsNonEmptyResult_ForHttpRequestMessageType()
         {
             // Arrange
             var binder = new HttpRequestMessageModelBinder();
@@ -24,7 +24,7 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShim
             var result = await binder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.NotNull(result);
+            Assert.NotEqual(ModelBindingResult.NoResult, result);
             Assert.True(result.IsModelSet);
             Assert.Same(expectedModel, result.Model);
             Assert.NotNull(result.ValidationNode);


### PR DESCRIPTION
MBR is a struct now, updated tests and names to reflect this. These were missed in an earlier pass.