### PR TITLE
Update DNX Core on Linux workarounds

### DIFF
--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ActionResultTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ActionResultTests.cs
@@ -8,9 +8,6 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
-#if DNXCORE50
-using Microsoft.AspNet.Testing.xunit;
-#endif
 using Xunit;
 
 namespace Microsoft.AspNet.Mvc.FunctionalTests
@@ -221,13 +218,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("content", await response.Content.ReadAsStringAsync());
         }
 
-#if DNXCORE50
-        // Work around aspnet/External#43. Encoding.ASCII is of type System.Text.UTF8Encoding with Core CLR on Linux.
-        [ConditionalTheory]
-        [OSSkipCondition(OperatingSystems.Linux)]
-#else
         [Theory]
-#endif
         public async Task ContentResult_WritesContent_SetsContentTypeAndEncoding()
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/HtmlGenerationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/HtmlGenerationTest.cs
@@ -12,9 +12,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Mvc.Internal;
 using Microsoft.AspNet.Mvc.TagHelpers;
-#if DNXCORE50
-using Microsoft.AspNet.Testing;
-#endif
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Xunit;
@@ -48,7 +45,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         {
             get
             {
-                var data = new TheoryData<string, string>
+                return new TheoryData<string, string>
                 {
                     { "Customer", "/Customer/HtmlGeneration_Customer" },
                     { "Index", null },
@@ -59,12 +56,16 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
                     { "CreateWarehouse", null },
                     // Testing the HTML helpers with FormTagHelper
                     { "EditWarehouse", null },
+                    // Testing MVC tag helpers invoked in the editor templates from HTML helpers
+                    { "EmployeeList", null },
                     // Testing the EnvironmentTagHelper
                     { "Environment", null },
                     // Testing the ImageTagHelper
                     { "Image", null },
                     // Testing InputTagHelper with File
                     { "Input", null },
+                    // Testing the LinkTagHelper
+                    { "Link", null },
                     // Test ability to generate nearly identical HTML with MVC tag and HTML helpers.
                     // Only attribute order should differ.
                     { "Order", "/HtmlGeneration_Order/Submit" },
@@ -74,19 +75,6 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
                     // Testing the ScriptTagHelper
                     { "Script", null },
                 };
-
-#if DNXCORE50
-                // Work around aspnet/External#33. Large resources corrupted with Core CLR on Linux.
-                if (!TestPlatformHelper.IsLinux)
-#endif
-                {
-                    // Testing MVC tag helpers invoked in the editor templates from HTML helpers
-                    data.Add("EmployeeList", null);
-                    // Testing the LinkTagHelper
-                    data.Add("Link", null);
-                }
-
-                return data;
             }
         }
 
@@ -144,26 +132,17 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         {
             get
             {
-                var data = new TheoryData<string, string>
+                return new TheoryData<string, string>
                 {
                     { "AttributesWithBooleanValues", null },
                     { "EditWarehouse", null },
                     { "Index", null },
                     { "Link", null },
+                    { "Order", "/HtmlGeneration_Order/Submit" },
                     { "OrderUsingHtmlHelpers", "/HtmlGeneration_Order/Submit" },
                     { "Product", null },
+                    { "Script", null },
                 };
-
-#if DNXCORE50
-                // Work around aspnet/External#33. Large resources corrupted with Core CLR on Linux.
-                if (!TestPlatformHelper.IsLinux)
-#endif
-                {
-                    data.Add("Order", "/HtmlGeneration_Order/Submit");
-                    data.Add("Script", null);
-                }
-
-                return data;
             }
         }
 

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/HtmlHelperOptionsTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/HtmlHelperOptionsTest.cs
@@ -4,9 +4,6 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Testing;
-#if DNXCORE50
-using Microsoft.AspNet.Testing.xunit;
-#endif
 using Xunit;
 
 namespace Microsoft.AspNet.Mvc.FunctionalTests
@@ -50,13 +47,7 @@ False";
             Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
 
-#if DNXCORE50
-        [ConditionalFact]
-        // Work around aspnet/External#42. Only the invariant culture works with Core CLR on Linux.
-        [OSSkipCondition(OperatingSystems.Linux)]
-#else
         [Fact]
-#endif
         [ReplaceCulture]
         public async Task OverrideAppWideDefaultsInViewAndPartialView()
         {

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/LinkGenerationTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/LinkGenerationTests.cs
@@ -31,23 +31,13 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         {
             get
             {
-                var data = new TheoryData<string, string>
+                return new TheoryData<string, string>
                 {
                     { "http://localhost/Home/RedirectToActionReturningTaskAction", "/Home/ActionReturningTask" },
                     { "http://localhost/Home/RedirectToRouteActionAsMethodAction", "/Home/ActionReturningTask" },
                     { "http://localhost/Home/RedirectToRouteUsingRouteName", "/api/orders/10" },
+                    { "http://pingüino/Home/RedirectToRouteUsingRouteName", "/api/orders/10" },
                 };
-
-#if DNXCORE50
-                // Work around aspnet/External#41. Non-ASCII hostnames lead to a NotImplementedException with Core CLR
-                // on Linux.
-                if (!TestPlatformHelper.IsLinux)
-#endif
-                {
-                    data.Add("http://pingüino/Home/RedirectToRouteUsingRouteName", "/api/orders/10");
-                }
-
-                return data;
             }
         }
 

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/LocalizationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/LocalizationTest.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Testing;
 using Microsoft.Net.Http.Headers;
-using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.AspNet.Mvc.FunctionalTests
@@ -28,26 +27,20 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         {
             get
             {
-#if DNXCORE50
-                // Work around aspnet/External#42. Only the invariant culture works with Core CLR on Linux.
-                if (!TestPlatformHelper.IsLinux)
-#endif
-                {
-                    var expected1 =
+                var expected1 =
 @"<language-layout>en-gb-index
 partial
 mypartial
 </language-layout>";
 
-                    yield return new[] { "en-GB", expected1 };
+                yield return new[] { "en-GB", expected1 };
 
-                    var expected2 =
+                var expected2 =
 @"<fr-language-layout>fr-index
 fr-partial
 mypartial
 </fr-language-layout>";
-                    yield return new[] { "fr", expected2 };
-                }
+                yield return new[] { "fr", expected2 };
 
                 if (!TestPlatformHelper.IsMono)
                 {

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ModelBindingTest.cs
@@ -11,7 +11,9 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Testing;
+#if DNX451
 using Microsoft.AspNet.Testing.xunit;
+#endif
 using ModelBindingWebSite.Models;
 using ModelBindingWebSite.ViewModels;
 using Newtonsoft.Json;
@@ -1181,13 +1183,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #endif
         }
 
-#if DNXCORE50
-        [ConditionalFact]
-        // Work around aspnet/External#42. Only the invariant culture works with Core CLR on Linux.
-        [OSSkipCondition(OperatingSystems.Linux)]
-#else
         [Fact]
-#endif
         public async Task UpdateDealerVehicle_UsesDefaultValuesForOptionalProperties()
         {
             // Arrange
@@ -1335,13 +1331,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("grandFatherName", employee.Parent.Parent.Name);
         }
 
-#if DNXCORE50
-        [ConditionalFact]
-        // Work around aspnet/External#42. Only the invariant culture works with Core CLR on Linux.
-        [OSSkipCondition(OperatingSystems.Linux)]
-#else
         [Fact]
-#endif
         public async Task HtmlHelper_DisplayFor_ShowsPropertiesInModelMetadataOrder()
         {
             // Arrange
@@ -1363,13 +1353,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #endif
         }
 
-#if DNXCORE50
-        [ConditionalFact]
-        // Work around aspnet/External#42. Only the invariant culture works with Core CLR on Linux.
-        [OSSkipCondition(OperatingSystems.Linux)]
-#else
         [Fact]
-#endif
         public async Task HtmlHelper_EditorFor_ShowsPropertiesInModelMetadataOrder()
         {
             // Arrange
@@ -1395,13 +1379,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 #endif
         }
 
-#if DNXCORE50
-        [ConditionalFact]
-        // Work around aspnet/External#42. Only the invariant culture works with Core CLR on Linux.
-        [OSSkipCondition(OperatingSystems.Linux)]
-#else
         [Fact]
-#endif
         public async Task HtmlHelper_EditorFor_ShowsPropertiesAndErrorsInModelMetadataOrder()
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/RemoteAttributeValidationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/RemoteAttributeValidationTest.cs
@@ -6,9 +6,6 @@ using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
-#if DNXCORE50
-using Microsoft.AspNet.Testing.xunit;
-#endif
 using Xunit;
 
 namespace Microsoft.AspNet.Mvc.FunctionalTests
@@ -25,13 +22,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 
         public HttpClient Client { get; }
 
-#if DNXCORE50
-        // Work around aspnet/External#33. Large resources corrupted with Core CLR on Linux.
-        [ConditionalTheory]
-        [OSSkipCondition(OperatingSystems.Linux)]
-#else
         [Theory]
-#endif
         [InlineData("Aria", "/Aria")]
         [InlineData("Root", "")]
         public async Task RemoteAttribute_LeadsToExpectedValidationAttributes(string areaName, string pathSegment)

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/TagHelpersTest.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/TagHelpersTest.cs
@@ -7,9 +7,6 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
 using System.Threading.Tasks;
-#if DNXCORE50
-using Microsoft.AspNet.Testing.xunit;
-#endif
 using Xunit;
 
 namespace Microsoft.AspNet.Mvc.FunctionalTests
@@ -191,13 +188,7 @@ page:<root>root-content</root>"
 #endif
         }
 
-#if DNXCORE50
-        [ConditionalFact]
-        // Work around aspnet/External#42. Only the invariant culture works with Core CLR on Linux.
-        [OSSkipCondition(OperatingSystems.Linux)]
-#else
         [Fact]
-#endif
         public async Task ViewsWithModelMetadataAttributes_CanRenderPostedValue()
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ViewEngineTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ViewEngineTests.cs
@@ -123,19 +123,13 @@ partial-contentcomponent-content";
         {
             get
             {
-#if DNXCORE50
-                // Work around aspnet/External#42. Only the invariant culture works with Core CLR on Linux.
-                if (!TestPlatformHelper.IsLinux)
-#endif
-                {
-                    var expected1 = @"expander-index
+                var expected1 = @"expander-index
 gb-partial";
-                    yield return new[] { "en-GB", expected1 };
+                yield return new[] { "en-GB", expected1 };
 
-                    var expected2 = @"fr-index
+                var expected2 = @"fr-index
 fr-partial";
-                    yield return new[] { "fr", expected2 };
-                }
+                yield return new[] { "fr", expected2 };
 
                 if (!TestPlatformHelper.IsMono)
                 {
@@ -275,16 +269,10 @@ index-content";
                     yield return new[] { "!-invalid-!", expected1 };
                 }
 
-#if DNXCORE50
-                // Work around aspnet/External#42. Only the invariant culture works with Core CLR on Linux.
-                if (!TestPlatformHelper.IsLinux)
-#endif
-                {
-                    var expected2 =
+                var expected2 =
 @"<fr-language-layout>View With Layout
 </fr-language-layout>";
-                    yield return new[] { "fr", expected2 };
-                }
+                yield return new[] { "fr", expected2 };
             }
         }
 

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Order.Encoded.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Order.Encoded.html
@@ -29,7 +29,7 @@
         </div>
         <div>
             <label class="order" for="HtmlEncode[[OrderDate]]">HtmlEncode[[OrderDate]]</label>
-            <input type="HtmlEncode[[datetime]]" data-val="HtmlEncode[[true]]" data-val-required="HtmlEncode[[The OrderDate field is required.]]" id="HtmlEncode[[OrderDate]]" name="HtmlEncode[[OrderDate]]" value="HtmlEncode[[0001/01/01/ A.D.]]" />
+            <input type="HtmlEncode[[datetime]]" data-val="HtmlEncode[[true]]" data-val-required="HtmlEncode[[The OrderDate field is required.]]" id="HtmlEncode[[OrderDate]]" name="HtmlEncode[[OrderDate]]" value="HtmlEncode[[0001/01/01 00:00:00]]" />
         </div>
         <div>
             <label class="order" for="HtmlEncode[[NeedSpecialHandle]]">HtmlEncode[[NeedSpecialHandle]]</label>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Order.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Order.html
@@ -29,7 +29,7 @@
         </div>
         <div>
             <label class="order" for="OrderDate">OrderDate</label>
-            <input type="datetime" data-val="true" data-val-required="The OrderDate field is required." id="OrderDate" name="OrderDate" value="0001/01/01/ A.D." />
+            <input type="datetime" data-val="true" data-val-required="The OrderDate field is required." id="OrderDate" name="OrderDate" value="0001/01/01 00:00:00" />
         </div>
         <div>
             <label class="order" for="NeedSpecialHandle">NeedSpecialHandle</label>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.OrderUsingHtmlHelpers.Encoded.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.OrderUsingHtmlHelpers.Encoded.html
@@ -29,7 +29,7 @@
         </div>
         <div>
             <label class="HtmlEncode[[order]]" for="HtmlEncode[[OrderDate]]">HtmlEncode[[OrderDate]]</label>
-            <input data-val="HtmlEncode[[true]]" data-val-required="HtmlEncode[[The OrderDate field is required.]]" id="HtmlEncode[[OrderDate]]" name="HtmlEncode[[OrderDate]]" type="HtmlEncode[[datetime]]" value="HtmlEncode[[0001/01/01/ A.D.]]" />
+            <input data-val="HtmlEncode[[true]]" data-val-required="HtmlEncode[[The OrderDate field is required.]]" id="HtmlEncode[[OrderDate]]" name="HtmlEncode[[OrderDate]]" type="HtmlEncode[[datetime]]" value="HtmlEncode[[0001/01/01 00:00:00]]" />
         </div>
         <div>
             <label class="HtmlEncode[[order]]" for="HtmlEncode[[NeedSpecialHandle]]">HtmlEncode[[NeedSpecialHandle]]</label>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.OrderUsingHtmlHelpers.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.OrderUsingHtmlHelpers.html
@@ -29,7 +29,7 @@
         </div>
         <div>
             <label class="order" for="OrderDate">OrderDate</label>
-            <input data-val="true" data-val-required="The OrderDate field is required." id="OrderDate" name="OrderDate" type="datetime" value="0001/01/01/ A.D." />
+            <input data-val="true" data-val-required="The OrderDate field is required." id="OrderDate" name="OrderDate" type="datetime" value="0001/01/01 00:00:00" />
         </div>
         <div>
             <label class="order" for="NeedSpecialHandle">NeedSpecialHandle</label>

--- a/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Order.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Order.cshtml
@@ -39,7 +39,7 @@
         </div>
         <div>
             <label asp-for="OrderDate" class="order"></label>
-            <input asp-for="OrderDate" type="datetime" asp-format="{0:yyyy/MM/dd/ g}" />
+            <input asp-for="OrderDate" type="datetime" asp-format="{0:yyyy/MM/dd HH:mm:ss}" />
         </div>
         <div>
             <label asp-for="NeedSpecialHandle" class="order"></label>

--- a/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/OrderUsingHtmlHelpers.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/OrderUsingHtmlHelpers.cshtml
@@ -34,7 +34,7 @@ Html.BeginForm(actionName: "Submit", controllerName: "HtmlGeneration_Order"))
         </div>
         <div>
             @Html.LabelFor(m => m.OrderDate, htmlAttributes: new { @class = "order" })
-            @Html.TextBoxFor(m => m.OrderDate, format: "{0:yyyy/MM/dd/ g}", htmlAttributes: new { type = "datetime" })
+            @Html.TextBoxFor(m => m.OrderDate, format: "{0:yyyy/MM/dd HH:mm:ss}", htmlAttributes: new { type = "datetime" })
         </div>
         <div>
             @Html.LabelFor(m => m.NeedSpecialHandle, htmlAttributes: new { @class = "order" })

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/ConditionTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/ConditionTagHelper.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
-using Microsoft.AspNet.Razor.TagHelpers;
 
 namespace TagHelpersWebSite.TagHelpers
 {
@@ -12,6 +11,15 @@ namespace TagHelpersWebSite.TagHelpers
     public class ConditionTagHelper : TagHelper
     {
         public bool? Condition { get; set; }
+
+        public override int Order
+        {
+            get
+            {
+                // Run after other tag helpers targeting the same element. Other tag helpers have Order <= 0.
+                return 1000;
+            }
+        }
 
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/NestedViewImportsTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/NestedViewImportsTagHelper.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
-using Microsoft.AspNet.Razor.TagHelpers;
 
 namespace TagHelpersWebSite.TagHelpers
 {

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/PrettyTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/PrettyTagHelper.cs
@@ -32,11 +32,14 @@ namespace TagHelpersWebSite.TagHelpers
 
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
-            // Need to check if output.TagName == null in-case the ConditionTagHelper calls into SuppressOutput and
-            // therefore sets the TagName to null.
-            if (MakePretty.HasValue && !MakePretty.Value ||
-                output.TagName == null)
+            if (MakePretty.HasValue && !MakePretty.Value)
             {
+                return;
+            }
+
+            if (output.TagName == null)
+            {
+                // Another tag helper e.g. TagHelperviewComponentTagHelper has suppressed the start and end tags.
                 return;
             }
 

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/RootViewStartTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/RootViewStartTagHelper.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
-using Microsoft.AspNet.Razor.TagHelpers;
 
 namespace TagHelpersWebSite.TagHelpers
 {


### PR DESCRIPTION
- remove skip conditions for aspnet/External#33, aspnet/External#41, aspnet/External#42, aspnet/External#43
- add workaround for aspnet/External#47; avoid "g" custom datetime format specifier
- make tag helper execution order determinate in `TagHelpersWebSite`

Will test DNX Core in Travis builds (use `--test-dnxcore`) once aspnet/Universe#290 fix is in.

nits:
- remove useless `using`s for `Microsoft.AspNet.Razor.TagHelpers`