### PR TITLE
[Build break] Correct doc comment references to match current namespaces

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/FormatFilterAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/FormatFilterAttribute.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNet.Mvc
 {
     /// <summary>
     /// A filter which will use the format value in the route data or query string to set the content type on an
-    /// <see cref="ActionResults.ObjectResult" /> returned from an action.
+    /// <see cref="ObjectResult" /> returned from an action.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public class FormatFilterAttribute : Attribute, IFilterFactory

--- a/src/Microsoft.AspNet.Mvc.Core/IUrlHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/IUrlHelper.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNet.Mvc
     public interface IUrlHelper
     {
         /// <summary>
-        /// Generates a fully qualified or absolute URL specified by <see cref="Mvc.UrlActionContext"/> for an action
+        /// Generates a fully qualified or absolute URL specified by <see cref="UrlActionContext"/> for an action
         /// method, which contains action name, controller name, route values, protocol to use, host name, and fragment.
         /// </summary>
         /// <param name="actionContext">The context object for the generated URLs for an action method.</param>
@@ -52,7 +52,7 @@ namespace Microsoft.AspNet.Mvc
         bool IsLocalUrl(string url);
 
         /// <summary>
-        /// Generates a fully qualified or absolute URL specified by <see cref="Mvc.UrlRouteContext"/>, which
+        /// Generates a fully qualified or absolute URL specified by <see cref="UrlRouteContext"/>, which
         /// contains the route name, the route values, protocol to use, host name and fragment.
         /// </summary>
         /// <param name="routeContext">The context object for the generated URLs for a route.</param>

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/GlobbingUrlBuilder.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/GlobbingUrlBuilder.cs
@@ -12,7 +12,8 @@ using Microsoft.Framework.FileSystemGlobbing;
 namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
 {
     /// <summary>
-    /// Utility methods for <see cref="ITagHelper"/>'s that support attributes containing file globbing patterns.
+    /// Utility methods for <see cref="AspNet.Razor.Runtime.TagHelpers.ITagHelper"/>'s that support
+    /// attributes containing file globbing patterns.
     /// </summary>
     public class GlobbingUrlBuilder
     {

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/PartialModeMatchLogValuesOfT.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/PartialModeMatchLogValuesOfT.cs
@@ -9,7 +9,7 @@ using Microsoft.Framework.Logging;
 namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
 {
     /// <summary>
-    /// Log values for <see cref="ITagHelper"/> instances that opt out of
+    /// Log values for <see cref="AspNet.Razor.Runtime.TagHelpers.ITagHelper"/> instances that opt out of
     /// processing due to missing attributes for one of several possible modes.
     /// </summary>
     public class PartialModeMatchLogValues<TMode> : ILogValues

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/PartialViewResult.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/PartialViewResult.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.Mvc
         /// Gets or sets the name of the partial view to render.
         /// </summary>
         /// <remarks>
-        /// When <c>null</c>, defaults to <see cref="ActionDescriptor.Name"/>.
+        /// When <c>null</c>, defaults to <see cref="Actions.ActionDescriptor.Name"/>.
         /// </remarks>
         public string ViewName { get; set; }
 

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/HtmlHelperDisplayExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/HtmlHelperDisplayExtensions.cs
@@ -54,8 +54,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </param>
         /// <param name="additionalViewData">
         /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{string, object}"/>
-        /// that can contain additional view data that will be merged into the <see cref="ViewDataDictionary{TModel}"/>
-        /// instance created for the template.
+        /// that can contain additional view data that will be merged into the
+        /// <see cref="ViewFeatures.ViewDataDictionary{TModel}"/> instance created for the template.
         /// </param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
         /// <remarks>
@@ -131,8 +131,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <param name="templateName">The name of the template used to create the HTML markup.</param>
         /// <param name="additionalViewData">
         /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{string, object}"/>
-        /// that can contain additional view data that will be merged into the <see cref="ViewDataDictionary{TModel}"/>
-        /// instance created for the template.
+        /// that can contain additional view data that will be merged into the
+        /// <see cref="ViewFeatures.ViewDataDictionary{TModel}"/> instance created for the template.
         /// </param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
         /// <remarks>
@@ -240,8 +240,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="additionalViewData">
         /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{string, object}"/>
-        /// that can contain additional view data that will be merged into the <see cref="ViewDataDictionary{TModel}"/>
-        /// instance created for the template.
+        /// that can contain additional view data that will be merged into the
+        /// <see cref="ViewFeatures.ViewDataDictionary{TModel}"/> instance created for the template.
         /// </param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
@@ -311,8 +311,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <param name="templateName">The name of the template used to create the HTML markup.</param>
         /// <param name="additionalViewData">
         /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{string, object}"/>
-        /// that can contain additional view data that will be merged into the <see cref="ViewDataDictionary{TModel}"/>
-        /// instance created for the template.
+        /// that can contain additional view data that will be merged into the
+        /// <see cref="ViewFeatures.ViewDataDictionary{TModel}"/> instance created for the template.
         /// </param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
@@ -410,8 +410,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="additionalViewData">
         /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{string, object}"/>
-        /// that can contain additional view data that will be merged into the <see cref="ViewDataDictionary{TModel}"/>
-        /// instance created for the template.
+        /// that can contain additional view data that will be merged into the
+        /// <see cref="ViewFeatures.ViewDataDictionary{TModel}"/> instance created for the template.
         /// </param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
         /// <remarks>
@@ -468,8 +468,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <param name="templateName">The name of the template used to create the HTML markup.</param>
         /// <param name="additionalViewData">
         /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{string, object}"/>
-        /// that can contain additional view data that will be merged into the <see cref="ViewDataDictionary{TModel}"/>
-        /// instance created for the template.
+        /// that can contain additional view data that will be merged into the
+        /// <see cref="ViewFeatures.ViewDataDictionary{TModel}"/> instance created for the template.
         /// </param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
         /// <remarks>
@@ -541,8 +541,8 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </param>
         /// <param name="additionalViewData">
         /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{string, object}"/>
-        /// that can contain additional view data that will be merged into the <see cref="ViewDataDictionary{TModel}"/>
-        /// instance created for the template.
+        /// that can contain additional view data that will be merged into the
+        /// <see cref="ViewFeatures.ViewDataDictionary{TModel}"/> instance created for the template.
         /// </param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
         /// <remarks>

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/ViewContext.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/ViewContext.cs
@@ -87,7 +87,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="Rendering.FormContext"/> for the form element being rendered.
+        /// Gets or sets the <see cref="FormContext"/> for the form element being rendered.
         /// A default context is returned if no form is currently being rendered.
         /// </summary>
         public virtual FormContext FormContext

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/ViewContextAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/ViewContextAttribute.cs
@@ -7,8 +7,8 @@ namespace Microsoft.AspNet.Mvc.ViewFeatures
 {
     /// <summary>
     /// Specifies that a tag helper property should be set with the current
-    /// <see cref="ViewContext"/> when creating the tag helper. The property must have a public
-    /// set method.
+    /// <see cref="Rendering.ViewContext"/> when creating the tag helper. The property must have a
+    /// public set method.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public class ViewContextAttribute : Attribute


### PR DESCRIPTION
- local command line builds fail consistently during `xml-docs-test`
- bit buried on the CI machine but repo is not testing successfully there