### PR TITLE
fix #3172: Remove mono check from localization test

### DIFF
--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/LocalizationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/LocalizationTest.cs
@@ -92,15 +92,11 @@ Hi John      ! You are in 2015 year and today is Thursday";
 
                 yield return new[] {"en-GB", expected1 };
 
-                if (!TestPlatformHelper.IsMono)
-                {
-                    // https://github.com/aspnet/Mvc/issues/3172
-                    var expected2 =
+                var expected2 =
 @"Bonjour!
 apprendre Encore Plus
 Salut John      ! Vous êtes en 2015 an aujourd'hui est Thursday";
-                    yield return new[] { "fr", expected2 };
-                }
+                yield return new[] { "fr", expected2 };
             }
         }
 


### PR DESCRIPTION
Removing the check since this issue could have been happening because of https://github.com/aspnet/dnx/issues/2802. I am not seeing this issue on mono now.