### PR TITLE
Make a few arrays explicitly `object[]`

### DIFF
--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBindingHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBindingHelperTest.cs
@@ -1161,7 +1161,7 @@ namespace Microsoft.AspNet.Mvc.Test
         }
 
         [Theory]
-        [InlineData(new object[] { new[] { 1, 0 } })]
+        [InlineData(new object[] { new object[] { 1, 0 } })]
         [InlineData(new object[] { new[] { "Value1", "Value0" } })]
         [InlineData(new object[] { new[] { "Value1", "value0" } })]
         public void ConvertTo_ConvertsEnumArrays(object value)
@@ -1179,9 +1179,9 @@ namespace Microsoft.AspNet.Mvc.Test
         }
 
         [Theory]
-        [InlineData(new object[] { new[] { 1, 2 }, new[] { FlagsEnum.Value1, FlagsEnum.Value2 } })]
+        [InlineData(new object[] { new object[] { 1, 2 }, new[] { FlagsEnum.Value1, FlagsEnum.Value2 } })]
         [InlineData(new object[] { new[] { "Value1", "Value2" }, new[] { FlagsEnum.Value1, FlagsEnum.Value2 } })]
-        [InlineData(new object[] { new[] { 5, 2 }, new[] { FlagsEnum.Value1 | FlagsEnum.Value4, FlagsEnum.Value2 } })]
+        [InlineData(new object[] { new object[] { 5, 2 }, new[] { FlagsEnum.Value1 | FlagsEnum.Value4, FlagsEnum.Value2 } })]
         public void ConvertTo_ConvertsFlagsEnumArrays(object value, FlagsEnum[] expected)
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ViewDataDictionaryTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ViewDataDictionaryTest.cs
@@ -311,8 +311,8 @@ namespace Microsoft.AspNet.Mvc.Core
         [Theory]
         [InlineData(typeof(int), "test string", typeof(string))]
         [InlineData(typeof(string), 23, typeof(int))]
-        [InlineData(typeof(IEnumerable<string>), new[] { "1", "2", "3", }, typeof(object[]))]
-        [InlineData(typeof(List<string>), new[] { 1, 2, 3, }, typeof(object[]))]
+        [InlineData(typeof(IEnumerable<string>), new object[] { "1", "2", "3", }, typeof(object[]))]
+        [InlineData(typeof(List<string>), new object[] { 1, 2, 3, }, typeof(object[]))]
         public void CopyConstructors_OverrideSourceMetadata_IfModelNonNull(
             Type sourceType,
             object instance,


### PR DESCRIPTION
- react to aspnet/aspnet.xunit#13
- latest xUnit bits maintains array types correctly, failing some `Type`-related assertions
  - previous xUnit versions mapped all arrays to `object[]`
  - fix likely part of xunit/xunit@bd6814c