### PR TITLE
Optimize allocations for creating ActionConstraints

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ActionConstraints/DefaultActionConstraintProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionConstraints/DefaultActionConstraintProvider.cs
@@ -29,9 +29,9 @@ namespace Microsoft.AspNet.Mvc.ActionConstraints
                 throw new ArgumentNullException(nameof(context));
             }
 
-            foreach (var item in context.Results)
+            for (var i = 0; i < context.Results.Count; i++)
             {
-                ProvideConstraint(item, context.HttpContext.RequestServices);
+                ProvideConstraint(context.Results[i], context.HttpContext.RequestServices);
             }
         }
 

--- a/src/Microsoft.AspNet.Mvc.Core/ActionConstraints/HttpMethodConstraint.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionConstraints/HttpMethodConstraint.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNet.Mvc.ActionConstraints
     {
         public static readonly int HttpMethodConstraintOrder = 100;
 
-        private readonly IReadOnlyList<string> _methods;
+        private readonly IReadOnlyList<string> _httpMethods;
 
         private readonly string OriginHeader = "Origin";
         private readonly string AccessControlRequestMethod = "Access-Control-Request-Method";
@@ -39,14 +39,14 @@ namespace Microsoft.AspNet.Mvc.ActionConstraints
                 methods.Add(method);
             }
 
-            _methods = new ReadOnlyCollection<string>(methods);
+            _httpMethods = new ReadOnlyCollection<string>(methods);
         }
 
         public IEnumerable<string> HttpMethods
         {
             get
             {
-                return _methods;
+                return _httpMethods;
             }
         }
 
@@ -62,7 +62,7 @@ namespace Microsoft.AspNet.Mvc.ActionConstraints
                 throw new ArgumentNullException(nameof(context));
             }
 
-            if (_methods.Count == 0)
+            if (_httpMethods.Count == 0)
             {
                 return true;
             }
@@ -83,7 +83,16 @@ namespace Microsoft.AspNet.Mvc.ActionConstraints
                 }
             }
 
-            return (HttpMethods.Any(m => m.Equals(method, StringComparison.Ordinal)));
+            for (var i = 0; i < _httpMethods.Count; i++)
+            {
+                var supportedMethod = _httpMethods[i];
+                if (string.Equals(supportedMethod, method, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
**Before**
![image](https://cloud.githubusercontent.com/assets/1430011/10301105/fd93f270-6bb3-11e5-88f4-95604d1a5740.png)

**After**
![image](https://cloud.githubusercontent.com/assets/1430011/10301115/12892d62-6bb4-11e5-8669-819b2cbb6f83.png)

This change is very similar to the `GetFilters` change. This is worth about .9mb for 3000 requests to an action with a single `[HttpGet]` attribute. This is fairly constrained and simple, and has a good outcome for just removing the linq code.

There's another task here to look at the allocations for the **execution** side of action constraints. 
