### PR TITLE
Work around aspnet/External#33, aspnet/External#41, aspnet/External#42, and aspnet/External#43

### DIFF
--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ActionResultTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ActionResultTests.cs
@@ -8,6 +8,9 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
+#if DNXCORE50
+using Microsoft.AspNet.Testing.xunit;
+#endif
 using Xunit;
 
 namespace Microsoft.AspNet.Mvc.FunctionalTests
@@ -218,7 +221,13 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("content", await response.Content.ReadAsStringAsync());
         }
 
-        [Fact]
+#if DNXCORE50
+        // Work around aspnet/External#43. Encoding.ASCII is of type System.Text.UTF8Encoding with Core CLR on Linux.
+        [ConditionalTheory]
+        [OSSkipCondition(OperatingSystems.Linux)]
+#else
+        [Theory]
+#endif
         public async Task ContentResult_WritesContent_SetsContentTypeAndEncoding()
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/HtmlGenerationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/HtmlGenerationTest.cs
@@ -12,6 +12,9 @@ using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Mvc.Internal;
 using Microsoft.AspNet.Mvc.TagHelpers;
+#if DNXCORE50
+using Microsoft.AspNet.Testing;
+#endif
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Extensions;
 using Xunit;
@@ -41,34 +44,54 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 
         public HttpClient EncodedClient { get; }
 
+        public static TheoryData<string, string> WebPagesData
+        {
+            get
+            {
+                var data = new TheoryData<string, string>
+                {
+                    { "Customer", "/Customer/HtmlGeneration_Customer" },
+                    { "Index", null },
+                    { "Product", null },
+                    // Testing attribute values with boolean and null values
+                    { "AttributesWithBooleanValues", null },
+                    // Testing SelectTagHelper with Html.BeginForm
+                    { "CreateWarehouse", null },
+                    // Testing the HTML helpers with FormTagHelper
+                    { "EditWarehouse", null },
+                    // Testing the EnvironmentTagHelper
+                    { "Environment", null },
+                    // Testing the ImageTagHelper
+                    { "Image", null },
+                    // Testing InputTagHelper with File
+                    { "Input", null },
+                    // Test ability to generate nearly identical HTML with MVC tag and HTML helpers.
+                    // Only attribute order should differ.
+                    { "Order", "/HtmlGeneration_Order/Submit" },
+                    { "OrderUsingHtmlHelpers", "/HtmlGeneration_Order/Submit" },
+                    // Testing InputTagHelpers invoked in the partial views
+                    { "ProductList", null },
+                    // Testing the ScriptTagHelper
+                    { "Script", null },
+                };
+
+#if DNXCORE50
+                // Work around aspnet/External#33. Large resources corrupted with Core CLR on Linux.
+                if (!TestPlatformHelper.IsLinux)
+#endif
+                {
+                    // Testing MVC tag helpers invoked in the editor templates from HTML helpers
+                    data.Add("EmployeeList", null);
+                    // Testing the LinkTagHelper
+                    data.Add("Link", null);
+                }
+
+                return data;
+            }
+        }
+
         [Theory]
-        [InlineData("Index", null)]
-        // Test ability to generate nearly identical HTML with MVC tag and HTML helpers.
-        // Only attribute order should differ.
-        [InlineData("Order", "/HtmlGeneration_Order/Submit")]
-        [InlineData("OrderUsingHtmlHelpers", "/HtmlGeneration_Order/Submit")]
-        [InlineData("Product", null)]
-        [InlineData("Customer", "/Customer/HtmlGeneration_Customer")]
-        // Testing InputTagHelpers invoked in the partial views
-        [InlineData("ProductList", null)]
-        // Testing MVC tag helpers invoked in the editor templates from HTML helpers
-        [InlineData("EmployeeList", null)]
-        // Testing SelectTagHelper with Html.BeginForm
-        [InlineData("CreateWarehouse", null)]
-        // Testing the HTML helpers with FormTagHelper
-        [InlineData("EditWarehouse", null)]
-        // Testing the EnvironmentTagHelper
-        [InlineData("Environment", null)]
-        // Testing the LinkTagHelper
-        [InlineData("Link", null)]
-        // Testing the ScriptTagHelper
-        [InlineData("Script", null)]
-        // Testing the ImageTagHelper
-        [InlineData("Image", null)]
-        // Testing InputTagHelper with File
-        [InlineData("Input", null)]
-        // Testing attribute values with boolean and null values
-        [InlineData("AttributesWithBooleanValues", null)]
+        [MemberData(nameof(WebPagesData))]
         public async Task HtmlGenerationWebSite_GeneratesExpectedResults(string action, string antiforgeryPath)
         {
             // Arrange
@@ -117,15 +140,35 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             }
         }
 
+        public static TheoryData<string, string> EncodedPagesData
+        {
+            get
+            {
+                var data = new TheoryData<string, string>
+                {
+                    { "AttributesWithBooleanValues", null },
+                    { "EditWarehouse", null },
+                    { "Index", null },
+                    { "Link", null },
+                    { "OrderUsingHtmlHelpers", "/HtmlGeneration_Order/Submit" },
+                    { "Product", null },
+                };
+
+#if DNXCORE50
+                // Work around aspnet/External#33. Large resources corrupted with Core CLR on Linux.
+                if (!TestPlatformHelper.IsLinux)
+#endif
+                {
+                    data.Add("Order", "/HtmlGeneration_Order/Submit");
+                    data.Add("Script", null);
+                }
+
+                return data;
+            }
+        }
+
         [Theory]
-        [InlineData("EditWarehouse", null)]
-        [InlineData("Index", null)]
-        [InlineData("Link", null)]
-        [InlineData("Order", "/HtmlGeneration_Order/Submit")]
-        [InlineData("OrderUsingHtmlHelpers", "/HtmlGeneration_Order/Submit")]
-        [InlineData("Product", null)]
-        [InlineData("Script", null)]
-        [InlineData("AttributesWithBooleanValues", null)]
+        [MemberData(nameof(EncodedPagesData))]
         public async Task HtmlGenerationWebSite_GenerateEncodedResults(string action, string antiforgeryPath)
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/HtmlHelperOptionsTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/HtmlHelperOptionsTest.cs
@@ -4,6 +4,9 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Testing;
+#if DNXCORE50
+using Microsoft.AspNet.Testing.xunit;
+#endif
 using Xunit;
 
 namespace Microsoft.AspNet.Mvc.FunctionalTests
@@ -47,7 +50,13 @@ False";
             Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
 
+#if DNXCORE50
+        [ConditionalFact]
+        // Work around aspnet/External#42. Only the invariant culture works with Core CLR on Linux.
+        [OSSkipCondition(OperatingSystems.Linux)]
+#else
         [Fact]
+#endif
         [ReplaceCulture]
         public async Task OverrideAppWideDefaultsInViewAndPartialView()
         {

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/LocalizationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/LocalizationTest.cs
@@ -30,20 +30,26 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         {
             get
             {
-                var expected1 =
- @"<language-layout>en-gb-index
+#if DNXCORE50
+                // Work around aspnet/External#42. Only the invariant culture works with Core CLR on Linux.
+                if (!TestPlatformHelper.IsLinux)
+#endif
+                {
+                    var expected1 =
+@"<language-layout>en-gb-index
 partial
 mypartial
 </language-layout>";
 
-                yield return new[] { "en-GB", expected1 };
+                    yield return new[] { "en-GB", expected1 };
 
-                var expected2 =
- @"<fr-language-layout>fr-index
+                    var expected2 =
+@"<fr-language-layout>fr-index
 fr-partial
 mypartial
 </fr-language-layout>";
-                yield return new[] { "fr", expected2 };
+                    yield return new[] { "fr", expected2 };
+                }
 
                 if (!TestPlatformHelper.IsMono)
                 {

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingTest.cs
@@ -1181,7 +1181,13 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #endif
         }
 
+#if DNXCORE50
+        [ConditionalFact]
+        // Work around aspnet/External#42. Only the invariant culture works with Core CLR on Linux.
+        [OSSkipCondition(OperatingSystems.Linux)]
+#else
         [Fact]
+#endif
         public async Task UpdateDealerVehicle_UsesDefaultValuesForOptionalProperties()
         {
             // Arrange
@@ -1329,7 +1335,13 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("grandFatherName", employee.Parent.Parent.Name);
         }
 
+#if DNXCORE50
+        [ConditionalFact]
+        // Work around aspnet/External#42. Only the invariant culture works with Core CLR on Linux.
+        [OSSkipCondition(OperatingSystems.Linux)]
+#else
         [Fact]
+#endif
         public async Task HtmlHelper_DisplayFor_ShowsPropertiesInModelMetadataOrder()
         {
             // Arrange
@@ -1351,7 +1363,13 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #endif
         }
 
+#if DNXCORE50
+        [ConditionalFact]
+        // Work around aspnet/External#42. Only the invariant culture works with Core CLR on Linux.
+        [OSSkipCondition(OperatingSystems.Linux)]
+#else
         [Fact]
+#endif
         public async Task HtmlHelper_EditorFor_ShowsPropertiesInModelMetadataOrder()
         {
             // Arrange
@@ -1377,7 +1395,13 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #endif
         }
 
+#if DNXCORE50
+        [ConditionalFact]
+        // Work around aspnet/External#42. Only the invariant culture works with Core CLR on Linux.
+        [OSSkipCondition(OperatingSystems.Linux)]
+#else
         [Fact]
+#endif
         public async Task HtmlHelper_EditorFor_ShowsPropertiesAndErrorsInModelMetadataOrder()
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/RemoteAttributeValidationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/RemoteAttributeValidationTest.cs
@@ -6,6 +6,9 @@ using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
+#if DNXCORE50
+using Microsoft.AspNet.Testing.xunit;
+#endif
 using Xunit;
 
 namespace Microsoft.AspNet.Mvc.FunctionalTests
@@ -22,7 +25,13 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 
         public HttpClient Client { get; }
 
+#if DNXCORE50
+        // Work around aspnet/External#33. Large resources corrupted with Core CLR on Linux.
+        [ConditionalTheory]
+        [OSSkipCondition(OperatingSystems.Linux)]
+#else
         [Theory]
+#endif
         [InlineData("Aria", "/Aria")]
         [InlineData("Root", "")]
         public async Task RemoteAttribute_LeadsToExpectedValidationAttributes(string areaName, string pathSegment)

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/TagHelpersTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/TagHelpersTest.cs
@@ -7,6 +7,9 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
 using System.Threading.Tasks;
+#if DNXCORE50
+using Microsoft.AspNet.Testing.xunit;
+#endif
 using Xunit;
 
 namespace Microsoft.AspNet.Mvc.FunctionalTests
@@ -175,7 +178,13 @@ page:<root>root-content</root>"
 #endif
         }
 
+#if DNXCORE50
+        [ConditionalFact]
+        // Work around aspnet/External#42. Only the invariant culture works with Core CLR on Linux.
+        [OSSkipCondition(OperatingSystems.Linux)]
+#else
         [Fact]
+#endif
         public async Task ViewsWithModelMetadataAttributes_CanRenderPostedValue()
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ViewEngineTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ViewEngineTests.cs
@@ -123,13 +123,19 @@ partial-contentcomponent-content";
         {
             get
             {
-                var expected1 = @"expander-index
+#if DNXCORE50
+                // Work around aspnet/External#42. Only the invariant culture works with Core CLR on Linux.
+                if (!TestPlatformHelper.IsLinux)
+#endif
+                {
+                    var expected1 = @"expander-index
 gb-partial";
-                yield return new[] { "en-GB", expected1 };
+                    yield return new[] { "en-GB", expected1 };
 
-                var expected2 = @"fr-index
+                    var expected2 = @"fr-index
 fr-partial";
-                yield return new[] { "fr", expected2 };
+                    yield return new[] { "fr", expected2 };
+                }
 
                 if (!TestPlatformHelper.IsMono)
                 {
@@ -269,11 +275,16 @@ index-content";
                     yield return new[] { "!-invalid-!", expected1 };
                 }
 
-                var expected2 =
- @"<fr-language-layout>View With Layout
+#if DNXCORE50
+                // Work around aspnet/External#42. Only the invariant culture works with Core CLR on Linux.
+                if (!TestPlatformHelper.IsLinux)
+#endif
+                {
+                    var expected2 =
+@"<fr-language-layout>View With Layout
 </fr-language-layout>";
-                yield return new[] { "fr", expected2 };
-
+                    yield return new[] { "fr", expected2 };
+                }
             }
         }
 


### PR DESCRIPTION
- do not run tests that hit known issues with Core CLR on Linux