### PR TITLE
Flow IHtmlContent through to the razor buffer

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
@@ -434,7 +434,7 @@ namespace Microsoft.AspNet.Mvc.Razor
                     // an attribute value that may have been quoted with single quotes, must handle any double quotes
                     // in the value. Writing the value out surrounded by double quotes.
                     //
-                    // Do not combine following condition with check of escapeQuotes; converting an IHtmlContent to
+                    // Be careful combining IHtmlContent with escapeQuotes= = true converting an IHtmlContent to
                     // a string can be very expensive.
                     using (var stringWriter = new StringWriter())
                     {
@@ -636,9 +636,13 @@ namespace Microsoft.AspNet.Mvc.Razor
                     WriteUnprefixedAttributeValueTo(valueBuffer, value);
                 }
 
-                var htmlString = new HtmlString(valueBuffer.ToString());
+                using (var stringWriter = new StringWriter())
+                {
+                    valueBuffer.Content.WriteTo(stringWriter, HtmlEncoder);
 
-                executionContext.AddHtmlAttribute(attributeName, htmlString);
+                    var htmlString = new HtmlString(stringWriter.ToString());
+                    executionContext.AddHtmlAttribute(attributeName, htmlString);
+                }
             }
         }
 

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
@@ -434,8 +434,7 @@ namespace Microsoft.AspNet.Mvc.Razor
                     // an attribute value that may have been quoted with single quotes, must handle any double quotes
                     // in the value. Writing the value out surrounded by double quotes.
                     //
-                    // Be careful combining IHtmlContent with escapeQuotes= = true converting an IHtmlContent to
-                    // a string can be very expensive.
+                    // This is really not optimal from a perf point of view, but it's the best we can do for right now.
                     using (var stringWriter = new StringWriter())
                     {
                         htmlContent.WriteTo(stringWriter, encoder);

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorTextWriter.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorTextWriter.cs
@@ -88,17 +88,17 @@ namespace Microsoft.AspNet.Mvc.Razor
             }
         }
 
-        /// <inheritdoct />
-        public override void Write(IHtmlContent content)
+        /// <inheritdoc />
+        public override void Write(IHtmlContent value)
         {
             var htmlTextWriter = TargetWriter as HtmlTextWriter;
             if (htmlTextWriter == null)
             {
-                content.WriteTo(TargetWriter, HtmlEncoder);
+                value.WriteTo(TargetWriter, HtmlEncoder);
             }
             else
             {
-                htmlTextWriter.Write(content);
+                htmlTextWriter.Write(value);
             }
         }
 

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorTextWriter.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorTextWriter.cs
@@ -2,12 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Html.Abstractions;
-using Microsoft.AspNet.Mvc.Razor.Internal;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.Framework.Internal;
 using Microsoft.Framework.WebEncoders;
@@ -15,7 +13,7 @@ using Microsoft.Framework.WebEncoders;
 namespace Microsoft.AspNet.Mvc.Razor
 {
     /// <summary>
-    /// A <see cref="TextWriter"/> that is backed by a unbuffered writer (over the Response stream) and a buffered
+    /// An <see cref="HtmlTextWriter"/> that is backed by a unbuffered writer (over the Response stream) and a buffered
     /// <see cref="StringCollectionTextWriter"/>. When <c>Flush</c> or <c>FlushAsync</c> is invoked, the writer
     /// copies all content from the buffered writer to the unbuffered one and switches to writing to the unbuffered
     /// writer for all further write operations.
@@ -24,7 +22,7 @@ namespace Microsoft.AspNet.Mvc.Razor
     /// This type is designed to avoid creating large in-memory strings when buffering and supporting the contract that
     /// <see cref="RazorPage.FlushAsync"/> expects.
     /// </remarks>
-    public class RazorTextWriter : TextWriter, IBufferedTextWriter
+    public class RazorTextWriter : HtmlTextWriter, IBufferedTextWriter
     {
         /// <summary>
         /// Creates a new instance of <see cref="RazorTextWriter"/>.
@@ -67,19 +65,6 @@ namespace Microsoft.AspNet.Mvc.Razor
         }
 
         /// <inheritdoc />
-        public override void Write(object value)
-        {
-            var htmlContent = value as IHtmlContent;
-            if (htmlContent != null)
-            {
-                htmlContent.WriteTo(TargetWriter, HtmlEncoder);
-                return;
-            }
-
-            base.Write(value);
-        }
-
-        /// <inheritdoc />
         public override void Write([NotNull] char[] buffer, int index, int count)
         {
             if (index < 0)
@@ -100,6 +85,20 @@ namespace Microsoft.AspNet.Mvc.Razor
             if (!string.IsNullOrEmpty(value))
             {
                 TargetWriter.Write(value);
+            }
+        }
+
+        /// <inheritdoct />
+        public override void Write(IHtmlContent content)
+        {
+            var htmlTextWriter = TargetWriter as HtmlTextWriter;
+            if (htmlTextWriter == null)
+            {
+                content.WriteTo(TargetWriter, HtmlEncoder);
+            }
+            else
+            {
+                htmlTextWriter.Write(content);
             }
         }
 

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/HtmlTextWriter.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/HtmlTextWriter.cs
@@ -4,7 +4,7 @@
 using System.IO;
 using Microsoft.AspNet.Html.Abstractions;
 
-namespace Microsoft.AspNet.Mvc.Razor
+namespace Microsoft.AspNet.Mvc.ViewFeatures
 {
     /// <summary>
     /// A <see cref="TextWriter"/> which supports special processing of <see cref="IHtmlContent"/>.

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/HtmlTextWriter.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/HtmlTextWriter.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using Microsoft.AspNet.Html.Abstractions;
+
+namespace Microsoft.AspNet.Mvc.Razor
+{
+    public abstract class HtmlTextWriter : TextWriter
+    {
+        public abstract void Write(IHtmlContent content);
+
+        /// <inheritdoc />
+        public override void Write(object value)
+        {
+            var htmlContent = value as IHtmlContent;
+            if (htmlContent == null)
+            {
+                base.Write(value);
+            }
+            else
+            {
+                Write(htmlContent);
+            }
+        }
+
+        /// <inheritdoc />
+        public override void WriteLine(object value)
+        {
+            var htmlContent = value as IHtmlContent;
+            if (htmlContent == null)
+            {
+                base.Write(value);
+            }
+            else
+            {
+                Write(htmlContent);
+            }
+
+            base.WriteLine();
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/HtmlTextWriter.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/HtmlTextWriter.cs
@@ -6,9 +6,16 @@ using Microsoft.AspNet.Html.Abstractions;
 
 namespace Microsoft.AspNet.Mvc.Razor
 {
+    /// <summary>
+    /// A <see cref="TextWriter"/> which supports special processing of <see cref="IHtmlContent"/>.
+    /// </summary>
     public abstract class HtmlTextWriter : TextWriter
     {
-        public abstract void Write(IHtmlContent content);
+        /// <summary>
+        /// Writes an <see cref="IHtmlContent"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="IHtmlContent"/> value.</param>
+        public abstract void Write(IHtmlContent value);
 
         /// <inheritdoc />
         public override void Write(object value)

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/HtmlHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/HtmlHelper.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNet.Html.Abstractions;
 using Microsoft.AspNet.Mvc.ModelBinding;
 using Microsoft.AspNet.Mvc.ModelBinding.Validation;
-using Microsoft.AspNet.Mvc.Razor;
 using Microsoft.AspNet.Mvc.Rendering.Expressions;
 using Microsoft.AspNet.Mvc.Rendering.Internal;
 using Microsoft.AspNet.Mvc.ViewFeatures;
@@ -803,7 +802,18 @@ namespace Microsoft.AspNet.Mvc.Rendering
             if (tagBuilder != null)
             {
                 tagBuilder.TagRenderMode = TagRenderMode.StartTag;
-                tagBuilder.WriteTo(ViewContext.Writer, _htmlEncoder);
+
+                // As a perf optimization, we can buffer this output rather than writing it
+                // out character by character.
+                var htmlWriter = ViewContext.Writer as HtmlTextWriter;
+                if (htmlWriter == null)
+                {
+                    tagBuilder.WriteTo(ViewContext.Writer, _htmlEncoder);
+                }
+                else
+                {
+                    htmlWriter.Write(tagBuilder);
+                }
             }
 
             return CreateForm();

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/HtmlHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/HtmlHelper.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNet.Html.Abstractions;
 using Microsoft.AspNet.Mvc.ModelBinding;
 using Microsoft.AspNet.Mvc.ModelBinding.Validation;
+using Microsoft.AspNet.Mvc.Razor;
 using Microsoft.AspNet.Mvc.Rendering.Expressions;
 using Microsoft.AspNet.Mvc.Rendering.Internal;
 using Microsoft.AspNet.Mvc.ViewFeatures;
@@ -748,7 +749,18 @@ namespace Microsoft.AspNet.Mvc.Rendering
             if (tagBuilder != null)
             {
                 tagBuilder.TagRenderMode = TagRenderMode.StartTag;
-                tagBuilder.WriteTo(ViewContext.Writer, _htmlEncoder);
+
+                // As a perf optimization, we can buffer this output rather than writing it
+                // out character by character.
+                var htmlWriter = ViewContext.Writer as HtmlTextWriter;
+                if (htmlWriter == null)
+                {
+                    tagBuilder.WriteTo(ViewContext.Writer, _htmlEncoder);
+                }
+                else
+                {
+                    htmlWriter.Write(tagBuilder);
+                }
             }
 
             return CreateForm();

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/TagBuilder.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/TagBuilder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -13,6 +14,7 @@ using Microsoft.Framework.WebEncoders;
 
 namespace Microsoft.AspNet.Mvc.Rendering
 {
+    [DebuggerDisplay("{DebuggerToString()}")]
     public class TagBuilder : IHtmlContent
     {
         public TagBuilder(string tagName)
@@ -224,6 +226,15 @@ namespace Microsoft.AspNet.Mvc.Rendering
                     writer.Write(TagName);
                     writer.Write(">");
                     break;
+            }
+        }
+
+        private string DebuggerToString()
+        {
+            using (var writer = new StringWriter())
+            {
+                WriteTo(writer, HtmlEncoder.Default);
+                return writer.ToString();
             }
         }
 

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/StringCollectionTextWriter.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/StringCollectionTextWriter.cs
@@ -10,11 +10,13 @@ using Microsoft.AspNet.Html.Abstractions;
 using Microsoft.Framework.Internal;
 using Microsoft.Framework.WebEncoders;
 using Microsoft.AspNet.Mvc.Razor;
+using System.Diagnostics;
 
 namespace Microsoft.AspNet.Mvc.Rendering
 {
     /// <summary>
-    /// A <see cref="TextWriter"/> that represents individual write operations as a sequence of strings.
+    /// A <see cref="HtmlTextWriter"/> that represents individual write operations as a sequence of
+    /// <see cref="string"/> and <see cref="IHtmlContent"/> instances.
     /// </summary>
     /// <remarks>
     /// This is primarily designed to avoid creating large in-memory strings.
@@ -98,9 +100,9 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <inheritdoc />
-        public override void Write(IHtmlContent content)
+        public override void Write(IHtmlContent value)
         {
-            _content.Append(content);
+            _content.Append(value);
         }
 
         /// <inheritdoc />
@@ -196,16 +198,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return _completedTask;
         }
 
-        /// <inheritdoc />
-        public override string ToString()
-        {
-            using (var writer = new StringWriter())
-            {
-                Content.WriteTo(writer, HtmlEncoder.Default);
-                return writer.ToString();
-            }
-        }
-
+        [DebuggerDisplay("{DebuggerToString()}")]
         private class StringCollectionTextWriterContent : IHtmlContent
         {
             private readonly List<object> _entries;
@@ -243,6 +236,15 @@ namespace Microsoft.AspNet.Mvc.Rendering
                     {
                         ((IHtmlContent)item).WriteTo(writer, encoder);
                     }
+                }
+            }
+
+            private string DebuggerToString()
+            {
+                using (var writer = new StringWriter())
+                {
+                    WriteTo(writer, HtmlEncoder.Default);
+                    return writer.ToString();
                 }
             }
         }

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/StringCollectionTextWriter.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/StringCollectionTextWriter.cs
@@ -3,19 +3,19 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Html.Abstractions;
 using Microsoft.Framework.Internal;
 using Microsoft.Framework.WebEncoders;
-using Microsoft.AspNet.Mvc.Razor;
-using System.Diagnostics;
+using Microsoft.AspNet.Mvc.ViewFeatures;
 
 namespace Microsoft.AspNet.Mvc.Rendering
 {
     /// <summary>
-    /// A <see cref="HtmlTextWriter"/> that represents individual write operations as a sequence of
+    /// A <see cref="HtmlTextWriter"/> that stores individual write operations as a sequence of
     /// <see cref="string"/> and <see cref="IHtmlContent"/> instances.
     /// </summary>
     /// <remarks>

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/StringCollectionTextWriter.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/StringCollectionTextWriter.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNet.Html.Abstractions;
 using Microsoft.Framework.Internal;
 using Microsoft.Framework.WebEncoders;
+using Microsoft.AspNet.Mvc.Razor;
 
 namespace Microsoft.AspNet.Mvc.Rendering
 {
@@ -19,7 +20,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
     /// This is primarily designed to avoid creating large in-memory strings.
     /// Refer to https://aspnetwebstack.codeplex.com/workitem/585 for more details.
     /// </remarks>
-    public class StringCollectionTextWriter : TextWriter
+    public class StringCollectionTextWriter : HtmlTextWriter
     {
         private const int MaxCharToStringLength = 1024;
         private static readonly Task _completedTask = Task.FromResult(0);
@@ -94,6 +95,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
             }
 
             _content.Append(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(IHtmlContent content)
+        {
+            _content.Append(content);
         }
 
         /// <inheritdoc />
@@ -199,7 +206,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
             }
         }
 
-        internal class StringCollectionTextWriterContent : IHtmlContent
+        private class StringCollectionTextWriterContent : IHtmlContent
         {
             private readonly List<object> _entries;
 

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/StringHtmlContent.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/StringHtmlContent.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using System.IO;
 using Microsoft.AspNet.Html.Abstractions;
 using Microsoft.Framework.Internal;
@@ -11,6 +12,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
     /// <summary>
     /// String content which gets encoded when written.
     /// </summary>
+    [DebuggerDisplay("{DebuggerToString()}")]
     public class StringHtmlContent : IHtmlContent
     {
         private readonly string _input;
@@ -30,10 +32,13 @@ namespace Microsoft.AspNet.Mvc.Rendering
             encoder.HtmlEncode(_input, writer);
         }
 
-        /// <inheritdoc />
-        public override string ToString()
+        private string DebuggerToString()
         {
-            return _input;
+            using (var writer = new StringWriter())
+            {
+                WriteTo(writer, HtmlEncoder.Default);
+                return writer.ToString();
+            }
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/RazorPageTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/RazorPageTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Html.Abstractions;
 using Microsoft.AspNet.Http.Internal;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Mvc.TestCommon;
@@ -847,7 +848,7 @@ namespace Microsoft.AspNet.Mvc.Razor
             var htmlAttribute = Assert.Single(executionContext.HTMLAttributes);
             Assert.Equal("someattr", htmlAttribute.Name, StringComparer.Ordinal);
             Assert.IsType<HtmlString>(htmlAttribute.Value);
-            Assert.Equal(expectedValue, htmlAttribute.Value.ToString(), StringComparer.Ordinal);
+            Assert.Equal(expectedValue, HtmlContentUtilities.HtmlContentToString((IHtmlContent)htmlAttribute.Value));
             Assert.False(htmlAttribute.Minimized);
             var allAttribute = Assert.Single(executionContext.AllAttributes);
             Assert.Equal("someattr", allAttribute.Name, StringComparer.Ordinal);
@@ -1032,7 +1033,7 @@ namespace Microsoft.AspNet.Mvc.Razor
             // Assert
             var buffer = writer.BufferedWriter.Entries;
             Assert.Equal(1, buffer.Count);
-            Assert.Equal("Hello world", buffer[0]);
+            Assert.Equal("Hello world", HtmlContentUtilities.HtmlContentToString(((IHtmlContent)buffer[0])));
         }
 
         public static TheoryData<TagHelperOutput, string> WriteTagHelper_InputData
@@ -1660,7 +1661,7 @@ namespace Microsoft.AspNet.Mvc.Razor
             await page.ExecuteAsync();
 
             // Assert
-            Assert.Equal(expected, writer.ToString());
+            Assert.Equal(expected, HtmlContentUtilities.HtmlContentToString(writer.Content));
         }
 
         [Theory]
@@ -1702,7 +1703,7 @@ namespace Microsoft.AspNet.Mvc.Razor
             await page.ExecuteAsync();
 
             // Assert
-            Assert.Equal(expected, writer.ToString());
+            Assert.Equal(expected, HtmlContentUtilities.HtmlContentToString(writer.Content));
         }
 
         [Fact]
@@ -1731,7 +1732,7 @@ namespace Microsoft.AspNet.Mvc.Razor
             await page.ExecuteAsync();
 
             // Assert
-            Assert.Equal("<p>Hello World!</p>", writer.ToString());
+            Assert.Equal("<p>Hello World!</p>", HtmlContentUtilities.HtmlContentToString(writer.Content));
         }
 
         [Theory]
@@ -1760,7 +1761,7 @@ namespace Microsoft.AspNet.Mvc.Razor
             await page.ExecuteAsync();
 
             // Assert
-            Assert.Equal(expected, writer.ToString());
+            Assert.Equal(expected, HtmlContentUtilities.HtmlContentToString(writer.Content));
         }
 
         private static TagHelperOutput GetTagHelperOutput(

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/RazorTextWriterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/RazorTextWriterTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Testing;
 using Microsoft.Framework.WebEncoders.Testing;
 using Moq;
@@ -213,6 +214,73 @@ namespace Microsoft.AspNet.Mvc.Razor.Test
             // Assert
             var actual = writer.BufferedWriter.Entries;
             Assert.Equal<object>(new[] { input1, input2, newLine, input3, input4, newLine }, actual);
+        }
+
+        [Fact]
+        public void Write_HtmlContent_AddsToEntries()
+        {
+            // Arrange
+            var writer = new RazorTextWriter(TextWriter.Null, Encoding.UTF8, new CommonTestEncoder());
+            var content = new HtmlString("Hello, world!");
+
+            // Act
+            writer.Write(content);
+
+            // Assert
+            Assert.Collection(
+                writer.BufferedWriter.Entries,
+                item => Assert.Same(content, item));
+        }
+
+        [Fact]
+        public void Write_Object_HtmlContent_AddsToEntries()
+        {
+            // Arrange
+            var writer = new RazorTextWriter(TextWriter.Null, Encoding.UTF8, new CommonTestEncoder());
+            var content = new HtmlString("Hello, world!");
+
+            // Act
+            writer.Write((object)content);
+
+            // Assert
+            Assert.Collection(
+                writer.BufferedWriter.Entries,
+                item => Assert.Same(content, item));
+        }
+
+        [Fact]
+        public void WriteLine_Object_HtmlContent_AddsToEntries()
+        {
+            // Arrange
+            var writer = new RazorTextWriter(TextWriter.Null, Encoding.UTF8, new CommonTestEncoder());
+            var content = new HtmlString("Hello, world!");
+
+            // Act
+            writer.WriteLine(content);
+
+            // Assert
+            Assert.Collection(
+                writer.BufferedWriter.Entries,
+                item => Assert.Same(content, item),
+                item => Assert.Equal(Environment.NewLine, item));
+        }
+
+        [Fact]
+        public void Write_HtmlContent_AfterFlush_GoesToStream()
+        {
+            // Arrange
+            var stringWriter = new StringWriter();
+
+            var writer = new RazorTextWriter(stringWriter, Encoding.UTF8, new CommonTestEncoder());
+            writer.Flush();
+
+            var content = new HtmlString("Hello, world!");
+
+            // Act
+            writer.Write(content);
+
+            // Assert
+            Assert.Equal("Hello, world!", stringWriter.ToString());
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/Rendering/StringCollectionTextWriterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/Rendering/StringCollectionTextWriterTest.cs
@@ -116,6 +116,55 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         [Fact]
+        public void Write_HtmlContent_AddsToEntries()
+        {
+            // Arrange
+            var writer = new StringCollectionTextWriter(Encoding.UTF8);
+            var content = new HtmlString("Hello, world!");
+
+            // Act
+            writer.Write(content);
+
+            // Assert
+            Assert.Collection(
+                writer.Entries,
+                item => Assert.Same(content, item));
+        }
+
+        [Fact]
+        public void Write_Object_HtmlContent_AddsToEntries()
+        {
+            // Arrange
+            var writer = new StringCollectionTextWriter(Encoding.UTF8);
+            var content = new HtmlString("Hello, world!");
+
+            // Act
+            writer.Write((object)content);
+
+            // Assert
+            Assert.Collection(
+                writer.Entries,
+                item => Assert.Same(content, item));
+        }
+
+        [Fact]
+        public void WriteLine_Object_HtmlContent_AddsToEntries()
+        {
+            // Arrange
+            var writer = new StringCollectionTextWriter(Encoding.UTF8);
+            var content = new HtmlString("Hello, world!");
+
+            // Act
+            writer.WriteLine(content);
+
+            // Assert
+            Assert.Collection(
+                writer.Entries,
+                item => Assert.Same(content, item),
+                item => Assert.Equal(Environment.NewLine, item));
+        }
+
+        [Fact]
         public void Copy_CopiesContent_IfTargetTextWriterIsAStringCollectionTextWriter()
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/Rendering/StringHtmlContentTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/Rendering/StringHtmlContentTest.cs
@@ -10,26 +10,6 @@ namespace Microsoft.AspNet.Mvc.Rendering
     public class StringHtmlContentTest
     {
         [Fact]
-        public void ToString_ReturnsAString()
-        {
-            // Arrange & Act
-            var content = new StringHtmlContent("Hello World");
-
-            // Assert
-            Assert.Equal("Hello World", content.ToString());
-        }
-
-        [Fact]
-        public void ToString_ReturnsNullForNullInput()
-        {
-            // Arrange & Act
-            var content = new StringHtmlContent(null);
-
-            // Assert
-            Assert.Null(content.ToString());
-        }
-
-        [Fact]
         public void WriteTo_WritesContent()
         {
             // Arrange & Act


### PR DESCRIPTION
In the current checked in code, an `IHtmlContent` instance will write itself out when it reaches the `RazorTextWriter`. This means that anything that needs to be encoded gets encoded at this time.

Generally (unless you flush) - the `RazorTextWriter` is buffering, which means that each of these writes adds an entry to a `List<object>` held onto by `StringCollectionTextWriter`. When you encode, text is written character by character, leading to lots of little entries. This allocates a lot even for a small site: 
![image](https://cloud.githubusercontent.com/assets/1430011/9886637/33aedcc2-5ba0-11e5-95e9-57bca044b6e3.png)

That 4 MB translates into over 1kb/request, for a very very small amount of HTML output.

---------------

The change here is to preserve the `IHtmlContent`-ness of values until they need to actually go on the wire (generally when the response is sent). This means that text is encoded character-by-character into the final `TextWriter` - which is an optimized path.

Look at the amount of `string` and `object[]` allocations with these changes

Before:
![image](https://cloud.githubusercontent.com/assets/1430011/9886729/9a24d81c-5ba0-11e5-895b-ed877cf703ff.png)


After:
![image](https://cloud.githubusercontent.com/assets/1430011/9886752/bb4b5dd6-5ba0-11e5-8544-58f8a5cfc34e.png)

`string`s are reduced by about 1.8mb
`object[]`s are reduced by about 5.5mb

This is for 3000 requests on a very small page.