### PR TITLE
Add `InputFormatterResult` and `InputFormatterContext.ModelName`

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Abstractions/Formatters/IInputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/Formatters/IInputFormatter.cs
@@ -6,25 +6,26 @@ using System.Threading.Tasks;
 namespace Microsoft.AspNet.Mvc.Formatters
 {
     /// <summary>
-    /// Reads an object from the request body.
+    /// Reads an <c>object</c> from the request body.
     /// </summary>
     public interface IInputFormatter
     {
         /// <summary>
-        /// Determines whether this <see cref="IInputFormatter"/> can de-serialize
-        /// an object of the specified type.
+        /// Determines whether this <see cref="IInputFormatter"/> can deserialize an <c>object</c> of the
+        /// <paramref name="context"/>'s <see cref="InputFormatterContext.ModelType"/>.
         /// </summary>
-        /// <param name="context">Input formatter context associated with this call.</param>
-        /// <returns>True if this <see cref="IInputFormatter"/> supports the passed in
-        /// request's content-type and is able to de-serialize the request body.
-        /// False otherwise.</returns>
+        /// <param name="context">The <see cref="InputFormatterContext"/>.</param>
+        /// <returns>
+        /// <c>true</c> if this <see cref="IInputFormatter"/> can deserialize an <c>object</c> of the
+        /// <paramref name="context"/>'s <see cref="InputFormatterContext.ModelType"/>. <c>false</c> otherwise.
+        /// </returns>
         bool CanRead(InputFormatterContext context);
 
         /// <summary>
-        /// Called during deserialization to read an object from the request.
+        /// Reads an <c>object</c> from the request body.
         /// </summary>
-        /// <param name="context">Input formatter context associated with this call.</param>
-        /// <returns>A task that deserializes the request body.</returns>
-        Task<object> ReadAsync(InputFormatterContext context);
+        /// <param name="context">The <see cref="InputFormatterContext"/>.</param>
+        /// <returns>A task that on completion deserializes the request body.</returns>
+        Task<InputFormatterResult> ReadAsync(InputFormatterContext context);
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Abstractions/Formatters/IInputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/Formatters/IInputFormatter.cs
@@ -6,26 +6,26 @@ using System.Threading.Tasks;
 namespace Microsoft.AspNet.Mvc.Formatters
 {
     /// <summary>
-    /// Reads an <c>object</c> from the request body.
+    /// Reads an object from the request body.
     /// </summary>
     public interface IInputFormatter
     {
         /// <summary>
-        /// Determines whether this <see cref="IInputFormatter"/> can deserialize an <c>object</c> of the
+        /// Determines whether this <see cref="IInputFormatter"/> can deserialize an object of the
         /// <paramref name="context"/>'s <see cref="InputFormatterContext.ModelType"/>.
         /// </summary>
         /// <param name="context">The <see cref="InputFormatterContext"/>.</param>
         /// <returns>
-        /// <c>true</c> if this <see cref="IInputFormatter"/> can deserialize an <c>object</c> of the
+        /// <c>true</c> if this <see cref="IInputFormatter"/> can deserialize an object of the
         /// <paramref name="context"/>'s <see cref="InputFormatterContext.ModelType"/>. <c>false</c> otherwise.
         /// </returns>
         bool CanRead(InputFormatterContext context);
 
         /// <summary>
-        /// Reads an <c>object</c> from the request body.
+        /// Reads an object from the request body.
         /// </summary>
         /// <param name="context">The <see cref="InputFormatterContext"/>.</param>
-        /// <returns>A task that on completion deserializes the request body.</returns>
+        /// <returns>A <see cref="Task"/> that on completion deserializes the request body.</returns>
         Task<InputFormatterResult> ReadAsync(InputFormatterContext context);
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Abstractions/Formatters/InputFormatterContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/Formatters/InputFormatterContext.cs
@@ -19,6 +19,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
         /// <param name="httpContext">
         /// The <see cref="Http.HttpContext"/> for the current operation.
         /// </param>
+        /// <param name="modelName">The name of the model.</param>
         /// <param name="modelState">
         /// The <see cref="ModelStateDictionary"/> for recording errors.
         /// </param>
@@ -27,10 +28,12 @@ namespace Microsoft.AspNet.Mvc.Formatters
         /// </param>
         public InputFormatterContext(
             [NotNull] HttpContext httpContext,
+            [NotNull] string modelName,
             [NotNull] ModelStateDictionary modelState,
             [NotNull] Type modelType)
         {
             HttpContext = httpContext;
+            ModelName = modelName;
             ModelState = modelState;
             ModelType = modelType;
         }
@@ -38,7 +41,12 @@ namespace Microsoft.AspNet.Mvc.Formatters
         /// <summary>
         /// Gets the <see cref="Http.HttpContext"/> associated with the current operation.
         /// </summary>
-        public HttpContext HttpContext { get; private set; }
+        public HttpContext HttpContext { get; }
+
+        /// <summary>
+        /// Gets the name of the model. Used as the key or key prefix for errors added to <see cref="ModelState"/>.
+        /// </summary>
+        public string ModelName { get; }
 
         /// <summary>
         /// Gets the <see cref="ModelStateDictionary"/> associated with the current operation.
@@ -48,6 +56,6 @@ namespace Microsoft.AspNet.Mvc.Formatters
         /// <summary>
         /// Gets the expected <see cref="Type"/> of the model represented by the request body.
         /// </summary>
-        public Type ModelType { get; private set; }
+        public Type ModelType { get; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Abstractions/Formatters/InputFormatterResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/Formatters/InputFormatterResult.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNet.Mvc.Formatters
+{
+    /// <summary>
+    /// Result of a <see cref="IInputFormatter.ReadAsync"/> operation.
+    /// </summary>
+    public class InputFormatterResult
+    {
+        private static readonly InputFormatterResult _failed = new InputFormatterResult();
+        private static readonly Task<InputFormatterResult> _failedAsync = Task.FromResult(_failed);
+
+        private InputFormatterResult()
+        {
+            HasError = true;
+        }
+
+        private InputFormatterResult(object model)
+        {
+            Model = model;
+        }
+
+        /// <summary>
+        /// Gets an indication whether the <see cref="IInputFormatter.ReadAsync"/> operation had an error.
+        /// </summary>
+        public bool HasError { get; }
+
+        /// <summary>
+        /// Gets the deserialized <see cref="object"/>.
+        /// </summary>
+        /// <value>
+        /// <c>null</c> if <see cref="HasError"/> is <c>true</c>.
+        /// </value>
+        public object Model { get; }
+
+        /// <summary>
+        /// Returns an <see cref="InputFormatterResult"/> indicating the <see cref="IInputFormatter.ReadAsync"/>
+        /// operation failed.
+        /// </summary>
+        /// <returns>
+        /// An <see cref="InputFormatterResult"/> indicating the <see cref="IInputFormatter.ReadAsync"/>
+        /// operation failed i.e. with <see cref="HasError"/> <c>true</c>.
+        /// </returns>
+        public static InputFormatterResult Failed()
+        {
+            return _failed;
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Task"/> that on completion provides an <see cref="InputFormatterResult"/> indicating
+        /// the <see cref="IInputFormatter.ReadAsync"/> operation failed.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> that on completion provides an <see cref="InputFormatterResult"/> indicating the
+        /// <see cref="IInputFormatter.ReadAsync"/> operation failed i.e. with <see cref="HasError"/> <c>true</c>.
+        /// </returns>
+        public static Task<InputFormatterResult> FailedAsync()
+        {
+            return _failedAsync;
+        }
+
+        /// <summary>
+        /// Returns an <see cref="InputFormatterResult"/> indicating the <see cref="IInputFormatter.ReadAsync"/>
+        /// operation was successful.
+        /// </summary>
+        /// <param name="model">The deserialized <see cref="object"/>.</param>
+        /// <returns>
+        /// An <see cref="InputFormatterResult"/> indicating the <see cref="IInputFormatter.ReadAsync"/>
+        /// operation succeeded i.e. with <see cref="HasError"/> <c>false</c>.
+        /// </returns>
+        public static InputFormatterResult Successful(object model)
+        {
+            return new InputFormatterResult(model);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Task"/> that on completion provides an <see cref="InputFormatterResult"/> indicating
+        /// the <see cref="IInputFormatter.ReadAsync"/> operation was successful.
+        /// </summary>
+        /// <param name="model">The deserialized <see cref="object"/>.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that on completion provides an <see cref="InputFormatterResult"/> indicating the
+        /// <see cref="IInputFormatter.ReadAsync"/> operation succeeded i.e. with <see cref="HasError"/> <c>false</c>.
+        /// </returns>
+        public static Task<InputFormatterResult> SuccessfulAsync(object model)
+        {
+            return Task.FromResult(Successful(model));
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Abstractions/Formatters/InputFormatterResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/Formatters/InputFormatterResult.cs
@@ -10,8 +10,8 @@ namespace Microsoft.AspNet.Mvc.Formatters
     /// </summary>
     public class InputFormatterResult
     {
-        private static readonly InputFormatterResult _failed = new InputFormatterResult();
-        private static readonly Task<InputFormatterResult> _failedAsync = Task.FromResult(_failed);
+        private static readonly InputFormatterResult _failure = new InputFormatterResult();
+        private static readonly Task<InputFormatterResult> _failureAsync = Task.FromResult(_failure);
 
         private InputFormatterResult()
         {
@@ -44,9 +44,9 @@ namespace Microsoft.AspNet.Mvc.Formatters
         /// An <see cref="InputFormatterResult"/> indicating the <see cref="IInputFormatter.ReadAsync"/>
         /// operation failed i.e. with <see cref="HasError"/> <c>true</c>.
         /// </returns>
-        public static InputFormatterResult Failed()
+        public static InputFormatterResult Failure()
         {
-            return _failed;
+            return _failure;
         }
 
         /// <summary>
@@ -57,9 +57,9 @@ namespace Microsoft.AspNet.Mvc.Formatters
         /// A <see cref="Task"/> that on completion provides an <see cref="InputFormatterResult"/> indicating the
         /// <see cref="IInputFormatter.ReadAsync"/> operation failed i.e. with <see cref="HasError"/> <c>true</c>.
         /// </returns>
-        public static Task<InputFormatterResult> FailedAsync()
+        public static Task<InputFormatterResult> FailureAsync()
         {
-            return _failedAsync;
+            return _failureAsync;
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
         /// An <see cref="InputFormatterResult"/> indicating the <see cref="IInputFormatter.ReadAsync"/>
         /// operation succeeded i.e. with <see cref="HasError"/> <c>false</c>.
         /// </returns>
-        public static InputFormatterResult Successful(object model)
+        public static InputFormatterResult Success(object model)
         {
             return new InputFormatterResult(model);
         }
@@ -85,9 +85,9 @@ namespace Microsoft.AspNet.Mvc.Formatters
         /// A <see cref="Task"/> that on completion provides an <see cref="InputFormatterResult"/> indicating the
         /// <see cref="IInputFormatter.ReadAsync"/> operation succeeded i.e. with <see cref="HasError"/> <c>false</c>.
         /// </returns>
-        public static Task<InputFormatterResult> SuccessfulAsync(object model)
+        public static Task<InputFormatterResult> SuccessAsync(object model)
         {
-            return Task.FromResult(Successful(model));
+            return Task.FromResult(Success(model));
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Formatters.Json/JsonPatchInputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Formatters.Json/JsonPatchInputFormatter.cs
@@ -27,15 +27,19 @@ namespace Microsoft.AspNet.Mvc.Formatters
         }
 
         /// <inheritdoc />
-        public async override Task<object> ReadRequestBodyAsync([NotNull] InputFormatterContext context)
+        public async override Task<InputFormatterResult> ReadRequestBodyAsync([NotNull] InputFormatterContext context)
         {
-            var jsonPatchDocument = (IJsonPatchDocument)(await base.ReadRequestBodyAsync(context));
-            if (jsonPatchDocument != null && SerializerSettings.ContractResolver != null)
+            var result = await base.ReadRequestBodyAsync(context);
+            if (!result.HasError)
             {
-                jsonPatchDocument.ContractResolver = SerializerSettings.ContractResolver;
+                var jsonPatchDocument = (IJsonPatchDocument)result.Model;
+                if (jsonPatchDocument != null && SerializerSettings.ContractResolver != null)
+                {
+                    jsonPatchDocument.ContractResolver = SerializerSettings.ContractResolver;
+                }
             }
 
-            return (object)jsonPatchDocument;
+            return result;
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.AspNet.Mvc.Formatters.Xml/XmlDataContractSerializerInputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Formatters.Xml/XmlDataContractSerializerInputFormatter.cs
@@ -89,17 +89,13 @@ namespace Microsoft.AspNet.Mvc.Formatters
         /// <inheritdoc />
         public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
         {
-            var request = context.HttpContext.Request;
-
-            MediaTypeHeaderValue requestContentType;
-            MediaTypeHeaderValue.TryParse(request.ContentType, out requestContentType);
-            var effectiveEncoding = SelectCharacterEncoding(requestContentType);
+            var effectiveEncoding = SelectCharacterEncoding(context);
             if (effectiveEncoding == null)
             {
-                context.ModelState.TryAddModelError(context.ModelName, GetNoEncodingMessage());
-                return InputFormatterResult.FailedAsync();
+                return InputFormatterResult.FailureAsync();
             }
 
+            var request = context.HttpContext.Request;
             using (var xmlReader = CreateXmlReader(new NonDisposableStream(request.Body), effectiveEncoding))
             {
                 var type = GetSerializableType(context.ModelType);
@@ -117,7 +113,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
                     }
                 }
 
-                return InputFormatterResult.SuccessfulAsync(deserializedObject);
+                return InputFormatterResult.SuccessAsync(deserializedObject);
             }
         }
 

--- a/src/Microsoft.AspNet.Mvc.Formatters.Xml/XmlSerializerInputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Formatters.Xml/XmlSerializerInputFormatter.cs
@@ -65,18 +65,19 @@ namespace Microsoft.AspNet.Mvc.Formatters
             get { return _readerQuotas; }
         }
 
-        /// <summary>
-        /// Reads the input XML.
-        /// </summary>
-        /// <param name="context">The input formatter context which contains the body to be read.</param>
-        /// <returns>Task which reads the input.</returns>
-        public override Task<object> ReadRequestBodyAsync(InputFormatterContext context)
+        /// <inheritdoc />
+        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
         {
             var request = context.HttpContext.Request;
 
             MediaTypeHeaderValue requestContentType;
             MediaTypeHeaderValue.TryParse(request.ContentType, out requestContentType);
             var effectiveEncoding = SelectCharacterEncoding(requestContentType);
+            if (effectiveEncoding == null)
+            {
+                context.ModelState.TryAddModelError(context.ModelName, GetNoEncodingMessage());
+                return InputFormatterResult.FailedAsync();
+            }
 
             using (var xmlReader = CreateXmlReader(new NonDisposableStream(request.Body), effectiveEncoding))
             {
@@ -96,7 +97,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
                     }
                 }
 
-                return Task.FromResult(deserializedObject);
+                return InputFormatterResult.SuccessfulAsync(deserializedObject);
             }
         }
 

--- a/src/Microsoft.AspNet.Mvc.Formatters.Xml/XmlSerializerInputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Formatters.Xml/XmlSerializerInputFormatter.cs
@@ -68,17 +68,13 @@ namespace Microsoft.AspNet.Mvc.Formatters
         /// <inheritdoc />
         public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
         {
-            var request = context.HttpContext.Request;
-
-            MediaTypeHeaderValue requestContentType;
-            MediaTypeHeaderValue.TryParse(request.ContentType, out requestContentType);
-            var effectiveEncoding = SelectCharacterEncoding(requestContentType);
+            var effectiveEncoding = SelectCharacterEncoding(context);
             if (effectiveEncoding == null)
             {
-                context.ModelState.TryAddModelError(context.ModelName, GetNoEncodingMessage());
-                return InputFormatterResult.FailedAsync();
+                return InputFormatterResult.FailureAsync();
             }
 
+            var request = context.HttpContext.Request;
             using (var xmlReader = CreateXmlReader(new NonDisposableStream(request.Body), effectiveEncoding))
             {
                 var type = GetSerializableType(context.ModelType);
@@ -97,7 +93,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
                     }
                 }
 
-                return InputFormatterResult.SuccessfulAsync(deserializedObject);
+                return InputFormatterResult.SuccessAsync(deserializedObject);
             }
         }
 

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BodyModelBinderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BodyModelBinderTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 .Returns(true)
                 .Verifiable();
             mockInputFormatter.Setup(o => o.ReadAsync(It.IsAny<InputFormatterContext>()))
-                              .Returns(InputFormatterResult.SuccessfulAsync(new Person()))
+                              .Returns(InputFormatterResult.SuccessAsync(new Person()))
                               .Verifiable();
             var inputFormatter = mockInputFormatter.Object;
 
@@ -327,7 +327,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             public Task<InputFormatterResult> ReadAsync(InputFormatterContext context)
             {
-                return InputFormatterResult.SuccessfulAsync(this);
+                return InputFormatterResult.SuccessAsync(this);
             }
         }
     }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BodyModelBinderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BodyModelBinderTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 .Returns(true)
                 .Verifiable();
             mockInputFormatter.Setup(o => o.ReadAsync(It.IsAny<InputFormatterContext>()))
-                              .Returns(Task.FromResult<object>(new Person()))
+                              .Returns(InputFormatterResult.SuccessfulAsync(new Person()))
                               .Verifiable();
             var inputFormatter = mockInputFormatter.Object;
 
@@ -305,7 +305,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 return true;
             }
 
-            public override Task<object> ReadRequestBodyAsync(InputFormatterContext context)
+            public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
             {
                 throw new InvalidOperationException("Your input is bad!");
             }
@@ -325,9 +325,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 return _canRead;
             }
 
-            public Task<object> ReadAsync(InputFormatterContext context)
+            public Task<InputFormatterResult> ReadAsync(InputFormatterContext context)
             {
-                return Task.FromResult<object>(this);
+                return InputFormatterResult.SuccessfulAsync(this);
             }
         }
     }

--- a/test/Microsoft.AspNet.Mvc.Formatters.Json.Test/JsonInputFormatterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Formatters.Json.Test/JsonInputFormatterTest.cs
@@ -38,7 +38,11 @@ namespace Microsoft.AspNet.Mvc.Formatters
             var contentBytes = Encoding.UTF8.GetBytes("content");
 
             var httpContext = GetHttpContext(contentBytes, contentType: requestContentType);
-            var formatterContext = new InputFormatterContext(httpContext, new ModelStateDictionary(), typeof(string));
+            var formatterContext = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: new ModelStateDictionary(),
+                modelType: typeof(string));
 
             // Act
             var result = formatter.CanRead(formatterContext);
@@ -80,13 +84,18 @@ namespace Microsoft.AspNet.Mvc.Formatters
             var contentBytes = Encoding.UTF8.GetBytes(content);
 
             var httpContext = GetHttpContext(contentBytes);
-            var context = new InputFormatterContext(httpContext, new ModelStateDictionary(), type);
+            var context = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: new ModelStateDictionary(),
+                modelType: type);
 
             // Act
-            var model = await formatter.ReadAsync(context);
+            var result = await formatter.ReadAsync(context);
 
             // Assert
-            Assert.Equal(expected, model);
+            Assert.False(result.HasError);
+            Assert.Equal(expected, result.Model);
         }
 
         [Fact]
@@ -98,13 +107,18 @@ namespace Microsoft.AspNet.Mvc.Formatters
             var contentBytes = Encoding.UTF8.GetBytes(content);
 
             var httpContext = GetHttpContext(contentBytes);
-            var context = new InputFormatterContext(httpContext, new ModelStateDictionary(), typeof(User));
+            var context = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: new ModelStateDictionary(),
+                modelType: typeof(User));
 
             // Act
-            var model = await formatter.ReadAsync(context);
+            var result = await formatter.ReadAsync(context);
 
             // Assert
-            var userModel = Assert.IsType<User>(model);
+            Assert.False(result.HasError);
+            var userModel = Assert.IsType<User>(result.Model);
             Assert.Equal("Person Name", userModel.Name);
             Assert.Equal(30, userModel.Age);
         }
@@ -119,13 +133,17 @@ namespace Microsoft.AspNet.Mvc.Formatters
 
             var modelState = new ModelStateDictionary();
             var httpContext = GetHttpContext(contentBytes);
-
-            var context = new InputFormatterContext(httpContext, modelState, typeof(User));
+            var context = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: modelState,
+                modelType: typeof(User));
 
             // Act
-            var model = await formatter.ReadAsync(context);
+            var result = await formatter.ReadAsync(context);
 
             // Assert
+            Assert.True(result.HasError);
             Assert.Equal(
                 "Could not convert string to decimal: not-an-age. Path 'Age', line 1, position 39.",
                 modelState["Age"].Errors[0].Exception.Message);
@@ -141,17 +159,21 @@ namespace Microsoft.AspNet.Mvc.Formatters
 
             var modelState = new ModelStateDictionary();
             var httpContext = GetHttpContext(contentBytes);
-
-            var context = new InputFormatterContext(httpContext, modelState, typeof(User));
+            var context = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: modelState,
+                modelType: typeof(User));
 
             modelState.MaxAllowedErrors = 3;
             modelState.AddModelError("key1", "error1");
             modelState.AddModelError("key2", "error2");
 
             // Act
-            var model = await formatter.ReadAsync(context);
+            var result = await formatter.ReadAsync(context);
 
             // Assert
+            Assert.True(result.HasError);
             Assert.False(modelState.ContainsKey("age"));
             var error = Assert.Single(modelState[""].Errors);
             Assert.IsType<TooManyModelErrorsException>(error.Exception);
@@ -193,13 +215,17 @@ namespace Microsoft.AspNet.Mvc.Formatters
 
             var modelState = new ModelStateDictionary();
             var httpContext = GetHttpContext(contentBytes, "application/json;charset=utf-8");
-
-            var inputFormatterContext = new InputFormatterContext(httpContext, modelState, typeof(UserLogin));
+            var inputFormatterContext = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: modelState,
+                modelType: typeof(UserLogin));
 
             // Act
-            var obj = await jsonFormatter.ReadAsync(inputFormatterContext);
+            var result = await jsonFormatter.ReadAsync(inputFormatterContext);
 
             // Assert
+            Assert.True(result.HasError);
             Assert.False(modelState.IsValid);
 
             var modelErrorMessage = modelState.Values.First().Errors[0].Exception.Message;
@@ -222,13 +248,17 @@ namespace Microsoft.AspNet.Mvc.Formatters
 
             var modelState = new ModelStateDictionary();
             var httpContext = GetHttpContext(contentBytes, "application/json;charset=utf-8");
-
-            var inputFormatterContext = new InputFormatterContext(httpContext, modelState, typeof(UserLogin));
+            var inputFormatterContext = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: modelState,
+                modelType: typeof(UserLogin));
 
             // Act
-            var obj = await jsonFormatter.ReadAsync(inputFormatterContext);
+            var result = await jsonFormatter.ReadAsync(inputFormatterContext);
 
             // Assert
+            Assert.True(result.HasError);
             Assert.False(modelState.IsValid);
 
             var modelErrorMessage = modelState.Values.First().Errors[0].Exception.Message;

--- a/test/Microsoft.AspNet.Mvc.Formatters.Json.Test/JsonPatchInputFormatterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Formatters.Json.Test/JsonPatchInputFormatterTest.cs
@@ -25,13 +25,18 @@ namespace Microsoft.AspNet.Mvc.Formatters
 
             var modelState = new ModelStateDictionary();
             var httpContext = GetHttpContext(contentBytes);
-            var context = new InputFormatterContext(httpContext, modelState, typeof(JsonPatchDocument<Customer>));
+            var context = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: modelState,
+                modelType: typeof(JsonPatchDocument<Customer>));
 
             // Act
-            var model = await formatter.ReadAsync(context);
+            var result = await formatter.ReadAsync(context);
 
             // Assert
-            var patchDoc = Assert.IsType<JsonPatchDocument<Customer>>(model);
+            Assert.False(result.HasError);
+            var patchDoc = Assert.IsType<JsonPatchDocument<Customer>>(result.Model);
             Assert.Equal("add", patchDoc.Operations[0].op);
             Assert.Equal("Customer/Name", patchDoc.Operations[0].path);
             Assert.Equal("John", patchDoc.Operations[0].value);
@@ -48,13 +53,18 @@ namespace Microsoft.AspNet.Mvc.Formatters
 
             var modelState = new ModelStateDictionary();
             var httpContext = GetHttpContext(contentBytes);
-            var context = new InputFormatterContext(httpContext, modelState, typeof(JsonPatchDocument<Customer>));
+            var context = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: modelState,
+                modelType: typeof(JsonPatchDocument<Customer>));
 
             // Act
-            var model = await formatter.ReadAsync(context);
+            var result = await formatter.ReadAsync(context);
 
             // Assert
-            var patchDoc = Assert.IsType<JsonPatchDocument<Customer>>(model);
+            Assert.False(result.HasError);
+            var patchDoc = Assert.IsType<JsonPatchDocument<Customer>>(result.Model);
             Assert.Equal("add", patchDoc.Operations[0].op);
             Assert.Equal("Customer/Name", patchDoc.Operations[0].path);
             Assert.Equal("John", patchDoc.Operations[0].value);
@@ -78,8 +88,9 @@ namespace Microsoft.AspNet.Mvc.Formatters
             var httpContext = GetHttpContext(contentBytes, contentType: requestContentType);
             var formatterContext = new InputFormatterContext(
                 httpContext,
-                modelState,
-                typeof(JsonPatchDocument<Customer>));
+                modelName: string.Empty,
+                modelState: modelState,
+                modelType: typeof(JsonPatchDocument<Customer>));
 
             // Act
             var result = formatter.CanRead(formatterContext);
@@ -100,7 +111,11 @@ namespace Microsoft.AspNet.Mvc.Formatters
 
             var modelState = new ModelStateDictionary();
             var httpContext = GetHttpContext(contentBytes, contentType: "application/json-patch+json");
-            var formatterContext = new InputFormatterContext(httpContext, modelState, modelType);
+            var formatterContext = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: modelState,
+                modelType: modelType);
 
             // Act
             var result = formatter.CanRead(formatterContext);
@@ -122,13 +137,17 @@ namespace Microsoft.AspNet.Mvc.Formatters
 
             var modelState = new ModelStateDictionary();
             var httpContext = GetHttpContext(contentBytes, contentType: "application/json-patch+json");
-
-            var context = new InputFormatterContext(httpContext, modelState, typeof(Customer));
+            var context = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: modelState,
+                modelType: typeof(Customer));
 
             // Act
-            var model = await formatter.ReadAsync(context);
+            var result = await formatter.ReadAsync(context);
 
             // Assert
+            Assert.True(result.HasError);
             Assert.Contains(exceptionMessage, modelState[""].Errors[0].Exception.Message);
         }
 

--- a/test/Microsoft.AspNet.Mvc.Formatters.Xml.Test/XmlDataContractSerializerInputFormatterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Formatters.Xml.Test/XmlDataContractSerializerInputFormatterTest.cs
@@ -73,7 +73,11 @@ namespace Microsoft.AspNet.Mvc.Formatters.Xml
 
             var modelState = new ModelStateDictionary();
             var httpContext = GetHttpContext(contentBytes, contentType: requestContentType);
-            var formatterContext = new InputFormatterContext(httpContext, modelState, typeof(string));
+            var formatterContext = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: modelState,
+                modelType: typeof(string));
 
             // Act
             var result = formatter.CanRead(formatterContext);
@@ -146,15 +150,15 @@ namespace Microsoft.AspNet.Mvc.Formatters.Xml
             var context = GetInputFormatterContext(contentBytes, typeof(TestLevelOne));
 
             // Act
-            var model = await formatter.ReadAsync(context);
+            var result = await formatter.ReadAsync(context);
 
             // Assert
-            Assert.NotNull(model);
-            Assert.IsType<TestLevelOne>(model);
+            Assert.NotNull(result);
+            Assert.False(result.HasError);
+            var model = Assert.IsType<TestLevelOne>(result.Model);
 
-            var levelOneModel = model as TestLevelOne;
-            Assert.Equal(expectedInt, levelOneModel.SampleInt);
-            Assert.Equal(expectedString, levelOneModel.sampleString);
+            Assert.Equal(expectedInt, model.SampleInt);
+            Assert.Equal(expectedString, model.sampleString);
         }
 
         [ConditionalFact]
@@ -177,16 +181,16 @@ namespace Microsoft.AspNet.Mvc.Formatters.Xml
             var context = GetInputFormatterContext(contentBytes, typeof(TestLevelTwo));
 
             // Act
-            var model = await formatter.ReadAsync(context);
+            var result = await formatter.ReadAsync(context);
 
             // Assert
-            Assert.NotNull(model);
-            Assert.IsType<TestLevelTwo>(model);
+            Assert.NotNull(result);
+            Assert.False(result.HasError);
+            var model = Assert.IsType<TestLevelTwo>(result.Model);
 
-            var levelTwoModel = model as TestLevelTwo;
-            Assert.Equal(expectedLevelTwoString, levelTwoModel.SampleString);
-            Assert.Equal(expectedInt, levelTwoModel.TestOne.SampleInt);
-            Assert.Equal(expectedString, levelTwoModel.TestOne.sampleString);
+            Assert.Equal(expectedLevelTwoString, model.SampleString);
+            Assert.Equal(expectedInt, model.TestOne.SampleInt);
+            Assert.Equal(expectedString, model.TestOne.sampleString);
         }
 
         [ConditionalFact]
@@ -206,13 +210,13 @@ namespace Microsoft.AspNet.Mvc.Formatters.Xml
 
 
             // Act
-            var model = await formatter.ReadAsync(context);
+            var result = await formatter.ReadAsync(context);
 
             // Assert
-            Assert.NotNull(model);
-            Assert.IsType<DummyClass>(model);
-            var dummyModel = model as DummyClass;
-            Assert.Equal(expectedInt, dummyModel.SampleInt);
+            Assert.NotNull(result);
+            Assert.False(result.HasError);
+            var model = Assert.IsType<DummyClass>(result.Model);
+            Assert.Equal(expectedInt, model.SampleInt);
         }
 
         [ConditionalFact]
@@ -276,10 +280,12 @@ namespace Microsoft.AspNet.Mvc.Formatters.Xml
             var context = GetInputFormatterContext(contentBytes, typeof(DummyClass));
 
             // Act
-            var model = await formatter.ReadAsync(context);
+            var result = await formatter.ReadAsync(context);
 
             // Assert
-            Assert.NotNull(model);
+            Assert.NotNull(result);
+            Assert.False(result.HasError);
+            Assert.NotNull(result.Model);
             Assert.True(context.HttpContext.Request.Body.CanRead);
         }
 
@@ -331,7 +337,11 @@ namespace Microsoft.AspNet.Mvc.Formatters.Xml
             var modelState = new ModelStateDictionary();
             var httpContext = GetHttpContext(inputBytes, contentType: "application/xml; charset=utf-16");
 
-            var context = new InputFormatterContext(httpContext, modelState, typeof(TestLevelOne));
+            var context = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: modelState,
+                modelType: typeof(TestLevelOne));
 
             // Act
             var ex = await Assert.ThrowsAsync(expectedException, () => formatter.ReadAsync(context));
@@ -361,14 +371,15 @@ namespace Microsoft.AspNet.Mvc.Formatters.Xml
             var context = GetInputFormatterContext(contentBytes, typeof(TestLevelTwo));
 
             // Act
-            var model = await formatter.ReadAsync(context);
+            var result = await formatter.ReadAsync(context);
 
             // Assert
-            Assert.NotNull(model);
-            var levelTwoModel = model as TestLevelTwo;
+            Assert.NotNull(result);
+            Assert.False(result.HasError);
+            var model = Assert.IsType<TestLevelTwo>(result.Model);
             Buffer.BlockCopy(sampleStringBytes, 0, expectedBytes, 0, sampleStringBytes.Length);
             Buffer.BlockCopy(bom, 0, expectedBytes, sampleStringBytes.Length, bom.Length);
-            Assert.Equal(expectedBytes, Encoding.UTF8.GetBytes(levelTwoModel.SampleString));
+            Assert.Equal(expectedBytes, Encoding.UTF8.GetBytes(model.SampleString));
         }
 
         [ConditionalFact]
@@ -390,18 +401,22 @@ namespace Microsoft.AspNet.Mvc.Formatters.Xml
             var modelState = new ModelStateDictionary();
             var httpContext = GetHttpContext(contentBytes, contentType: "application/xml; charset=utf-16");
 
-            var context = new InputFormatterContext(httpContext, modelState, typeof(TestLevelOne));
+            var context = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: modelState,
+                modelType: typeof(TestLevelOne));
 
             // Act
-            var model = await formatter.ReadAsync(context);
+            var result = await formatter.ReadAsync(context);
 
             // Assert
-            Assert.NotNull(model);
-            Assert.IsType<TestLevelOne>(model);
+            Assert.NotNull(result);
+            Assert.False(result.HasError);
+            var model = Assert.IsType<TestLevelOne>(result.Model);
 
-            var levelOneModel = model as TestLevelOne;
-            Assert.Equal(expectedInt, levelOneModel.SampleInt);
-            Assert.Equal(expectedString, levelOneModel.sampleString);
+            Assert.Equal(expectedInt, model.SampleInt);
+            Assert.Equal(expectedString, model.sampleString);
         }
 
         [ConditionalFact]
@@ -455,12 +470,13 @@ namespace Microsoft.AspNet.Mvc.Formatters.Xml
             var context = GetInputFormatterContext(contentBytes, typeof(DummyClass));
 
             // Act
-            var model = await formatter.ReadAsync(context);
+            var result = await formatter.ReadAsync(context);
 
             // Assert
-            Assert.NotNull(model);
-            var dummyModel = Assert.IsType<DummyClass>(model);
-            Assert.Equal(expectedInt, dummyModel.SampleInt);
+            Assert.NotNull(result);
+            Assert.False(result.HasError);
+            var model = Assert.IsType<DummyClass>(result.Model);
+            Assert.Equal(expectedInt, model.SampleInt);
         }
 
         [ConditionalFact]
@@ -515,19 +531,24 @@ namespace Microsoft.AspNet.Mvc.Formatters.Xml
             var context = GetInputFormatterContext(contentBytes, typeof(DummyClass));
 
             // Act
-            var model = await formatter.ReadAsync(context);
+            var result = await formatter.ReadAsync(context);
 
             // Assert
-            Assert.NotNull(model);
-            var dummyModel = Assert.IsType<SomeDummyClass>(model);
-            Assert.Equal(expectedInt, dummyModel.SampleInt);
-            Assert.Equal(expectedString, dummyModel.SampleString);
+            Assert.NotNull(result);
+            Assert.False(result.HasError);
+            var model = Assert.IsType<SomeDummyClass>(result.Model);
+            Assert.Equal(expectedInt, model.SampleInt);
+            Assert.Equal(expectedString, model.SampleString);
         }
 
         private InputFormatterContext GetInputFormatterContext(byte[] contentBytes, Type modelType)
         {
             var httpContext = GetHttpContext(contentBytes);
-            return new InputFormatterContext(httpContext, new ModelStateDictionary(), modelType);
+            return new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: new ModelStateDictionary(),
+                modelType: modelType);
         }
 
         private static HttpContext GetHttpContext(

--- a/test/Microsoft.AspNet.Mvc.Formatters.Xml.Test/XmlSerializerInputFormatterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Formatters.Xml.Test/XmlSerializerInputFormatterTest.cs
@@ -59,7 +59,11 @@ namespace Microsoft.AspNet.Mvc.Formatters.Xml
             var modelState = new ModelStateDictionary();
             var httpContext = GetHttpContext(contentBytes, contentType: requestContentType);
 
-            var formatterContext = new InputFormatterContext(httpContext, modelState, typeof(string));
+            var formatterContext = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: modelState,
+                modelType: typeof(string));
 
             // Act
             var result = formatter.CanRead(formatterContext);
@@ -148,17 +152,18 @@ namespace Microsoft.AspNet.Mvc.Formatters.Xml
             var context = GetInputFormatterContext(contentBytes, typeof(TestLevelOne));
 
             // Act
-            var model = await formatter.ReadAsync(context);
+            var result = await formatter.ReadAsync(context);
 
             // Assert
-            Assert.NotNull(model);
-            Assert.IsType<TestLevelOne>(model);
+            Assert.NotNull(result);
+            Assert.False(result.HasError);
+            var model = Assert.IsType<TestLevelOne>(result.Model);
 
-            var levelOneModel = model as TestLevelOne;
-            Assert.Equal(expectedInt, levelOneModel.SampleInt);
-            Assert.Equal(expectedString, levelOneModel.sampleString);
-            Assert.Equal(XmlConvert.ToDateTime(expectedDateTime, XmlDateTimeSerializationMode.Utc),
-                         levelOneModel.SampleDate);
+            Assert.Equal(expectedInt, model.SampleInt);
+            Assert.Equal(expectedString, model.sampleString);
+            Assert.Equal(
+                XmlConvert.ToDateTime(expectedDateTime, XmlDateTimeSerializationMode.Utc),
+                model.SampleDate);
         }
 
         [Fact]
@@ -181,18 +186,19 @@ namespace Microsoft.AspNet.Mvc.Formatters.Xml
             var context = GetInputFormatterContext(contentBytes, typeof(TestLevelTwo));
 
             // Act
-            var model = await formatter.ReadAsync(context);
+            var result = await formatter.ReadAsync(context);
 
             // Assert
-            Assert.NotNull(model);
-            Assert.IsType<TestLevelTwo>(model);
+            Assert.NotNull(result);
+            Assert.False(result.HasError);
+            var model = Assert.IsType<TestLevelTwo>(result.Model);
 
-            var levelTwoModel = model as TestLevelTwo;
-            Assert.Equal(expectedLevelTwoString, levelTwoModel.SampleString);
-            Assert.Equal(expectedInt, levelTwoModel.TestOne.SampleInt);
-            Assert.Equal(expectedString, levelTwoModel.TestOne.sampleString);
-            Assert.Equal(XmlConvert.ToDateTime(expectedDateTime, XmlDateTimeSerializationMode.Utc),
-                        levelTwoModel.TestOne.SampleDate);
+            Assert.Equal(expectedLevelTwoString, model.SampleString);
+            Assert.Equal(expectedInt, model.TestOne.SampleInt);
+            Assert.Equal(expectedString, model.TestOne.sampleString);
+            Assert.Equal(
+                XmlConvert.ToDateTime(expectedDateTime, XmlDateTimeSerializationMode.Utc),
+                model.TestOne.SampleDate);
         }
 
         [Fact]
@@ -208,15 +214,14 @@ namespace Microsoft.AspNet.Mvc.Formatters.Xml
             var contentBytes = Encoding.UTF8.GetBytes(input);
             var context = GetInputFormatterContext(contentBytes, typeof(DummyClass));
 
-
             // Act
-            var model = await formatter.ReadAsync(context);
+            var result = await formatter.ReadAsync(context);
 
             // Assert
-            Assert.NotNull(model);
-            Assert.IsType<DummyClass>(model);
-            var dummyModel = model as DummyClass;
-            Assert.Equal(expectedInt, dummyModel.SampleInt);
+            Assert.NotNull(result);
+            Assert.False(result.HasError);
+            var model = Assert.IsType<DummyClass>(result.Model);
+            Assert.Equal(expectedInt, model.SampleInt);
         }
 
         [ConditionalFact]
@@ -282,10 +287,12 @@ namespace Microsoft.AspNet.Mvc.Formatters.Xml
             var context = GetInputFormatterContext(contentBytes, typeof(DummyClass));
 
             // Act
-            var model = await formatter.ReadAsync(context);
+            var result = await formatter.ReadAsync(context);
 
             // Assert
-            Assert.NotNull(model);
+            Assert.NotNull(result);
+            Assert.False(result.HasError);
+            Assert.NotNull(result.Model);
             Assert.True(context.HttpContext.Request.Body.CanRead);
         }
 
@@ -335,7 +342,11 @@ namespace Microsoft.AspNet.Mvc.Formatters.Xml
             var modelState = new ModelStateDictionary();
             var httpContext = GetHttpContext(inputBytes, contentType: "application/xml; charset=utf-16");
 
-            var context = new InputFormatterContext(httpContext, modelState, typeof(TestLevelOne));
+            var context = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: modelState,
+                modelType: typeof(TestLevelOne));
 
             // Act and Assert
             var ex = await Assert.ThrowsAsync(expectedException, () => formatter.ReadAsync(context));
@@ -363,14 +374,15 @@ namespace Microsoft.AspNet.Mvc.Formatters.Xml
             var context = GetInputFormatterContext(contentBytes, typeof(TestLevelTwo));
 
             // Act
-            var model = await formatter.ReadAsync(context);
+            var result = await formatter.ReadAsync(context);
 
             // Assert
-            Assert.NotNull(model);
-            var levelTwoModel = model as TestLevelTwo;
+            Assert.NotNull(result);
+            Assert.False(result.HasError);
+            var model = Assert.IsType<TestLevelTwo>(result.Model);
             Buffer.BlockCopy(sampleStringBytes, 0, expectedBytes, 0, sampleStringBytes.Length);
             Buffer.BlockCopy(bom, 0, expectedBytes, sampleStringBytes.Length, bom.Length);
-            Assert.Equal(expectedBytes, Encoding.UTF8.GetBytes(levelTwoModel.SampleString));
+            Assert.Equal(expectedBytes, Encoding.UTF8.GetBytes(model.SampleString));
         }
 
         [Fact]
@@ -391,25 +403,33 @@ namespace Microsoft.AspNet.Mvc.Formatters.Xml
 
             var modelState = new ModelStateDictionary();
             var httpContext = GetHttpContext(contentBytes, contentType: "application/xml; charset=utf-16");
-            var context = new InputFormatterContext(httpContext, modelState, typeof(TestLevelOne));
+            var context = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: modelState,
+                modelType: typeof(TestLevelOne));
 
             // Act
-            var model = await formatter.ReadAsync(context);
+            var result = await formatter.ReadAsync(context);
 
             // Assert
-            Assert.NotNull(model);
-            Assert.IsType<TestLevelOne>(model);
+            Assert.NotNull(result);
+            Assert.False(result.HasError);
+            var model = Assert.IsType<TestLevelOne>(result.Model);
 
-            var levelOneModel = model as TestLevelOne;
-            Assert.Equal(expectedInt, levelOneModel.SampleInt);
-            Assert.Equal(expectedString, levelOneModel.sampleString);
-            Assert.Equal(XmlConvert.ToDateTime(expectedDateTime, XmlDateTimeSerializationMode.Utc), levelOneModel.SampleDate);
+            Assert.Equal(expectedInt, model.SampleInt);
+            Assert.Equal(expectedString, model.sampleString);
+            Assert.Equal(XmlConvert.ToDateTime(expectedDateTime, XmlDateTimeSerializationMode.Utc), model.SampleDate);
         }
 
         private InputFormatterContext GetInputFormatterContext(byte[] contentBytes, Type modelType)
         {
             var httpContext = GetHttpContext(contentBytes);
-            return new InputFormatterContext(httpContext, new ModelStateDictionary(), modelType);
+            return new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: new ModelStateDictionary(),
+                modelType: modelType);
         }
 
         private static HttpContext GetHttpContext(

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/BodyValidationIntegrationTests.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/BodyValidationIntegrationTests.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc.Actions;
 using Microsoft.AspNet.Mvc.ModelBinding;
-using Microsoft.AspNet.Testing;
 using Xunit;
 
 namespace Microsoft.AspNet.Mvc.IntegrationTests
@@ -111,7 +110,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             public int Address { get; set; }
         }
 
-        [Fact(Skip = "#2722 validation error from formatter is recorded with the wrong key.")]
+        [Fact]
         public async Task FromBodyAndRequiredOnValueTypeProperty_EmptyBody_JsonFormatterAddsModelStateError()
         {
             // Arrange
@@ -146,13 +145,70 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var entry = Assert.Single(modelState);
             Assert.Equal("CustomParameter.Address", entry.Key);
             Assert.Null(entry.Value.AttemptedValue);
-            Assert.Same(boundPerson, entry.Value.RawValue);
+            Assert.Null(entry.Value.RawValue);
             var error = Assert.Single(entry.Value.Errors);
             Assert.NotNull(error.Exception);
 
             // Json.NET currently throws an exception starting with "No JSON content found and type 'System.Int32' is
             // not nullable." but do not tie test to a particular Json.NET build.
             Assert.NotEmpty(error.Exception.Message);
+        }
+
+        private class Person5
+        {
+            [FromBody]
+            public Address5 Address { get; set; }
+        }
+
+        private class Address5
+        {
+            public int Number { get; set; }
+
+            [Required]
+            public int RequiredNumber { get; set; }
+        }
+
+        [Fact]
+        public async Task FromBodyAndRequiredOnInnerValueTypeProperty_NotBound_JsonFormatterSuccessful()
+        {
+            // Arrange
+            var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
+            var parameter = new ParameterDescriptor
+            {
+                Name = "Parameter1",
+                BindingInfo = new BindingInfo
+                {
+                    BinderModelName = "CustomParameter",
+                },
+                ParameterType = typeof(Person5)
+            };
+
+            var operationContext = ModelBindingTestHelper.GetOperationBindingContext(
+                request =>
+                {
+                    request.Body = new MemoryStream(Encoding.UTF8.GetBytes("{ \"Number\": 5 }"));
+                    request.ContentType = "application/json";
+                });
+
+            var modelState = new ModelStateDictionary();
+
+            // Act
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+
+            // Assert
+            Assert.True(modelBindingResult.IsModelSet);
+            var boundPerson = Assert.IsType<Person5>(modelBindingResult.Model);
+            Assert.NotNull(boundPerson.Address);
+            Assert.Equal(5, boundPerson.Address.Number);
+            Assert.Equal(0, boundPerson.Address.RequiredNumber);
+
+            Assert.True(modelState.IsValid);
+            var entry = Assert.Single(modelState);
+            Assert.Equal("CustomParameter.Address", entry.Key);
+            Assert.NotNull(entry.Value);
+            Assert.Null(entry.Value.AttemptedValue);
+            Assert.Same(boundPerson.Address, entry.Value.RawValue);
+            Assert.Empty(entry.Value.Errors);
         }
 
         private class Person2

--- a/test/WebSites/FormatterWebSite/StringInputFormatter.cs
+++ b/test/WebSites/FormatterWebSite/StringInputFormatter.cs
@@ -22,20 +22,17 @@ namespace FormatterWebSite
 
         public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
         {
-            var request = context.HttpContext.Request;
-            MediaTypeHeaderValue requestContentType = null;
-            MediaTypeHeaderValue.TryParse(request.ContentType, out requestContentType);
-            var effectiveEncoding = SelectCharacterEncoding(requestContentType);
+            var effectiveEncoding = SelectCharacterEncoding(context);
             if (effectiveEncoding == null)
             {
-                context.ModelState.TryAddModelError(context.ModelName, GetNoEncodingMessage());
-                return InputFormatterResult.FailedAsync();
+                return InputFormatterResult.FailureAsync();
             }
 
+            var request = context.HttpContext.Request;
             using (var reader = new StreamReader(request.Body, effectiveEncoding))
             {
                 var stringContent = reader.ReadToEnd();
-                return InputFormatterResult.SuccessfulAsync(stringContent);
+                return InputFormatterResult.SuccessAsync(stringContent);
             }
         }
     }

--- a/test/WebSites/FormatterWebSite/StringInputFormatter.cs
+++ b/test/WebSites/FormatterWebSite/StringInputFormatter.cs
@@ -4,6 +4,7 @@
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Mvc;
 using Microsoft.AspNet.Mvc.Formatters;
 using Microsoft.Net.Http.Headers;
 
@@ -19,17 +20,22 @@ namespace FormatterWebSite
             SupportedEncodings.Add(Encoding.Unicode);
         }
 
-        public override Task<object> ReadRequestBodyAsync(InputFormatterContext context)
+        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
         {
             var request = context.HttpContext.Request;
             MediaTypeHeaderValue requestContentType = null;
             MediaTypeHeaderValue.TryParse(request.ContentType, out requestContentType);
             var effectiveEncoding = SelectCharacterEncoding(requestContentType);
+            if (effectiveEncoding == null)
+            {
+                context.ModelState.TryAddModelError(context.ModelName, GetNoEncodingMessage());
+                return InputFormatterResult.FailedAsync();
+            }
 
             using (var reader = new StreamReader(request.Body, effectiveEncoding))
             {
                 var stringContent = reader.ReadToEnd();
-                return Task.FromResult<object>(stringContent);
+                return InputFormatterResult.SuccessfulAsync(stringContent);
             }
         }
     }


### PR DESCRIPTION
- #2722
- make communication of errors from formatters to `BodyModelBinder` explicit

nits:
- improve some doc comments
- add another `BodyValidationIntegrationTests` test