### PR TITLE
Reduce allocations in MSD enumeration

### DIFF
--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/ViewDataDictionary.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/ViewDataDictionary.cs
@@ -227,7 +227,7 @@ namespace Microsoft.AspNet.Mvc.ViewFeatures
         /// </remarks>
         protected ViewDataDictionary(ViewDataDictionary source, object model, Type declaredModelType)
             : this(source._metadataProvider,
-                   new ModelStateDictionary(source.ModelState),
+                   source.ModelState,
                    declaredModelType,
                    data: new CopyOnWriteDictionary<string, object>(source, StringComparer.OrdinalIgnoreCase),
                    templateInfo: new TemplateInfo(source.TemplateInfo))

--- a/test/Microsoft.AspNet.Mvc.Abstractions.Test/ModelBinding/ModelStateDictionaryTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Abstractions.Test/ModelBinding/ModelStateDictionaryTest.cs
@@ -2,8 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
-using Microsoft.Extensions.Internal;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Microsoft.AspNet.Mvc.ModelBinding
@@ -156,7 +155,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             Assert.Equal(0, target.ErrorCount);
             Assert.Equal(1, target.Count);
             Assert.Same(modelState, target["key"]);
-            Assert.IsType<CopyOnWriteDictionary<string, ModelState>>(target.InnerDictionary);
+            Assert.IsType<Dictionary<string, ModelState>>(target.InnerDictionary);
         }
 
         [Fact]


### PR DESCRIPTION
Introduces a struct `Enumerable` and `Enumerator` to remove a common source of allocations.