### PR TITLE
[quick fix] Allow `TestCommon` project to build successfully

### DIFF
--- a/test/Microsoft.AspNet.Mvc.TestCommon/project.json
+++ b/test/Microsoft.AspNet.Mvc.TestCommon/project.json
@@ -1,8 +1,12 @@
 {
-    "version": "6.0.0-*",
-    "shared": "**/*.cs",
-    "frameworks": {
-      "dnx451": {},
-      "dnxcore50": {}
+  "version": "6.0.0-*",
+  "shared": "**/*.cs",
+  "frameworks": {
+    "dnx451": {},
+    "dnxcore50": {
+      "dependencies": {
+          "System.Runtime": "4.0.21-beta-*"
+      }
     }
+  }
 }


### PR DESCRIPTION
- otherwise may fail in VS or when using `BuildV2` from the command line