### PR TITLE
Workaround Mono bugs to fix travis

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/Validation/ValidationStateDictionary.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/Validation/ValidationStateDictionary.cs
@@ -163,6 +163,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         
         private class ReferenceEqualityComparer : IEqualityComparer<object>
         {
+            private static readonly bool IsMono = Type.GetType("Mono.Runtime") != null;
+
             public static readonly ReferenceEqualityComparer Instance = new ReferenceEqualityComparer();
 
             public new bool Equals(object x, object y)
@@ -172,6 +174,13 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
 
             public int GetHashCode(object obj)
             {
+                // RuntimeHelpers.GetHashCode sometimes crashes the runtime on Mono 4.0.4
+                // The workaround here is to just not hash anything, and fall back to an equality check.
+                if (IsMono)
+                {
+                    return 0;
+                }
+
                 return RuntimeHelpers.GetHashCode(obj);
             }
         }

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Validation/DefaultComplexObjectValidationStrategy.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Validation/DefaultComplexObjectValidationStrategy.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
 {
@@ -12,6 +13,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
     /// </summary>
     public class DefaultComplexObjectValidationStrategy : IValidationStrategy
     {
+        private static readonly bool IsMono = Type.GetType("Mono.Runtime") != null;
+
         /// <summary>
         /// Gets an instance of <see cref="DefaultComplexObjectValidationStrategy"/>.
         /// </summary>
@@ -78,7 +81,34 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
                 var property = _properties[_index];
                 var propertyName = property.BinderModelName ?? property.PropertyName;
                 var key = ModelNames.CreatePropertyModelName(_key, propertyName);
-                var model = property.PropertyGetter(_model);
+
+                object model;
+
+                // Our property accessors don't work on Mono 4.0.4 - see https://bugzilla.xamarin.com/show_bug.cgi?id=25717
+                // This is a workaround for what the PropertyGetter does in the background.
+                if (IsMono)
+                {
+                    if (_model == null)
+                    {
+                        model = null;
+                    }
+                    else
+                    {
+                        var propertyInfo = _model.GetType().GetRuntimeProperty(property.PropertyName);
+                        try
+                        {
+                            model = propertyInfo.GetValue(_model);
+                        }
+                        catch (TargetInvocationException ex)
+                        {
+                            throw ex.InnerException;
+                        }
+                    }
+                }
+                else
+                {
+                    model = property.PropertyGetter(_model);
+                }
 
                 _entry = new ValidationEntry(property, key, model);
 

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Validation/ReferenceEqualityComparer.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Validation/ReferenceEqualityComparer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
@@ -9,6 +10,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
     internal class ReferenceEqualityComparer : IEqualityComparer<object>
     {
         private static readonly ReferenceEqualityComparer _instance = new ReferenceEqualityComparer();
+
+        private static readonly bool IsMono = Type.GetType("Mono.Runtime") != null;
 
         public static ReferenceEqualityComparer Instance
         {
@@ -25,6 +28,13 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
 
         public int GetHashCode(object obj)
         {
+            // RuntimeHelpers.GetHashCode sometimes crashes the runtime on Mono 4.0.4
+            // The workaround here is to just not hash anything, and fall back to an equality check.
+            if (IsMono)
+            {
+                return 0;
+            }
+
             return RuntimeHelpers.GetHashCode(obj);
         }
     }


### PR DESCRIPTION
This change works around two mono issues that are blocking travis. I'd
like to have tests skip instead, but unfortunately that would mean not
running any validation tests on mono so this seems better.

- RuntimeHelpers.GetHashCode will sometimes crash the runtime
- PropertyHelper sometimes throws null-ref