### PR TITLE
Rename ViewComponent.Context to HttpContext

### DIFF
--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewComponent.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewComponent.cs
@@ -27,9 +27,9 @@ namespace Microsoft.AspNet.Mvc
         private ICompositeViewEngine _viewEngine;
 
         /// <summary>
-        /// Gets the <see cref="HttpContext"/>.
+        /// Gets the <see cref="Http.HttpContext"/>.
         /// </summary>
-        public HttpContext Context
+        public HttpContext HttpContext
         {
             get
             {


### PR DESCRIPTION
Rename the property to `HttpContext` to be consistent with the `Controller` class.

#3332 