### PR TITLE
Fix #3087 - use IHtmlContentBuilder in TagBuilder

### DIFF
--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/DefaultDisplayTemplates.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/DefaultDisplayTemplates.cs
@@ -52,13 +52,11 @@ namespace Microsoft.AspNet.Mvc.Rendering
             selectTag.AddCssClass("tri-state");
             selectTag.Attributes["disabled"] = "disabled";
 
-            var content = new BufferedHtmlContent();
             foreach (var item in TriStateValues(value))
             {
-                content.Append(DefaultHtmlGenerator.GenerateOption(item, item.Text));
+                selectTag.InnerHtml.Append(DefaultHtmlGenerator.GenerateOption(item, item.Text));
             }
-
-            selectTag.InnerHtml = content;
+            
             return selectTag;
         }
 
@@ -251,14 +249,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
                     if (!string.IsNullOrEmpty(label))
                     {
                         var labelTag = new TagBuilder("div");
-                        labelTag.SetInnerText(label);
+                        labelTag.InnerHtml.SetContent(label);
                         labelTag.AddCssClass("display-label");
                         content.AppendLine(labelTag);
                     }
 
                     var valueDivTag = new TagBuilder("div");
                     valueDivTag.AddCssClass("display-field");
-                    valueDivTag.InnerHtml = templateBuilderResult;
+                    valueDivTag.InnerHtml.SetContent(templateBuilderResult);
                     content.AppendLine(valueDivTag);
                 }
                 else
@@ -304,7 +302,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         {
             var hyperlinkTag = new TagBuilder("a");
             hyperlinkTag.MergeAttribute("href", uriString);
-            hyperlinkTag.SetInnerText(linkedText);
+            hyperlinkTag.InnerHtml.SetContent(linkedText);
             return hyperlinkTag;
         }
     }

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/DefaultEditorTemplates.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/DefaultEditorTemplates.cs
@@ -274,22 +274,20 @@ namespace Microsoft.AspNet.Mvc.Rendering
                     {
                         var labelTag = new TagBuilder("div");
                         labelTag.AddCssClass("editor-label");
-                        labelTag.InnerHtml = label;
+                        labelTag.InnerHtml.SetContent(label);
                         content.AppendLine(labelTag);
                     }
 
                     var valueDivTag = new TagBuilder("div");
                     valueDivTag.AddCssClass("editor-field");
-
-                    var innerContent = new BufferedHtmlContent();
-                    innerContent.Append(templateBuilderResult);
-                    innerContent.AppendEncoded(" ");
-                    innerContent.Append(htmlHelper.ValidationMessage(
+                    
+                    valueDivTag.InnerHtml.Append(templateBuilderResult);
+                    valueDivTag.InnerHtml.AppendEncoded(" ");
+                    valueDivTag.InnerHtml.Append(htmlHelper.ValidationMessage(
                         propertyMetadata.PropertyName,
                         message: null,
                         htmlAttributes: null,
                         tag: null));
-                    valueDivTag.InnerHtml = innerContent;
 
                     content.AppendLine(valueDivTag);
                 }

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/TagBuilder.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/Html/TagBuilder.cs
@@ -24,13 +24,18 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
             TagName = tagName;
             Attributes = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            InnerHtml = new BufferedHtmlContent();
         }
 
-        public IDictionary<string, string> Attributes { get; private set; }
+        /// <summary>
+        /// Gets the set of attributes that will be written to the tag.
+        /// </summary>
+        public IDictionary<string, string> Attributes { get; }
 
-        public IHtmlContent InnerHtml { get; [param: NotNull] set; } = HtmlString.Empty;
+        public IHtmlContentBuilder InnerHtml { get; }
 
-        public string TagName { get; private set; }
+        public string TagName { get; }
 
         /// <summary>
         /// The <see cref="Rendering.TagRenderMode"/> with which the tag is written.
@@ -185,11 +190,6 @@ namespace Microsoft.AspNet.Mvc.Rendering
                     MergeAttribute(key, value, replaceExisting);
                 }
             }
-        }
-
-        public void SetInnerText(string innerText)
-        {
-            InnerHtml = new StringHtmlContent(innerText);
         }
 
         /// <inheritdoc />

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ValidationMessageTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ValidationMessageTagHelperTest.cs
@@ -5,13 +5,13 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Html.Abstractions;
 using Microsoft.AspNet.Http.Internal;
 using Microsoft.AspNet.Mvc.Actions;
 using Microsoft.AspNet.Mvc.ModelBinding;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 using Microsoft.AspNet.Routing;
-using Microsoft.Framework.WebEncoders.Testing;
 using Moq;
 using Xunit;
 
@@ -143,10 +143,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             string childContent, string outputContent, string expectedOutputContent)
         {
             // Arrange
-            var tagBuilder = new TagBuilder("span2")
-            {
-                InnerHtml = new HtmlString("New HTML")
-            };
+            var tagBuilder = new TagBuilder("span2");
+            tagBuilder.InnerHtml.SetContentEncoded("New HTML");
             tagBuilder.Attributes.Add("data-foo", "bar");
             tagBuilder.Attributes.Add("data-hello", "world");
 
@@ -204,10 +202,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             string childContent, string expectedOutputContent)
         {
             // Arrange
-            var tagBuilder = new TagBuilder("span2")
-            {
-                InnerHtml = new HtmlString("New HTML")
-            };
+            var tagBuilder = new TagBuilder("span2");
+            tagBuilder.InnerHtml.SetContentEncoded("New HTML");
             tagBuilder.Attributes.Add("data-foo", "bar");
             tagBuilder.Attributes.Add("data-hello", "world");
 

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ValidationSummaryTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ValidationSummaryTagHelperTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Html.Abstractions;
 using Microsoft.AspNet.Http.Internal;
 using Microsoft.AspNet.Mvc.Actions;
 using Microsoft.AspNet.Mvc.ModelBinding;
@@ -13,7 +14,6 @@ using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 using Microsoft.AspNet.Routing;
 using Microsoft.AspNet.Testing;
-using Microsoft.Framework.WebEncoders;
 using Moq;
 using Xunit;
 
@@ -131,11 +131,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         public async Task ProcessAsync_MergesTagBuilderFromGenerateValidationSummary()
         {
             // Arrange
-            var tagBuilder = new TagBuilder("span2")
-            {
-                InnerHtml = new HtmlString("New HTML")
-            };
-
+            var tagBuilder = new TagBuilder("span2");
+            tagBuilder.InnerHtml.SetContentEncoded("New HTML");
             tagBuilder.Attributes.Add("data-foo", "bar");
             tagBuilder.Attributes.Add("data-hello", "world");
             tagBuilder.Attributes.Add("anything", "something");
@@ -225,10 +222,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         public async Task ProcessAsync_GeneratesValidationSummaryWhenNotNone(ValidationSummary validationSummary)
         {
             // Arrange
-            var tagBuilder = new TagBuilder("span2")
-            {
-                InnerHtml = new HtmlString("New HTML")
-            };
+            var tagBuilder = new TagBuilder("span2");
+            tagBuilder.InnerHtml.SetContentEncoded("New HTML");
 
             var generator = new Mock<IHtmlGenerator>();
             generator

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/Rendering/TagBuilderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/Rendering/TagBuilderTest.cs
@@ -3,8 +3,8 @@
 
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.AspNet.Html.Abstractions;
 using Microsoft.AspNet.Mvc.Rendering;
-using Microsoft.AspNet.Mvc.TestCommon;
 using Microsoft.Framework.WebEncoders.Testing;
 using Xunit;
 
@@ -92,21 +92,6 @@ namespace Microsoft.AspNet.Mvc.Core.Rendering
             }
         }
 
-        [Fact]
-        public void SetInnerText_HtmlEncodesValue()
-        {
-            // Arrange
-            var tagBuilder = new TagBuilder("p");
-
-            // Act
-            tagBuilder.SetInnerText("TestValue");
-
-            // Assert
-            Assert.Equal(
-                "HtmlEncode[[TestValue]]",
-                HtmlContentUtilities.HtmlContentToString(tagBuilder.InnerHtml));
-        }
-
         [Theory]
         [InlineData("HelloWorld", "HelloWorld")]
         [InlineData("¡HelloWorld", "zHelloWorld")]
@@ -118,6 +103,24 @@ namespace Microsoft.AspNet.Mvc.Core.Rendering
 
             // Assert
             Assert.Equal(output, result);
+        }
+
+        [Fact]
+        public void WriteTo_IncludesInnerHtml()
+        {
+            // Arrange
+            var tagBuilder = new TagBuilder("p");
+            tagBuilder.InnerHtml.AppendEncoded("<span>Hello</span>");
+            tagBuilder.InnerHtml.Append(", World!");
+
+            // Act
+            using (var writer = new StringWriter())
+            {
+                tagBuilder.WriteTo(writer, new CommonTestEncoder());
+
+                // Assert
+                Assert.Equal("<p><span>Hello</span>HtmlEncode[[, World!]]</p>", writer.ToString());
+            }
         }
     }
 }

--- a/test/WebSites/ActivatorWebSite/TagHelpers/TitleTagHelper.cs
+++ b/test/WebSites/ActivatorWebSite/TagHelpers/TitleTagHelper.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.AspNet.Html.Abstractions;
 using Microsoft.AspNet.Mvc;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
@@ -26,8 +27,8 @@ namespace ActivatorWebSite.TagHelpers
             (HtmlHelper as ICanHasViewContext)?.Contextualize(ViewContext);
 
             var builder = new TagBuilder("h2");
-            var title = ViewContext.ViewBag.Title;
-            builder.SetInnerText(title);
+            var title = (string)ViewContext.ViewBag.Title;
+            builder.InnerHtml.SetContent(title);
             output.PreContent.SetContent(builder);
         }
     }


### PR DESCRIPTION
Improves authoring experience when using TagBuilder by taking advantage of
IHtmlContentBuilder and its extension methods.

TagBuilder.InnerHtml is no longer settable.