### PR TITLE
Making the HtmlHelper.GetEnumSelectList take GroupName into consideration when creating the list.

### DIFF
--- a/samples/MvcSample.Web/Models/TestEnum.cs
+++ b/samples/MvcSample.Web/Models/TestEnum.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MvcSample.Web.Models
+{
+    public enum TestEnum
+    {
+        Zero = 0,
+        [Display(GroupName = "Primes")]
+        One = 1,
+        [Display(GroupName = "Evens", Name = "Dos")]
+        Two = 2,
+        [Display(GroupName = "Primes")]
+        Three = 3,
+        [Display(Name = "4th")]
+        Four = 4
+    }
+}

--- a/samples/MvcSample.Web/Models/User.cs
+++ b/samples/MvcSample.Web/Models/User.cs
@@ -29,6 +29,7 @@ namespace MvcSample.Web.Models
         public string About { get; set; }
         public string Log { get; set; }
         public IEnumerable<string> OwnedAddresses { get; private set; }
+        public TestEnum EnumInformation { get; set; }
 
         // This does not bind correctly. Only gets highest value.
         public List<int> ParentsAges { get; private set; }

--- a/samples/MvcSample.Web/Views/Home/Create.cshtml
+++ b/samples/MvcSample.Web/Views/Home/Create.cshtml
@@ -45,6 +45,16 @@
             <table>
                 <tr>
                     <td>
+                        <label class="control-label col-md-2" for="Name">Enum Select List</label>
+                    </td>
+                    <td>
+                         @Html.DropDownList("Name", Html.GetEnumSelectList(typeof(TestEnum)))
+                    </td>
+                    <td>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
                         <label class="control-label col-md-2" for="Name">Model.Name</label>
                     </td>
                     <td>

--- a/samples/MvcSample.Web/Views/Home/Create.cshtml
+++ b/samples/MvcSample.Web/Views/Home/Create.cshtml
@@ -45,16 +45,6 @@
             <table>
                 <tr>
                     <td>
-                        <label class="control-label col-md-2" for="Name">Enum Select List</label>
-                    </td>
-                    <td>
-                         @Html.DropDownList("Name", Html.GetEnumSelectList(typeof(TestEnum)))
-                    </td>
-                    <td>
-                    </td>
-                </tr>
-                <tr>
-                    <td>
                         <label class="control-label col-md-2" for="Name">Model.Name</label>
                     </td>
                     <td>
@@ -117,10 +107,20 @@
                 </tr>
                 <tr>
                     <td>
+                        <label class="control-label col-md-2" for="Name">Model.EnumInformation</label>
+                    </td>
+                    <td>
+                        @Html.DropDownList("EnumInformation", Html.GetEnumSelectList<TestEnum>())
+                    </td>
+                    <td></td>
+                </tr>
+                <tr>
+                    <td>
                         <input type="submit" value="Save" class="btn btn-default" style="margin-left: 10px" />
                     </td>
                     <td></td>
                 </tr>
+
             </table>
         }
     </div>

--- a/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/EnumGroupAndName.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/EnumGroupAndName.cs
@@ -1,13 +1,36 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.AspNet.Mvc.ModelBinding
 {
     /// <summary>
-    /// An abstraction used when grouping enum values for <see cref="ModelMetadata.EnumGroupedDisplayNamesAndValues"/>
+    /// An abstraction used when grouping enum values for <see cref="ModelMetadata.EnumGroupedDisplayNamesAndValues"/>.
     /// </summary>
     public struct EnumGroupAndName
     {
+        /// <summary>
+        /// Initializes a new instance of the EnumGroupAndName structure.
+        /// </summary>
+        /// <param name="group">The group name.</param>
+        /// <param name="name">The name.</param>
+        public EnumGroupAndName(string group, string name)
+        {
+            if (group == null)
+            {
+                throw new ArgumentNullException(nameof(group));
+            }
+
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            Group = group;
+            Name = name;
+        }
+
         /// <summary>
         /// Gets the Group name.
         /// </summary>
@@ -17,16 +40,5 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// Gets the name.
         /// </summary>
         public string Name { get; }
-
-        /// <summary>
-        /// Initializes a new instance of the EnumGroupAndName structure.
-        /// </summary>
-        /// <param name="group">The group name.</param>
-        /// <param name="name">The name.</param>
-        public EnumGroupAndName(string group, string name)
-        {
-            Group = group;
-            Name = name;
-        }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/EnumGroupAndName.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/EnumGroupAndName.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.AspNet.Mvc.ModelBinding
 {
     /// <summary>
-    /// An abstraction used when grouping enum values for <see cref="ModelMetadata.EnumGroupedDisplayNameAndValues"/>
+    /// An abstraction used when grouping enum values for <see cref="ModelMetadata.EnumGroupedDisplayNamesAndValues"/>
     /// </summary>
     public struct EnumGroupAndName
     {

--- a/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/EnumGroupAndName.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/EnumGroupAndName.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNet.Mvc.ModelBinding
+{
+    /// <summary>
+    /// An abstraction used when grouping enum values for <see cref="ModelMetadata.EnumGroupedDisplayNameAndValues"/>
+    /// </summary>
+    public struct EnumGroupAndName
+    {
+        /// <summary>
+        /// Gets the Group name.
+        /// </summary>
+        public string Group { get; }
+
+        /// <summary>
+        /// Gets the name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the EnumGroupAndName structure.
+        /// </summary>
+        /// <param name="group">The group name.</param>
+        /// <param name="name">The name.</param>
+        public EnumGroupAndName(string group, string name)
+        {
+            Group = group;
+            Name = name;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/ModelMetadata.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/ModelMetadata.cs
@@ -143,11 +143,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// <see cref="UnderlyingOrModelType"/>.
         /// </summary>
         /// <value>
-        /// An <see cref="IEnumerable{KeyValuePair{Tuple{string, string}, string}"/> of mappings between <see cref="Enum"/> field groups, names
-        /// and values. <c>null</c> if <see cref="IsEnum"/> is <c>false</c>. The first item in the tuple is the group name (empty string if not defined).
-        /// The second item in the tuple is the display name.
+        /// An <see cref="IEnumerable{KeyValuePair{EnumGroupAndName, string}"/> of mappings between
+        /// <see cref="Enum"/> field groups, names and values. <c>null</c> if <see cref="IsEnum"/> is <c>false</c>.
         /// </value>
-        public abstract IEnumerable<KeyValuePair<Tuple<string, string>, string>> EnumGroupedDisplayNamesAndValues { get; }
+        public abstract IEnumerable<KeyValuePair<EnumGroupAndName, string>> EnumGroupedDisplayNamesAndValues { get; }
 
         /// <summary>
         /// Gets the names and values of all <see cref="Enum"/> values in <see cref="UnderlyingOrModelType"/>.

--- a/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/ModelMetadata.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/ModelMetadata.cs
@@ -139,14 +139,15 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         public abstract ModelMetadata ElementMetadata { get; }
 
         /// <summary>
-        /// Gets the ordered display names and values of all <see cref="Enum"/> values in
+        /// Gets the ordered and grouped display names and values of all <see cref="Enum"/> values in
         /// <see cref="UnderlyingOrModelType"/>.
         /// </summary>
         /// <value>
-        /// An <see cref="IEnumerable{KeyValuePair{string, string}}"/> of mappings between <see cref="Enum"/> field names
-        /// and values. <c>null</c> if <see cref="IsEnum"/> is <c>false</c>.
+        /// An <see cref="IEnumerable{KeyValuePair{Tuple{string, string}, string}"/> of mappings between <see cref="Enum"/> field groups, names
+        /// and values. <c>null</c> if <see cref="IsEnum"/> is <c>false</c>. The first item in the tuple is the group name (empty string if not defined).
+        /// The second item in the tuple is the display name.
         /// </value>
-        public abstract IEnumerable<KeyValuePair<string, string>> EnumDisplayNamesAndValues { get; }
+        public abstract IEnumerable<KeyValuePair<Tuple<string, string>, string>> EnumGroupedDisplayNamesAndValues { get; }
 
         /// <summary>
         /// Gets the names and values of all <see cref="Enum"/> values in <see cref="UnderlyingOrModelType"/>.

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Metadata/DefaultModelMetadata.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Metadata/DefaultModelMetadata.cs
@@ -272,7 +272,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         }
 
         /// <inheritdoc />
-        public override IEnumerable<KeyValuePair<Tuple<string, string>, string>> EnumGroupedDisplayNamesAndValues
+        public override IEnumerable<KeyValuePair<EnumGroupAndName, string>> EnumGroupedDisplayNamesAndValues
         {
             get
             {

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Metadata/DefaultModelMetadata.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Metadata/DefaultModelMetadata.cs
@@ -272,11 +272,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         }
 
         /// <inheritdoc />
-        public override IEnumerable<KeyValuePair<string, string>> EnumDisplayNamesAndValues
+        public override IEnumerable<KeyValuePair<Tuple<string, string>, string>> EnumGroupedDisplayNamesAndValues
         {
             get
             {
-                return DisplayMetadata.EnumDisplayNamesAndValues;
+                return DisplayMetadata.EnumGroupedDisplayNamesAndValues;
             }
         }
 

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Metadata/DisplayMetadata.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Metadata/DisplayMetadata.cs
@@ -57,11 +57,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         public string EditFormatString { get; set; }
 
         /// <summary>
-        /// Gets the ordered display names and values of all <see cref="System.Enum"/> values in
+        /// Gets the ordered and grouped display names and values of all <see cref="System.Enum"/> values in
         /// <see cref="ModelMetadata.UnderlyingOrModelType"/>. See
-        /// <see cref="ModelMetadata.EnumDisplayNamesAndValues"/>.
+        /// <see cref="ModelMetadata.EnumGroupedDisplayNamesAndValues"/>.
         /// </summary>
-        public IEnumerable<KeyValuePair<string, string>> EnumDisplayNamesAndValues { get; set; }
+        public IEnumerable<KeyValuePair<Tuple<string, string>, string>> EnumGroupedDisplayNamesAndValues { get; set; }
 
         /// <summary>
         /// Gets the names and values of all <see cref="System.Enum"/> values in

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Metadata/DisplayMetadata.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Metadata/DisplayMetadata.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         /// <see cref="ModelMetadata.UnderlyingOrModelType"/>. See
         /// <see cref="ModelMetadata.EnumGroupedDisplayNamesAndValues"/>.
         /// </summary>
-        public IEnumerable<KeyValuePair<Tuple<string, string>, string>> EnumGroupedDisplayNamesAndValues { get; set; }
+        public IEnumerable<KeyValuePair<EnumGroupAndName, string>> EnumGroupedDisplayNamesAndValues { get; set; }
 
         /// <summary>
         /// Gets the names and values of all <see cref="System.Enum"/> values in

--- a/src/Microsoft.AspNet.Mvc.DataAnnotations/DataAnnotationsMetadataProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.DataAnnotations/DataAnnotationsMetadataProvider.cs
@@ -120,7 +120,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
                 // Order EnumDisplayNamesAndValues to match Enum.GetNames(). That method orders by absolute value,
                 // then its behavior is undefined (but hopefully stable). Add to EnumNamesAndValues in same order but
                 // Dictionary does not guarantee order will be preserved.
-                var groupedDisplayNamesAndValues = new List<KeyValuePair<Tuple<string, string>, string>>();
+                var groupedDisplayNamesAndValues = new List<KeyValuePair<EnumGroupAndName, string>>();
                 var namesAndValues = new Dictionary<string, string>();
                 foreach (var name in Enum.GetNames(underlyingType))
                 {
@@ -129,7 +129,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
                     var groupName = GetDisplayGroup(field);
                     var value = ((Enum)field.GetValue(obj: null)).ToString("d");
 
-                    groupedDisplayNamesAndValues.Add(new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(groupName, displayName), value));
+                    groupedDisplayNamesAndValues.Add(new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(groupName, displayName), value));
                     namesAndValues.Add(name, value);
                 }
 

--- a/src/Microsoft.AspNet.Mvc.DataAnnotations/DataAnnotationsMetadataProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.DataAnnotations/DataAnnotationsMetadataProvider.cs
@@ -120,19 +120,20 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
                 // Order EnumDisplayNamesAndValues to match Enum.GetNames(). That method orders by absolute value,
                 // then its behavior is undefined (but hopefully stable). Add to EnumNamesAndValues in same order but
                 // Dictionary does not guarantee order will be preserved.
-                var displayNamesAndValues = new List<KeyValuePair<string, string>>();
+                var groupedDisplayNamesAndValues = new List<KeyValuePair<Tuple<string, string>, string>>();
                 var namesAndValues = new Dictionary<string, string>();
                 foreach (var name in Enum.GetNames(underlyingType))
                 {
                     var field = underlyingType.GetField(name);
                     var displayName = GetDisplayName(field);
+                    var groupName = GetDisplayGroup(field);
                     var value = ((Enum)field.GetValue(obj: null)).ToString("d");
 
-                    displayNamesAndValues.Add(new KeyValuePair<string, string>(displayName, value));
+                    groupedDisplayNamesAndValues.Add(new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(groupName, displayName), value));
                     namesAndValues.Add(name, value);
                 }
 
-                displayMetadata.EnumDisplayNamesAndValues = displayNamesAndValues;
+                displayMetadata.EnumGroupedDisplayNamesAndValues = groupedDisplayNamesAndValues;
                 displayMetadata.EnumNamesAndValues = namesAndValues;
             }
 
@@ -257,6 +258,23 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
             }
 
             return field.Name;
+        }
+
+        // Return non-empty group specified in a [Display] attribute for a field, if any; string.Empty otherwise.
+        private static string GetDisplayGroup(FieldInfo field)
+        {
+            var display = field.GetCustomAttribute<DisplayAttribute>(inherit: false);
+            if (display != null)
+            {
+                // Note [Display(Group = "")] is allowed.
+                var group = display.GetGroupName();
+                if (group != null)
+                {
+                    return group;
+                }
+            }
+
+            return string.Empty;
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/HtmlHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/HtmlHelper.cs
@@ -1168,13 +1168,24 @@ namespace Microsoft.AspNet.Mvc.ViewFeatures
             }
 
             var selectList = new List<SelectListItem>();
-            foreach (var keyValuePair in metadata.EnumDisplayNamesAndValues)
+            var groupList = new Dictionary<string, SelectListGroup>();
+            foreach (var keyValuePair in metadata.EnumGroupedDisplayNamesAndValues)
             {
                 var selectListItem = new SelectListItem
                 {
-                    Text = keyValuePair.Key,
+                    Text = keyValuePair.Key.Item2,
                     Value = keyValuePair.Value,
                 };
+
+                if(string.IsNullOrEmpty(keyValuePair.Key.Item1) == false)
+                {
+                    if(groupList.ContainsKey(keyValuePair.Key.Item1) == false)
+                    {
+                        groupList[keyValuePair.Key.Item1] = new SelectListGroup() { Name = keyValuePair.Key.Item1 };
+                    }
+
+                    selectListItem.Group = groupList[keyValuePair.Key.Item1];
+                }
 
                 selectList.Add(selectListItem);
             }

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/HtmlHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/HtmlHelper.cs
@@ -1179,7 +1179,7 @@ namespace Microsoft.AspNet.Mvc.ViewFeatures
 
                 if (!string.IsNullOrEmpty(keyValuePair.Key.Group))
                 {
-                    if(!groupList.ContainsKey(keyValuePair.Key.Group))
+                    if (!groupList.ContainsKey(keyValuePair.Key.Group))
                     {
                         groupList[keyValuePair.Key.Group] = new SelectListGroup() { Name = keyValuePair.Key.Group };
                     }

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/HtmlHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/HtmlHelper.cs
@@ -1173,18 +1173,18 @@ namespace Microsoft.AspNet.Mvc.ViewFeatures
             {
                 var selectListItem = new SelectListItem
                 {
-                    Text = keyValuePair.Key.Item2,
+                    Text = keyValuePair.Key.Name,
                     Value = keyValuePair.Value,
                 };
 
-                if(string.IsNullOrEmpty(keyValuePair.Key.Item1) == false)
+                if (!string.IsNullOrEmpty(keyValuePair.Key.Group))
                 {
-                    if(groupList.ContainsKey(keyValuePair.Key.Item1) == false)
+                    if(!groupList.ContainsKey(keyValuePair.Key.Group))
                     {
-                        groupList[keyValuePair.Key.Item1] = new SelectListGroup() { Name = keyValuePair.Key.Item1 };
+                        groupList[keyValuePair.Key.Group] = new SelectListGroup() { Name = keyValuePair.Key.Group };
                     }
 
-                    selectListItem.Group = groupList[keyValuePair.Key.Item1];
+                    selectListItem.Group = groupList[keyValuePair.Key.Group];
                 }
 
                 selectList.Add(selectListItem);

--- a/test/Microsoft.AspNet.Mvc.Abstractions.Test/ModelBinding/ModelMetadataTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Abstractions.Test/ModelBinding/ModelMetadataTest.cs
@@ -369,7 +369,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 }
             }
 
-            public override IEnumerable<KeyValuePair<string, string>> EnumDisplayNamesAndValues
+            public override IEnumerable<KeyValuePair<Tuple<string, string>, string>> EnumGroupedDisplayNamesAndValues
             {
                 get
                 {

--- a/test/Microsoft.AspNet.Mvc.Abstractions.Test/ModelBinding/ModelMetadataTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Abstractions.Test/ModelBinding/ModelMetadataTest.cs
@@ -369,7 +369,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 }
             }
 
-            public override IEnumerable<KeyValuePair<Tuple<string, string>, string>> EnumGroupedDisplayNamesAndValues
+            public override IEnumerable<KeyValuePair<EnumGroupAndName, string>> EnumGroupedDisplayNamesAndValues
             {
                 get
                 {

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/Metadata/DefaultModelMetadataTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/Metadata/DefaultModelMetadataTest.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
             Assert.Null(metadata.DisplayName);
             Assert.Null(metadata.EditFormatString);
             Assert.Null(metadata.ElementMetadata);
-            Assert.Null(metadata.EnumDisplayNamesAndValues);
+            Assert.Null(metadata.EnumGroupedDisplayNamesAndValues);
             Assert.Null(metadata.EnumNamesAndValues);
             Assert.Null(metadata.NullDisplayText);
             Assert.Null(metadata.TemplateHint);

--- a/test/Microsoft.AspNet.Mvc.DataAnnotations.Test/DataAnnotationsMetadataProviderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.DataAnnotations.Test/DataAnnotationsMetadataProviderTest.cs
@@ -410,112 +410,112 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         }
 
         // Type -> expected EnumDisplayNamesAndValues
-        public static TheoryData<Type, IEnumerable<KeyValuePair<Tuple<string, string>, string>>> EnumDisplayNamesData
+        public static TheoryData<Type, IEnumerable<KeyValuePair<EnumGroupAndName, string>>> EnumDisplayNamesData
         {
             get
             {
-                return new TheoryData<Type, IEnumerable<KeyValuePair<Tuple<string, string>, string>>>
+                return new TheoryData<Type, IEnumerable<KeyValuePair<EnumGroupAndName, string>>>
                 {
                     { typeof(ClassWithFields), null },
                     { typeof(StructWithFields), null },
-                    { typeof(EmptyEnum), new List<KeyValuePair<Tuple<string, string>, string>>() },
-                    { typeof(EmptyEnum?), new List<KeyValuePair<Tuple<string, string>, string>>() },
+                    { typeof(EmptyEnum), new List<KeyValuePair<EnumGroupAndName, string>>() },
+                    { typeof(EmptyEnum?), new List<KeyValuePair<EnumGroupAndName, string>>() },
                     {
                         typeof(EnumWithDisplayNames),
-                        new List<KeyValuePair<Tuple<string, string>, string>>
+                        new List<KeyValuePair<EnumGroupAndName, string>>
                         {
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create("Zero", string.Empty), "0"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDisplayNames.One)), "1"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, "dos"), "2"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, "tres"), "3"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, "name from resources"), "-2"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create("Negatives", "menos uno"), "-1"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName("Zero", string.Empty), "0"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithDisplayNames.One)), "1"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, "dos"), "2"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, "tres"), "3"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, "name from resources"), "-2"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName("Negatives", "menos uno"), "-1"),
                         }
                     },
                     {
                         typeof(EnumWithDisplayNames?),
-                        new List<KeyValuePair<Tuple<string, string>, string>>
+                        new List<KeyValuePair<EnumGroupAndName, string>>
                         {
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create("Zero", string.Empty), "0"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDisplayNames.One)), "1"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, "dos"), "2"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, "tres"), "3"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, "name from resources"), "-2"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create("Negatives", "menos uno"), "-1"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName("Zero", string.Empty), "0"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithDisplayNames.One)), "1"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, "dos"), "2"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, "tres"), "3"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, "name from resources"), "-2"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName("Negatives", "menos uno"), "-1"),
                         }
                     },
                     {
                         // Note order duplicates appear cannot be inferred easily e.g. does not match the source.
                         // Zero is before None but Two is before Duece in the class below.
                         typeof(EnumWithDuplicates),
-                        new List<KeyValuePair<Tuple<string, string>, string>>
+                        new List<KeyValuePair<EnumGroupAndName, string>>
                         {
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.Zero)), "0"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.None)), "0"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.One)), "1"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.Duece)), "2"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.Two)), "2"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.MoreThanTwo)), "3"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.Three)), "3"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithDuplicates.Zero)), "0"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithDuplicates.None)), "0"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithDuplicates.One)), "1"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithDuplicates.Duece)), "2"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithDuplicates.Two)), "2"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithDuplicates.MoreThanTwo)), "3"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithDuplicates.Three)), "3"),
                         }
                     },
                     {
                         typeof(EnumWithDuplicates?),
-                        new List<KeyValuePair<Tuple<string, string>, string>>
+                        new List<KeyValuePair<EnumGroupAndName, string>>
                         {
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.Zero)), "0"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.None)), "0"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.One)), "1"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.Duece)), "2"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.Two)), "2"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.MoreThanTwo)), "3"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.Three)), "3"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithDuplicates.Zero)), "0"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithDuplicates.None)), "0"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithDuplicates.One)), "1"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithDuplicates.Duece)), "2"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithDuplicates.Two)), "2"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithDuplicates.MoreThanTwo)), "3"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithDuplicates.Three)), "3"),
                         }
                     },
                     {
                         typeof(EnumWithFlags),
-                        new List<KeyValuePair<Tuple<string, string>, string>>
+                        new List<KeyValuePair<EnumGroupAndName, string>>
                         {
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFlags.Zero)), "0"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFlags.One)), "1"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFlags.Two)), "2"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFlags.Four)), "4"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFlags.All)), "-1"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithFlags.Zero)), "0"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithFlags.One)), "1"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithFlags.Two)), "2"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithFlags.Four)), "4"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithFlags.All)), "-1"),
                         }
                     },
                     {
                         typeof(EnumWithFlags?),
-                        new List<KeyValuePair<Tuple<string, string>, string>>
+                        new List<KeyValuePair<EnumGroupAndName, string>>
                         {
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFlags.Zero)), "0"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFlags.One)), "1"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFlags.Two)), "2"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFlags.Four)), "4"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFlags.All)), "-1"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithFlags.Zero)), "0"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithFlags.One)), "1"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithFlags.Two)), "2"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithFlags.Four)), "4"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithFlags.All)), "-1"),
                         }
                     },
                     {
                         typeof(EnumWithFields),
-                        new List<KeyValuePair<Tuple<string, string>, string>>
+                        new List<KeyValuePair<EnumGroupAndName, string>>
                         {
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.Zero)), "0"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.One)), "1"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.Two)), "2"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.Three)), "3"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.MinusTwo)), "-2"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.MinusOne)), "-1"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithFields.Zero)), "0"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithFields.One)), "1"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithFields.Two)), "2"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithFields.Three)), "3"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithFields.MinusTwo)), "-2"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithFields.MinusOne)), "-1"),
                         }
                     },
                     {
                         typeof(EnumWithFields?),
-                        new List<KeyValuePair<Tuple<string, string>, string>>
+                        new List<KeyValuePair<EnumGroupAndName, string>>
                         {
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.Zero)), "0"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.One)), "1"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.Two)), "2"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.Three)), "3"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.MinusTwo)), "-2"),
-                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.MinusOne)), "-1"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithFields.Zero)), "0"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithFields.One)), "1"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithFields.Two)), "2"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithFields.Three)), "3"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithFields.MinusTwo)), "-2"),
+                            new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithFields.MinusOne)), "-1"),
                         }
                     },
                 };
@@ -526,7 +526,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         [MemberData(nameof(EnumDisplayNamesData))]
         public void GetDisplayMetadata_EnumGroupedDisplayNamesAndValues_ReflectsModelType(
             Type type,
-            IEnumerable<KeyValuePair<Tuple<string, string>, string>> expectedKeyValuePairs)
+            IEnumerable<KeyValuePair<EnumGroupAndName, string>> expectedKeyValuePairs)
         {
             // Arrange
             var provider = new DataAnnotationsMetadataProvider();
@@ -541,8 +541,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
             // Assert
             // OrderBy is used because the order of the results may very depending on the platform / client.
             Assert.Equal(
-                expectedKeyValuePairs?.OrderBy(item => item.Key.Item1, StringComparer.Ordinal).ThenBy(item => item.Key.Item2, StringComparer.Ordinal),
-                context.DisplayMetadata.EnumGroupedDisplayNamesAndValues?.OrderBy(item => item.Key.Item1, StringComparer.Ordinal).ThenBy(item => item.Key.Item2, StringComparer.Ordinal));
+                expectedKeyValuePairs?.OrderBy(item => item.Key.Group, StringComparer.Ordinal)
+                .ThenBy(item => item.Key.Name, StringComparer.Ordinal),
+                context.DisplayMetadata.EnumGroupedDisplayNamesAndValues?.OrderBy(item => item.Key.Group, StringComparer.Ordinal)
+                .ThenBy(item => item.Key.Name, StringComparer.Ordinal));
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Mvc.DataAnnotations.Test/DataAnnotationsMetadataProviderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.DataAnnotations.Test/DataAnnotationsMetadataProviderTest.cs
@@ -410,112 +410,112 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         }
 
         // Type -> expected EnumDisplayNamesAndValues
-        public static TheoryData<Type, IEnumerable<KeyValuePair<string, string>>> EnumDisplayNamesData
+        public static TheoryData<Type, IEnumerable<KeyValuePair<Tuple<string, string>, string>>> EnumDisplayNamesData
         {
             get
             {
-                return new TheoryData<Type, IEnumerable<KeyValuePair<string, string>>>
+                return new TheoryData<Type, IEnumerable<KeyValuePair<Tuple<string, string>, string>>>
                 {
                     { typeof(ClassWithFields), null },
                     { typeof(StructWithFields), null },
-                    { typeof(EmptyEnum), new List<KeyValuePair<string, string>>() },
-                    { typeof(EmptyEnum?), new List<KeyValuePair<string, string>>() },
+                    { typeof(EmptyEnum), new List<KeyValuePair<Tuple<string, string>, string>>() },
+                    { typeof(EmptyEnum?), new List<KeyValuePair<Tuple<string, string>, string>>() },
                     {
                         typeof(EnumWithDisplayNames),
-                        new List<KeyValuePair<string, string>>
+                        new List<KeyValuePair<Tuple<string, string>, string>>
                         {
-                            new KeyValuePair<string, string>(string.Empty, "0"),
-                            new KeyValuePair<string, string>(nameof(EnumWithDisplayNames.One), "1"),
-                            new KeyValuePair<string, string>("dos", "2"),
-                            new KeyValuePair<string, string>("tres", "3"),
-                            new KeyValuePair<string, string>("name from resources", "-2"),
-                            new KeyValuePair<string, string>("menos uno", "-1"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create("Zero", string.Empty), "0"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDisplayNames.One)), "1"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, "dos"), "2"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, "tres"), "3"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, "name from resources"), "-2"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create("Negatives", "menos uno"), "-1"),
                         }
                     },
                     {
                         typeof(EnumWithDisplayNames?),
-                        new List<KeyValuePair<string, string>>
+                        new List<KeyValuePair<Tuple<string, string>, string>>
                         {
-                            new KeyValuePair<string, string>(string.Empty, "0"),
-                            new KeyValuePair<string, string>(nameof(EnumWithDisplayNames.One), "1"),
-                            new KeyValuePair<string, string>("dos", "2"),
-                            new KeyValuePair<string, string>("tres", "3"),
-                            new KeyValuePair<string, string>("name from resources", "-2"),
-                            new KeyValuePair<string, string>("menos uno", "-1"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create("Zero", string.Empty), "0"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDisplayNames.One)), "1"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, "dos"), "2"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, "tres"), "3"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, "name from resources"), "-2"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create("Negatives", "menos uno"), "-1"),
                         }
                     },
                     {
                         // Note order duplicates appear cannot be inferred easily e.g. does not match the source.
                         // Zero is before None but Two is before Duece in the class below.
                         typeof(EnumWithDuplicates),
-                        new List<KeyValuePair<string, string>>
+                        new List<KeyValuePair<Tuple<string, string>, string>>
                         {
-                            new KeyValuePair<string, string>(nameof(EnumWithDuplicates.Zero), "0"),
-                            new KeyValuePair<string, string>(nameof(EnumWithDuplicates.None), "0"),
-                            new KeyValuePair<string, string>(nameof(EnumWithDuplicates.One), "1"),
-                            new KeyValuePair<string, string>(nameof(EnumWithDuplicates.Duece), "2"),
-                            new KeyValuePair<string, string>(nameof(EnumWithDuplicates.Two), "2"),
-                            new KeyValuePair<string, string>(nameof(EnumWithDuplicates.MoreThanTwo), "3"),
-                            new KeyValuePair<string, string>(nameof(EnumWithDuplicates.Three), "3"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.Zero)), "0"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.None)), "0"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.One)), "1"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.Duece)), "2"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.Two)), "2"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.MoreThanTwo)), "3"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.Three)), "3"),
                         }
                     },
                     {
                         typeof(EnumWithDuplicates?),
-                        new List<KeyValuePair<string, string>>
+                        new List<KeyValuePair<Tuple<string, string>, string>>
                         {
-                            new KeyValuePair<string, string>(nameof(EnumWithDuplicates.Zero), "0"),
-                            new KeyValuePair<string, string>(nameof(EnumWithDuplicates.None), "0"),
-                            new KeyValuePair<string, string>(nameof(EnumWithDuplicates.One), "1"),
-                            new KeyValuePair<string, string>(nameof(EnumWithDuplicates.Duece), "2"),
-                            new KeyValuePair<string, string>(nameof(EnumWithDuplicates.Two), "2"),
-                            new KeyValuePair<string, string>(nameof(EnumWithDuplicates.MoreThanTwo), "3"),
-                            new KeyValuePair<string, string>(nameof(EnumWithDuplicates.Three), "3"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.Zero)), "0"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.None)), "0"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.One)), "1"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.Duece)), "2"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.Two)), "2"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.MoreThanTwo)), "3"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithDuplicates.Three)), "3"),
                         }
                     },
                     {
                         typeof(EnumWithFlags),
-                        new List<KeyValuePair<string, string>>
+                        new List<KeyValuePair<Tuple<string, string>, string>>
                         {
-                            new KeyValuePair<string, string>(nameof(EnumWithFlags.Zero), "0"),
-                            new KeyValuePair<string, string>(nameof(EnumWithFlags.One), "1"),
-                            new KeyValuePair<string, string>(nameof(EnumWithFlags.Two), "2"),
-                            new KeyValuePair<string, string>(nameof(EnumWithFlags.Four), "4"),
-                            new KeyValuePair<string, string>(nameof(EnumWithFlags.All), "-1"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFlags.Zero)), "0"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFlags.One)), "1"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFlags.Two)), "2"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFlags.Four)), "4"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFlags.All)), "-1"),
                         }
                     },
                     {
                         typeof(EnumWithFlags?),
-                        new List<KeyValuePair<string, string>>
+                        new List<KeyValuePair<Tuple<string, string>, string>>
                         {
-                            new KeyValuePair<string, string>(nameof(EnumWithFlags.Zero), "0"),
-                            new KeyValuePair<string, string>(nameof(EnumWithFlags.One), "1"),
-                            new KeyValuePair<string, string>(nameof(EnumWithFlags.Two), "2"),
-                            new KeyValuePair<string, string>(nameof(EnumWithFlags.Four), "4"),
-                            new KeyValuePair<string, string>(nameof(EnumWithFlags.All), "-1"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFlags.Zero)), "0"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFlags.One)), "1"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFlags.Two)), "2"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFlags.Four)), "4"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFlags.All)), "-1"),
                         }
                     },
                     {
                         typeof(EnumWithFields),
-                        new List<KeyValuePair<string, string>>
+                        new List<KeyValuePair<Tuple<string, string>, string>>
                         {
-                            new KeyValuePair<string, string>(nameof(EnumWithFields.Zero), "0"),
-                            new KeyValuePair<string, string>(nameof(EnumWithFields.One), "1"),
-                            new KeyValuePair<string, string>(nameof(EnumWithFields.Two), "2"),
-                            new KeyValuePair<string, string>(nameof(EnumWithFields.Three), "3"),
-                            new KeyValuePair<string, string>(nameof(EnumWithFields.MinusTwo), "-2"),
-                            new KeyValuePair<string, string>(nameof(EnumWithFields.MinusOne), "-1"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.Zero)), "0"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.One)), "1"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.Two)), "2"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.Three)), "3"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.MinusTwo)), "-2"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.MinusOne)), "-1"),
                         }
                     },
                     {
                         typeof(EnumWithFields?),
-                        new List<KeyValuePair<string, string>>
+                        new List<KeyValuePair<Tuple<string, string>, string>>
                         {
-                            new KeyValuePair<string, string>(nameof(EnumWithFields.Zero), "0"),
-                            new KeyValuePair<string, string>(nameof(EnumWithFields.One), "1"),
-                            new KeyValuePair<string, string>(nameof(EnumWithFields.Two), "2"),
-                            new KeyValuePair<string, string>(nameof(EnumWithFields.Three), "3"),
-                            new KeyValuePair<string, string>(nameof(EnumWithFields.MinusTwo), "-2"),
-                            new KeyValuePair<string, string>(nameof(EnumWithFields.MinusOne), "-1"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.Zero)), "0"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.One)), "1"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.Two)), "2"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.Three)), "3"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.MinusTwo)), "-2"),
+                            new KeyValuePair<Tuple<string, string>, string>(Tuple.Create(string.Empty, nameof(EnumWithFields.MinusOne)), "-1"),
                         }
                     },
                 };
@@ -524,9 +524,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
 
         [Theory]
         [MemberData(nameof(EnumDisplayNamesData))]
-        public void GetDisplayMetadata_EnumDisplayNamesAndValues_ReflectsModelType(
+        public void GetDisplayMetadata_EnumGroupedDisplayNamesAndValues_ReflectsModelType(
             Type type,
-            IEnumerable<KeyValuePair<string, string>> expectedKeyValuePairs)
+            IEnumerable<KeyValuePair<Tuple<string, string>, string>> expectedKeyValuePairs)
         {
             // Arrange
             var provider = new DataAnnotationsMetadataProvider();
@@ -541,8 +541,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
             // Assert
             // OrderBy is used because the order of the results may very depending on the platform / client.
             Assert.Equal(
-                expectedKeyValuePairs?.OrderBy(item => item.Key, StringComparer.Ordinal),
-                context.DisplayMetadata.EnumDisplayNamesAndValues?.OrderBy(item => item.Key, StringComparer.Ordinal));
+                expectedKeyValuePairs?.OrderBy(item => item.Key.Item1, StringComparer.Ordinal).ThenBy(item => item.Key.Item2, StringComparer.Ordinal),
+                context.DisplayMetadata.EnumGroupedDisplayNamesAndValues?.OrderBy(item => item.Key.Item1, StringComparer.Ordinal).ThenBy(item => item.Key.Item2, StringComparer.Ordinal));
         }
 
         [Fact]
@@ -708,10 +708,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
             [Display(ShortName = "uno")]
             One = 1,
 
-            [Display(Name = "")]
+            [Display(Name = "", GroupName = "Zero")]
             Zero = 0,
 
-            [Display(Name = "menos uno")]
+            [Display(Name = "menos uno", GroupName = "Negatives")]
             MinusOne = -1,
 
 #if USE_REAL_RESOURCES

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/MvcSampleTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/MvcSampleTests.cs
@@ -112,8 +112,8 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             "\"http://schemas.datacontract.org/2004/07/MvcSample.Web.Models\"><About>I like playing Football" +
             "</About><Address>My address</Address><Age>13</Age><Alive>true</Alive><Dependent><About i:nil=\"true\" />" +
             "<Address>Dependents address</Address><Age>0</Age><Alive>false</Alive><Dependent i:nil=\"true\" />" +
-            "<GPA>0</GPA><Log i:nil=\"true\" /><Name>Dependents name</Name>" +
-            "<Profession i:nil=\"true\" /></Dependent><GPA>13.37</GPA><Log i:nil=\"true\" />" +
+            "<EnumInformation>Zero</EnumInformation><GPA>0</GPA><Log i:nil=\"true\" /><Name>Dependents name</Name>" +
+            "<Profession i:nil=\"true\" /></Dependent><EnumInformation>Zero</EnumInformation><GPA>13.37</GPA><Log i:nil=\"true\" />" +
             "<Name>My name</Name><Profession>Software Engineer</Profession></User>",
                 await response.Content.ReadAsStringAsync());
         }


### PR DESCRIPTION
aspnet/Mvc#2292

Adding the DisplayAttribute.GroupName into the mix when using HtmlHelper.GetEnumSelectList for grouping of items in the list.

No sorting by default.