### PR TITLE
PhysicalFileResult throws NotSupported on path not rooted

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/PhysicalFileResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/PhysicalFileResult.cs
@@ -87,7 +87,7 @@ namespace Microsoft.AspNet.Mvc
         {
             if (!Path.IsPathRooted(FileName))
             {
-                throw new FileNotFoundException(Resources.FormatFileResult_InvalidPath(FileName), FileName);
+                throw new NotSupportedException(Resources.FormatFileResult_PathNotRooted(FileName));
             }
 
             var sendFile = response.HttpContext.Features.Get<IHttpSendFileFeature>();

--- a/src/Microsoft.AspNet.Mvc.Core/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Properties/Resources.Designer.cs
@@ -650,6 +650,11 @@ namespace Microsoft.AspNet.Mvc.Core
             return string.Format(CultureInfo.CurrentCulture, GetString("FileResult_InvalidPath"), p0);
         }
 
+        internal static string FormatFileResult_PathNotRooted(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("FileResult_PathNotRooted"), p0);
+        }
+
         /// <summary>
         /// The input was not valid.
         /// </summary>

--- a/src/Microsoft.AspNet.Mvc.Core/Resources.resx
+++ b/src/Microsoft.AspNet.Mvc.Core/Resources.resx
@@ -315,4 +315,8 @@
   <data name="HttpResponseStreamWriter_InvalidBufferSize" xml:space="preserve">
     <value>The byte buffer must have a length of at least '{0}' to be used with a char buffer of size '{1}' and encoding '{2}'. Use '{3}.{4}' to compute the correct size for the byte buffer.</value>
   </data>
+  <data name="FileResult_PathNotRooted" xml:space="preserve">
+    <value>Path '{0}' was not rooted.</value>
+    <comment>{0} is the path which wasn't rooted</comment>
+  </data>
 </root>

--- a/test/Microsoft.AspNet.Mvc.Core.Test/PhysicalFileResultTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/PhysicalFileResultTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -131,19 +132,18 @@ namespace Microsoft.AspNet.Mvc
         [InlineData("..\\TestFiles\\SubFolder/SubFolderTestFile.txt")]
         [InlineData("~/SubFolder/SubFolderTestFile.txt")]
         [InlineData("~/SubFolder\\SubFolderTestFile.txt")]
-        public async Task ExecuteAsync_ThrowsFileNotFound_ForNonRootedPaths(string path)
+        public async Task ExecuteAsync_ThrowsNotSupported_ForNonRootedPaths(string path)
         {
             // Arrange
             var result = new TestPhysicalFileResult(path, "text/plain");
             var context = new ActionContext(new DefaultHttpContext(), new RouteData(), new ActionDescriptor());
-            var expectedMessage = "Could not find file: " + path;
+            var expectedMessage = $"Path '{path}' was not rooted.";
 
             // Act
-            var ex = await Assert.ThrowsAsync<FileNotFoundException>(() => result.ExecuteResultAsync(context));
+            var ex = await Assert.ThrowsAsync<NotSupportedException>(() => result.ExecuteResultAsync(context));
 
             // Assert
             Assert.Equal(expectedMessage, ex.Message);
-            Assert.Equal(path, ex.FileName);
         }
 
         [Theory]


### PR DESCRIPTION
Makes PhysicalFileResult throw a more accurate and informative error in the case that a given path is not rooted. 