### PR TITLE
Generic ModelStateDictionary add and remove extensions

### DIFF
--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ModelStateDictionaryExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ModelStateDictionaryExtensions.cs
@@ -15,13 +15,12 @@ namespace Microsoft.AspNet.Mvc
     {
         /// <summary>
         /// Adds the specified <paramref name="errorMessage"/> to the <see cref="ModelState.Errors"/> instance
-        /// that is associated with the specified <paramref name="expression"/> text key repressentation.
+        /// that is associated with the specified <paramref name="expression"/>.
         /// </summary>
         /// <typeparam name="TModel">The type of the model.</typeparam>
         /// <param name="modelState">The <see cref="ModelStateDictionary"/> instance this method extends.</param>
-        /// <param name="expression">The expression of <typeparamref name="TModel"/> from
-        /// which text representation will be used as a key of the <see cref="ModelState"/> to add errors to.</param>
-        /// <param name="errorMessage"></param>
+        /// <param name="expression">An expression to be evaluated against an item in the current model.</param>
+        /// <param name="errorMessage">The error message to add.</param>
         public static void AddModelError<TModel>(this ModelStateDictionary modelState, Expression<Func<TModel, object>> expression, string errorMessage)
         {
             modelState.AddModelError(GetExpressionText(expression), errorMessage);
@@ -29,28 +28,26 @@ namespace Microsoft.AspNet.Mvc
 
         /// <summary>
         /// Adds the specified <paramref name="exception"/> to the <see cref="ModelState.Errors"/> instance
-        /// that is associated with the specified <paramref name="expression"/> text key repressentation.
+        /// that is associated with the specified <paramref name="expression"/>.
         /// </summary>
         /// <typeparam name="TModel">The type of the model.</typeparam>
         /// <param name="modelState">The <see cref="ModelStateDictionary"/> instance this method extends.</param>
-        /// <param name="expression">The expression of <typeparamref name="TModel"/> from
-        /// which text representation will be used as a key of the <see cref="ModelState"/> to add errors to.</param>
-        /// <param name="exception">The error message to add.</param>
+        /// <param name="expression">An expression to be evaluated against an item in the current model.</param>
+        /// <param name="exception">The <see cref="Exception"/> to add.</param>
         public static void AddModelError<TModel>(this ModelStateDictionary modelState, Expression<Func<TModel, object>> expression, Exception exception)
         {
             modelState.AddModelError(GetExpressionText(expression), exception);
         }
 
         /// <summary>
-        /// Removes the specified <paramref name="expression"/> text key repressentation from the <see cref="ModelStateDictionary"/>.
+        /// Removes the specified <paramref name="expression"/> from the <see cref="ModelStateDictionary"/>.
         /// </summary>
         /// <typeparam name="TModel">The type of the model.</typeparam>
         /// <param name="modelState">The <see cref="ModelStateDictionary"/> instance this method extends.</param>
-        /// <param name="expression">The expression of <typeparamref name="TModel"/> from
-        /// which text representation will be used as a key of the <see cref="ModelState"/> to add errors to.</param>
+        /// <param name="expression">An expression to be evaluated against an item in the current model.</param>
         /// <returns>
         /// true if the element is successfully removed; otherwise, false.
-        /// This method also returns false if expression's text key was not found in the model-state dictionary.
+        /// This method also returns false if <paramref name="expression"/> was not found in the model-state dictionary.
         /// </returns>
         public static bool Remove<TModel>(this ModelStateDictionary modelState, Expression<Func<TModel, object>> expression)
         {
@@ -61,12 +58,15 @@ namespace Microsoft.AspNet.Mvc
         {
             var unaryExpression = expression.Body as UnaryExpression;
 
-            if (IsConvertToObject(unaryExpression))
+            if (IsConvertibleToObject(unaryExpression))
+            {
                 return ExpressionHelper.GetExpressionText(Expression.Lambda(unaryExpression.Operand, expression.Parameters[0]));
+            }
 
             return ExpressionHelper.GetExpressionText(expression);
         }
-        private static bool IsConvertToObject(UnaryExpression expression)
+
+        private static bool IsConvertibleToObject(UnaryExpression expression)
         {
             return expression?.NodeType == ExpressionType.Convert &&
                 expression.Operand is MemberExpression &&

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ModelStateDictionaryExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ModelStateDictionaryExtensions.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using Microsoft.AspNet.Mvc.ModelBinding;
+using Microsoft.AspNet.Mvc.ViewFeatures;
+
+namespace Microsoft.AspNet.Mvc
+{
+    /// <summary>
+    /// Extensions methods for <see cref="ModelStateDictionary"/>.
+    /// </summary>
+    public static class ModelStateDictionaryExtensions
+    {
+        /// <summary>
+        /// Adds the specified <paramref name="errorMessage"/> to the <see cref="ModelState.Errors"/> instance
+        /// that is associated with the specified <paramref name="expression"/> text key repressentation.
+        /// </summary>
+        /// <typeparam name="TModel">The type of the model.</typeparam>
+        /// <param name="modelState">The <see cref="ModelStateDictionary"/> instance this method extends.</param>
+        /// <param name="expression">The expression of <typeparamref name="TModel"/> from
+        /// which text representation will be used as a key of the <see cref="ModelState"/> to add errors to.</param>
+        /// <param name="errorMessage"></param>
+        public static void AddModelError<TModel>(this ModelStateDictionary modelState, Expression<Func<TModel, object>> expression, string errorMessage)
+        {
+            modelState.AddModelError(GetExpressionText(expression), errorMessage);
+        }
+
+        /// <summary>
+        /// Adds the specified <paramref name="exception"/> to the <see cref="ModelState.Errors"/> instance
+        /// that is associated with the specified <paramref name="expression"/> text key repressentation.
+        /// </summary>
+        /// <typeparam name="TModel">The type of the model.</typeparam>
+        /// <param name="modelState">The <see cref="ModelStateDictionary"/> instance this method extends.</param>
+        /// <param name="expression">The expression of <typeparamref name="TModel"/> from
+        /// which text representation will be used as a key of the <see cref="ModelState"/> to add errors to.</param>
+        /// <param name="exception">The error message to add.</param>
+        public static void AddModelError<TModel>(this ModelStateDictionary modelState, Expression<Func<TModel, object>> expression, Exception exception)
+        {
+            modelState.AddModelError(GetExpressionText(expression), exception);
+        }
+
+        /// <summary>
+        /// Removes the specified <paramref name="expression"/> text key repressentation from the <see cref="ModelStateDictionary"/>.
+        /// </summary>
+        /// <typeparam name="TModel">The type of the model.</typeparam>
+        /// <param name="modelState">The <see cref="ModelStateDictionary"/> instance this method extends.</param>
+        /// <param name="expression">The expression of <typeparamref name="TModel"/> from
+        /// which text representation will be used as a key of the <see cref="ModelState"/> to add errors to.</param>
+        /// <returns>
+        /// true if the element is successfully removed; otherwise, false.
+        /// This method also returns false if expression's text key was not found in the model-state dictionary.
+        /// </returns>
+        public static bool Remove<TModel>(this ModelStateDictionary modelState, Expression<Func<TModel, object>> expression)
+        {
+            return modelState.Remove(GetExpressionText(expression));
+        }
+
+        private static string GetExpressionText(LambdaExpression expression)
+        {
+            var unaryExpression = expression.Body as UnaryExpression;
+
+            if (IsConvertToObject(unaryExpression))
+                return ExpressionHelper.GetExpressionText(Expression.Lambda(unaryExpression.Operand, expression.Parameters[0]));
+
+            return ExpressionHelper.GetExpressionText(expression);
+        }
+        private static bool IsConvertToObject(UnaryExpression expression)
+        {
+            return expression?.NodeType == ExpressionType.Convert &&
+                expression.Operand is MemberExpression &&
+                expression.Type == typeof(object);
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ModelStateDictionaryExtensionsTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ModelStateDictionaryExtensionsTest.cs
@@ -1,0 +1,241 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.AspNet.Mvc.ModelBinding;
+using Xunit;
+
+namespace Microsoft.AspNet.Mvc
+{
+    public class ModelStateDictionaryExtensionsTest
+    {
+        [Fact]
+        public void AddsModelErrorMessage_ForSingleExpression()
+        {
+            // Arrange
+            var modelState = new ModelStateDictionary();
+
+            // Act
+            modelState.AddModelError<TestModel>(model => model.Text, "Message");
+
+            // Assert
+            Assert.Equal("Text", modelState.Single().Key);
+            Assert.Equal("Message", modelState.Single().Value.Errors.Single().ErrorMessage);
+        }
+
+        [Fact]
+        public void AddsModelErrorMessage_ForRelationExpression()
+        {
+            // Arrange
+            var modelState = new ModelStateDictionary();
+
+            // Act
+            modelState.AddModelError<TestModel>(model => model.Child.Text, "Message");
+
+            // Assert
+            Assert.Equal("Child.Text", modelState.Single().Key);
+            Assert.Equal("Message", modelState.Single().Value.Errors.Single().ErrorMessage);
+        }
+
+        [Fact]
+        public void AddsModelErrorMessage_ForImplicitlyCastedToObjectExpression()
+        {
+            // Arrange
+            var modelState = new ModelStateDictionary();
+
+            // Act
+            modelState.AddModelError<TestModel>(model => model.Child.Value, "Message");
+
+            // Assert
+            Assert.Equal("Child.Value", modelState.Single().Key);
+            Assert.Equal("Message", modelState.Single().Value.Errors.Single().ErrorMessage);
+        }
+
+        [Fact]
+        public void AddsModelErrorMessage_ForExplicitlyCastedToObjectExpression()
+        {
+            // Arrange
+            var modelState = new ModelStateDictionary();
+
+            // Act
+            modelState.AddModelError<TestModel>(model => (object)model.Child.Value, "Message");
+
+            // Assert
+            Assert.Equal("Child.Value", modelState.Single().Key);
+            Assert.Equal("Message", modelState.Single().Value.Errors.Single().ErrorMessage);
+        }
+
+        [Fact]
+        public void AddsModelErrorMessage_ForExpressionWithoutTextRepresentation()
+        {
+            // Arrange
+            var modelState = new ModelStateDictionary();
+
+            // Act
+            modelState.AddModelError<TestModel>(model => model.ToString(), "Message");
+
+            // Assert
+            Assert.Equal("", modelState.Single().Key);
+            Assert.Equal("Message", modelState.Single().Value.Errors.Single().ErrorMessage);
+        }
+
+        [Fact]
+        public void AddsModelErrorException_ForSingleExpression()
+        {
+            // Arrange
+            var exception = new Exception();
+            var modelState = new ModelStateDictionary();
+
+            // Act
+            modelState.AddModelError<TestModel>(model => model.Text, exception);
+
+            // Assert
+            Assert.Equal("Text", modelState.Single().Key);
+            Assert.Same(exception, modelState.Single().Value.Errors.Single().Exception);
+        }
+
+        [Fact]
+        public void AddsModelErrorException_ForRelationExpression()
+        {
+            // Arrange
+            var exception = new Exception();
+            var modelState = new ModelStateDictionary();
+
+            // Act
+            modelState.AddModelError<TestModel>(model => model.Child.Text, exception);
+
+            // Assert
+            Assert.Equal("Child.Text", modelState.Single().Key);
+            Assert.Same(exception, modelState.Single().Value.Errors.Single().Exception);
+        }
+
+        [Fact]
+        public void AddsModelErrorException_ForImplicitlyCastedToObjectExpression()
+        {
+            // Arrange
+            var exception = new Exception();
+            var modelState = new ModelStateDictionary();
+
+            // Act
+            modelState.AddModelError<TestModel>(model => model.Child.Value, exception);
+
+            // Assert
+            Assert.Equal("Child.Value", modelState.Single().Key);
+            Assert.Same(exception, modelState.Single().Value.Errors.Single().Exception);
+        }
+
+        [Fact]
+        public void AddsModelErrorException_ForExplicitlyCastedToObjectExpression()
+        {
+            // Arrange
+            var exception = new Exception();
+            var modelState = new ModelStateDictionary();
+
+            // Act
+            modelState.AddModelError<TestModel>(model => (object)model.Child.Value, exception);
+
+            // Assert
+            Assert.Equal("Child.Value", modelState.Single().Key);
+            Assert.Same(exception, modelState.Single().Value.Errors.Single().Exception);
+        }
+
+        [Fact]
+        public void AddsModelErrorException_ForExpressionWithoutTextRepresentation()
+        {
+            // Arrange
+            var exception = new Exception();
+            var modelState = new ModelStateDictionary();
+
+            // Act
+            modelState.AddModelError<TestModel>(model => model.ToString(), exception);
+
+            // Assert
+            Assert.Equal("", modelState.Single().Key);
+            Assert.Same(exception, modelState.Single().Value.Errors.Single().Exception);
+        }
+
+        [Fact]
+        public void RemovesModelStateKey_ForSingleExpression()
+        {
+            // Arrange
+            var modelState = new ModelStateDictionary();
+            modelState.Add("Text", new ModelState());
+
+            // Act
+            modelState.Remove<TestModel>(model => model.Text);
+
+            // Assert
+            Assert.Empty(modelState);
+        }
+
+        [Fact]
+        public void RemovesModelStateKey_ForRelationExpression()
+        {
+            // Arrange
+            var modelState = new ModelStateDictionary();
+            modelState.Add("Child.Text", new ModelState());
+
+            // Act
+            modelState.Remove<TestModel>(model => model.Child.Text);
+
+            // Assert
+            Assert.Empty(modelState);
+        }
+
+        [Fact]
+        public void RemovesModelStateKey_ForImplicitlyCastedToObjectExpression()
+        {
+            // Arrange
+            var modelState = new ModelStateDictionary();
+            modelState.Add("Child.Value", new ModelState());
+
+            // Act
+            modelState.Remove<TestModel>(model => model.Child.Value);
+
+            // Assert
+            Assert.Empty(modelState);
+        }
+
+        [Fact]
+        public void RemovesModelStateKey_ForExplicitlyCastedToObjectExpression()
+        {
+            // Arrange
+            var modelState = new ModelStateDictionary();
+            modelState.Add("Child.Value", new ModelState());
+
+            // Act
+            modelState.Remove<TestModel>(model => (object)model.Child.Value);
+
+            // Assert
+            Assert.Empty(modelState);
+        }
+
+        [Fact]
+        public void RemovesModelStateKey_ForExpressionWithoutTextRepresentation()
+        {
+            // Arrange
+            var modelState = new ModelStateDictionary();
+            modelState.Add("", new ModelState());
+
+            // Act
+            modelState.Remove<TestModel>(model => model.ToString());
+
+            // Assert
+            Assert.Empty(modelState);
+        }
+
+        private class TestModel
+        {
+            public string Text { get; set; }
+
+            public ChildModel Child { get; set; }
+        }
+
+        private class ChildModel
+        {
+            public int Value { get; set; }
+            public string Text { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ModelStateDictionaryExtensionsTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ModelStateDictionaryExtensionsTest.cs
@@ -225,6 +225,101 @@ namespace Microsoft.AspNet.Mvc
             Assert.Empty(modelState);
         }
 
+        [Fact]
+        public void RemoveAll_ForSingleExpression_RemovesModelStateKeys()
+        {
+            // Arrange
+            var state = new ModelState();
+            var modelState = new ModelStateDictionary();
+
+            modelState.Add("Key", state);
+            modelState.Add("Text", new ModelState());
+            modelState.Add("Text.Length", new ModelState());
+
+            // Act
+            modelState.RemoveAll<TestModel>(model => model.Text);
+
+            // Assert
+            Assert.Equal("Key", modelState.Single().Key);
+            Assert.Same(state, modelState.Single().Value);
+        }
+
+        [Fact]
+        public void RemoveAll_ForRelationExpression_RemovesModelStateKeys()
+        {
+            // Arrange
+            var state = new ModelState();
+            var modelState = new ModelStateDictionary();
+
+            modelState.Add("Key", state);
+            modelState.Add("Child", new ModelState());
+            modelState.Add("Child.Text", new ModelState());
+
+            // Act
+            modelState.RemoveAll<TestModel>(model => model.Child);
+
+            // Assert
+            Assert.Equal("Key", modelState.Single().Key);
+            Assert.Same(state, modelState.Single().Value);
+        }
+
+        [Fact]
+        public void RemoveAll_ForImplicitlyCastedToObjectExpression_RemovesModelStateKeys()
+        {
+            // Arrange
+            var state = new ModelState();
+            var modelState = new ModelStateDictionary();
+
+            modelState.Add("Child", state);
+            modelState.Add("Child.Value", new ModelState());
+
+            // Act
+            modelState.RemoveAll<TestModel>(model => model.Child.Value);
+
+            // Assert
+            Assert.Equal("Child", modelState.Single().Key);
+            Assert.Same(state, modelState.Single().Value);
+        }
+
+        [Fact]
+        public void RemoveAll_ForExplicitlyCastedToObjectExpression_RemovesModelStateKeys()
+        {
+            // Arrange
+            var state = new ModelState();
+            var modelState = new ModelStateDictionary();
+
+            modelState.Add("Child", state);
+            modelState.Add("Child.Value", new ModelState());
+
+            // Act
+            modelState.RemoveAll<TestModel>(model => (object)model.Child.Value);
+
+            // Assert
+            Assert.Equal("Child", modelState.Single().Key);
+            Assert.Same(state, modelState.Single().Value);
+        }
+
+        [Fact]
+        public void RemoveAll_ForExpressionWithoutStringRepresentation_RemovesModelPropertyKeys()
+        {
+            // Arrange
+            var state = new ModelState();
+            var modelState = new ModelStateDictionary();
+
+            modelState.Add("Key", state);
+            modelState.Add("Text", new ModelState());
+            modelState.Add("Child", new ModelState());
+            modelState.Add("Child.Text", new ModelState());
+            modelState.Add("Child.NoValue", new ModelState());
+
+            // Act
+            modelState.RemoveAll<TestModel>(model => model.ToString());
+
+            // Assert
+            Assert.Equal("Key", modelState.Single().Key);
+            Assert.Same(state, modelState.Single().Value);
+        }
+
         private class TestModel
         {
             public string Text { get; set; }

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ModelStateDictionaryExtensionsTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ModelStateDictionaryExtensionsTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using Microsoft.AspNet.Mvc.ModelBinding;
 using Xunit;
 
@@ -14,70 +13,69 @@ namespace Microsoft.AspNet.Mvc
         public void AddModelError_ForSingleExpression_AddsExpectedMessage()
         {
             // Arrange
-            var modelState = new ModelStateDictionary();
+            var dictionary = new ModelStateDictionary();
 
             // Act
-            modelState.AddModelError<TestModel>(model => model.Text, "Message");
+            dictionary.AddModelError<TestModel>(model => model.Text, "Message");
 
             // Assert
-            Assert.Equal("Text", modelState.Single().Key);
-            Assert.Equal("Message", modelState.Single().Value.Errors.Single().ErrorMessage);
+            var modelState = Assert.Single(dictionary);
+            var modelError = Assert.Single(modelState.Value.Errors);
+
+            Assert.Equal("Text", modelState.Key);
+            Assert.Equal("Message", modelError.ErrorMessage);
         }
 
         [Fact]
         public void AddModelError_ForRelationExpression_AddsExpectedMessage()
         {
             // Arrange
-            var modelState = new ModelStateDictionary();
+            var dictionary = new ModelStateDictionary();
 
             // Act
-            modelState.AddModelError<TestModel>(model => model.Child.Text, "Message");
+            dictionary.AddModelError<TestModel>(model => model.Child.Text, "Message");
 
             // Assert
-            Assert.Equal("Child.Text", modelState.Single().Key);
-            Assert.Equal("Message", modelState.Single().Value.Errors.Single().ErrorMessage);
+            var modelState = Assert.Single(dictionary);
+            var modelError = Assert.Single(modelState.Value.Errors);
+
+            Assert.Equal("Child.Text", modelState.Key);
+            Assert.Equal("Message", modelError.ErrorMessage);
         }
 
         [Fact]
         public void AddModelError_ForImplicitlyCastedToObjectExpression_AddsExpectedMessage()
         {
             // Arrange
-            var modelState = new ModelStateDictionary();
+            var dictionary = new ModelStateDictionary();
 
             // Act
-            modelState.AddModelError<TestModel>(model => model.Child.Value, "Message");
+            dictionary.AddModelError<TestModel>(model => model.Child.Value, "Message");
 
             // Assert
-            Assert.Equal("Child.Value", modelState.Single().Key);
-            Assert.Equal("Message", modelState.Single().Value.Errors.Single().ErrorMessage);
+            var modelState = Assert.Single(dictionary);
+            var modelError = Assert.Single(modelState.Value.Errors);
+
+            Assert.Equal("Child.Value", modelState.Key);
+            Assert.Equal("Message", modelError.ErrorMessage);
         }
 
         [Fact]
-        public void AddModelError_ForExplicitlyCastedToObjectExpression_AddsExpectedMessage()
+        public void AddModelError_ForNotModelsExpression_AddsExpectedMessage()
         {
             // Arrange
-            var modelState = new ModelStateDictionary();
+            var variable = "Test";
+            var dictionary = new ModelStateDictionary();
 
             // Act
-            modelState.AddModelError<TestModel>(model => (object)model.Child.Value, "Message");
+            dictionary.AddModelError<TestModel>(model => variable, "Message");
 
             // Assert
-            Assert.Equal("Child.Value", modelState.Single().Key);
-            Assert.Equal("Message", modelState.Single().Value.Errors.Single().ErrorMessage);
-        }
+            var modelState = Assert.Single(dictionary);
+            var modelError = Assert.Single(modelState.Value.Errors);
 
-        [Fact]
-        public void AddModelError_ForExpressionWithoutStringRepresentation_AddsExpectedMessage()
-        {
-            // Arrange
-            var modelState = new ModelStateDictionary();
-
-            // Act
-            modelState.AddModelError<TestModel>(model => model.ToString(), "Message");
-
-            // Assert
-            Assert.Equal("", modelState.Single().Key);
-            Assert.Equal("Message", modelState.Single().Value.Errors.Single().ErrorMessage);
+            Assert.Equal("variable", modelState.Key);
+            Assert.Equal("Message", modelError.ErrorMessage);
         }
 
         [Fact]
@@ -85,14 +83,17 @@ namespace Microsoft.AspNet.Mvc
         {
             // Arrange
             var exception = new Exception();
-            var modelState = new ModelStateDictionary();
+            var dictionary = new ModelStateDictionary();
 
             // Act
-            modelState.AddModelError<TestModel>(model => model.Text, exception);
+            dictionary.AddModelError<TestModel>(model => model.Text, exception);
 
             // Assert
-            Assert.Equal("Text", modelState.Single().Key);
-            Assert.Same(exception, modelState.Single().Value.Errors.Single().Exception);
+            var modelState = Assert.Single(dictionary);
+            var modelError = Assert.Single(modelState.Value.Errors);
+
+            Assert.Equal("Text", modelState.Key);
+            Assert.Same(exception, modelError.Exception);
         }
 
         [Fact]
@@ -100,14 +101,17 @@ namespace Microsoft.AspNet.Mvc
         {
             // Arrange
             var exception = new Exception();
-            var modelState = new ModelStateDictionary();
+            var dictionary = new ModelStateDictionary();
 
             // Act
-            modelState.AddModelError<TestModel>(model => model.Child.Text, exception);
+            dictionary.AddModelError<TestModel>(model => model.Child.Text, exception);
 
             // Assert
-            Assert.Equal("Child.Text", modelState.Single().Key);
-            Assert.Same(exception, modelState.Single().Value.Errors.Single().Exception);
+            var modelState = Assert.Single(dictionary);
+            var modelError = Assert.Single(modelState.Value.Errors);
+
+            Assert.Equal("Child.Text", modelState.Key);
+            Assert.Same(exception, modelError.Exception);
         }
 
         [Fact]
@@ -115,114 +119,93 @@ namespace Microsoft.AspNet.Mvc
         {
             // Arrange
             var exception = new Exception();
-            var modelState = new ModelStateDictionary();
+            var dictionary = new ModelStateDictionary();
 
             // Act
-            modelState.AddModelError<TestModel>(model => model.Child.Value, exception);
+            dictionary.AddModelError<TestModel>(model => model.Child.Value, exception);
 
             // Assert
-            Assert.Equal("Child.Value", modelState.Single().Key);
-            Assert.Same(exception, modelState.Single().Value.Errors.Single().Exception);
+            var modelState = Assert.Single(dictionary);
+            var modelError = Assert.Single(modelState.Value.Errors);
+
+            Assert.Equal("Child.Value", modelState.Key);
+            Assert.Same(exception, modelError.Exception);
         }
 
         [Fact]
-        public void AddModelError_ForExplicitlyCastedToObjectExpression_AddsExpectedException()
+        public void AddModelError_ForNotModelsExpression_AddsExpectedException()
         {
             // Arrange
+            var variable = "Test";
             var exception = new Exception();
-            var modelState = new ModelStateDictionary();
+            var dictionary = new ModelStateDictionary();
 
             // Act
-            modelState.AddModelError<TestModel>(model => (object)model.Child.Value, exception);
+            dictionary.AddModelError<TestModel>(model => variable, exception);
 
             // Assert
-            Assert.Equal("Child.Value", modelState.Single().Key);
-            Assert.Same(exception, modelState.Single().Value.Errors.Single().Exception);
-        }
+            var modelState = Assert.Single(dictionary);
+            var modelError = Assert.Single(modelState.Value.Errors);
 
-        [Fact]
-        public void AddModelError_ForExpressionWithoutStringRepresentation_AddsExpectedException()
-        {
-            // Arrange
-            var exception = new Exception();
-            var modelState = new ModelStateDictionary();
-
-            // Act
-            modelState.AddModelError<TestModel>(model => model.ToString(), exception);
-
-            // Assert
-            Assert.Equal("", modelState.Single().Key);
-            Assert.Same(exception, modelState.Single().Value.Errors.Single().Exception);
+            Assert.Equal("variable", modelState.Key);
+            Assert.Same(exception, modelError.Exception);
         }
 
         [Fact]
         public void Remove_ForSingleExpression_RemovesModelStateKey()
         {
             // Arrange
-            var modelState = new ModelStateDictionary();
-            modelState.Add("Text", new ModelState());
+            var dictionary = new ModelStateDictionary();
+            dictionary.Add("Text", new ModelState());
 
             // Act
-            modelState.Remove<TestModel>(model => model.Text);
+            dictionary.Remove<TestModel>(model => model.Text);
 
             // Assert
-            Assert.Empty(modelState);
+            Assert.Empty(dictionary);
         }
 
         [Fact]
         public void Remove_ForRelationExpression_RemovesModelStateKey()
         {
             // Arrange
-            var modelState = new ModelStateDictionary();
-            modelState.Add("Child.Text", new ModelState());
+            var dictionary = new ModelStateDictionary();
+            dictionary.Add("Child.Text", new ModelState());
 
             // Act
-            modelState.Remove<TestModel>(model => model.Child.Text);
+            dictionary.Remove<TestModel>(model => model.Child.Text);
 
             // Assert
-            Assert.Empty(modelState);
+            Assert.Empty(dictionary);
         }
 
         [Fact]
         public void Remove_ForImplicitlyCastedToObjectExpression_RemovesModelStateKey()
         {
             // Arrange
-            var modelState = new ModelStateDictionary();
-            modelState.Add("Child.Value", new ModelState());
+            var dictionary = new ModelStateDictionary();
+            dictionary.Add("Child.Value", new ModelState());
 
             // Act
-            modelState.Remove<TestModel>(model => model.Child.Value);
+            dictionary.Remove<TestModel>(model => model.Child.Value);
 
             // Assert
-            Assert.Empty(modelState);
+            Assert.Empty(dictionary);
         }
 
         [Fact]
-        public void Remove_ForExplicitlyCastedToObjectExpression_RemovesModelStateKey()
+        public void Remove_ForNotModelsExpression_RemovesModelStateKey()
         {
             // Arrange
-            var modelState = new ModelStateDictionary();
-            modelState.Add("Child.Value", new ModelState());
+            var variable = "Test";
+            var dictionary = new ModelStateDictionary();
+            dictionary.Add("variable", new ModelState());
 
             // Act
-            modelState.Remove<TestModel>(model => (object)model.Child.Value);
+            dictionary.Remove<TestModel>(model => variable);
 
             // Assert
-            Assert.Empty(modelState);
-        }
-
-        [Fact]
-        public void Remove_ForExpressionWithoutStringRepresentation_RemovesModelStateKey()
-        {
-            // Arrange
-            var modelState = new ModelStateDictionary();
-            modelState.Add("", new ModelState());
-
-            // Act
-            modelState.Remove<TestModel>(model => model.ToString());
-
-            // Assert
-            Assert.Empty(modelState);
+            Assert.Empty(dictionary);
         }
 
         [Fact]
@@ -230,18 +213,20 @@ namespace Microsoft.AspNet.Mvc
         {
             // Arrange
             var state = new ModelState();
-            var modelState = new ModelStateDictionary();
+            var dictionary = new ModelStateDictionary();
 
-            modelState.Add("Key", state);
-            modelState.Add("Text", new ModelState());
-            modelState.Add("Text.Length", new ModelState());
+            dictionary.Add("Key", state);
+            dictionary.Add("Text", new ModelState());
+            dictionary.Add("Text.Length", new ModelState());
 
             // Act
-            modelState.RemoveAll<TestModel>(model => model.Text);
+            dictionary.RemoveAll<TestModel>(model => model.Text);
 
             // Assert
-            Assert.Equal("Key", modelState.Single().Key);
-            Assert.Same(state, modelState.Single().Value);
+            var modelState = Assert.Single(dictionary);
+
+            Assert.Equal("Key", modelState.Key);
+            Assert.Same(state, modelState.Value);
         }
 
         [Fact]
@@ -249,18 +234,20 @@ namespace Microsoft.AspNet.Mvc
         {
             // Arrange
             var state = new ModelState();
-            var modelState = new ModelStateDictionary();
+            var dictionary = new ModelStateDictionary();
 
-            modelState.Add("Key", state);
-            modelState.Add("Child", new ModelState());
-            modelState.Add("Child.Text", new ModelState());
+            dictionary.Add("Key", state);
+            dictionary.Add("Child", new ModelState());
+            dictionary.Add("Child.Text", new ModelState());
 
             // Act
-            modelState.RemoveAll<TestModel>(model => model.Child);
+            dictionary.RemoveAll<TestModel>(model => model.Child);
 
             // Assert
-            Assert.Equal("Key", modelState.Single().Key);
-            Assert.Same(state, modelState.Single().Value);
+            var modelState = Assert.Single(dictionary);
+
+            Assert.Equal("Key", modelState.Key);
+            Assert.Same(state, modelState.Value);
         }
 
         [Fact]
@@ -268,56 +255,65 @@ namespace Microsoft.AspNet.Mvc
         {
             // Arrange
             var state = new ModelState();
-            var modelState = new ModelStateDictionary();
+            var dictionary = new ModelStateDictionary();
 
-            modelState.Add("Child", state);
-            modelState.Add("Child.Value", new ModelState());
+            dictionary.Add("Child", state);
+            dictionary.Add("Child.Value", new ModelState());
 
             // Act
-            modelState.RemoveAll<TestModel>(model => model.Child.Value);
+            dictionary.RemoveAll<TestModel>(model => model.Child.Value);
 
             // Assert
-            Assert.Equal("Child", modelState.Single().Key);
-            Assert.Same(state, modelState.Single().Value);
+            var modelState = Assert.Single(dictionary);
+
+            Assert.Equal("Child", modelState.Key);
+            Assert.Same(state, modelState.Value);
         }
 
         [Fact]
-        public void RemoveAll_ForExplicitlyCastedToObjectExpression_RemovesModelStateKeys()
+        public void RemoveAll_ForNotModelsExpression_RemovesModelStateKeys()
         {
             // Arrange
+            var variable = "Test";
             var state = new ModelState();
-            var modelState = new ModelStateDictionary();
+            var dictionary = new ModelStateDictionary();
 
-            modelState.Add("Child", state);
-            modelState.Add("Child.Value", new ModelState());
+            dictionary.Add("Key", state);
+            dictionary.Add("variable", new ModelState());
+            dictionary.Add("variable.Text", new ModelState());
+            dictionary.Add("variable.Value", new ModelState());
 
             // Act
-            modelState.RemoveAll<TestModel>(model => (object)model.Child.Value);
+            dictionary.RemoveAll<TestModel>(model => variable);
 
             // Assert
-            Assert.Equal("Child", modelState.Single().Key);
-            Assert.Same(state, modelState.Single().Value);
+            var modelState = Assert.Single(dictionary);
+
+            Assert.Equal("Key", modelState.Key);
+            Assert.Same(state, modelState.Value);
         }
 
         [Fact]
-        public void RemoveAll_ForExpressionWithoutStringRepresentation_RemovesModelPropertyKeys()
+        public void RemoveAll_ForModelExpression_RemovesModelPropertyKeys()
         {
             // Arrange
             var state = new ModelState();
-            var modelState = new ModelStateDictionary();
+            var dictionary = new ModelStateDictionary();
 
-            modelState.Add("Key", state);
-            modelState.Add("Text", new ModelState());
-            modelState.Add("Child", new ModelState());
-            modelState.Add("Child.Text", new ModelState());
-            modelState.Add("Child.NoValue", new ModelState());
+            dictionary.Add("Key", state);
+            dictionary.Add("Text", new ModelState());
+            dictionary.Add("Child", new ModelState());
+            dictionary.Add("Child.Text", new ModelState());
+            dictionary.Add("Child.NoValue", new ModelState());
 
             // Act
-            modelState.RemoveAll<TestModel>(model => model.ToString());
+            dictionary.RemoveAll<TestModel>(model => model);
 
             // Assert
-            Assert.Equal("Key", modelState.Single().Key);
-            Assert.Same(state, modelState.Single().Value);
+            var modelState = Assert.Single(dictionary);
+
+            Assert.Equal("Key", modelState.Key);
+            Assert.Same(state, modelState.Value);
         }
 
         private class TestModel

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ModelStateDictionaryExtensionsTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ModelStateDictionaryExtensionsTest.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNet.Mvc
     public class ModelStateDictionaryExtensionsTest
     {
         [Fact]
-        public void AddsModelErrorMessage_ForSingleExpression()
+        public void AddModelError_ForSingleExpression_AddsExpectedMessage()
         {
             // Arrange
             var modelState = new ModelStateDictionary();
@@ -25,7 +25,7 @@ namespace Microsoft.AspNet.Mvc
         }
 
         [Fact]
-        public void AddsModelErrorMessage_ForRelationExpression()
+        public void AddModelError_ForRelationExpression_AddsExpectedMessage()
         {
             // Arrange
             var modelState = new ModelStateDictionary();
@@ -39,7 +39,7 @@ namespace Microsoft.AspNet.Mvc
         }
 
         [Fact]
-        public void AddsModelErrorMessage_ForImplicitlyCastedToObjectExpression()
+        public void AddModelError_ForImplicitlyCastedToObjectExpression_AddsExpectedMessage()
         {
             // Arrange
             var modelState = new ModelStateDictionary();
@@ -53,7 +53,7 @@ namespace Microsoft.AspNet.Mvc
         }
 
         [Fact]
-        public void AddsModelErrorMessage_ForExplicitlyCastedToObjectExpression()
+        public void AddModelError_ForExplicitlyCastedToObjectExpression_AddsExpectedMessage()
         {
             // Arrange
             var modelState = new ModelStateDictionary();
@@ -67,7 +67,7 @@ namespace Microsoft.AspNet.Mvc
         }
 
         [Fact]
-        public void AddsModelErrorMessage_ForExpressionWithoutTextRepresentation()
+        public void AddModelError_ForExpressionWithoutStringRepresentation_AddsExpectedMessage()
         {
             // Arrange
             var modelState = new ModelStateDictionary();
@@ -81,7 +81,7 @@ namespace Microsoft.AspNet.Mvc
         }
 
         [Fact]
-        public void AddsModelErrorException_ForSingleExpression()
+        public void AddModelError_ForSingleExpression_AddsExpectedException()
         {
             // Arrange
             var exception = new Exception();
@@ -96,7 +96,7 @@ namespace Microsoft.AspNet.Mvc
         }
 
         [Fact]
-        public void AddsModelErrorException_ForRelationExpression()
+        public void AddModelError_ForRelationExpression_AddsExpectedException()
         {
             // Arrange
             var exception = new Exception();
@@ -111,7 +111,7 @@ namespace Microsoft.AspNet.Mvc
         }
 
         [Fact]
-        public void AddsModelErrorException_ForImplicitlyCastedToObjectExpression()
+        public void AddModelError_ForImplicitlyCastedToObjectExpression_AddsExpectedException()
         {
             // Arrange
             var exception = new Exception();
@@ -126,7 +126,7 @@ namespace Microsoft.AspNet.Mvc
         }
 
         [Fact]
-        public void AddsModelErrorException_ForExplicitlyCastedToObjectExpression()
+        public void AddModelError_ForExplicitlyCastedToObjectExpression_AddsExpectedException()
         {
             // Arrange
             var exception = new Exception();
@@ -141,7 +141,7 @@ namespace Microsoft.AspNet.Mvc
         }
 
         [Fact]
-        public void AddsModelErrorException_ForExpressionWithoutTextRepresentation()
+        public void AddModelError_ForExpressionWithoutStringRepresentation_AddsExpectedException()
         {
             // Arrange
             var exception = new Exception();
@@ -156,7 +156,7 @@ namespace Microsoft.AspNet.Mvc
         }
 
         [Fact]
-        public void RemovesModelStateKey_ForSingleExpression()
+        public void Remove_ForSingleExpression_RemovesModelStateKey()
         {
             // Arrange
             var modelState = new ModelStateDictionary();
@@ -170,7 +170,7 @@ namespace Microsoft.AspNet.Mvc
         }
 
         [Fact]
-        public void RemovesModelStateKey_ForRelationExpression()
+        public void Remove_ForRelationExpression_RemovesModelStateKey()
         {
             // Arrange
             var modelState = new ModelStateDictionary();
@@ -184,7 +184,7 @@ namespace Microsoft.AspNet.Mvc
         }
 
         [Fact]
-        public void RemovesModelStateKey_ForImplicitlyCastedToObjectExpression()
+        public void Remove_ForImplicitlyCastedToObjectExpression_RemovesModelStateKey()
         {
             // Arrange
             var modelState = new ModelStateDictionary();
@@ -198,7 +198,7 @@ namespace Microsoft.AspNet.Mvc
         }
 
         [Fact]
-        public void RemovesModelStateKey_ForExplicitlyCastedToObjectExpression()
+        public void Remove_ForExplicitlyCastedToObjectExpression_RemovesModelStateKey()
         {
             // Arrange
             var modelState = new ModelStateDictionary();
@@ -212,7 +212,7 @@ namespace Microsoft.AspNet.Mvc
         }
 
         [Fact]
-        public void RemovesModelStateKey_ForExpressionWithoutTextRepresentation()
+        public void Remove_ForExpressionWithoutStringRepresentation_RemovesModelStateKey()
         {
             // Arrange
             var modelState = new ModelStateDictionary();


### PR DESCRIPTION
This adds generic add model error and remove extension methods for ModelStateDictionary, to avoid using hard coded strings then specifying model state dictionary keys. #3164

There are few concerns what comes to mind
- Initial [thought](https://github.com/aspnet/Mvc/issues/3164#issuecomment-142053478) by @rynowak was to add this to `Microsoft.AspNet.Mvc.Core`, but I couldn't because of circular references, so for now it's in `Microsoft.AspNet.Mvc.ViewFeatures`.
- Will three method be enough for covering most of the model state dictionary usage cases?
- Does `Remove<TModel>(this ModelStateDictionary, Expression)` is clear enough, maybe extension method should be named RemoveKey?
- Is adding and removing empty key on expressions without normal text representation is correct and naturally expected behavior?


<!---
@huboard:{"order":3028.794921875,"milestone_order":3182,"custom_state":""}
-->
