### PR TITLE
Include ViewEngine Type in ViewResult Telemetry Source Notifications

### DIFF
--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewResult.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewResult.cs
@@ -79,7 +79,7 @@ namespace Microsoft.AspNet.Mvc
                             actionContext = context,
                             result = this,
                             viewName = viewName,
-                            viewEgineType = viewEngine.GetType(),
+                            viewEngineType = viewEngine.GetType(),
                             searchedLocations = viewEngineResult.SearchedLocations
                         });
                 }
@@ -100,7 +100,7 @@ namespace Microsoft.AspNet.Mvc
                         actionContext = context,
                         result = this,
                         viewName,
-                        viewEgineType = viewEngine.GetType(),
+                        viewEngineType = viewEngine.GetType(),
                         view = view
                     });
             }

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewResult.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewResult.cs
@@ -79,6 +79,7 @@ namespace Microsoft.AspNet.Mvc
                             actionContext = context,
                             result = this,
                             viewName = viewName,
+                            viewEgineType = viewEngine.GetType(),
                             searchedLocations = viewEngineResult.SearchedLocations
                         });
                 }
@@ -94,7 +95,14 @@ namespace Microsoft.AspNet.Mvc
             {
                 telemetry.WriteTelemetry(
                     "Microsoft.AspNet.Mvc.ViewResultViewFound",
-                    new { actionContext = context, result = this, viewName, view = view });
+                    new
+                    {
+                        actionContext = context,
+                        result = this,
+                        viewName,
+                        viewEgineType = viewEngine.GetType(),
+                        view = view
+                    });
             }
 
             logger.LogVerbose("The view '{ViewName}' was found.", viewName);

--- a/test/Microsoft.AspNet.Mvc.TestTelemetryListener.Sources/TestTelemetryListener.cs
+++ b/test/Microsoft.AspNet.Mvc.TestTelemetryListener.Sources/TestTelemetryListener.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Framework.TelemetryAdapter;
 
@@ -57,6 +58,7 @@ namespace Microsoft.AspNet.Mvc
             public IProxyActionResult Result { get; set; }
             public string ViewName { get; set; }
             public IProxyView View { get; set; }
+            public Type ViewEngineType { get; set; }
         }
 
         public OnViewResultViewFoundEventData ViewResultViewFound { get; set; }
@@ -66,6 +68,7 @@ namespace Microsoft.AspNet.Mvc
             IProxyActionContext actionContext,
             IProxyActionResult result,
             string viewName,
+            Type viewEngineType,
             IProxyView view)
         {
             ViewResultViewFound = new OnViewResultViewFoundEventData()
@@ -73,6 +76,7 @@ namespace Microsoft.AspNet.Mvc
                 ActionContext = actionContext,
                 Result = result,
                 ViewName = viewName,
+                ViewEngineType = viewEngineType,
                 View = view,
             };
         }
@@ -83,6 +87,7 @@ namespace Microsoft.AspNet.Mvc
             public IProxyActionResult Result { get; set; }
             public string ViewName { get; set; }
             public IEnumerable<string> SearchedLocations { get; set; }
+            public Type ViewEngineType { get; set; }
         }
 
         public OnViewResultViewNotFoundEventData ViewResultViewNotFound { get; set; }
@@ -92,6 +97,7 @@ namespace Microsoft.AspNet.Mvc
             IProxyActionContext actionContext,
             IProxyActionResult result,
             string viewName,
+            Type viewEngineType,
             IEnumerable<string> searchedLocations)
         {
             ViewResultViewNotFound = new OnViewResultViewNotFoundEventData()
@@ -99,6 +105,7 @@ namespace Microsoft.AspNet.Mvc
                 ActionContext = actionContext,
                 Result = result,
                 ViewName = viewName,
+                ViewEngineType = viewEngineType,
                 SearchedLocations = searchedLocations,
             };
         }


### PR DESCRIPTION
Provide a way so that we know which ViewEngine was used to check if it could handle the request.