### PR TITLE
Fixed typo (occured to occurred) in comments and resources.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Properties/Resources.Designer.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         }
 
         /// <summary>
-        /// One or more compilation failures occured:
+        /// One or more compilation failures occurred:
         /// </summary>
         internal static string CompilationFailed
         {
@@ -35,7 +35,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         }
 
         /// <summary>
-        /// One or more compilation failures occured:
+        /// One or more compilation failures occurred:
         /// </summary>
         internal static string FormatCompilationFailed()
         {

--- a/src/Microsoft.AspNet.Mvc.Razor/Resources.resx
+++ b/src/Microsoft.AspNet.Mvc.Razor/Resources.resx
@@ -121,7 +121,7 @@
     <value>Value cannot be null or empty.</value>
   </data>
   <data name="CompilationFailed" xml:space="preserve">
-    <value>One or more compilation failures occured:</value>
+    <value>One or more compilation failures occurred:</value>
   </data>
   <data name="FlushPointCannotBeInvoked" xml:space="preserve">
     <value>'{0}' cannot be invoked when a Layout page is set to be executed.</value>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ExceptionInfo.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ExceptionInfo.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.AspNet.Mvc.FunctionalTests
 {
     /// <summary>
-    /// Information about an exception that occured on the server side of a functional
+    /// Information about an exception that occurred on the server side of a functional
     /// test.
     /// </summary>
     public class ExceptionInfo


### PR DESCRIPTION
I just fixed a typo in three files. This is my first attempt to collaborate in an open source project so I picked something simple to get the hang of it.