### PR TITLE
[quick fix] Remove `version` property from `project.json` for Logging…

### DIFF
--- a/test/WebSites/LoggingWebSite/project.json
+++ b/test/WebSites/LoggingWebSite/project.json
@@ -1,6 +1,5 @@
 {
     "webroot": "wwwroot",
-    "version": "1.0.0-*",
     "exclude": [
         "wwwroot"
     ],


### PR DESCRIPTION
…WebSite

- avoid warning when building Microsoft.AspNet.Mvc.FunctionalTests project
- now consistent w/ other web sites in this repo
  - all but MvcMinimalSample.Web and that isn't used in functional tests