### PR TITLE
Allow _ViewImports to remove default inherited tag helpers.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor.Host/Directives/ChunkHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/Directives/ChunkHelper.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Linq;
-using Microsoft.AspNet.Mvc.Razor.Host;
 using Microsoft.AspNet.Razor.Chunks;
 
 namespace Microsoft.AspNet.Mvc.Razor.Directives
@@ -14,33 +13,6 @@ namespace Microsoft.AspNet.Mvc.Razor.Directives
     public static class ChunkHelper
     {
         private const string TModelToken = "<TModel>";
-
-        /// <summary>
-        /// Attempts to cast the passed in <see cref="Chunk"/> to type <typeparamref name="TChunk"/> and throws if the
-        /// cast fails.
-        /// </summary>
-        /// <typeparam name="TChunk">The type to cast to.</typeparam>
-        /// <param name="chunk">The chunk to cast.</param>
-        /// <returns>The <paramref name="chunk"/> cast to <typeparamref name="TChunk"/>.</returns>
-        /// <exception cref="ArgumentException"><paramref name="chunk"/> is not an instance of
-        /// <typeparamref name="TChunk"/>.</exception>
-        public static TChunk EnsureChunk<TChunk>(Chunk chunk)
-            where TChunk : Chunk
-        {
-            if (chunk == null)
-            {
-                throw new ArgumentNullException(nameof(chunk));
-            }
-
-            var chunkOfT = chunk as TChunk;
-            if (chunkOfT == null)
-            {
-                var message = Resources.FormatArgumentMustBeOfType(typeof(TChunk).FullName);
-                throw new ArgumentException(message, nameof(chunk));
-            }
-
-            return chunkOfT;
-        }
 
         /// <summary>
         /// Returns the <see cref="ModelChunk"/> used to determine the model name for the page generated

--- a/src/Microsoft.AspNet.Mvc.Razor.Host/Directives/IChunkMerger.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/Directives/IChunkMerger.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using Microsoft.AspNet.Razor.Chunks;
 
 namespace Microsoft.AspNet.Mvc.Razor.Directives
@@ -20,7 +21,7 @@ namespace Microsoft.AspNet.Mvc.Razor.Directives
         /// Merges an inherited <see cref="Chunk"/> into the <see cref="ChunkTree"/>.
         /// </summary>
         /// <param name="ChunkTree">The <see cref="ChunkTree"/> to merge into.</param>
-        /// <param name="chunk">The <see cref="Chunk"/> to merge.</param>
-        void Merge(ChunkTree chunkTree, Chunk chunk);
+        /// <param name="inheritedChunks">The <see cref="IReadOnlyList{Chunk}"/>s to merge.</param>
+        void MergeInheritedChunks(ChunkTree chunkTree, IReadOnlyList<Chunk> inheritedChunks);
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Razor.Host/Directives/UsingChunkMerger.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/Directives/UsingChunkMerger.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNet.Razor.Chunks;
 
 namespace Microsoft.AspNet.Mvc.Razor.Directives
@@ -22,29 +23,33 @@ namespace Microsoft.AspNet.Mvc.Razor.Directives
                 throw new ArgumentNullException(nameof(chunk));
             }
 
-            var namespaceChunk = ChunkHelper.EnsureChunk<UsingChunk>(chunk);
-            _currentUsings.Add(namespaceChunk.Namespace);
+            var namespaceChunk = chunk as UsingChunk;
+            if (namespaceChunk != null)
+            {
+                _currentUsings.Add(namespaceChunk.Namespace);
+            }
         }
 
         /// <inheritdoc />
-        public void Merge(ChunkTree chunkTree, Chunk chunk)
+        public void MergeInheritedChunks(ChunkTree chunkTree, IReadOnlyList<Chunk> inheritedChunks)
         {
             if (chunkTree == null)
             {
                 throw new ArgumentNullException(nameof(chunkTree));
             }
 
-            if (chunk == null)
+            if (inheritedChunks == null)
             {
-                throw new ArgumentNullException(nameof(chunk));
+                throw new ArgumentNullException(nameof(inheritedChunks));
             }
 
-            var namespaceChunk = ChunkHelper.EnsureChunk<UsingChunk>(chunk);
-
-            if (!_currentUsings.Contains(namespaceChunk.Namespace))
+            var namespaceChunks = inheritedChunks.OfType<UsingChunk>();
+            foreach (var namespaceChunk in namespaceChunks)
             {
-                _currentUsings.Add(namespaceChunk.Namespace);
-                chunkTree.Chunks.Add(namespaceChunk);
+                if (_currentUsings.Add(namespaceChunk.Namespace))
+                {
+                    chunkTree.Chunks.Add(namespaceChunk);
+                }
             }
         }
     }

--- a/src/Microsoft.AspNet.Mvc.Razor.Host/MvcRazorParser.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/MvcRazorParser.cs
@@ -117,15 +117,8 @@ namespace Microsoft.AspNet.Mvc.Razor
         {
             var descriptors = new List<TagHelperDirectiveDescriptor>();
 
-            // For tag helpers, the @removeTagHelper only applies tag helpers that were added prior to it.
-            // Consequently we must visit tag helpers outside-in - furthest _ViewImports first and nearest one last.
-            // This is different from the behavior of chunk merging where we visit the nearest one first and ignore
-            // chunks that were previously visited.
-            var chunksFromViewImports = inheritedChunkTrees
-                .Reverse()
-                .SelectMany(tree => tree.Chunks);
-            var chunksInOrder = defaultInheritedChunks.Concat(chunksFromViewImports);
-            foreach (var chunk in chunksInOrder)
+            var inheritedChunks = defaultInheritedChunks.Concat(inheritedChunkTrees.SelectMany(tree => tree.Chunks));
+            foreach (var chunk in inheritedChunks)
             {
                 // All TagHelperDirectiveDescriptors created here have undefined source locations because the source
                 // that created them is not in the same file.

--- a/src/Microsoft.AspNet.Mvc.Razor.Host/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/Properties/Resources.Designer.cs
@@ -27,22 +27,6 @@ namespace Microsoft.AspNet.Mvc.Razor.Host
         }
 
         /// <summary>
-        /// Argument must be an instance of '{0}'.
-        /// </summary>
-        internal static string ArgumentMustBeOfType
-        {
-            get { return GetString("ArgumentMustBeOfType"); }
-        }
-
-        /// <summary>
-        /// Argument must be an instance of '{0}'.
-        /// </summary>
-        internal static string FormatArgumentMustBeOfType(object p0)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("ArgumentMustBeOfType"), p0);
-        }
-
-        /// <summary>
         /// The 'inherits' keyword is not allowed when a '{0}' keyword is used.
         /// </summary>
         internal static string MvcRazorCodeParser_CannotHaveModelAndInheritsKeyword

--- a/src/Microsoft.AspNet.Mvc.Razor.Host/Resources.resx
+++ b/src/Microsoft.AspNet.Mvc.Razor.Host/Resources.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -119,9 +119,6 @@
   </resheader>
   <data name="ArgumentCannotBeNullOrEmpy" xml:space="preserve">
     <value>Value cannot be null or empty.</value>
-  </data>
-  <data name="ArgumentMustBeOfType" xml:space="preserve">
-    <value>Argument must be an instance of '{0}'.</value>
   </data>
   <data name="MvcRazorCodeParser_CannotHaveModelAndInheritsKeyword" xml:space="preserve">
     <value>The 'inherits' keyword is not allowed when a '{0}' keyword is used.</value>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/TagHelpersTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/TagHelpersTest.cs
@@ -150,6 +150,19 @@ page:<root>root-content</root>"
         }
 
         [Fact]
+        public async Task DefaultInheritedTagsCanBeRemoved()
+        {
+            // Arrange
+            var expected =
+@"<a href=""~/VirtualPath"">Virtual path</a>";
+
+            var result = await Client.GetStringAsync("RemoveDefaultInheritedTagHelpers");
+
+            // Assert
+            Assert.Equal(expected, result.Trim(), ignoreLineEndingDifferences: true);
+        }
+
+        [Fact]
         public async Task ViewsWithModelMetadataAttributes_CanRenderForm()
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/Directives/ChunkInheritanceUtilityTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/Directives/ChunkInheritanceUtilityTest.cs
@@ -42,28 +42,6 @@ namespace Microsoft.AspNet.Mvc.Razor.Directives
             Assert.Collection(chunkTreeResults,
                 chunkTreeResult =>
                 {
-                    var viewImportsPath = PlatformNormalizer.NormalizePath(@"Views\home\_ViewImports.cshtml");
-                    Assert.Collection(chunkTreeResult.ChunkTree.Chunks,
-                        chunk =>
-                        {
-                            Assert.IsType<LiteralChunk>(chunk);
-                            Assert.Equal(viewImportsPath, chunk.Start.FilePath);
-                        },
-                        chunk =>
-                        {
-                            var usingChunk = Assert.IsType<UsingChunk>(chunk);
-                            Assert.Equal("MyNamespace", usingChunk.Namespace);
-                            Assert.Equal(viewImportsPath, chunk.Start.FilePath);
-                        },
-                        chunk =>
-                        {
-                            Assert.IsType<LiteralChunk>(chunk);
-                            Assert.Equal(viewImportsPath, chunk.Start.FilePath);
-                        });
-                    Assert.Equal(viewImportsPath, chunkTreeResult.FilePath);
-                },
-                chunkTreeResult =>
-                {
                     var viewImportsPath = PlatformNormalizer.NormalizePath(@"Views\_ViewImports.cshtml");
                     Assert.Collection(chunkTreeResult.ChunkTree.Chunks,
                         chunk =>
@@ -98,6 +76,28 @@ namespace Microsoft.AspNet.Mvc.Razor.Directives
                         chunk =>
                         {
                             Assert.IsType<StatementChunk>(chunk);
+                            Assert.Equal(viewImportsPath, chunk.Start.FilePath);
+                        },
+                        chunk =>
+                        {
+                            Assert.IsType<LiteralChunk>(chunk);
+                            Assert.Equal(viewImportsPath, chunk.Start.FilePath);
+                        });
+                    Assert.Equal(viewImportsPath, chunkTreeResult.FilePath);
+                },
+                chunkTreeResult =>
+                {
+                    var viewImportsPath = PlatformNormalizer.NormalizePath(@"Views\home\_ViewImports.cshtml");
+                    Assert.Collection(chunkTreeResult.ChunkTree.Chunks,
+                        chunk =>
+                        {
+                            Assert.IsType<LiteralChunk>(chunk);
+                            Assert.Equal(viewImportsPath, chunk.Start.FilePath);
+                        },
+                        chunk =>
+                        {
+                            var usingChunk = Assert.IsType<UsingChunk>(chunk);
+                            Assert.Equal("MyNamespace", usingChunk.Namespace);
                             Assert.Equal(viewImportsPath, chunk.Start.FilePath);
                         },
                         chunk =>
@@ -173,10 +173,10 @@ namespace Microsoft.AspNet.Mvc.Razor.Directives
             utility.MergeInheritedChunkTrees(chunkTree, inheritedChunkTrees, "dynamic");
 
             // Assert
-            Assert.Equal(3, chunkTree.Chunks.Count);
-            Assert.Same(inheritedChunkTrees[0].Chunks[0], chunkTree.Chunks[0]);
-            Assert.Same(inheritedChunkTrees[1].Chunks[0], chunkTree.Chunks[1]);
-            Assert.Same(defaultChunks[0], chunkTree.Chunks[2]);
+            Assert.Collection(chunkTree.Chunks,
+                chunk => Assert.Same(defaultChunks[1], chunk),
+                chunk => Assert.Same(inheritedChunkTrees[0].Chunks[0], chunk),
+                chunk => Assert.Same(defaultChunks[0], chunk));
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/MvcRazorParserTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/MvcRazorParserTest.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNet.Mvc.Rendering;
-using Microsoft.AspNet.Mvc.ViewFeatures;
 using Microsoft.AspNet.Razor;
 using Microsoft.AspNet.Razor.Chunks;
 using Microsoft.AspNet.Razor.Parser;
@@ -66,8 +65,8 @@ namespace Microsoft.AspNet.Mvc.Razor
                     {
                         new[]
                         {
-                            CreateChunkTree(new TagHelperPrefixDirectiveChunk { Prefix = "THP1" }),
                             CreateChunkTree(new TagHelperPrefixDirectiveChunk { Prefix = "THP2" }),
+                            CreateChunkTree(new TagHelperPrefixDirectiveChunk { Prefix = "THP1" }),
                         },
                         new[] { CreateDirectiveDescriptor("THP1", TagHelperDirectiveType.TagHelperPrefix) }
                     },
@@ -89,10 +88,10 @@ namespace Microsoft.AspNet.Mvc.Razor
                     {
                         new[]
                         {
+                            CreateChunkTree(new RemoveTagHelperChunk { LookupText = "RTH" }),
                             CreateChunkTree(
                                 new LiteralChunk { Text = "Hello world" },
                                 new AddTagHelperChunk { LookupText = "ATH" }),
-                            CreateChunkTree(new RemoveTagHelperChunk { LookupText = "RTH" })
                         },
                         new[]
                         {
@@ -103,11 +102,11 @@ namespace Microsoft.AspNet.Mvc.Razor
                     {
                         new[]
                         {
-                            CreateChunkTree(new TagHelperPrefixDirectiveChunk { Prefix = "THP" }),
+                            CreateChunkTree(new RemoveTagHelperChunk { LookupText = "RTH" }),
                             CreateChunkTree(
                                 new LiteralChunk { Text = "Hello world" },
                                 new AddTagHelperChunk { LookupText = "ATH" }),
-                            CreateChunkTree(new RemoveTagHelperChunk { LookupText = "RTH" })
+                            CreateChunkTree(new TagHelperPrefixDirectiveChunk { Prefix = "THP" }),
                         },
                         new[]
                         {
@@ -119,10 +118,10 @@ namespace Microsoft.AspNet.Mvc.Razor
                     {
                         new[]
                         {
-                            CreateChunkTree(new TagHelperPrefixDirectiveChunk { Prefix = "THP1" }),
-                            CreateChunkTree(new AddTagHelperChunk { LookupText = "ATH" }),
-                            CreateChunkTree(new RemoveTagHelperChunk { LookupText = "RTH" }),
                             CreateChunkTree(new TagHelperPrefixDirectiveChunk { Prefix = "THP2" }),
+                            CreateChunkTree(new RemoveTagHelperChunk { LookupText = "RTH" }),
+                            CreateChunkTree(new AddTagHelperChunk { LookupText = "ATH" }),
+                            CreateChunkTree(new TagHelperPrefixDirectiveChunk { Prefix = "THP1" }),
                         },
                         new[]
                         {

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/Basic.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/Basic.cs
@@ -16,13 +16,13 @@ namespace Asp
         }
         #line hidden
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<dynamic> Html { get; private set; }
-        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
+        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
+        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
+        public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<dynamic> Html { get; private set; }
 
         #line hidden
 

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/Inject.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/Inject.cs
@@ -30,13 +30,13 @@ using MyNamespace
 #line hidden
         { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<dynamic> Html { get; private set; }
-        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
+        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
+        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
+        public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<dynamic> Html { get; private set; }
 
         #line hidden
 

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/InjectWithModel.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/InjectWithModel.cs
@@ -38,11 +38,11 @@ namespace Asp
 #line hidden
         { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
+        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
+        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
 
         #line hidden
 

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/InjectWithSemicolon.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/InjectWithSemicolon.cs
@@ -54,11 +54,11 @@ namespace Asp
 #line hidden
         { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
+        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
+        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
 
         #line hidden
 

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/Model.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/Model.cs
@@ -22,13 +22,13 @@ namespace Asp
         }
         #line hidden
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<System.Collections.IEnumerable> Html { get; private set; }
-        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
+        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
+        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
+        public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<System.Collections.IEnumerable> Html { get; private set; }
 
         #line hidden
 

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/ModelExpressionTagHelper.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/DesignTime/ModelExpressionTagHelper.cs
@@ -38,13 +38,13 @@ namespace Asp
         }
         #line hidden
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<DateTime> Html { get; private set; }
-        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
+        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
+        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
+        public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<DateTime> Html { get; private set; }
 
         #line hidden
 

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/Basic.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/Basic.cs
@@ -16,13 +16,13 @@ namespace Asp
         }
         #line hidden
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<dynamic> Html { get; private set; }
-        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
+        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
+        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
+        public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<dynamic> Html { get; private set; }
 
         #line hidden
 

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/Inject.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/Inject.cs
@@ -24,13 +24,13 @@ using MyNamespace
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public MyApp MyPropertyName { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<dynamic> Html { get; private set; }
-        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
+        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
+        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
+        public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<dynamic> Html { get; private set; }
 
         #line hidden
 

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/InjectWithModel.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/InjectWithModel.cs
@@ -26,11 +26,11 @@ namespace Asp
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public MyService<MyModel> Html { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
+        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
+        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
 
         #line hidden
 

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/InjectWithSemicolon.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/InjectWithSemicolon.cs
@@ -30,11 +30,11 @@ namespace Asp
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public MyService<MyModel> Html2 { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
+        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
+        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
 
         #line hidden
 

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/Model.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/Model.cs
@@ -22,13 +22,13 @@ namespace Asp
         }
         #line hidden
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<System.Collections.IEnumerable> Html { get; private set; }
-        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
+        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
+        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
+        public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<System.Collections.IEnumerable> Html { get; private set; }
 
         #line hidden
 

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/ModelExpressionTagHelper.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/ModelExpressionTagHelper.cs
@@ -31,13 +31,13 @@ namespace Asp
         }
         #line hidden
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<DateTime> Html { get; private set; }
-        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
+        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
         public Microsoft.AspNet.Mvc.IViewComponentHelper Component { get; private set; }
         [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
-        public Microsoft.AspNet.Mvc.IUrlHelper Url { get; private set; }
+        public Microsoft.AspNet.Mvc.Rendering.IJsonHelper Json { get; private set; }
+        [Microsoft.AspNet.Mvc.Razor.Internal.RazorInjectAttribute]
+        public Microsoft.AspNet.Mvc.Rendering.IHtmlHelper<DateTime> Html { get; private set; }
 
         #line hidden
 

--- a/test/WebSites/TagHelpersWebSite/Controllers/RemoveDefaultInheritedTagHelpersController.cs
+++ b/test/WebSites/TagHelpersWebSite/Controllers/RemoveDefaultInheritedTagHelpersController.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Mvc;
+
+namespace TagHelpersWebSite.Controllers
+{
+    public class RemoveDefaultInheritedTagHelpersController : Controller
+    {
+        public IActionResult Index() => View();
+    }
+}

--- a/test/WebSites/TagHelpersWebSite/Views/RemoveDefaultInheritedTagHelpers/Index.cshtml
+++ b/test/WebSites/TagHelpersWebSite/Views/RemoveDefaultInheritedTagHelpers/Index.cshtml
@@ -1,0 +1,4 @@
+﻿@{ 
+    Layout = null;
+}
+<a href="~/VirtualPath">Virtual path</a>

--- a/test/WebSites/TagHelpersWebSite/Views/RemoveDefaultInheritedTagHelpers/_ViewImports.cshtml
+++ b/test/WebSites/TagHelpersWebSite/Views/RemoveDefaultInheritedTagHelpers/_ViewImports.cshtml
@@ -1,0 +1,1 @@
+﻿@removeTagHelper "*, Microsoft.AspNet.Mvc.Razor"


### PR DESCRIPTION
Additionally simplifying the contract for ChunkInheritaceUtility \ IChunkMerger so we don't have to understand the
order in which CodeTrees appear.

Fixes #2989