### PR TITLE
Correct polarity of MediaTypeHeaderValue.IsSubsetOf()` checks and remove one conneg fallback

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Abstractions/project.json
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/project.json
@@ -25,7 +25,8 @@
     "Microsoft.Extensions.PropertyHelper.Sources": {
       "version": "1.0.0-*",
       "type": "build"
-    }
+    },
+    "Microsoft.Net.Http.Headers": "1.0.0-*"
   },
   "frameworks": {
     "dnx451": { },

--- a/src/Microsoft.AspNet.Mvc.Core/ConsumesAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ConsumesAttribute.cs
@@ -56,10 +56,10 @@ namespace Microsoft.AspNet.Mvc
                 MediaTypeHeaderValue requestContentType = null;
                 MediaTypeHeaderValue.TryParse(context.HttpContext.Request.ContentType, out requestContentType);
 
-                // Only execute if this is the last filter before calling the action.
-                // This ensures that we only run the filter which is closest to the action.
+                // Confirm the request's content type is more specific than a media type this action supports e.g. OK
+                // if client sent "text/plain" data and this action supports "text/*".
                 if (requestContentType != null &&
-                    !ContentTypes.Any(contentType => contentType.IsSubsetOf(requestContentType)))
+                    !ContentTypes.Any(contentType => requestContentType.IsSubsetOf(contentType)))
                 {
                     context.Result = new UnsupportedMediaTypeResult();
                 }
@@ -102,7 +102,9 @@ namespace Microsoft.AspNet.Mvc
                 return !isActionWithoutConsumeConstraintPresent;
             }
 
-            if (ContentTypes.Any(c => c.IsSubsetOf(requestContentType)))
+            // Confirm the request's content type is more specific than a media type this action supports e.g. OK
+            // if client sent "text/plain" data and this action supports "text/*".
+            if (ContentTypes.Any(contentType => requestContentType.IsSubsetOf(contentType)))
             {
                 return true;
             }

--- a/src/Microsoft.AspNet.Mvc.Core/Controllers/FilterActionInvoker.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Controllers/FilterActionInvoker.cs
@@ -183,7 +183,7 @@ namespace Microsoft.AspNet.Mvc.Controllers
             _cursor = new FilterCursor(_filters);
 
             ActionContext.ModelState.MaxAllowedErrors = _maxModelValidationErrors;
-            
+
             await InvokeAllAuthorizationFiltersAsync();
 
             // If Authorization Filters return a result, it's a short circuit because
@@ -663,7 +663,7 @@ namespace Microsoft.AspNet.Mvc.Controllers
                                 "Microsoft.AspNet.Mvc.BeforeActionMethod",
                                 new
                                 {
-                                    actionContext = ActionContext, 
+                                    actionContext = ActionContext,
                                     arguments = _actionExecutingContext.ActionArguments,
                                     controller = _actionExecutingContext.Controller
                                 });

--- a/src/Microsoft.AspNet.Mvc.Core/Formatters/FormatFilter.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Formatters/FormatFilter.cs
@@ -13,7 +13,7 @@ using Microsoft.Net.Http.Headers;
 namespace Microsoft.AspNet.Mvc.Formatters
 {
     /// <summary>
-    /// A filter which will use the format value in the route data or query string to set the content type on an 
+    /// A filter which will use the format value in the route data or query string to set the content type on an
     /// <see cref="ObjectResult" /> returned from an action.
     /// </summary>
     public class FormatFilter : IFormatFilter, IResourceFilter, IResultFilter
@@ -48,13 +48,13 @@ namespace Microsoft.AspNet.Mvc.Formatters
         public MediaTypeHeaderValue ContentType { get; }
 
         /// <summary>
-        /// <c>true</c> if the current <see cref="FormatFilter"/> is active and will execute. 
+        /// <c>true</c> if the current <see cref="FormatFilter"/> is active and will execute.
         /// </summary>
         public bool IsActive { get; }
 
         /// <summary>
         /// As a <see cref="IResourceFilter"/>, this filter looks at the request and rejects it before going ahead if
-        /// 1. The format in the request doesnt match any format in the map.
+        /// 1. The format in the request does not match any format in the map.
         /// 2. If there is a conflicting producesFilter.
         /// </summary>
         /// <param name="context">The <see cref="ResourceExecutingContext"/>.</param>
@@ -67,7 +67,8 @@ namespace Microsoft.AspNet.Mvc.Formatters
 
             if (!IsActive)
             {
-                return; // no format specified by user, so the filter is muted
+                // no format specified by user, so the filter is muted
+                return;
             }
 
             if (ContentType == null)
@@ -77,19 +78,22 @@ namespace Microsoft.AspNet.Mvc.Formatters
                 return;
             }
 
+            // Determine media types this action supports.
             var responseTypeFilters = context.Filters.OfType<IApiResponseMetadataProvider>();
-            var contentTypes = new List<MediaTypeHeaderValue>();
-
+            var supportedMediaTypes = new List<MediaTypeHeaderValue>();
             foreach (var filter in responseTypeFilters)
             {
-                filter.SetContentTypes(contentTypes);
+                filter.SetContentTypes(supportedMediaTypes);
             }
 
-            if (contentTypes.Count != 0)
+            // Check if support is adequate for requested media type.
+            if (supportedMediaTypes.Count != 0)
             {
-                // We need to check if the action can generate the content type the user asked for. If it cannot, exit
-                // here with not found result. 
-                if (!contentTypes.Any(c => ContentType.IsSubsetOf(c)))
+                // We need to check if the action can generate the content type the user asked for. That is, treat the
+                // request's format and IApiResponseMetadataProvider-provided content types similarly to an Accept
+                // header and an output formatter's SupportedMediaTypes: Confirm action supports a more specific media
+                // type than requested e.g. OK if "text/*" requested and action supports "text/plain".
+                if (!supportedMediaTypes.Any(contentType => contentType.IsSubsetOf(ContentType)))
                 {
                     context.Result = new HttpNotFoundResult();
                 }

--- a/src/Microsoft.AspNet.Mvc.Core/Formatters/InputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Formatters/InputFormatter.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
 
             var contentType = context.HttpContext.Request.ContentType;
             MediaTypeHeaderValue requestContentType;
-            if (!MediaTypeHeaderValue.TryParse(contentType, out requestContentType) || requestContentType == null)
+            if (!MediaTypeHeaderValue.TryParse(contentType, out requestContentType))
             {
                 return false;
             }

--- a/src/Microsoft.AspNet.Mvc.Core/Formatters/InputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Formatters/InputFormatter.cs
@@ -62,12 +62,17 @@ namespace Microsoft.AspNet.Mvc.Formatters
 
             var contentType = context.HttpContext.Request.ContentType;
             MediaTypeHeaderValue requestContentType;
-            if (!MediaTypeHeaderValue.TryParse(contentType, out requestContentType))
+            if (!MediaTypeHeaderValue.TryParse(contentType, out requestContentType) || requestContentType == null)
             {
                 return false;
             }
 
-            return SupportedMediaTypes.Any(supportedMediaType => supportedMediaType.IsSubsetOf(requestContentType));
+            // Confirm the request's content type is more specific than a media type this formatter supports e.g. OK if
+            // client sent "text/plain" data and this formatter supports "text/*".
+            return SupportedMediaTypes.Any(supportedMediaType =>
+            {
+                return requestContentType.IsSubsetOf(supportedMediaType);
+            });
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Mvc.Core/Formatters/OutputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Formatters/OutputFormatter.cs
@@ -203,7 +203,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
             // Copy the media type as we don't want it to affect the next request
             selectedMediaType = selectedMediaType.Copy();
 
-            // Note text-based media types will use an encoding/charset - binary formats just ignore it. We want to
+            // Note: Text-based media types will use an encoding/charset - binary formats just ignore it. We want to
             // make this class work with media types that use encodings, and those that don't.
             //
             // The default implementation of SelectCharacterEncoding will read from the list of SupportedEncodings

--- a/src/Microsoft.AspNet.Mvc.Core/ObjectResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ObjectResult.cs
@@ -103,12 +103,12 @@ namespace Microsoft.AspNet.Mvc
             if (ContentTypes == null || ContentTypes.Count == 0)
             {
                 // Check if we have enough information to do content-negotiation, otherwise get the first formatter
-                // which can write the type.
+                // which can write the type. Let the formatter choose the Content-Type.
                 if (!sortedAcceptHeaderMediaTypes.Any())
                 {
                     logger.LogVerbose("No information found on request to perform content negotiation.");
 
-                    return SelectFormatterBasedOnTypeMatch(formatterContext, formatters);
+                    return SelectFormatterNotUsingAcceptHeaders(formatterContext, formatters);
                 }
 
                 //
@@ -121,7 +121,8 @@ namespace Microsoft.AspNet.Mvc
                     formatters,
                     sortedAcceptHeaderMediaTypes);
 
-                // 2. No formatter was found based on Accept header. Fallback to type-based match.
+                // 2. No formatter was found based on Accept header. Fallback to the first formatter which can write
+                // the type. Let the formatter choose the Content-Type.
                 if (selectedFormatter == null)
                 {
                     logger.LogVerbose("Could not find an output formatter based on content negotiation.");
@@ -130,7 +131,7 @@ namespace Microsoft.AspNet.Mvc
                     // if they want to write the response or not.
                     formatterContext.FailedContentNegotiation = true;
 
-                    return SelectFormatterBasedOnTypeMatch(formatterContext, formatters);
+                    return SelectFormatterNotUsingAcceptHeaders(formatterContext, formatters);
                 }
             }
             else
@@ -167,7 +168,7 @@ namespace Microsoft.AspNet.Mvc
             return selectedFormatter;
         }
 
-        public virtual IOutputFormatter SelectFormatterBasedOnTypeMatch(
+        public virtual IOutputFormatter SelectFormatterNotUsingAcceptHeaders(
             OutputFormatterContext formatterContext,
             IEnumerable<IOutputFormatter> formatters)
         {

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/InputFormatterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/InputFormatterTest.cs
@@ -1,0 +1,292 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Http.Internal;
+using Microsoft.AspNet.Mvc.ModelBinding;
+using Microsoft.Net.Http.Headers;
+using Xunit;
+
+namespace Microsoft.AspNet.Mvc.Formatters
+{
+    public class InputFormatterTest
+    {
+        private class CatchAllFormatter : TestFormatter
+        {
+            public CatchAllFormatter()
+            {
+                SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("*/*"));
+            }
+        }
+
+        [Theory]
+        [InlineData("application/mathml-content+xml")]
+        [InlineData("application/mathml-presentation+xml")]
+        [InlineData("application/mathml+xml; undefined=ignored")]
+        [InlineData("application/octet-stream; padding=3")]
+        [InlineData("application/xml")]
+        [InlineData("application/xml-dtd; undefined=ignored")]
+        [InlineData("multipart/mixed; boundary=gc0p4Jq0M2Yt08j34c0p")]
+        [InlineData("multipart/mixed; boundary=gc0p4Jq0M2Yt08j34c0p; undefined=ignored")]
+        [InlineData("text/html")]
+        public void CatchAll_CanRead_ReturnsTrueForSupportedMediaTypes(string requestContentType)
+        {
+            // Arrange
+            var formatter = new CatchAllFormatter();
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.ContentType = requestContentType;
+            var context = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: new ModelStateDictionary(),
+                modelType: typeof(void));
+
+            // Act
+            var result = formatter.CanRead(context);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        private class MultipartFormatter : TestFormatter
+        {
+            public MultipartFormatter()
+            {
+                SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("multipart/*"));
+            }
+        }
+
+        [Theory]
+        [InlineData("multipart/mixed; boundary=gc0p4Jq0M2Yt08j34c0p")]
+        [InlineData("multipart/mixed; boundary=gc0p4Jq0M2Yt08j34c0p; undefined=ignored")]
+        public void MultipartFormatter_CanRead_ReturnsTrueForSupportedMediaTypes(string requestContentType)
+        {
+            // Arrange
+            var formatter = new MultipartFormatter();
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.ContentType = requestContentType;
+            var context = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: new ModelStateDictionary(),
+                modelType: typeof(void));
+
+            // Act
+            var result = formatter.CanRead(context);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [InlineData("application/mathml-content+xml")]
+        [InlineData("application/mathml-presentation+xml")]
+        [InlineData("application/mathml+xml; undefined=ignored")]
+        [InlineData("application/octet-stream; padding=3")]
+        [InlineData("application/xml")]
+        [InlineData("application/xml-dtd; undefined=ignored")]
+        [InlineData("text/html")]
+        public void MultipartFormatter_CanRead_ReturnsFalseForUnsupportedMediaTypes(string requestContentType)
+        {
+            // Arrange
+            var formatter = new MultipartFormatter();
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.ContentType = requestContentType;
+            var context = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: new ModelStateDictionary(),
+                modelType: typeof(void));
+
+            // Act
+            var result = formatter.CanRead(context);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        private class MultipartMixedFormatter : TestFormatter
+        {
+            public MultipartMixedFormatter()
+            {
+                SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("multipart/mixed"));
+            }
+        }
+
+        [Theory]
+        [InlineData("multipart/mixed; boundary=gc0p4Jq0M2Yt08j34c0p")]
+        [InlineData("multipart/mixed; boundary=gc0p4Jq0M2Yt08j34c0p; undefined=ignored")]
+        public void MultipartMixedFormatter_CanRead_ReturnsTrueForSupportedMediaTypes(string requestContentType)
+        {
+            // Arrange
+            var formatter = new MultipartMixedFormatter();
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.ContentType = requestContentType;
+            var context = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: new ModelStateDictionary(),
+                modelType: typeof(void));
+
+            // Act
+            var result = formatter.CanRead(context);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [InlineData("application/mathml-content+xml")]
+        [InlineData("application/mathml-presentation+xml")]
+        [InlineData("application/mathml+xml; undefined=ignored")]
+        [InlineData("application/octet-stream; padding=3")]
+        [InlineData("application/xml")]
+        [InlineData("application/xml-dtd; undefined=ignored")]
+        [InlineData("text/html")]
+        public void MultipartMixedFormatter_CanRead_ReturnsFalseForUnsupportedMediaTypes(string requestContentType)
+        {
+            // Arrange
+            var formatter = new MultipartMixedFormatter();
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.ContentType = requestContentType;
+            var context = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: new ModelStateDictionary(),
+                modelType: typeof(void));
+
+            // Act
+            var result = formatter.CanRead(context);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        private class MathMLFormatter : TestFormatter
+        {
+            public MathMLFormatter()
+            {
+                SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/mathml-content+xml"));
+                SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/mathml-presentation+xml"));
+                SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/mathml+xml"));
+            }
+        }
+
+        [Theory]
+        [InlineData("application/mathml-content+xml")]
+        [InlineData("application/mathml-presentation+xml")]
+        [InlineData("application/mathml+xml; undefined=ignored")]
+        public void MathMLFormatter_CanRead_ReturnsTrueForSupportedMediaTypes(string requestContentType)
+        {
+            // Arrange
+            var formatter = new MathMLFormatter();
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.ContentType = requestContentType;
+            var context = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: new ModelStateDictionary(),
+                modelType: typeof(void));
+
+            // Act
+            var result = formatter.CanRead(context);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [InlineData("application/octet-stream; padding=3")]
+        [InlineData("application/xml")]
+        [InlineData("application/xml-dtd; undefined=ignored")]
+        [InlineData("multipart/mixed; boundary=gc0p4Jq0M2Yt08j34c0p")]
+        [InlineData("multipart/mixed; boundary=gc0p4Jq0M2Yt08j34c0p; undefined=ignored")]
+        [InlineData("text/html")]
+        public void MathMLFormatter_CanRead_ReturnsFalseForUnsupportedMediaTypes(string requestContentType)
+        {
+            // Arrange
+            var formatter = new MathMLFormatter();
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.ContentType = requestContentType;
+            var context = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: new ModelStateDictionary(),
+                modelType: typeof(void));
+
+            // Act
+            var result = formatter.CanRead(context);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        // IsSubsetOf does not follow XML media type conventions. This formatter does not support "application/*+xml".
+        private class XmlFormatter : TestFormatter
+        {
+            public XmlFormatter()
+            {
+                SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/xml"));
+                SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("text/xml"));
+            }
+        }
+
+        [Theory]
+        [InlineData("application/xml")]
+        public void XMLFormatter_CanRead_ReturnsTrueForSupportedMediaTypes(string requestContentType)
+        {
+            // Arrange
+            var formatter = new XmlFormatter();
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.ContentType = requestContentType;
+            var context = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: new ModelStateDictionary(),
+                modelType: typeof(void));
+
+            // Act
+            var result = formatter.CanRead(context);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [InlineData("application/mathml-content+xml")]
+        [InlineData("application/mathml-presentation+xml")]
+        [InlineData("application/mathml+xml; undefined=ignored")]
+        [InlineData("application/octet-stream; padding=3")]
+        [InlineData("application/xml-dtd; undefined=ignored")]
+        [InlineData("multipart/mixed; boundary=gc0p4Jq0M2Yt08j34c0p")]
+        [InlineData("multipart/mixed; boundary=gc0p4Jq0M2Yt08j34c0p; undefined=ignored")]
+        [InlineData("text/html")]
+        public void XMLFormatter_CanRead_ReturnsFalseForUnsupportedMediaTypes(string requestContentType)
+        {
+            // Arrange
+            var formatter = new XmlFormatter();
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.ContentType = requestContentType;
+            var context = new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: new ModelStateDictionary(),
+                modelType: typeof(void));
+
+            // Act
+            var result = formatter.CanRead(context);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        private class TestFormatter : InputFormatter
+        {
+            public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Mvc.Formatters.Json.Test/JsonInputFormatterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Formatters.Json.Test/JsonInputFormatterTest.cs
@@ -22,10 +22,10 @@ namespace Microsoft.AspNet.Mvc.Formatters
 
         [Theory]
         [InlineData("application/json", true)]
-        [InlineData("application/*", true)]
-        [InlineData("*/*", true)]
+        [InlineData("application/*", false)]
+        [InlineData("*/*", false)]
         [InlineData("text/json", true)]
-        [InlineData("text/*", true)]
+        [InlineData("text/*", false)]
         [InlineData("text/xml", false)]
         [InlineData("application/xml", false)]
         [InlineData("", false)]

--- a/test/Microsoft.AspNet.Mvc.Formatters.Json.Test/JsonPatchInputFormatterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Formatters.Json.Test/JsonPatchInputFormatterTest.cs
@@ -75,8 +75,8 @@ namespace Microsoft.AspNet.Mvc.Formatters
         [Theory]
         [InlineData("application/json-patch+json", true)]
         [InlineData("application/json", false)]
-        [InlineData("application/*", true)]
-        [InlineData("*/*", true)]
+        [InlineData("application/*", false)]
+        [InlineData("*/*", false)]
         public void CanRead_ReturnsTrueOnlyForJsonPatchContentType(string requestContentType, bool expectedCanRead)
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.Formatters.Xml.Test/XmlDataContractSerializerInputFormatterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Formatters.Xml.Test/XmlDataContractSerializerInputFormatterTest.cs
@@ -56,10 +56,10 @@ namespace Microsoft.AspNet.Mvc.Formatters.Xml
         // Mono issue - https://github.com/aspnet/External/issues/18
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         [InlineData("application/xml", true)]
-        [InlineData("application/*", true)]
-        [InlineData("*/*", true)]
+        [InlineData("application/*", false)]
+        [InlineData("*/*", false)]
         [InlineData("text/xml", true)]
-        [InlineData("text/*", true)]
+        [InlineData("text/*", false)]
         [InlineData("text/json", false)]
         [InlineData("application/json", false)]
         [InlineData("", false)]

--- a/test/Microsoft.AspNet.Mvc.Formatters.Xml.Test/XmlSerializerInputFormatterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Formatters.Xml.Test/XmlSerializerInputFormatterTest.cs
@@ -41,10 +41,10 @@ namespace Microsoft.AspNet.Mvc.Formatters.Xml
 
         [Theory]
         [InlineData("application/xml", true)]
-        [InlineData("application/*", true)]
-        [InlineData("*/*", true)]
+        [InlineData("application/*", false)]
+        [InlineData("*/*", false)]
         [InlineData("text/xml", true)]
-        [InlineData("text/*", true)]
+        [InlineData("text/*", false)]
         [InlineData("text/json", false)]
         [InlineData("application/json", false)]
         [InlineData("", false)]

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/ActionResultTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/ActionResultTests.cs
@@ -170,7 +170,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
                 "<DummyClass xmlns=\"http://schemas.datacontract.org/2004/07/ActionResultsWebSite\">" +
                 "<SampleInt>2</SampleInt><SampleString>foo</SampleString></DummyClass>";
             var request = new HttpRequestMessage(HttpMethod.Post, "Home/GetCustomErrorObject");
-            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;charset=utf-8"));
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
             request.Content = new StringContent(input, Encoding.UTF8, "application/xml");
 
             // Act
@@ -218,7 +218,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             Assert.Equal("content", await response.Content.ReadAsStringAsync());
         }
 
-        [Theory]
+        [Fact]
         public async Task ContentResult_WritesContent_SetsContentTypeAndEncoding()
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/InputFormatterTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/InputFormatterTests.cs
@@ -43,10 +43,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
 
         [Theory]
         [InlineData("application/json")]
-        [InlineData("application/*")]
-        [InlineData("*/*")]
         [InlineData("text/json")]
-        [InlineData("text/*")]
         public async Task JsonInputFormatter_IsSelectedForJsonRequest(string requestContentType)
         {
             // Arrange

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/MvcSampleTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/MvcSampleTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
         {
             // Arrange
             var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/Home/ReturnUser");
-            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/xml;charset=utf-8"));
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/xml"));
 
             // Act
             var response = await Client.SendAsync(request);

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/XmlOutputFormatterTests.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/XmlOutputFormatterTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
                 "http://localhost/Home/GetDummyClass?sampleInput=10");
-            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/xml;charset=utf-8"));
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/xml"));
 
             // Act
             var response = await Client.SendAsync(request);
@@ -50,7 +50,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
                 "http://localhost/XmlSerializer/GetDummyClass?sampleInput=10");
-            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/xml;charset=utf-8"));
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/xml"));
 
             // Act
             var response = await Client.SendAsync(request);
@@ -72,7 +72,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
                 "http://localhost/DataContractSerializer/GetPerson?name=HelloWorld");
-            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/xml;charset=utf-8"));
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/xml"));
 
             // Act
             var response = await Client.SendAsync(request);
@@ -93,7 +93,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
                 "http://localhost/XmlSerializer/GetDerivedDummyClass?sampleInput=10");
-            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/xml;charset=utf-8"));
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/xml"));
 
             // Act
             var response = await Client.SendAsync(request);
@@ -116,7 +116,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
                 "http://localhost/Home/GetDerivedDummyClass?sampleInput=10");
-            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/xml;charset=utf-8"));
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/xml"));
 
             // Act
             var response = await Client.SendAsync(request);
@@ -137,7 +137,7 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
                 "http://localhost/XmlSerializer/GetDictionary");
-            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/xml;charset=utf-8"));
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/xml"));
 
             // Act
             var response = await Client.SendAsync(request);


### PR DESCRIPTION
- aspnet/Mvc#3138 part 2/2
- request's Content-Type header must be a subset of what an `IInputFormatter` can consume
  - `[Consumes]` is similar
- what an `IOutputFormatter` produces must be a subset of the request's Accept header
  - `FormatFilter` and `ObjectResult` are similar
- `ObjectResult` no longer falls back to `Content-Type` header if no `Accept` value is acceptable
- left `WebApiCompatShim` code alone for consistency with down-level `System.Net.Http.Formatting`
- correct tests to match new behaviour
  - do not test `Accept` values containing a `charset` parameter; that case is not valid

nits:
- add `InputFormatterTests`
- add / update comments and doc comments
- correct xUnit attributes in `ActionResultTest`; odd it doesn't show up in command-line runs