### PR TITLE
[Design] Custom type for handling dictionaries of HTML attributes

### DIFF
--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Properties/Resources.Designer.cs
@@ -842,6 +842,22 @@ namespace Microsoft.AspNet.Mvc.ViewFeatures
             return string.Format(CultureInfo.CurrentCulture, GetString("TempData_CannotSerializeToSession"), p0, p1);
         }
 
+        /// <summary>
+        /// The collection already contains an entry with key '{0}'.
+        /// </summary>
+        internal static string Dictionary_DuplicateKey
+        {
+            get { return GetString("Dictionary_DuplicateKey"); }
+        }
+
+        /// <summary>
+        /// The collection already contains an entry with key '{0}'.
+        /// </summary>
+        internal static string FormatDictionary_DuplicateKey(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Dictionary_DuplicateKey"), p0);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Resources.resx
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Resources.resx
@@ -274,4 +274,7 @@
   <data name="TempData_CannotSerializeToSession" xml:space="preserve">
     <value>The '{0}' cannot serialize an object of type '{1}' to session state.</value>
   </data>
+  <data name="Dictionary_DuplicateKey" xml:space="preserve">
+    <value>The collection already contains an entry with key '{0}'.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/AttributeDictionary.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/AttributeDictionary.cs
@@ -1,0 +1,681 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNet.Mvc.ViewFeatures
+{
+    /// <summary>
+    /// A dictionary for HTML attributes.
+    /// </summary>
+    public class AttributeDictionary : IDictionary<string, string>, IReadOnlyDictionary<string, string>
+    {
+        private List<KeyValuePair<string, string>> _items;
+
+        /// <inheritdoc />
+        public string this[string key]
+        {
+            get
+            {
+                if (key == null)
+                {
+                    throw new ArgumentNullException(nameof(key));
+                }
+
+                var index = Find(key);
+                if (index < 0)
+                {
+                    throw new KeyNotFoundException();
+                }
+                else
+                {
+                    return Get(index).Value;
+                }
+            }
+
+            set
+            {
+                if (key == null)
+                {
+                    throw new ArgumentNullException(nameof(key));
+                }
+
+                var item = new KeyValuePair<string, string>(key, value);
+                var index = Find(key);
+                if (index < 0)
+                {
+                    Insert(~index, item);
+                }
+                else
+                {
+                    Set(index, item);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public int Count => _items == null ? 0 : _items.Count;
+
+        /// <inheritdoc />
+        public bool IsReadOnly
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        /// <inheritdoc />
+        public ICollection<string> Keys
+        {
+            get
+            {
+                return new KeyCollection(this);
+            }
+        }
+
+        /// <inheritdoc />
+        public ICollection<string> Values
+        {
+            get
+            {
+                return new ValueCollection(this);
+            }
+        }
+
+        /// <inheritdoc />
+        IEnumerable<string> IReadOnlyDictionary<string, string>.Keys
+        {
+            get
+            {
+                return new KeyCollection(this);
+            }
+        }
+
+        /// <inheritdoc />
+        IEnumerable<string> IReadOnlyDictionary<string, string>.Values
+        {
+            get
+            {
+                return new ValueCollection(this);
+            }
+        }
+
+        private KeyValuePair<string, string> Get(int index)
+        {
+            if (index >= Count)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            return _items[index];
+        }
+
+        private void Set(int index, KeyValuePair<string, string> value)
+        {
+            if (index > Count)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            if (_items == null)
+            {
+                _items = new List<KeyValuePair<string, string>>();
+            }
+
+            _items[index] = value;
+        }
+
+        private void Insert(int index, KeyValuePair<string, string> value)
+        {
+            if (index > Count)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            if (_items == null)
+            {
+                _items = new List<KeyValuePair<string, string>>();
+            }
+
+            _items.Insert(index, value);
+        }
+
+        private void Remove(int index)
+        {
+            if (index >= Count)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            
+            _items.RemoveAt(index);
+        }
+
+        // This API is a lot like List<T>.BinarySearch https://msdn.microsoft.com/en-us/library/3f90y839(v=vs.110).aspx
+        // If an item is not found, we return the compliment of where it belongs. Then we don't need to search again
+        // to do something with it.
+        private int Find(string key)
+        {
+            if (Count == 0)
+            {
+                return ~0;
+            }
+
+            var start = 0;
+            var end = Count - 1;
+
+            while (start <= end)
+            {
+                var pivot = start + (end - start >> 1);
+
+                var compare = StringComparer.OrdinalIgnoreCase.Compare(Get(pivot).Key, key);
+                if (compare == 0)
+                {
+                    return pivot;
+                }
+                if (compare < 0)
+                {
+                    start = pivot + 1;
+                }
+                else
+                {
+                    end = pivot - 1;
+                }
+            }
+
+            return ~start;
+        }
+
+        /// <inheritdoc />
+        public void Clear()
+        {
+            if (_items != null)
+            {
+                _items.Clear();
+            }
+        }
+
+        /// <inheritdoc />
+        public void Add(KeyValuePair<string, string> item)
+        {
+            if (item.Key == null)
+            {
+                throw new ArgumentException(
+                    Resources.FormatPropertyOfTypeCannotBeNull(
+                        nameof(KeyValuePair<string, string>.Key),
+                        nameof(KeyValuePair<string, string>)),
+                    nameof(item));
+            }
+
+            var index = Find(item.Key);
+            if (index < 0)
+            {
+                Insert(~index, item);
+            }
+            else
+            {
+                throw new InvalidOperationException(Resources.FormatDictionary_DuplicateKey(item.Key));
+            }
+        }
+
+        /// <inheritdoc />
+        public void Add(string key, string value)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            Add(new KeyValuePair<string, string>(key, value));
+        }
+
+        /// <inheritdoc />
+        public bool Contains(KeyValuePair<string, string> item)
+        {
+            if (item.Key == null)
+            {
+                throw new ArgumentException(
+                    Resources.FormatPropertyOfTypeCannotBeNull(
+                        nameof(KeyValuePair<string, string>.Key),
+                        nameof(KeyValuePair<string, string>)),
+                    nameof(item));
+            }
+
+            var index = Find(item.Key);
+            if (index < 0)
+            {
+                return false;
+            }
+            else
+            {
+                return string.Equals(item.Value, Get(index).Value, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        /// <inheritdoc />
+        public bool ContainsKey(string key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            if (Count == 0)
+            {
+                return false;
+            }
+
+            return Find(key) >= 0;
+        }
+
+        /// <inheritdoc />
+        public void CopyTo(KeyValuePair<string, string>[] array, int arrayIndex)
+        {
+            if (array == null)
+            {
+                throw new ArgumentNullException(nameof(array));
+            }
+
+            if (arrayIndex < 0 || arrayIndex >= array.Length)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            for (var i = 0; i < Count; i++)
+            {
+                array[arrayIndex + i] = Get(i);
+            }
+        }
+
+        /// <inheritdoc />
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        /// <inheritdoc />
+        public bool Remove(KeyValuePair<string, string> item)
+        {
+            if (item.Key == null)
+            {
+                throw new ArgumentException(
+                    Resources.FormatPropertyOfTypeCannotBeNull(
+                        nameof(KeyValuePair<string, string>.Key),
+                        nameof(KeyValuePair<string, string>)),
+                    nameof(item));
+            }
+
+            var index = Find(item.Key);
+            if (index < 0)
+            {
+                return false;
+            }
+            else if (string.Equals(item.Value, Get(index).Value, StringComparison.OrdinalIgnoreCase))
+            {
+                Remove(index);
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <inheritdoc />
+        public bool Remove(string key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            var index = Find(key);
+            if (index < 0)
+            {
+                return false;
+            }
+            else
+            {
+                Remove(index);
+                return true;
+            }
+        }
+
+        /// <inheritdoc />
+        public bool TryGetValue(string key, out string value)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            var index = Find(key);
+            if (index < 0)
+            {
+                value = null;
+                return false;
+            }
+            else
+            {
+                value = Get(index).Value;
+                return true;
+            }
+        }
+
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        /// <inheritdoc />
+        IEnumerator<KeyValuePair<string, string>> IEnumerable<KeyValuePair<string, string>>.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        /// <summary>
+        /// An enumerator for <see cref="AttributeDictionary"/>.
+        /// </summary>
+        public struct Enumerator : IEnumerator<KeyValuePair<string, string>>
+        {
+            private readonly AttributeDictionary _attributes;
+
+            private int _index;
+
+            /// <summary>
+            /// Creates a new <see cref="Enumerator"/>.
+            /// </summary>
+            /// <param name="attributes">The <see cref="AttributeDictionary"/>.</param>
+            public Enumerator(AttributeDictionary attributes)
+            {
+                _attributes = attributes;
+
+                _index = -1;
+            }
+
+            /// <inheritdoc />
+            public KeyValuePair<string, string> Current
+            {
+                get
+                {
+                    return _attributes.Get(_index);
+                }
+            }
+
+            /// <inheritdoc />
+            object IEnumerator.Current
+            {
+                get
+                {
+                    return Current;
+                }
+            }
+
+            /// <inheritdoc />
+            public void Dispose()
+            {
+            }
+
+            /// <inheritdoc />
+            public bool MoveNext()
+            {
+                _index++;
+                return _index < _attributes.Count;
+            }
+
+            /// <inheritdoc />
+            public void Reset()
+            {
+                _index = -1;
+            }
+        }
+
+        private class KeyCollection : ICollection<string>
+        {
+            private readonly AttributeDictionary _attributes;
+
+            public KeyCollection(AttributeDictionary attributes)
+            {
+                _attributes = attributes;
+            }
+
+            public int Count => _attributes.Count;
+
+            public bool IsReadOnly => true;
+
+            public void Add(string item)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void Clear()
+            {
+                throw new NotSupportedException();
+            }
+
+            public bool Contains(string item)
+            {
+                if (item == null)
+                {
+                    throw new ArgumentNullException(nameof(item));
+                }
+
+                for (var i = 0; i < _attributes.Count; i++)
+                {
+                    if (string.Equals(item, _attributes.Get(i).Key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            public void CopyTo(string[] array, int arrayIndex)
+            {
+                if (array == null)
+                {
+                    throw new ArgumentNullException(nameof(array));
+                }
+
+                if (arrayIndex < 0 || arrayIndex >= array.Length)
+                {
+                    throw new IndexOutOfRangeException();
+                }
+
+                for (var i = 0; i < _attributes.Count; i++)
+                {
+                    array[arrayIndex + i] = _attributes.Get(i).Key;
+                }
+            }
+
+            public Enumerator GetEnumerator()
+            {
+                return new Enumerator(this._attributes);
+            }
+
+            public bool Remove(string item)
+            {
+                throw new NotSupportedException();
+            }
+
+            IEnumerator<string> IEnumerable<string>.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            public struct Enumerator : IEnumerator<string>
+            {
+                private readonly AttributeDictionary _attributes;
+
+                private int _index;
+
+                public Enumerator(AttributeDictionary attributes)
+                {
+                    _attributes = attributes;
+
+                    _index = -1;
+                }
+
+                public string Current
+                {
+                    get
+                    {
+                        return _attributes.Get(_index).Key;
+                    }
+                }
+
+                object IEnumerator.Current
+                {
+                    get
+                    {
+                        return Current;
+                    }
+                }
+
+                public void Dispose()
+                {
+                }
+
+                public bool MoveNext()
+                {
+                    _index++;
+                    return _index < _attributes.Count;
+                }
+
+                public void Reset()
+                {
+                    _index = -1;
+                }
+            }
+        }
+
+        private class ValueCollection : ICollection<string>
+        {
+            private readonly AttributeDictionary _attributes;
+
+            public ValueCollection(AttributeDictionary attributes)
+            {
+                _attributes = attributes;
+            }
+            public int Count => _attributes.Count;
+
+            public bool IsReadOnly => true;
+
+            public void Add(string item)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void Clear()
+            {
+                throw new NotSupportedException();
+            }
+
+            public bool Contains(string item)
+            {
+                for (var i = 0; i < _attributes.Count; i++)
+                {
+                    if (string.Equals(item, _attributes.Get(i).Value, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            public void CopyTo(string[] array, int arrayIndex)
+            {
+                if (array == null)
+                {
+                    throw new ArgumentNullException(nameof(array));
+                }
+
+                if (arrayIndex < 0 || arrayIndex >= array.Length)
+                {
+                    throw new IndexOutOfRangeException();
+                }
+
+                for (var i = 0; i < _attributes.Count; i++)
+                {
+                    array[arrayIndex + i] = _attributes.Get(i).Value;
+                }
+            }
+
+            public Enumerator GetEnumerator()
+            {
+                return new Enumerator(this._attributes);
+            }
+
+            public bool Remove(string item)
+            {
+                throw new NotSupportedException();
+            }
+
+            IEnumerator<string> IEnumerable<string>.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            public struct Enumerator : IEnumerator<string>
+            {
+                private readonly AttributeDictionary _attributes;
+
+                private int _index;
+
+                public Enumerator(AttributeDictionary attributes)
+                {
+                    _attributes = attributes;
+
+                    _index = -1;
+                }
+
+                public string Current
+                {
+                    get
+                    {
+                        return _attributes.Get(_index).Key;
+                    }
+                }
+
+                object IEnumerator.Current
+                {
+                    get
+                    {
+                        return Current;
+                    }
+                }
+
+                public void Dispose()
+                {
+                }
+
+                public bool MoveNext()
+                {
+                    _index++;
+                    return _index < _attributes.Count;
+                }
+
+                public void Reset()
+                {
+                    _index = -1;
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/Rendering/TagBuilderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/Rendering/TagBuilderTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.Mvc.Core.Rendering
 
         [Theory]
         [InlineData(false, "Hello", "World")]
-        [InlineData(true, "Hello", "something else")]
+        [InlineData(true, "hello", "something else")]
         public void MergeAttribute_IgnoresCase(bool replaceExisting, string expectedKey, string expectedValue)
         {
             // Arrange
@@ -54,7 +54,7 @@ namespace Microsoft.AspNet.Mvc.Core.Rendering
 
             // Assert
             var attribute = Assert.Single(tagBuilder.Attributes);
-            Assert.Equal(new KeyValuePair<string, string>("ClaSs", "success btn"), attribute);
+            Assert.Equal(new KeyValuePair<string, string>("class", "success btn"), attribute);
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ViewFeatures/AttributeDictionaryTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ViewFeatures/AttributeDictionaryTest.cs
@@ -1,0 +1,464 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.AspNet.Mvc.ViewFeatures
+{
+    public class AttributeDictionaryTest
+    {
+        [Fact]
+        public void AttributeDictionary_AddItems()
+        {
+            // Arrange
+            var attributes = new AttributeDictionary();
+
+            // Act
+            attributes.Add("zero", "0");
+            attributes.Add("one", "1");
+            attributes.Add("two", "2");
+
+            // Assert
+            Assert.Equal(3, attributes.Count);
+            Assert.Collection(
+                attributes,
+                kvp => Assert.Equal(new KeyValuePair<string, string>("one", "1"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, string>("two", "2"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, string>("zero", "0"), kvp));
+        }
+
+        [Fact]
+        public void AttributeDictionary_AddItems_AsKeyValuePairs()
+        {
+            // Arrange
+            var attributes = new AttributeDictionary();
+
+            // Act
+            attributes.Add(new KeyValuePair<string, string>("zero", "0"));
+            attributes.Add(new KeyValuePair<string, string>("one", "1"));
+            attributes.Add(new KeyValuePair<string, string>("two", "2"));
+
+            // Assert
+            Assert.Equal(3, attributes.Count);
+            Assert.Collection(
+                attributes,
+                kvp => Assert.Equal(new KeyValuePair<string, string>("one", "1"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, string>("two", "2"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, string>("zero", "0"), kvp));
+        }
+
+        [Fact]
+        public void AttributeDictionary_Add_DuplicateKey()
+        {
+            // Arrange
+            var attributes = new AttributeDictionary();
+
+            attributes.Add("zero", "0");
+            attributes.Add("one", "1");
+            attributes.Add("two", "2");
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() => attributes.Add("one", "15"));
+        }
+
+        [Fact]
+        public void AttributeDictionary_Clear()
+        {
+            // Arrange
+            var attributes = new AttributeDictionary();
+
+            attributes.Add(new KeyValuePair<string, string>("zero", "0"));
+            attributes.Add(new KeyValuePair<string, string>("one", "1"));
+            attributes.Add(new KeyValuePair<string, string>("two", "2"));
+
+            // Act
+            attributes.Clear();
+
+            // Assert
+            Assert.Equal(0, attributes.Count);
+            Assert.Empty(attributes);
+        }
+
+        [Fact]
+        public void AttributeDictionary_Contains_Success()
+        {
+            // Arrange
+            var attributes = new AttributeDictionary();
+
+            attributes.Add(new KeyValuePair<string, string>("zero", "0"));
+            attributes.Add(new KeyValuePair<string, string>("one", "1"));
+            attributes.Add(new KeyValuePair<string, string>("two", "2"));
+
+            // Act
+            var result = attributes.Contains(new KeyValuePair<string, string>("zero", "0"));
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void AttributeDictionary_Contains_Failure()
+        {
+            // Arrange
+            var attributes = new AttributeDictionary();
+
+            attributes.Add(new KeyValuePair<string, string>("zero", "0"));
+            attributes.Add(new KeyValuePair<string, string>("one", "1"));
+            attributes.Add(new KeyValuePair<string, string>("two", "2"));
+
+            // Act
+            var result = attributes.Contains(new KeyValuePair<string, string>("zero", "nada"));
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void AttributeDictionary_ContainsKey_Success()
+        {
+            // Arrange
+            var attributes = new AttributeDictionary();
+
+            attributes.Add(new KeyValuePair<string, string>("zero", "0"));
+            attributes.Add(new KeyValuePair<string, string>("one", "1"));
+            attributes.Add(new KeyValuePair<string, string>("two", "2"));
+
+            // Act
+            var result = attributes.ContainsKey("one");
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void AttributeDictionary_ContainsKey_Failure()
+        {
+            // Arrange
+            var attributes = new AttributeDictionary();
+
+            attributes.Add(new KeyValuePair<string, string>("zero", "0"));
+            attributes.Add(new KeyValuePair<string, string>("one", "1"));
+            attributes.Add(new KeyValuePair<string, string>("two", "2"));
+
+            // Act
+            var result = attributes.ContainsKey("one!");
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void AttributeDictionary_CopyTo()
+        {
+            // Arrange
+            var attributes = new AttributeDictionary();
+
+            attributes.Add(new KeyValuePair<string, string>("zero", "0"));
+            attributes.Add(new KeyValuePair<string, string>("one", "1"));
+            attributes.Add(new KeyValuePair<string, string>("two", "2"));
+
+            var array = new KeyValuePair<string, string>[attributes.Count + 1];
+
+            // Act
+            attributes.CopyTo(array, 1);
+
+            // Assert
+            Assert.Collection(
+                array,
+                kvp => Assert.Equal(default(KeyValuePair<string, string>), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, string>("one", "1"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, string>("two", "2"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, string>("zero", "0"), kvp));
+        }
+
+        [Fact]
+        public void AttributeDictionary_IsReadOnly()
+        {
+            // Arrange
+            var attributes = new AttributeDictionary();
+
+            // Act
+            var result = attributes.IsReadOnly;
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void AttributeDictionary_Keys()
+        {
+            // Arrange
+            var attributes = new AttributeDictionary();
+
+            attributes.Add(new KeyValuePair<string, string>("zero", "0"));
+            attributes.Add(new KeyValuePair<string, string>("one", "1"));
+            attributes.Add(new KeyValuePair<string, string>("two", "2"));
+
+            // Act
+            var keys = attributes.Keys;
+
+            // Assert
+            Assert.Equal(3, keys.Count);
+            Assert.Collection(
+                keys,
+                key => Assert.Equal("one", key),
+                key => Assert.Equal("two", key),
+                key => Assert.Equal("zero", key));
+        }
+
+        [Fact]
+        public void AttributeDictionary_Remove_Success()
+        {
+            // Arrange
+            var attributes = new AttributeDictionary();
+
+            attributes.Add(new KeyValuePair<string, string>("zero", "0"));
+            attributes.Add(new KeyValuePair<string, string>("one", "1"));
+            attributes.Add(new KeyValuePair<string, string>("two", "2"));
+
+            // Act
+            var result = attributes.Remove("one");
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(2, attributes.Count);
+            Assert.Collection(
+                attributes,
+                kvp => Assert.Equal(new KeyValuePair<string, string>("two", "2"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, string>("zero", "0"), kvp));
+        }
+
+        [Fact]
+        public void AttributeDictionary_Remove_Failure()
+        {
+            // Arrange
+            var attributes = new AttributeDictionary();
+
+            attributes.Add(new KeyValuePair<string, string>("zero", "0"));
+            attributes.Add(new KeyValuePair<string, string>("one", "1"));
+            attributes.Add(new KeyValuePair<string, string>("two", "2"));
+
+            // Act
+            var result = attributes.Remove("nada");
+
+            // Assert
+            Assert.False(result);
+            Assert.Equal(3, attributes.Count);
+            Assert.Collection(
+                attributes,
+                kvp => Assert.Equal(new KeyValuePair<string, string>("one", "1"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, string>("two", "2"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, string>("zero", "0"), kvp));
+        }
+
+        [Fact]
+        public void AttributeDictionary_Remove_KeyValuePair_Success()
+        {
+            // Arrange
+            var attributes = new AttributeDictionary();
+
+            attributes.Add(new KeyValuePair<string, string>("zero", "0"));
+            attributes.Add(new KeyValuePair<string, string>("one", "1"));
+            attributes.Add(new KeyValuePair<string, string>("two", "2"));
+
+            // Act
+            var result = attributes.Remove(new KeyValuePair<string, string>("one", "1"));
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(2, attributes.Count);
+            Assert.Collection(
+                attributes,
+                kvp => Assert.Equal(new KeyValuePair<string, string>("two", "2"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, string>("zero", "0"), kvp));
+        }
+
+        [Fact]
+        public void AttributeDictionary_Remove_KeyValuePair_Failure()
+        {
+            // Arrange
+            var attributes = new AttributeDictionary();
+
+            attributes.Add(new KeyValuePair<string, string>("zero", "0"));
+            attributes.Add(new KeyValuePair<string, string>("one", "1"));
+            attributes.Add(new KeyValuePair<string, string>("two", "2"));
+
+            // Act
+            var result = attributes.Remove(new KeyValuePair<string, string>("one", "0"));
+
+            // Assert
+            Assert.False(result);
+            Assert.Equal(3, attributes.Count);
+            Assert.Collection(
+                attributes,
+                kvp => Assert.Equal(new KeyValuePair<string, string>("one", "1"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, string>("two", "2"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, string>("zero", "0"), kvp));
+        }
+
+        [Fact]
+        public void AttributeDictionary_TryGetValue_Success()
+        {
+            // Arrange
+            var attributes = new AttributeDictionary();
+
+            attributes.Add(new KeyValuePair<string, string>("zero", "0"));
+            attributes.Add(new KeyValuePair<string, string>("one", "1"));
+            attributes.Add(new KeyValuePair<string, string>("two", "2"));
+
+            string value;
+
+            // Act
+            var result = attributes.TryGetValue("two", out value);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal("2", value);
+        }
+
+        [Fact]
+        public void AttributeDictionary_TryGetValue_Failure()
+        {
+            // Arrange
+            var attributes = new AttributeDictionary();
+
+            attributes.Add(new KeyValuePair<string, string>("zero", "0"));
+            attributes.Add(new KeyValuePair<string, string>("one", "1"));
+            attributes.Add(new KeyValuePair<string, string>("two", "2"));
+
+            string value;
+
+            // Act
+            var result = attributes.TryGetValue("nada", out value);
+
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public void AttributeDictionary_Values()
+        {
+            // Arrange
+            var attributes = new AttributeDictionary();
+
+            attributes.Add(new KeyValuePair<string, string>("zero", "0"));
+            attributes.Add(new KeyValuePair<string, string>("one", "1"));
+            attributes.Add(new KeyValuePair<string, string>("two", "2"));
+
+            // Act
+            var values = attributes.Values;
+
+            // Assert
+            Assert.Equal(3, values.Count);
+            Assert.Collection(
+                values,
+                key => Assert.Equal("1", key),
+                key => Assert.Equal("2", key),
+                key => Assert.Equal("0", key));
+        }
+
+        [Fact]
+        public void AttributeDictionary_Indexer_Success()
+        {
+            // Arrange
+            var attributes = new AttributeDictionary();
+
+            attributes.Add(new KeyValuePair<string, string>("zero", "0"));
+            attributes.Add(new KeyValuePair<string, string>("one", "1"));
+            attributes.Add(new KeyValuePair<string, string>("two", "2"));
+
+            // Act
+            var value = attributes["two"];
+
+            // Assert
+            Assert.Equal("2", value);
+        }
+
+        [Fact]
+        public void AttributeDictionary_Indexer_Fails()
+        {
+            // Arrange
+            var attributes = new AttributeDictionary();
+
+            attributes.Add(new KeyValuePair<string, string>("zero", "0"));
+            attributes.Add(new KeyValuePair<string, string>("one", "1"));
+            attributes.Add(new KeyValuePair<string, string>("two", "2"));
+
+            // Act & Assert
+            Assert.Throws<KeyNotFoundException>(() => attributes["nada"]);
+        }
+
+        [Fact]
+        public void AttributeDictionary_Indexer_SetValue()
+        {
+            // Arrange
+            var attributes = new AttributeDictionary();
+
+            attributes.Add(new KeyValuePair<string, string>("zero", "0"));
+            attributes.Add(new KeyValuePair<string, string>("one", "1"));
+            attributes.Add(new KeyValuePair<string, string>("two", "2"));
+
+            // Act
+            attributes["one"] = "1!";
+
+            // Assert
+            Assert.Equal(3, attributes.Count);
+            Assert.Collection(
+                attributes,
+                kvp => Assert.Equal(new KeyValuePair<string, string>("one", "1!"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, string>("two", "2"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, string>("zero", "0"), kvp));
+        }
+
+        [Fact]
+        public void AttributeDictionary_Indexer_Insert()
+        {
+            // Arrange
+            var attributes = new AttributeDictionary();
+
+            attributes.Add(new KeyValuePair<string, string>("zero", "0"));
+            attributes.Add(new KeyValuePair<string, string>("one", "1"));
+            attributes.Add(new KeyValuePair<string, string>("two", "2"));
+
+            // Act
+            attributes["exciting!"] = "1!";
+
+            // Assert
+            Assert.Equal(4, attributes.Count);
+            Assert.Collection(
+                attributes,
+                kvp => Assert.Equal(new KeyValuePair<string, string>("exciting!", "1!"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, string>("one", "1"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, string>("two", "2"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, string>("zero", "0"), kvp));
+        }
+
+        [Fact]
+        public void AttributeDictionary_CaseInsensitive()
+        {
+            // Arrange
+            var attributes = new AttributeDictionary();
+
+            attributes.Add(new KeyValuePair<string, string>("zero", "0"));
+            attributes.Add(new KeyValuePair<string, string>("one", "1"));
+            attributes.Add(new KeyValuePair<string, string>("two", "2"));
+
+            // Act
+            attributes["oNe"] = "1!";
+
+            // Assert
+            Assert.Equal(3, attributes.Count);
+            Assert.Collection(
+                attributes,
+                kvp => Assert.Equal(new KeyValuePair<string, string>("oNe", "1!"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, string>("two", "2"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, string>("zero", "0"), kvp));
+        }
+    }
+}


### PR DESCRIPTION
TagBuilder currently uses `SortedDictionary<string, string>` for HTML attributes. Its memory usage pattern is pretty bad for our usage pattern (lots of small, short-lived objects).

Here's some numbers for a very small site with model binding and views - showing allocations for 3001 requests. This is all the flotsam created by these dictionaries:
![image](https://cloud.githubusercontent.com/assets/1430011/10182375/599ada7e-66d8-11e5-88d6-54270dce1073.png)

Rough math says it's about 5.2mb or about 4.5% of total allocations. **something must be done**

===============================
The first approach that I tried here is use a `List<>` inside of a `IDictionary<,>` List is a fairly lean data structure to begin with.

![image](https://cloud.githubusercontent.com/assets/1430011/10182403/9813c8e2-66d8-11e5-9927-d241e1031286.png)
![image](https://cloud.githubusercontent.com/assets/1430011/10182409/b2521bfa-66d8-11e5-9413-df8a4eaed978.png)

You can see here that a number of these lists need to grow (reallocate) as items are added since the count of arrays > count of lists.

==============================
The second attempt is much more extreme, and uses fields inside the `AttributeDictionary` for the first 4 elements, only allocating the list after those 4 have been filled.

![image](https://cloud.githubusercontent.com/assets/1430011/10182416/c1069af4-66d8-11e5-844e-34e2993f92e4.png)
![image](https://cloud.githubusercontent.com/assets/1430011/10182425/d42d8778-66d8-11e5-81ab-e2a77b973279.png)

If you look at the second, you'll see far fewer of either are allocated. I have a bug in this example where the list is always being allocated - accounting for the discrepancy between arrays and lists. Assume that a good version of this would have only 9003 lists allocated.

=============================

At this point, more research and testing is needed. I wanted to get the idea out there to get feedback on the craziness of the idea. It's likely that the sweet spot here is around 6-8. Upping the number of 'inline' items to 6 might turn out to be much better for practical usage.

I'm happy to conclude that if we can't make the second option show a really **significant** improvement, then we should stick with the first one. :+1:
