### PR TITLE
Asynchronously flush the HttpResponseStreamWriter once a view has been rendered.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/HttpResponseStreamWriter.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/HttpResponseStreamWriter.cs
@@ -15,7 +15,10 @@ namespace Microsoft.AspNet.Mvc
     /// </summary>
     public class HttpResponseStreamWriter : TextWriter
     {
-        private const int DefaultBufferSize = 1024;
+        /// <summary>
+        /// Default buffer size.
+        /// </summary>
+        public const int DefaultBufferSize = 1024;
         private readonly Stream _stream;
         private Encoder _encoder;
         private byte[] _byteBuffer;

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/ViewExecutor.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/ViewExecutor.cs
@@ -62,6 +62,9 @@ namespace Microsoft.AspNet.Mvc.ViewFeatures
                     htmlHelperOptions);
 
                 await view.RenderAsync(viewContext);
+                // Invoke FlushAsync to ensure any buffered content is asynchronously written to the underlying response. In the absence
+                // of this line, the buffer gets synchronously written to the response as part of the Dispose which has a perf impact.
+                await writer.FlushAsync();
             }
         }
     }


### PR DESCRIPTION
This solves a perf issue for views which produce content that is smaller
than the buffer size of HttpResponseStreamWriter. In this case, the writer
ends up synchronously writing to the Response as part of Dispose which
affects perf.