### PR TITLE
Fix for #3252 - Issues with pooled buffer + unicode

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Properties/Resources.Designer.cs
@@ -1002,6 +1002,22 @@ namespace Microsoft.AspNet.Mvc.Core
             return string.Format(CultureInfo.CurrentCulture, GetString("ValueProviderResult_NoConverterExists"), p0, p1);
         }
 
+        /// <summary>
+        /// The byte buffer must have a length of at least '{0}' to be used with a char buffer of size '{1}' and encoding '{2}'. Use '{3}.{4}' to compute the correct size for the byte buffer.
+        /// </summary>
+        internal static string HttpResponseStreamWriter_InvalidBufferSize
+        {
+            get { return GetString("HttpResponseStreamWriter_InvalidBufferSize"); }
+        }
+
+        /// <summary>
+        /// The byte buffer must have a length of at least '{0}' to be used with a char buffer of size '{1}' and encoding '{2}'. Use '{3}.{4}' to compute the correct size for the byte buffer.
+        /// </summary>
+        internal static string FormatHttpResponseStreamWriter_InvalidBufferSize(object p0, object p1, object p2, object p3, object p4)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("HttpResponseStreamWriter_InvalidBufferSize"), p0, p1, p2, p3, p4);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNet.Mvc.Core/Resources.resx
+++ b/src/Microsoft.AspNet.Mvc.Core/Resources.resx
@@ -312,4 +312,7 @@
   <data name="ValueProviderResult_NoConverterExists" xml:space="preserve">
     <value>The parameter conversion from type '{0}' to type '{1}' failed because no type converter can convert between these types.</value>
   </data>
+  <data name="HttpResponseStreamWriter_InvalidBufferSize" xml:space="preserve">
+    <value>The byte buffer must have a length of at least '{0}' to be used with a char buffer of size '{1}' and encoding '{2}'. Use '{3}.{4}' to compute the correct size for the byte buffer.</value>
+  </data>
 </root>

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Infrastructure/MemoryPoolHttpResponseStreamWriterFactoryTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Infrastructure/MemoryPoolHttpResponseStreamWriterFactoryTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             // Arrange
             var bytePool = new Mock<IArraySegmentPool<byte>>(MockBehavior.Strict);
             bytePool
-                .Setup(p => p.Lease(MemoryPoolHttpResponseStreamWriterFactory.DefaultBufferSize))
+                .Setup(p => p.Lease(It.IsAny<int>()))
                 .Returns(new LeasedArraySegment<byte>(new ArraySegment<byte>(new byte[0]), bytePool.Object));
             bytePool
                 .Setup(p => p.Return(It.IsAny<LeasedArraySegment<byte>>()))
@@ -32,7 +32,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
                 .Setup(p => p.Return(It.IsAny<LeasedArraySegment<char>>()))
                 .Verifiable();
 
-            var encoding = new Mock<Encoding>(MockBehavior.Strict);
+            var encoding = new Mock<Encoding>();
             encoding
                 .Setup(e => e.GetEncoder())
                 .Throws(new InvalidOperationException());


### PR DESCRIPTION
- Dispose buffers when Flush throws inside the Dispose method
- Compute size of buffers correctly
- Throw earlier when handed invalid-sized buffers