### PR TITLE
 * Allow null ViewData and TempData

### DIFF
--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewComponentResult.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewComponentResult.cs
@@ -84,6 +84,12 @@ namespace Microsoft.AspNet.Mvc
                 viewData = new ViewDataDictionary(modelMetadataProvider, context.ModelState);
             }
 
+            var tempData = TempData;
+            if (tempData == null)
+            {
+                tempData = services.GetRequiredService<ITempDataDictionary>();
+            }
+
             var contentType = ContentType;
             if (contentType != null && contentType.Encoding == null)
             {
@@ -98,8 +104,8 @@ namespace Microsoft.AspNet.Mvc
             //      3. ViewExecutor.DefaultContentType (sensible default)
             //
             //
-            response.ContentType = 
-                contentType?.ToString() ?? 
+            response.ContentType =
+                contentType?.ToString() ??
                 response.ContentType ??
                 ViewExecutor.DefaultContentType.ToString();
 
@@ -115,7 +121,7 @@ namespace Microsoft.AspNet.Mvc
                     context,
                     NullView.Instance,
                     viewData,
-                    TempData,
+                    tempData,
                     writer,
                     htmlHelperOptions);
 

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/ViewExecutor.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/ViewExecutor.cs
@@ -6,8 +6,10 @@ using System.Diagnostics;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc.Infrastructure;
+using Microsoft.AspNet.Mvc.ModelBinding;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Mvc.ViewEngines;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.OptionsModel;
 using Microsoft.Net.Http.Headers;
 
@@ -117,14 +119,16 @@ namespace Microsoft.AspNet.Mvc.ViewFeatures
                 throw new ArgumentNullException(nameof(view));
             }
 
+            var services = actionContext.HttpContext.RequestServices;
             if (viewData == null)
             {
-                throw new ArgumentNullException(nameof(viewData));
+                var metadataProvider = services.GetRequiredService<IModelMetadataProvider>();
+                viewData = new ViewDataDictionary(metadataProvider);
             }
 
             if (tempData == null)
             {
-                throw new ArgumentNullException(nameof(tempData));
+                tempData = services.GetRequiredService<ITempDataDictionary>();
             }
 
             var response = actionContext.HttpContext.Response;

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ViewFeatures/DefaultDisplayTemplatesTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ViewFeatures/DefaultDisplayTemplatesTest.cs
@@ -122,12 +122,11 @@ namespace Microsoft.AspNet.Mvc.ViewFeatures
         public void ObjectTemplate_IgnoresPropertiesWith_ScaffoldColumnFalse()
         {
             // Arrange
-            var expected =
-@"<div class=""HtmlEncode[[display-label]]"">HtmlEncode[[Property1]]</div>
-<div class=""HtmlEncode[[display-field]]""></div>
-<div class=""HtmlEncode[[display-label]]"">HtmlEncode[[Property3]]</div>
-<div class=""HtmlEncode[[display-field]]""></div>
-";
+            var expected = "<div class=\"HtmlEncode[[display-label]]\">HtmlEncode[[Property1]]</div>" + Environment.NewLine +
+                "<div class=\"HtmlEncode[[display-field]]\"></div>"+ Environment.NewLine +
+                "<div class=\"HtmlEncode[[display-label]]\">HtmlEncode[[Property3]]</div>"+ Environment.NewLine +
+                "<div class=\"HtmlEncode[[display-field]]\"></div>"+ Environment.NewLine;
+
             var model = new DefaultTemplatesUtilities.ObjectWithScaffoldColumn();
             var viewEngine = new Mock<ICompositeViewEngine>();
             viewEngine.Setup(v => v.FindPartialView(It.IsAny<ActionContext>(), It.IsAny<string>()))

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ViewFeatures/ViewExecutorTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ViewFeatures/ViewExecutorTest.cs
@@ -8,12 +8,14 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Internal;
 using Microsoft.AspNet.Mvc.Abstractions;
 using Microsoft.AspNet.Mvc.ModelBinding;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Mvc.ViewEngines;
 using Microsoft.AspNet.Routing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Net.Http.Headers;
 using Moq;
 using Xunit;
@@ -110,6 +112,62 @@ namespace Microsoft.AspNet.Mvc.ViewFeatures
             // Assert
             Assert.Equal(expectedContentType, context.Response.ContentType);
             Assert.Equal("abcd", Encoding.UTF8.GetString(memoryStream.ToArray()));
+        }
+
+        private static IServiceProvider GetServiceProvider()
+        {
+            var httpContext = new HttpContextAccessor() { HttpContext = new DefaultHttpContext() };
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddInstance<IModelMetadataProvider>(new EmptyModelMetadataProvider());
+            var tempDataProvider = new SessionStateTempDataProvider();
+            serviceCollection.AddInstance<ITempDataDictionary>(new TempDataDictionary(httpContext, tempDataProvider));
+
+            return serviceCollection.BuildServiceProvider();
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_ViewResultAllowNull()
+        {
+            // Arrange
+            var tempDataNull = false;
+            var viewDataNull = false;
+            var deligateHit = false;
+
+            var view = CreateView(async (v) =>
+            {
+                deligateHit = true;
+                tempDataNull = v.TempData == null;
+                viewDataNull = v.ViewData == null;
+
+                await v.Writer.WriteAsync("abcd");
+            });
+            var context = new DefaultHttpContext();
+
+            var memoryStream = new MemoryStream();
+            context.Response.Body = memoryStream;
+
+            var actionContext = new ActionContext(
+                context,
+                new RouteData(),
+                new ActionDescriptor());
+            
+            context.RequestServices = GetServiceProvider();
+            var viewExecutor = CreateViewExecutor();
+
+            // Act
+            await viewExecutor.ExecuteAsync(
+                actionContext,
+                view,
+                null,
+                null,
+                contentType: null,
+                statusCode: 200);
+
+            // Assert
+            Assert.Equal(200, context.Response.StatusCode);
+            Assert.True(deligateHit);
+            Assert.False(viewDataNull);
+            Assert.False(tempDataNull);
         }
 
         [Fact]


### PR DESCRIPTION
If you're manually constructing a ViewResult you shouldn't have to pass in a ViewData and TempData just for us. This change allows them to be left null, the behavior on a resulting page being that references to ViewData just don't put anything out and references to TempData cause a 500.