### PR TITLE
Ensure DefaultViewLocationCache.Set will update value if cache key already exists

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/DefaultViewLocationCache.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/DefaultViewLocationCache.cs
@@ -54,7 +54,14 @@ namespace Microsoft.AspNet.Mvc.Razor
             }
 
             var cacheKey = GenerateKey(context, copyViewExpanderValues: true);
-            _cache.TryAdd(cacheKey, value);
+            if (!_cache.TryAdd(cacheKey, value))
+            {
+                ViewLocationCacheResult comparisonValue;
+                if (_cache.TryGetValue(cacheKey, out comparisonValue))
+                {
+                    _cache.TryUpdate(cacheKey, value, comparisonValue);
+                }
+            }
         }
 
         // Internal for unit testing

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/DefaultViewLocationCacheTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/DefaultViewLocationCacheTest.cs
@@ -90,6 +90,50 @@ namespace Microsoft.AspNet.Mvc.Razor
         }
 
         [Theory]
+        [MemberData(nameof(CacheEntryData))]
+        public void InvokingGetAfterSecondSet_ReturnsCachedItem(ViewLocationExpanderContext context)
+        {
+            // Arrange
+            var cache = new DefaultViewLocationCache();
+            var value = new ViewLocationCacheResult(
+                Guid.NewGuid().ToString(),
+                new[]
+                {
+                    Guid.NewGuid().ToString(),
+                    Guid.NewGuid().ToString()
+                });
+            var updatedValue = new ViewLocationCacheResult(
+                Guid.NewGuid().ToString(),
+                new[]
+                {
+                    Guid.NewGuid().ToString(),
+                    Guid.NewGuid().ToString()
+                });
+
+            // Act - 1
+            cache.Set(context, value);
+            var result = cache.Get(context);
+
+            // Assert - 1
+            Assert.Equal(value, result);
+
+            // Act - 2
+            result = cache.Get(context);
+
+            // Assert - 2
+            Assert.Equal(value, result);
+
+            // Act - 3
+            cache.Set(context, updatedValue);
+
+            // Act - 4
+            result = cache.Get(context);
+
+            // Assert - 3
+            Assert.Equal(updatedValue, result);
+        }
+
+        [Theory]
         [InlineData("View1", "View2")]
         [InlineData("View1", "view1")]
         public void ViewLocationCacheKeyComparer_EqualsReturnsFalseIfViewNamesAreDifferent(

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/DefaultViewLocationCacheTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/DefaultViewLocationCacheTest.cs
@@ -89,7 +89,7 @@ namespace Microsoft.AspNet.Mvc.Razor
             Assert.Equal(value, result);
         }
 
-        [Theory]
+        [Fact]
         [MemberData(nameof(CacheEntryData))]
         public void InvokingGetAfterSecondSet_ReturnsCachedItem(ViewLocationExpanderContext context)
         {


### PR DESCRIPTION
Fix for #3335.

Consequent call to DefaultViewLocationCache should update cached value.