### PR TITLE
[Design][Perf] Hoist simple Expression<Func<T, U>> into fields in Razor

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <add key="AspNetVNext" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />


### PR DESCRIPTION
This change uses Roslyn to transform the syntax tree of a Razor page and hoist all **simple** expressions into static readonly fields.

For code like:
```
@Html.EditorFor(m => m.Occupation)
```

The c# compiler inserts a bunch of code calling into `System.Linq.Expressions` to construct and verify an `Expression<Func<T, U>>` matching the lambda being passed here. This runs **every** time the page is rendered, and allocates a lot of collections to verify that the types are valid.


The transformation done here looks like this:
```
public class __Generated_RazorPage
{
    private static readonly Expression<Func<Person, string>> __Hoist_1 = m => m.Occuptation;

    public Task RenderAsync()
    {
        ...
        Write(Html.EditorFor(__Hoist_1));
        ...
    }
}
```

When we encounter a case that we can't hoist, we simply ignore it. The 90% case in Razor is a property accessor or identity func. The only common case we can't handle is indexers, as usually the index is captured.