### PR TITLE
Move ModelExplorer to ViewFeatures

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/ModelMetadataProviderExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/ModelMetadataProviderExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.AspNet.Mvc.Core;
-using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Mvc.ModelBinding
 {
@@ -13,25 +12,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
     public static class ModelMetadataProviderExtensions
     {
         /// <summary>
-        /// Gets a <see cref="ModelExplorer"/> for the provided <paramref name="modelType"/> and
-        /// <paramref name="model"/>.
-        /// </summary>
-        /// <param name="provider">The <see cref="IModelMetadataProvider"/>.</param>
-        /// <param name="modelType">The declared <see cref="Type"/> of the model object.</param>
-        /// <param name="model">The model object.</param>
-        /// <returns>
-        /// A <see cref="ModelExplorer"/> for the <paramref name="modelType"/> and <paramref name="model"/>.
-        /// </returns>
-        public static ModelExplorer GetModelExplorerForType(
-            [NotNull] this IModelMetadataProvider provider,
-            [NotNull] Type modelType,
-            object model)
-        {
-            var modelMetadata = provider.GetMetadataForType(modelType);
-            return new ModelExplorer(provider, modelMetadata, model);
-        }
-
-        /// <summary>
         /// Gets a <see cref="ModelMetadata"/> for property identified by the provided
         /// <paramref name="containerType"/> and <paramref name="propertyName"/>.
         /// </summary>
@@ -40,10 +20,25 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// <param name="propertyName">The property name.</param>
         /// <returns>A <see cref="ModelMetadata"/> for the property.</returns>
         public static ModelMetadata GetMetadataForProperty(
-            [NotNull] this IModelMetadataProvider provider,
-            [NotNull] Type containerType,
-            [NotNull] string propertyName)
+            this IModelMetadataProvider provider,
+            Type containerType,
+            string propertyName)
         {
+            if (provider == null)
+            {
+                throw new ArgumentNullException(nameof(provider));
+            }
+
+            if (containerType == null)
+            {
+                throw new ArgumentNullException(nameof(containerType));
+            }
+
+            if (propertyName == null)
+            {
+                throw new ArgumentNullException(nameof(propertyName));
+            }
+
             var containerMetadata = provider.GetMetadataForType(containerType);
 
             var propertyMetadata = containerMetadata.Properties[propertyName];

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/ModelExplorer.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/ModelExplorer.cs
@@ -5,9 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.AspNet.Mvc.ModelBinding;
 using Microsoft.Framework.Internal;
 
-namespace Microsoft.AspNet.Mvc.ModelBinding
+namespace Microsoft.AspNet.Mvc.ViewFeatures
 {
     /// <summary>
     /// Associates a model object with it's corresponding <see cref="ModelMetadata"/>.
@@ -29,10 +30,20 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// <param name="metadata">The <see cref="ModelMetadata"/>.</param>
         /// <param name="model">The model object. May be <c>null</c>.</param>
         public ModelExplorer(
-            [NotNull] IModelMetadataProvider metadataProvider, 
-            [NotNull] ModelMetadata metadata, 
+            IModelMetadataProvider metadataProvider, 
+            ModelMetadata metadata, 
             object model)
         {
+            if (metadataProvider == null)
+            {
+                throw new ArgumentNullException(nameof(metadataProvider));
+            }
+
+            if (metadata == null)
+            {
+                throw new ArgumentNullException(nameof(metadata));
+            }
+
             _metadataProvider = metadataProvider;
             Metadata = metadata;
             _model = model;
@@ -46,11 +57,26 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// <param name="metadata">The <see cref="ModelMetadata"/>.</param>
         /// <param name="modelAccessor">A model accessor function. May be <c>null</c>.</param>
         public ModelExplorer(
-            [NotNull] IModelMetadataProvider metadataProvider,
-            [NotNull] ModelExplorer container,
-            [NotNull] ModelMetadata metadata,
+            IModelMetadataProvider metadataProvider,
+            ModelExplorer container,
+            ModelMetadata metadata,
             Func<object, object> modelAccessor)
         {
+            if (metadataProvider == null)
+            {
+                throw new ArgumentNullException(nameof(metadataProvider));
+            }
+
+            if (container == null)
+            {
+                throw new ArgumentNullException(nameof(container));
+            }
+
+            if (metadata == null)
+            {
+                throw new ArgumentNullException(nameof(metadata));
+            }
+
             _metadataProvider = metadataProvider;
             Container = container;
             Metadata = metadata;
@@ -65,11 +91,21 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// <param name="metadata">The <see cref="ModelMetadata"/>.</param>
         /// <param name="model">The model object. May be <c>null</c>.</param>
         public ModelExplorer(
-            [NotNull] IModelMetadataProvider metadataProvider,
-            [NotNull] ModelExplorer container,
-            [NotNull] ModelMetadata metadata,
+            IModelMetadataProvider metadataProvider,
+            ModelExplorer container,
+            ModelMetadata metadata,
             object model)
         {
+            if (metadataProvider == null)
+            {
+                throw new ArgumentNullException(nameof(metadataProvider));
+            }
+
+            if (metadata == null)
+            {
+                throw new ArgumentNullException(nameof(metadata));
+            }
+
             _metadataProvider = metadataProvider;
             Container = container;
             Metadata = metadata;
@@ -216,8 +252,13 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// </summary>
         /// <param name="name">The property name.</param>
         /// <returns>A <see cref="ModelExplorer"/>, or <c>null</c>.</returns>
-        public ModelExplorer GetExplorerForProperty([NotNull] string name)
+        public ModelExplorer GetExplorerForProperty(string name)
         {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
             return Properties.FirstOrDefault(p => string.Equals(
                 p.Metadata.PropertyName, 
                 name, 
@@ -234,8 +275,13 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// <remarks>
         /// As this creates a model explorer with a specific model accessor function, the result is not cached.
         /// </remarks>
-        public ModelExplorer GetExplorerForProperty([NotNull] string name, Func<object, object> modelAccessor)
+        public ModelExplorer GetExplorerForProperty(string name, Func<object, object> modelAccessor)
         {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
             var metadata = GetMetadataForRuntimeType();
 
             var propertyMetadata = metadata.Properties[name];
@@ -257,8 +303,13 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// <remarks>
         /// As this creates a model explorer with a specific model value, the result is not cached.
         /// </remarks>
-        public ModelExplorer GetExplorerForProperty([NotNull] string name, object model)
+        public ModelExplorer GetExplorerForProperty(string name, object model)
         {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
             var metadata = GetMetadataForRuntimeType();
 
             var propertyMetadata = metadata.Properties[name];
@@ -286,8 +337,13 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// The returned <see cref="ModelExplorer"/> will have the current instance set as its <see cref="Container"/>.
         /// </para>
         /// </remarks>
-        public ModelExplorer GetExplorerForExpression([NotNull] Type modelType, object model)
+        public ModelExplorer GetExplorerForExpression(Type modelType, object model)
         {
+            if (modelType == null)
+            {
+                throw new ArgumentNullException(nameof(modelType));
+            }
+
             var metadata = _metadataProvider.GetMetadataForType(modelType);
             return GetExplorerForExpression(metadata, model);
         }
@@ -309,8 +365,13 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// The returned <see cref="ModelExplorer"/> will have the current instance set as its <see cref="Container"/>.
         /// </para>
         /// </remarks>
-        public ModelExplorer GetExplorerForExpression([NotNull] ModelMetadata metadata, object model)
+        public ModelExplorer GetExplorerForExpression(ModelMetadata metadata, object model)
         {
+            if (metadata == null)
+            {
+                throw new ArgumentNullException(nameof(metadata));
+            }
+
             return new ModelExplorer(_metadataProvider, this, metadata, model);
         }
 
@@ -331,8 +392,13 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// The returned <see cref="ModelExplorer"/> will have the current instance set as its <see cref="Container"/>.
         /// </para>
         /// </remarks>
-        public ModelExplorer GetExplorerForExpression([NotNull] Type modelType, Func<object, object> modelAccessor)
+        public ModelExplorer GetExplorerForExpression(Type modelType, Func<object, object> modelAccessor)
         {
+            if (modelType == null)
+            {
+                throw new ArgumentNullException(nameof(modelType));
+            }
+
             var metadata = _metadataProvider.GetMetadataForType(modelType);
             return GetExplorerForExpression(metadata, modelAccessor);
         }
@@ -354,8 +420,13 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// The returned <see cref="ModelExplorer"/> will have the current instance set as its <see cref="Container"/>.
         /// </para>
         /// </remarks>
-        public ModelExplorer GetExplorerForExpression([NotNull] ModelMetadata metadata, Func<object, object> modelAccessor)
+        public ModelExplorer GetExplorerForExpression(ModelMetadata metadata, Func<object, object> modelAccessor)
         {
+            if (metadata == null)
+            {
+                throw new ArgumentNullException(nameof(metadata));
+            }
+
             return new ModelExplorer(_metadataProvider, this, metadata, modelAccessor);
         }
 

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/ModelExplorerExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/ModelExplorerExtensions.cs
@@ -4,9 +4,9 @@
 using System;
 using System.Linq;
 using System.Globalization;
-using Microsoft.Framework.Internal;
+using Microsoft.AspNet.Mvc.ModelBinding;
 
-namespace Microsoft.AspNet.Mvc.ModelBinding
+namespace Microsoft.AspNet.Mvc.ViewFeatures
 {
     /// <summary>
     /// Extension methods for <see cref="ModelExplorer"/>.
@@ -19,8 +19,13 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// </summary>
         /// <param name="modelExplorer">The <see cref="ModelExplorer"/>.</param>
         /// <returns>A simple display string for the model.</returns>
-        public static string GetSimpleDisplayText([NotNull] this ModelExplorer modelExplorer)
+        public static string GetSimpleDisplayText(this ModelExplorer modelExplorer)
         {
+            if (modelExplorer == null)
+            {
+                throw new ArgumentNullException(nameof(modelExplorer));
+            }
+
             if (modelExplorer.Metadata.SimpleDisplayProperty != null)
             {
                 var propertyExplorer = modelExplorer.GetExplorerForProperty(

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/ModelExpression.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/ModelExpression.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.AspNet.Mvc.ModelBinding;
+using Microsoft.AspNet.Mvc.ViewFeatures;
 
 namespace Microsoft.AspNet.Mvc.Rendering
 {

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/ModelMetadataProviderExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/ModelMetadataProviderExtensions.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNet.Mvc.ModelBinding;
+
+namespace Microsoft.AspNet.Mvc.ViewFeatures
+{
+    /// <summary>
+    /// Extensions methods for <see cref="IModelMetadataProvider"/>.
+    /// </summary>
+    public static class ModelMetadataProviderExtensions
+    {
+        /// <summary>
+        /// Gets a <see cref="ModelExplorer"/> for the provided <paramref name="modelType"/> and
+        /// <paramref name="model"/>.
+        /// </summary>
+        /// <param name="provider">The <see cref="IModelMetadataProvider"/>.</param>
+        /// <param name="modelType">The declared <see cref="Type"/> of the model object.</param>
+        /// <param name="model">The model object.</param>
+        /// <returns>
+        /// A <see cref="ModelExplorer"/> for the <paramref name="modelType"/> and <paramref name="model"/>.
+        /// </returns>
+        public static ModelExplorer GetModelExplorerForType(
+            this IModelMetadataProvider provider,
+            Type modelType,
+            object model)
+        {
+            if (provider == null)
+            {
+                throw new ArgumentNullException(nameof(provider));
+            }
+
+            if (modelType == null)
+            {
+                throw new ArgumentNullException(nameof(modelType));
+            }
+
+            var modelMetadata = provider.GetMetadataForType(modelType);
+            return new ModelExplorer(provider, modelMetadata, model);
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/TemplateInfo.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/TemplateInfo.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.AspNet.Mvc.ModelBinding;
 
 namespace Microsoft.AspNet.Mvc.ViewFeatures
 {

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/ApiController.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/ApiController.cs
@@ -415,10 +415,7 @@ namespace System.Web.Http
         /// </param>
         public void Validate<TEntity>(TEntity entity, string keyPrefix)
         {
-            var modelExplorer = MetadataProvider.GetModelExplorerForType(typeof(TEntity), entity);
-
             var validatidationState = new ValidationStateDictionary();
-
             ObjectValidator.Validate(
                 BindingContext.ValidatorProvider,
                 ModelState,

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/MutableObjectModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/MutableObjectModelBinderTest.cs
@@ -1240,14 +1240,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var bindingContext = CreateContext(GetMetadataForType(model.GetType()), model);
 
             var metadataProvider = bindingContext.OperationBindingContext.MetadataProvider;
-            var modelExplorer = metadataProvider.GetModelExplorerForType(typeof(Person), model);
-            var propertyMetadata = bindingContext.ModelMetadata.Properties[nameof(model.PropertyWithDefaultValue)];
+            var metadata = metadataProvider.GetMetadataForType(typeof(Person));
+            var propertyMetadata = metadata.Properties[nameof(model.PropertyWithDefaultValue)];
 
             var result = ModelBindingResult.Failed("foo");
             var testableBinder = new TestableMutableObjectModelBinder();
 
             // Act
-            testableBinder.SetProperty(bindingContext, modelExplorer, propertyMetadata, result);
+            testableBinder.SetProperty(bindingContext, metadata, propertyMetadata, result);
 
             // Assert
             var person = Assert.IsType<Person>(bindingContext.Model);
@@ -1263,8 +1263,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var bindingContext = CreateContext(GetMetadataForType(model.GetType()), model);
 
             var metadataProvider = bindingContext.OperationBindingContext.MetadataProvider;
-            var modelExplorer = metadataProvider.GetModelExplorerForType(typeof(Person), model);
-            var propertyMetadata = bindingContext.ModelMetadata.Properties[nameof(model.PropertyWithInitializedValue)];
+            var metadata = metadataProvider.GetMetadataForType(typeof(Person));
+            var propertyMetadata = metadata.Properties[nameof(model.PropertyWithInitializedValue)];
 
             // The null model value won't be used because IsModelBound = false.
             var result = ModelBindingResult.Failed("foo");
@@ -1272,7 +1272,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var testableBinder = new TestableMutableObjectModelBinder();
 
             // Act
-            testableBinder.SetProperty(bindingContext, modelExplorer, propertyMetadata, result);
+            testableBinder.SetProperty(bindingContext, metadata, propertyMetadata, result);
 
             // Assert
             var person = Assert.IsType<Person>(bindingContext.Model);
@@ -1288,9 +1288,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var bindingContext = CreateContext(GetMetadataForType(model.GetType()), model);
 
             var metadataProvider = bindingContext.OperationBindingContext.MetadataProvider;
-            var modelExplorer = metadataProvider.GetModelExplorerForType(typeof(Person), model);
-            var propertyMetadata =
-                bindingContext.ModelMetadata.Properties[nameof(model.PropertyWithInitializedValueAndDefault)];
+            var metadata = metadataProvider.GetMetadataForType(typeof(Person));
+            var propertyMetadata = metadata.Properties[nameof(model.PropertyWithInitializedValueAndDefault)];
 
             // The null model value won't be used because IsModelBound = false.
             var result = ModelBindingResult.Failed("foo");
@@ -1298,7 +1297,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var testableBinder = new TestableMutableObjectModelBinder();
 
             // Act
-            testableBinder.SetProperty(bindingContext, modelExplorer, propertyMetadata, result);
+            testableBinder.SetProperty(bindingContext, metadata, propertyMetadata, result);
 
             // Assert
             var person = Assert.IsType<Person>(bindingContext.Model);
@@ -1314,14 +1313,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var bindingContext = CreateContext(GetMetadataForType(model.GetType()), model);
 
             var metadataProvider = bindingContext.OperationBindingContext.MetadataProvider;
-            var modelExplorer = metadataProvider.GetModelExplorerForType(typeof(Person), model);
-            var propertyMetadata = bindingContext.ModelMetadata.Properties[nameof(model.NonUpdateableProperty)];
+            var metadata = metadataProvider.GetMetadataForType(typeof(Person));
+            var propertyMetadata = metadata.Properties[nameof(model.NonUpdateableProperty)];
 
             var result = ModelBindingResult.Failed("foo");
             var testableBinder = new TestableMutableObjectModelBinder();
 
             // Act
-            testableBinder.SetProperty(bindingContext, modelExplorer, propertyMetadata, result);
+            testableBinder.SetProperty(bindingContext, metadata, propertyMetadata, result);
 
             // Assert
             // If didn't throw, success!
@@ -1351,7 +1350,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         [MemberData(nameof(MyCanUpdateButCannotSetPropertyData))]
         public void SetProperty_ValueProvidedAndCanUpdatePropertyTrue_DoesNothing(
             string propertyName,
-            Func<object, object> propertAccessor)
+            Func<object, object> propertyAccessor)
         {
             // Arrange
             var model = new MyModelTestingCanUpdateProperty();
@@ -1359,7 +1358,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var bindingContext = CreateContext(GetMetadataForType(type), model);
             var modelState = bindingContext.ModelState;
             var metadataProvider = bindingContext.OperationBindingContext.MetadataProvider;
-            var modelExplorer = metadataProvider.GetModelExplorerForType(type, model);
+            var metadata = metadataProvider.GetMetadataForType(type);
 
             var propertyMetadata = bindingContext.ModelMetadata.Properties[propertyName];
             var result = ModelBindingResult.Success(
@@ -1369,10 +1368,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var testableBinder = new TestableMutableObjectModelBinder();
 
             // Act
-            testableBinder.SetProperty(bindingContext, modelExplorer, propertyMetadata, result);
+            testableBinder.SetProperty(bindingContext, metadata, propertyMetadata, result);
 
             // Assert
-            Assert.Equal("Joe", propertAccessor(model));
+            Assert.Equal("Joe", propertyAccessor(model));
             Assert.True(modelState.IsValid);
             Assert.Empty(modelState);
         }
@@ -1436,14 +1435,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var bindingContext = CreateContext(GetMetadataForType(type), model);
             var modelState = bindingContext.ModelState;
             var metadataProvider = bindingContext.OperationBindingContext.MetadataProvider;
-            var modelExplorer = metadataProvider.GetModelExplorerForType(type, model);
+            var metadata = metadataProvider.GetMetadataForType(type);
 
             var propertyMetadata = bindingContext.ModelMetadata.Properties[propertyName];
             var result = ModelBindingResult.Success(propertyName, collection);
             var testableBinder = new TestableMutableObjectModelBinder();
 
             // Act
-            testableBinder.SetProperty(bindingContext, modelExplorer, propertyMetadata, result);
+            testableBinder.SetProperty(bindingContext, metadata, propertyMetadata, result);
 
             // Assert
             Assert.Equal(collection, propertyAccessor(model));
@@ -1459,14 +1458,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var bindingContext = CreateContext(GetMetadataForType(model.GetType()), model);
 
             var metadataProvider = bindingContext.OperationBindingContext.MetadataProvider;
-            var modelExplorer = metadataProvider.GetModelExplorerForType(typeof(Person), model);
+            var metadata = metadataProvider.GetMetadataForType(typeof(Person));
             var propertyMetadata = bindingContext.ModelMetadata.Properties[nameof(model.DateOfBirth)];
 
             var result = ModelBindingResult.Success("foo", new DateTime(2001, 1, 1));
             var testableBinder = new TestableMutableObjectModelBinder();
 
             // Act
-            testableBinder.SetProperty(bindingContext, modelExplorer, propertyMetadata, result);
+            testableBinder.SetProperty(bindingContext, metadata, propertyMetadata, result);
 
             // Assert
             Assert.True(bindingContext.ModelState.IsValid);
@@ -1486,14 +1485,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var bindingContext = CreateContext(GetMetadataForType(model.GetType()), model);
 
             var metadataProvider = bindingContext.OperationBindingContext.MetadataProvider;
-            var modelExplorer = metadataProvider.GetModelExplorerForType(typeof(Person), model);
+            var metadata = metadataProvider.GetMetadataForType(typeof(Person));
             var propertyMetadata = bindingContext.ModelMetadata.Properties[nameof(model.DateOfDeath)];
 
             var result = ModelBindingResult.Success("foo", new DateTime(1800, 1, 1));
             var testableBinder = new TestableMutableObjectModelBinder();
 
             // Act
-            testableBinder.SetProperty(bindingContext, modelExplorer, propertyMetadata, result);
+            testableBinder.SetProperty(bindingContext, metadata, propertyMetadata, result);
 
             // Assert
             Assert.Equal("Date of death can't be before date of birth." + Environment.NewLine
@@ -1511,14 +1510,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var bindingContext = CreateContext(GetMetadataForType(model.GetType()), model);
 
             var metadataProvider = bindingContext.OperationBindingContext.MetadataProvider;
-            var modelExplorer = metadataProvider.GetModelExplorerForType(typeof(Person), model);
+            var metadata = metadataProvider.GetMetadataForType(typeof(Person));
             var propertyMetadata = bindingContext.ModelMetadata.Properties[nameof(model.DateOfBirth)];
 
             var result = ModelBindingResult.Success("foo.DateOfBirth", model: null);
             var testableBinder = new TestableMutableObjectModelBinder();
 
             // Act
-            testableBinder.SetProperty(bindingContext, modelExplorer, propertyMetadata, result);
+            testableBinder.SetProperty(bindingContext, metadata, propertyMetadata, result);
 
             // Assert
             Assert.False(bindingContext.ModelState.IsValid);
@@ -1539,14 +1538,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             bindingContext.ModelName = "foo";
 
             var metadataProvider = bindingContext.OperationBindingContext.MetadataProvider;
-            var modelExplorer = metadataProvider.GetModelExplorerForType(typeof(ModelWhosePropertySetterThrows), model);
+            var metadata = metadataProvider.GetMetadataForType(typeof(ModelWhosePropertySetterThrows));
             var propertyMetadata = bindingContext.ModelMetadata.Properties[nameof(model.NameNoAttribute)];
 
             var result = ModelBindingResult.Success("foo.NameNoAttribute", model: null);
             var testableBinder = new TestableMutableObjectModelBinder();
 
             // Act
-            testableBinder.SetProperty(bindingContext, modelExplorer, propertyMetadata, result);
+            testableBinder.SetProperty(bindingContext, metadata, propertyMetadata, result);
 
             // Assert
             Assert.False(bindingContext.ModelState.IsValid);
@@ -1898,11 +1897,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             public new void SetProperty(
                 ModelBindingContext bindingContext,
-                ModelExplorer modelExplorer,
+                ModelMetadata metadata,
                 ModelMetadata propertyMetadata,
                 ModelBindingResult result)
             {
-                base.SetProperty(bindingContext, modelExplorer, propertyMetadata, result);
+                base.SetProperty(bindingContext, metadata, propertyMetadata, result);
             }
         }
     }

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LabelTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LabelTagHelperTest.cs
@@ -6,8 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc.ModelBinding;
-using Microsoft.AspNet.Mvc.TestCommon;
 using Microsoft.AspNet.Mvc.Rendering;
+using Microsoft.AspNet.Mvc.TestCommon;
+using Microsoft.AspNet.Mvc.ViewFeatures;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 using Xunit;
 

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/Rendering/HtmlHelperLabelExtensionsTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/Rendering/HtmlHelperLabelExtensionsTest.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.AspNet.Mvc.ModelBinding;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Mvc.TestCommon;
+using Microsoft.AspNet.Mvc.ViewFeatures;
 using Xunit;
 
 namespace Microsoft.AspNet.Mvc.Core

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ViewFeatures/ModelExplorerExtensionsTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ViewFeatures/ModelExplorerExtensionsTest.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
+using Microsoft.AspNet.Mvc.ModelBinding;
 using Xunit;
 
-namespace Microsoft.AspNet.Mvc.ModelBinding
+namespace Microsoft.AspNet.Mvc.ViewFeatures
 {
     public class ModelExplorerExtensionsTest
     {

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ViewFeatures/ModelExplorerTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ViewFeatures/ModelExplorerTest.cs
@@ -2,9 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
+using Microsoft.AspNet.Mvc.ModelBinding;
 using Xunit;
 
-namespace Microsoft.AspNet.Mvc.ModelBinding
+namespace Microsoft.AspNet.Mvc.ViewFeatures
 {
     public class ModelExplorerTest
     {


### PR DESCRIPTION
This change removes the last vestiges of `ModelExplorer` from the model binding code, and moves it to ViewFeatures