### PR TITLE
React to aspnet/Razor#571.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.TagHelpers/CacheTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/CacheTagHelper.cs
@@ -158,7 +158,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     // created within this scope get copied to this scope.
                     using (var link = MemoryCache.CreateLinkingScope())
                     {
-                        result = await context.GetChildContentAsync();
+                        result = await output.GetChildContentAsync();
 
                         MemoryCache.Set(key, result, GetMemoryCacheEntryOptions(link));
                     }
@@ -173,7 +173,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             }
             else
             {
-                result = await context.GetChildContentAsync();
+                result = await output.GetChildContentAsync();
                 output.Content.SetContent(result);
             }
         }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/LabelTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/LabelTagHelper.cs
@@ -77,7 +77,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 // </label>
                 if (!output.IsContentModified)
                 {
-                    var childContent = await context.GetChildContentAsync();
+                    var childContent = await output.GetChildContentAsync();
 
                     if (childContent.IsWhiteSpace)
                     {

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/OptionTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/OptionTagHelper.cs
@@ -111,7 +111,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     }
                     else
                     {
-                        var childContent = await context.GetChildContentAsync();
+                        var childContent = await output.GetChildContentAsync();
                         selected = encodedValues.Contains(childContent.GetContent());
                     }
 

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/RenderAtEndOfFormTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/RenderAtEndOfFormTagHelper.cs
@@ -25,6 +25,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         public ViewContext ViewContext { get; set; }
 
         /// <inheritdoc />
+        public override void Init(TagHelperContext context)
+        {
+            // Push the new FormContext.
+            ViewContext.FormContext = new FormContext
+            {
+                CanRenderAtEndOfForm = true
+            };
+        }
+
+        /// <inheritdoc />
         public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
             if (context == null)
@@ -37,13 +47,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 throw new ArgumentNullException(nameof(output));
             }
 
-            // Push the new FormContext.
-            ViewContext.FormContext = new FormContext
-            {
-                CanRenderAtEndOfForm = true
-            };
-
-            await context.GetChildContentAsync();
+            await output.GetChildContentAsync();
 
             var formContext = ViewContext.FormContext;
             if (formContext.HasEndOfFormContent)

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationMessageTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ValidationMessageTagHelper.cs
@@ -79,7 +79,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     // </span>
                     if (!output.IsContentModified)
                     {
-                        var childContent = await context.GetChildContentAsync();
+                        var childContent = await output.GetChildContentAsync();
 
                         if (childContent.IsWhiteSpace)
                         {

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/RazorPageTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/RazorPageTest.cs
@@ -1662,7 +1662,10 @@ namespace Microsoft.AspNet.Mvc.Razor
                 },
                 startTagHelperWritingScope: () => { },
                 endTagHelperWritingScope: () => defaultTagHelperContent);
-            tagHelperExecutionContext.Output = new TagHelperOutput("p", new TagHelperAttributeList());
+            tagHelperExecutionContext.Output = new TagHelperOutput(
+                tagName: "p",
+                attributes: new TagHelperAttributeList(),
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
             if (childContentRetrieved)
             {
                 await tagHelperExecutionContext.GetChildContentAsync(useCachedResult: true);
@@ -1694,7 +1697,10 @@ namespace Microsoft.AspNet.Mvc.Razor
                 executeChildContentAsync: () => { return Task.FromResult(result: true); },
                 startTagHelperWritingScope: () => { },
                 endTagHelperWritingScope: () => new DefaultTagHelperContent());
-            tagHelperExecutionContext.Output = new TagHelperOutput("p", new TagHelperAttributeList());
+            tagHelperExecutionContext.Output = new TagHelperOutput(
+                tagName: "p",
+                attributes: new TagHelperAttributeList(),
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
             tagHelperExecutionContext.Output.Content.AppendEncoded("Hello World!");
 
             // Act
@@ -1748,7 +1754,10 @@ namespace Microsoft.AspNet.Mvc.Razor
             string postContent,
             string postElement)
         {
-            var output = new TagHelperOutput(tagName, attributes)
+            var output = new TagHelperOutput(
+                tagName,
+                attributes,
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()))
             {
                 TagMode = tagMode
             };

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/TagHelpers/UrlResolutionTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/TagHelpers/UrlResolutionTagHelperTest.cs
@@ -52,7 +52,8 @@ namespace Microsoft.AspNet.Mvc.Razor.TagHelpers
                 attributes: new TagHelperAttributeList
                 {
                     { "href", url }
-                });
+                },
+                getChildContentAsync: _ => Task.FromResult<TagHelperContent>(null));
             var urlHelperMock = new Mock<IUrlHelper>();
             urlHelperMock
                 .Setup(urlHelper => urlHelper.Content(It.IsAny<string>()))
@@ -63,8 +64,7 @@ namespace Microsoft.AspNet.Mvc.Razor.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
-                getChildContentAsync: _ => Task.FromResult<TagHelperContent>(null));
+                uniqueId: "test");
 
             // Act
             tagHelper.Process(context, tagHelperOutput);
@@ -108,7 +108,8 @@ namespace Microsoft.AspNet.Mvc.Razor.TagHelpers
                 attributes: new TagHelperAttributeList
                 {
                     { "href", url }
-                });
+                },
+                getChildContentAsync: _ => Task.FromResult<TagHelperContent>(null));
             var urlHelperMock = new Mock<IUrlHelper>();
             urlHelperMock
                 .Setup(urlHelper => urlHelper.Content(It.IsAny<string>()))
@@ -119,8 +120,7 @@ namespace Microsoft.AspNet.Mvc.Razor.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
-                getChildContentAsync: _ => Task.FromResult<TagHelperContent>(null));
+                uniqueId: "test");
 
             // Act
             tagHelper.Process(context, tagHelperOutput);
@@ -141,15 +141,15 @@ namespace Microsoft.AspNet.Mvc.Razor.TagHelpers
                 attributes: new TagHelperAttributeList
                 {
                     { "href", true }
-                });
+                },
+                getChildContentAsync: _ => Task.FromResult<TagHelperContent>(null));
             var tagHelper = new UrlResolutionTagHelper(urlHelper: null, htmlEncoder: null);
 
             var context = new TagHelperContext(
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
-                getChildContentAsync: _ => Task.FromResult<TagHelperContent>(null));
+                uniqueId: "test");
 
             // Act
             tagHelper.Process(context, tagHelperOutput);
@@ -178,7 +178,8 @@ namespace Microsoft.AspNet.Mvc.Razor.TagHelpers
                 attributes: new TagHelperAttributeList
                 {
                     { "href", new HtmlString(relativeUrl) }
-                });
+                },
+                getChildContentAsync: _ => Task.FromResult<TagHelperContent>(null));
             var urlHelperMock = new Mock<IUrlHelper>();
             urlHelperMock
                 .Setup(urlHelper => urlHelper.Content(It.IsAny<string>()))
@@ -189,8 +190,7 @@ namespace Microsoft.AspNet.Mvc.Razor.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
-                getChildContentAsync: _ => Task.FromResult<TagHelperContent>(null));
+                uniqueId: "test");
 
             // Act & Assert
             var exception = Assert.Throws<InvalidOperationException>(

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/AnchorTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/AnchorTagHelperTest.cs
@@ -36,18 +36,18 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     { "asp-protocol", "http" }
                 },
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
-                getChildContentAsync: useCachedResult =>
-                {
-                    var tagHelperContent = new DefaultTagHelperContent();
-                    tagHelperContent.SetContent("Something Else");
-                    return Task.FromResult<TagHelperContent>(tagHelperContent);
-                });
+                uniqueId: "test");
             var output = new TagHelperOutput(
                 expectedTagName,
                 attributes: new TagHelperAttributeList
                 {
                     { "id", "myanchor" },
+                },
+                getChildContentAsync: useCachedResult =>
+                {
+                    var tagHelperContent = new DefaultTagHelperContent();
+                    tagHelperContent.SetContent("Something Else");
+                    return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
             output.Content.SetContent("Something");
 
@@ -93,16 +93,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                uniqueId: "test");
+            var output = new TagHelperOutput(
+                "a",
+                attributes: new TagHelperAttributeList(),
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-            var output = new TagHelperOutput(
-                "a",
-                attributes: new TagHelperAttributeList());
             output.Content.SetContent(string.Empty);
 
             var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
@@ -141,16 +141,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                uniqueId: "test");
+            var output = new TagHelperOutput(
+                "a",
+                attributes: new TagHelperAttributeList(),
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-            var output = new TagHelperOutput(
-                "a",
-                attributes: new TagHelperAttributeList());
             output.Content.SetContent(string.Empty);
 
             var generator = new Mock<IHtmlGenerator>();
@@ -204,7 +204,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 attributes: new TagHelperAttributeList
                 {
                     { "href", "http://www.contoso.com" }
-                });
+                },
+                getChildContentAsync: _ => Task.FromResult<TagHelperContent>(null));
             if (propertyName == "asp-route-")
             {
                 anchorTagHelper.RouteValues.Add("name", "value");
@@ -223,8 +224,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
-                getChildContentAsync: _ => Task.FromResult<TagHelperContent>(null));
+                uniqueId: "test");
 
             // Act & Assert
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -250,7 +250,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             typeof(AnchorTagHelper).GetProperty(propertyName).SetValue(anchorTagHelper, "Home");
             var output = new TagHelperOutput(
                 "a",
-                attributes: new TagHelperAttributeList());
+                attributes: new TagHelperAttributeList(),
+                getChildContentAsync: _ => Task.FromResult<TagHelperContent>(null));
             var expectedErrorMessage = "Cannot determine an 'href' attribute for <a>. An <a> with a specified " +
                 "'asp-route' must not have an 'asp-action' or 'asp-controller' attribute.";
 
@@ -258,8 +259,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
-                getChildContentAsync: _ => Task.FromResult<TagHelperContent>(null));
+                uniqueId: "test");
 
             // Act & Assert
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/CacheTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/CacheTagHelperTest.cs
@@ -258,8 +258,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             object cacheResult;
             cache.Setup(c => c.TryGetValue(It.IsAny<string>(), out cacheResult))
                 .Returns(false);
-            var tagHelperContext = GetTagHelperContext(id, childContent);
-            var tagHelperOutput = new TagHelperOutput("cache", new TagHelperAttributeList());
+            var tagHelperContext = GetTagHelperContext(id);
+            var tagHelperOutput = GetTagHelperOutput(
+                attributes: new TagHelperAttributeList(),
+                childContent: childContent);
             var cacheTagHelper = new CacheTagHelper(cache.Object)
             {
                 ViewContext = GetViewContext(),
@@ -297,8 +299,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             object cacheResult;
             cache.Setup(c => c.TryGetValue(It.IsAny<string>(), out cacheResult))
                 .Returns(false);
-            var tagHelperContext = GetTagHelperContext(id, childContent);
-            var tagHelperOutput = new TagHelperOutput("cache", new TagHelperAttributeList());
+            var tagHelperContext = GetTagHelperContext(id);
+            var tagHelperOutput = GetTagHelperOutput(
+                attributes: new TagHelperAttributeList(),
+                childContent: childContent);
             var cacheTagHelper = new CacheTagHelper(cache.Object)
             {
                 ViewContext = GetViewContext(),
@@ -327,8 +331,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var id = "unique-id";
             var childContent = "original-child-content";
             var cache = new MemoryCache(new MemoryCacheOptions());
-            var tagHelperContext1 = GetTagHelperContext(id, childContent);
-            var tagHelperOutput1 = new TagHelperOutput("cache", new TagHelperAttributeList());
+            var tagHelperContext1 = GetTagHelperContext(id);
+            var tagHelperOutput1 = GetTagHelperOutput(
+                attributes: new TagHelperAttributeList(),
+                childContent: childContent);
             var cacheTagHelper1 = new CacheTagHelper(cache)
             {
                 VaryByQuery = "key1,key2",
@@ -347,8 +353,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal(childContent, tagHelperOutput1.Content.GetContent());
 
             // Arrange - 2
-            var tagHelperContext2 = GetTagHelperContext(id, "different-content");
-            var tagHelperOutput2 = new TagHelperOutput("cache", new TagHelperAttributeList());
+            var tagHelperContext2 = GetTagHelperContext(id);
+            var tagHelperOutput2 = GetTagHelperOutput(
+                attributes: new TagHelperAttributeList(),
+                childContent: "different-content");
             var cacheTagHelper2 = new CacheTagHelper(cache)
             {
                 VaryByQuery = "key1,key2",
@@ -374,8 +382,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var id = "unique-id";
             var childContent1 = "original-child-content";
             var cache = new MemoryCache(new MemoryCacheOptions());
-            var tagHelperContext1 = GetTagHelperContext(id, childContent1);
-            var tagHelperOutput1 = new TagHelperOutput("cache", new TagHelperAttributeList { { "attr", "value" } });
+            var tagHelperContext1 = GetTagHelperContext(id);
+            var tagHelperOutput1 = GetTagHelperOutput(childContent: childContent1);
             tagHelperOutput1.PreContent.Append("<cache>");
             tagHelperOutput1.PostContent.SetContent("</cache>");
             var cacheTagHelper1 = new CacheTagHelper(cache)
@@ -396,8 +404,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             // Arrange - 2
             var childContent2 = "different-content";
-            var tagHelperContext2 = GetTagHelperContext(id, childContent2);
-            var tagHelperOutput2 = new TagHelperOutput("cache", new TagHelperAttributeList { { "attr", "value" } });
+            var tagHelperContext2 = GetTagHelperContext(id);
+            var tagHelperOutput2 = GetTagHelperOutput(childContent: childContent2);
             tagHelperOutput2.PreContent.SetContent("<cache>");
             tagHelperOutput2.PostContent.SetContent("</cache>");
             var cacheTagHelper2 = new CacheTagHelper(cache)
@@ -564,8 +572,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             clock.SetupGet(p => p.UtcNow)
                  .Returns(() => currentTime);
             var cache = new MemoryCache(new MemoryCacheOptions { Clock = clock.Object });
-            var tagHelperContext1 = GetTagHelperContext(id, childContent1);
-            var tagHelperOutput1 = new TagHelperOutput("cache", new TagHelperAttributeList { { "attr", "value" } });
+            var tagHelperContext1 = GetTagHelperContext(id);
+            var tagHelperOutput1 = GetTagHelperOutput(childContent: childContent1);
             tagHelperOutput1.PreContent.SetContent("<cache>");
             tagHelperOutput1.PostContent.SetContent("</cache>");
             var cacheTagHelper1 = new CacheTagHelper(cache)
@@ -585,8 +593,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
             // Arrange - 2
             var childContent2 = "different-content";
-            var tagHelperContext2 = GetTagHelperContext(id, childContent2);
-            var tagHelperOutput2 = new TagHelperOutput("cache", new TagHelperAttributeList { { "attr", "value" } });
+            var tagHelperContext2 = GetTagHelperContext(id);
+            var tagHelperOutput2 = GetTagHelperOutput(childContent: childContent2);
             tagHelperOutput2.PreContent.SetContent("<cache>");
             tagHelperOutput2.PostContent.SetContent("</cache>");
             var cacheTagHelper2 = new CacheTagHelper(cache)
@@ -617,8 +625,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             clock.SetupGet(p => p.UtcNow)
                  .Returns(() => currentTime);
             var cache = new MemoryCache(new MemoryCacheOptions { Clock = clock.Object });
-            var tagHelperContext1 = GetTagHelperContext(id, childContent1);
-            var tagHelperOutput1 = new TagHelperOutput("cache", new TagHelperAttributeList { { "attr", "value" } });
+            var tagHelperContext1 = GetTagHelperContext(id);
+            var tagHelperOutput1 = GetTagHelperOutput(childContent: childContent1);
             tagHelperOutput1.PreContent.SetContent("<cache>");
             tagHelperOutput1.PostContent.SetContent("</cache>");
             var cacheTagHelper1 = new CacheTagHelper(cache)
@@ -639,8 +647,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange - 2
             currentTime = currentTime.AddMinutes(5).AddSeconds(2);
             var childContent2 = "different-content";
-            var tagHelperContext2 = GetTagHelperContext(id, childContent2);
-            var tagHelperOutput2 = new TagHelperOutput("cache", new TagHelperAttributeList { { "attr", "value" } });
+            var tagHelperContext2 = GetTagHelperContext(id);
+            var tagHelperOutput2 = GetTagHelperOutput(childContent: childContent2);
             tagHelperOutput2.PreContent.SetContent("<cache>");
             tagHelperOutput2.PostContent.SetContent("</cache>");
             var cacheTagHelper2 = new CacheTagHelper(cache)
@@ -670,8 +678,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             clock.SetupGet(p => p.UtcNow)
                  .Returns(() => currentTime);
             var cache = new MemoryCache(new MemoryCacheOptions { Clock = clock.Object });
-            var tagHelperContext1 = GetTagHelperContext(id, childContent1);
-            var tagHelperOutput1 = new TagHelperOutput("cache", new TagHelperAttributeList { { "attr", "value" } });
+            var tagHelperContext1 = GetTagHelperContext(id);
+            var tagHelperOutput1 = GetTagHelperOutput(childContent: childContent1);
             tagHelperOutput1.PreContent.SetContent("<cache>");
             tagHelperOutput1.PostContent.SetContent("</cache>");
             var cacheTagHelper1 = new CacheTagHelper(cache)
@@ -692,8 +700,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange - 2
             currentTime = currentTime.AddSeconds(35);
             var childContent2 = "different-content";
-            var tagHelperContext2 = GetTagHelperContext(id, childContent2);
-            var tagHelperOutput2 = new TagHelperOutput("cache", new TagHelperAttributeList { { "attr", "value" } });
+            var tagHelperContext2 = GetTagHelperContext(id);
+            var tagHelperOutput2 = GetTagHelperOutput(childContent: childContent2);
             tagHelperOutput2.PreContent.SetContent("<cache>");
             tagHelperOutput2.PostContent.SetContent("</cache>");
             var cacheTagHelper2 = new CacheTagHelper(cache)
@@ -726,11 +734,14 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var tagHelperContext = new TagHelperContext(
                 allAttributes: new TagHelperAttributeList(),
                 items: new Dictionary<object, object>(),
-                uniqueId: id,
+                uniqueId: id);
+            var tagHelperOutput = new TagHelperOutput(
+                "cache",
+                new TagHelperAttributeList { { "attr", "value" } },
                 getChildContentAsync: useCachedResult =>
                 {
                     TagHelperContent tagHelperContent;
-                    if(!cache.TryGetValue("key1", out tagHelperContent))
+                    if (!cache.TryGetValue("key1", out tagHelperContent))
                     {
                         tagHelperContent = expectedContent;
                         cache.Set("key1", tagHelperContent, cacheEntryOptions);
@@ -738,7 +749,6 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
                     return Task.FromResult(tagHelperContent);
                 });
-            var tagHelperOutput = new TagHelperOutput("cache", new TagHelperAttributeList { { "attr", "value" } });
             tagHelperOutput.PreContent.SetContent("<cache>");
             tagHelperOutput.PostContent.SetContent("</cache>");
             var cacheTagHelper = new CacheTagHelper(cache)
@@ -777,14 +787,24 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                                    new HtmlHelperOptions());
         }
 
-        private static TagHelperContext GetTagHelperContext(
-            string id = "testid",
-            string childContent = "some child content")
+        private static TagHelperContext GetTagHelperContext(string id = "testid")
         {
             return new TagHelperContext(
                 allAttributes: new TagHelperAttributeList(),
                 items: new Dictionary<object, object>(),
-                uniqueId: id,
+                uniqueId: id);
+        }
+
+        private static TagHelperOutput GetTagHelperOutput(
+            string tagName = "cache",
+            TagHelperAttributeList attributes = null,
+            string childContent = "some child content")
+        {
+            attributes = attributes ?? new TagHelperAttributeList { { "attr", "value" } };
+
+            return new TagHelperOutput(
+                tagName,
+                attributes,
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/EnvironmentTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/EnvironmentTagHelperTest.cs
@@ -79,10 +79,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Test
         {
             // Arrange
             var content = "content";
-            var context = MakeTagHelperContext(
-                attributes: new TagHelperAttributeList { { "names", namesAttribute } },
-                content: content);
-            var output = MakeTagHelperOutput("environment");
+            var context = MakeTagHelperContext(attributes: new TagHelperAttributeList { { "names", namesAttribute } });
+            var output = MakeTagHelperOutput("environment", childContent: content);
             var hostingEnvironment = new Mock<IHostingEnvironment>();
             hostingEnvironment.SetupProperty(h => h.EnvironmentName);
             hostingEnvironment.Object.EnvironmentName = environmentName;
@@ -107,9 +105,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Test
             // Arrange
             var content = "content";
             var context = MakeTagHelperContext(
-                attributes: new TagHelperAttributeList { { "names", namesAttribute } },
-                content: content);
-            var output = MakeTagHelperOutput("environment");
+                attributes: new TagHelperAttributeList { { "names", namesAttribute } });
+            var output = MakeTagHelperOutput("environment", childContent: content);
             var hostingEnvironment = new Mock<IHostingEnvironment>();
             hostingEnvironment.SetupProperty(h => h.EnvironmentName);
             hostingEnvironment.Object.EnvironmentName = environmentName;
@@ -126,29 +123,32 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Test
             Assert.False(output.IsContentModified);
         }
 
-        private TagHelperContext MakeTagHelperContext(
-            TagHelperAttributeList attributes = null,
-            string content = null)
+        private TagHelperContext MakeTagHelperContext(TagHelperAttributeList attributes = null)
         {
             attributes = attributes ?? new TagHelperAttributeList();
 
             return new TagHelperContext(
                 attributes,
                 items: new Dictionary<object, object>(),
-                uniqueId: Guid.NewGuid().ToString("N"),
-                getChildContentAsync: useCachedResult =>
-                {
-                    var tagHelperContent = new DefaultTagHelperContent();
-                    tagHelperContent.SetContent(content);
-                    return Task.FromResult<TagHelperContent>(tagHelperContent);
-                });
+                uniqueId: Guid.NewGuid().ToString("N"));
         }
 
-        private TagHelperOutput MakeTagHelperOutput(string tagName, TagHelperAttributeList attributes = null)
+        private TagHelperOutput MakeTagHelperOutput(
+            string tagName,
+            TagHelperAttributeList attributes = null,
+            string childContent = null)
         {
             attributes = attributes ?? new TagHelperAttributeList();
 
-            return new TagHelperOutput(tagName, attributes);
+            return new TagHelperOutput(
+                tagName,
+                attributes,
+                getChildContentAsync: useCachedResult =>
+                {
+                    var tagHelperContent = new DefaultTagHelperContent();
+                    tagHelperContent.SetContent(childContent);
+                    return Task.FromResult<TagHelperContent>(tagHelperContent);
+                });
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/FormTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/FormTagHelperTest.cs
@@ -41,18 +41,18 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     { "asp-antiforgery", true }
                 },
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
-                getChildContentAsync: useCachedResult =>
-                {
-                    var tagHelperContent = new DefaultTagHelperContent();
-                    tagHelperContent.SetContent("Something Else");
-                    return Task.FromResult<TagHelperContent>(tagHelperContent);
-                });
+                uniqueId: "test");
             var output = new TagHelperOutput(
                 expectedTagName,
                 attributes: new TagHelperAttributeList
                 {
                     { "id", "myform" },
+                },
+                getChildContentAsync: useCachedResult =>
+                {
+                    var tagHelperContent = new DefaultTagHelperContent();
+                    tagHelperContent.SetContent("Something Else");
+                    return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
             output.PostContent.SetContent("Something");
             var urlHelper = new Mock<IUrlHelper>();
@@ -110,16 +110,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                uniqueId: "test");
+            var output = new TagHelperOutput(
+                "form",
+                attributes: new TagHelperAttributeList(),
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-            var output = new TagHelperOutput(
-                "form",
-                attributes: new TagHelperAttributeList());
             var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
             generator
                 .Setup(mock => mock.GenerateForm(
@@ -161,17 +161,17 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                uniqueId: "test");
+            var expectedAttribute = new TagHelperAttribute("asp-ROUTEE-NotRoute", "something");
+            var output = new TagHelperOutput(
+                "form",
+                attributes: new TagHelperAttributeList(),
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-            var expectedAttribute = new TagHelperAttribute("asp-ROUTEE-NotRoute", "something");
-            var output = new TagHelperOutput(
-                "form",
-                attributes: new TagHelperAttributeList());
             output.Attributes.Add(expectedAttribute);
 
             var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
@@ -233,16 +233,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                uniqueId: "test");
+            var output = new TagHelperOutput(
+                "form",
+                attributes: new TagHelperAttributeList(),
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-            var output = new TagHelperOutput(
-                "form",
-                attributes: new TagHelperAttributeList());
             var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
             generator
                 .Setup(mock => mock.GenerateForm(
@@ -284,16 +284,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                uniqueId: "test");
+            var output = new TagHelperOutput(
+                "form",
+                attributes: new TagHelperAttributeList(),
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-            var output = new TagHelperOutput(
-                "form",
-                attributes: new TagHelperAttributeList());
             var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
             generator
                 .Setup(mock => mock.GenerateRouteForm(
@@ -349,22 +349,23 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 ViewContext = viewContext,
             };
 
-            var output = new TagHelperOutput("form",
-                                             attributes: new TagHelperAttributeList
-                                             {
-                                                 { "aCTiON", "my-action" },
-                                             });
-            var context = new TagHelperContext(
-                allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
-                    Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
-                items: new Dictionary<object, object>(),
-                uniqueId: "test",
+            var output = new TagHelperOutput(
+                tagName: "form",
+                attributes: new TagHelperAttributeList
+                {
+                    { "aCTiON", "my-action" },
+                },
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
+            var context = new TagHelperContext(
+                allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
+                    Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
+                items: new Dictionary<object, object>(),
+                uniqueId: "test");
 
 
             // Act
@@ -393,7 +394,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 attributes: new TagHelperAttributeList
                 {
                     { "action", "my-action" },
-                });
+                },
+                getChildContentAsync: _ => Task.FromResult<TagHelperContent>(null));
             if (propertyName == "asp-route-")
             {
                 formTagHelper.RouteValues.Add("name", "value");
@@ -411,8 +413,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
-                getChildContentAsync: _ => Task.FromResult<TagHelperContent>(null));
+                uniqueId: "test");
 
             // Act & Assert
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -434,7 +435,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             typeof(FormTagHelper).GetProperty(propertyName).SetValue(formTagHelper, "Home");
             var output = new TagHelperOutput(
                 "form",
-                attributes: new TagHelperAttributeList());
+                attributes: new TagHelperAttributeList(),
+                getChildContentAsync: _ => Task.FromResult<TagHelperContent>(null));
             var expectedErrorMessage = "Cannot determine an 'action' attribute for <form>. A <form> with a specified " +
                 "'asp-route' must not have an 'asp-action' or 'asp-controller' attribute.";
 
@@ -442,8 +444,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
-                getChildContentAsync: _ => Task.FromResult<TagHelperContent>(null));
+                uniqueId: "test");
 
             // Act & Assert
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ImageTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ImageTagHelperTest.cs
@@ -50,7 +50,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     { "alt", new HtmlString("Testing") },
                     { "src", srcOutput },
                 };
-            var output = new TagHelperOutput("img", outputAttributes);
+            var output = new TagHelperOutput(
+                "img",
+                outputAttributes,
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
             var hostingEnvironment = MakeHostingEnvironment();
             var viewContext = MakeViewContext();
             var urlHelper = new Mock<IUrlHelper>();
@@ -272,20 +275,22 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             return new TagHelperContext(
                 attributes,
                 items: new Dictionary<object, object>(),
-                uniqueId: Guid.NewGuid().ToString("N"),
-                getChildContentAsync: useCachedResult =>
-                {
-                    var tagHelperContent = new DefaultTagHelperContent();
-                    tagHelperContent.SetContent(default(string));
-                    return Task.FromResult<TagHelperContent>(tagHelperContent);
-                });
+                uniqueId: Guid.NewGuid().ToString("N"));
         }
 
         private static TagHelperOutput MakeImageTagHelperOutput(TagHelperAttributeList attributes)
         {
             attributes = attributes ?? new TagHelperAttributeList();
 
-            return new TagHelperOutput("img", attributes);
+            return new TagHelperOutput(
+                "img",
+                attributes,
+                getChildContentAsync: useCachedResult =>
+                {
+                    var tagHelperContent = new DefaultTagHelperContent();
+                    tagHelperContent.SetContent(default(string));
+                    return Task.FromResult<TagHelperContent>(tagHelperContent);
+                });
         }
 
         private static IHostingEnvironment MakeHostingEnvironment()

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/InputTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/InputTagHelperTest.cs
@@ -90,9 +90,11 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
-                getChildContentAsync: useCachedResult => Task.FromResult<TagHelperContent>(result: null));
-            var output = new TagHelperOutput(originalTagName, outputAttributes)
+                uniqueId: "test");
+            var output = new TagHelperOutput(
+                originalTagName,
+                outputAttributes,
+                getChildContentAsync: useCachedResult => Task.FromResult<TagHelperContent>(result: null))
             {
                 TagMode = TagMode.SelfClosing,
             };
@@ -194,18 +196,20 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                uniqueId: "test");
+            var originalAttributes = new TagHelperAttributeList
+            {
+                { "class", "form-control" },
+            };
+            var output = new TagHelperOutput(
+                expectedTagName,
+                originalAttributes,
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
-                });
-            var originalAttributes = new TagHelperAttributeList
-            {
-                { "class", "form-control" },
-            };
-            var output = new TagHelperOutput(expectedTagName, originalAttributes)
+                })
             {
                 TagMode = TagMode.StartTagOnly,
             };
@@ -256,18 +260,20 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                uniqueId: "test");
+            var originalAttributes = new TagHelperAttributeList
+            {
+                { "class", "form-control" },
+            };
+            var output = new TagHelperOutput(
+                originalTagName,
+                originalAttributes,
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
-                });
-            var originalAttributes = new TagHelperAttributeList
-            {
-                { "class", "form-control" },
-            };
-            var output = new TagHelperOutput(originalTagName, originalAttributes)
+                })
             {
                 TagMode = TagMode.SelfClosing,
             };
@@ -353,18 +359,20 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var context = new TagHelperContext(
                 allAttributes: contextAttributes,
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                uniqueId: "test");
+            var originalAttributes = new TagHelperAttributeList
+            {
+                { "class", "form-control" },
+            };
+            var output = new TagHelperOutput(
+                expectedTagName,
+                originalAttributes,
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
-                });
-            var originalAttributes = new TagHelperAttributeList
-            {
-                { "class", "form-control" },
-            };
-            var output = new TagHelperOutput(expectedTagName, originalAttributes)
+                })
             {
                 TagMode = TagMode.StartTagOnly,
             };
@@ -452,18 +460,20 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var context = new TagHelperContext(
                 allAttributes: contextAttributes,
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                uniqueId: "test");
+            var originalAttributes = new TagHelperAttributeList
+            {
+                { "class", "form-control" },
+            };
+            var output = new TagHelperOutput(
+                expectedTagName,
+                originalAttributes,
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
-                });
-            var originalAttributes = new TagHelperAttributeList
-            {
-                { "class", "form-control" },
-            };
-            var output = new TagHelperOutput(expectedTagName, originalAttributes)
+                })
             {
                 TagMode = TagMode.StartTagOnly,
             };
@@ -548,18 +558,20 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var context = new TagHelperContext(
                 allAttributes: contextAttributes,
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                uniqueId: "test");
+            var originalAttributes = new TagHelperAttributeList
+            {
+                { "class", "form-control" },
+            };
+            var output = new TagHelperOutput(
+                expectedTagName,
+                originalAttributes,
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
-                });
-            var originalAttributes = new TagHelperAttributeList
-            {
-                { "class", "form-control" },
-            };
-            var output = new TagHelperOutput(expectedTagName, originalAttributes)
+                })
             {
                 TagMode = TagMode.StartTagOnly,
             };
@@ -655,18 +667,20 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var context = new TagHelperContext(
                 allAttributes: contextAttributes,
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                uniqueId: "test");
+            var originalAttributes = new TagHelperAttributeList
+            {
+                { "class", "form-control" },
+            };
+            var output = new TagHelperOutput(
+                expectedTagName,
+                originalAttributes,
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
-                });
-            var originalAttributes = new TagHelperAttributeList
-            {
-                { "class", "form-control" },
-            };
-            var output = new TagHelperOutput(expectedTagName, originalAttributes)
+                })
             {
                 TagMode = TagMode.StartTagOnly,
             };
@@ -773,10 +787,12 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
-                getChildContentAsync: useCachedResult => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+                uniqueId: "test");
 
-            var output = new TagHelperOutput(expectedTagName, attributes: new TagHelperAttributeList())
+            var output = new TagHelperOutput(
+                expectedTagName,
+                attributes: new TagHelperAttributeList(),
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()))
             {
                 TagMode = TagMode.SelfClosing,
             };
@@ -854,10 +870,12 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
-                getChildContentAsync: useCachedResult => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+                uniqueId: "test");
 
-            var output = new TagHelperOutput(expectedTagName, attributes: new TagHelperAttributeList())
+            var output = new TagHelperOutput(
+                expectedTagName,
+                attributes: new TagHelperAttributeList(),
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()))
             {
                 TagMode = TagMode.SelfClosing,
             };

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/Internal/AttributeMatcherTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/Internal/AttributeMatcherTest.cs
@@ -128,13 +128,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
             return new TagHelperContext(
                 attributes,
                 items: new Dictionary<object, object>(),
-                uniqueId: Guid.NewGuid().ToString("N"),
-                getChildContentAsync: useCachedResult =>
-                {
-                    var tagHelperContent = new DefaultTagHelperContent();
-                    tagHelperContent.Append(content);
-                    return Task.FromResult((TagHelperContent)tagHelperContent);
-                });
+                uniqueId: Guid.NewGuid().ToString("N"));
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LabelTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LabelTagHelperTest.cs
@@ -193,18 +193,20 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                uniqueId: "test");
+            var htmlAttributes = new TagHelperAttributeList
+            {
+                { "class", "form-control" },
+            };
+            var output = new TagHelperOutput(
+                expectedTagName,
+                htmlAttributes,
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.AppendEncoded(tagHelperOutputContent.OriginalChildContent);
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-            var htmlAttributes = new TagHelperAttributeList
-            {
-                { "class", "form-control" },
-            };
-            var output = new TagHelperOutput(expectedTagName, htmlAttributes);
             output.PreContent.AppendEncoded(expectedPreContent);
             output.PostContent.AppendEncoded(expectedPostContent);
 

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LinkTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/LinkTagHelperTest.cs
@@ -830,29 +830,24 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             return viewContext;
         }
 
-        private static TagHelperContext MakeTagHelperContext(
-            TagHelperAttributeList attributes = null,
-            string content = null)
+        private static TagHelperContext MakeTagHelperContext(TagHelperAttributeList attributes = null)
         {
             attributes = attributes ?? new TagHelperAttributeList();
 
             return new TagHelperContext(
                 attributes,
                 items: new Dictionary<object, object>(),
-                uniqueId: Guid.NewGuid().ToString("N"),
-                getChildContentAsync: useCachedResult =>
-                {
-                    var tagHelperContent = new DefaultTagHelperContent();
-                    tagHelperContent.SetContent(content);
-                    return Task.FromResult<TagHelperContent>(tagHelperContent);
-                });
+                uniqueId: Guid.NewGuid().ToString("N"));
         }
 
         private static TagHelperOutput MakeTagHelperOutput(string tagName, TagHelperAttributeList attributes = null)
         {
             attributes = attributes ?? new TagHelperAttributeList();
 
-            return new TagHelperOutput(tagName, attributes);
+            return new TagHelperOutput(
+                tagName,
+                attributes,
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
         }
 
         private static IHostingEnvironment MakeHostingEnvironment()

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/OptionTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/OptionTagHelperTest.cs
@@ -397,15 +397,17 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var tagHelperContext = new TagHelperContext(
                 contextAttributes,
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                uniqueId: "test");
+
+            var output = new TagHelperOutput(
+                expectedTagHelperOutput.TagName,
+                originalAttributes,
                 getChildContentAsync: useCachedResult =>
                 {
                     // GetChildContentAsync should not be invoked since we are setting the content below.
                     Assert.True(false);
                     return Task.FromResult<TagHelperContent>(null);
-                });
-
-            var output = new TagHelperOutput(expectedTagHelperOutput.TagName, originalAttributes)
+                })
             {
                 TagMode = TagMode.StartTagAndEndTag
             };
@@ -466,14 +468,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var tagHelperContext = new TagHelperContext(
                 contextAttributes,
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                uniqueId: "test");
+            var output = new TagHelperOutput(
+                originalTagName,
+                originalAttributes,
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.SetContent(originalContent);
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
-                });
-            var output = new TagHelperOutput(originalTagName, originalAttributes)
+                })
             {
                 TagMode = TagMode.StartTagAndEndTag,
             };
@@ -527,15 +531,17 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var tagHelperContext = new TagHelperContext(
                 contextAttributes,
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                uniqueId: "test");
+
+            var output = new TagHelperOutput(
+                originalTagName,
+                originalAttributes,
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.SetContent(originalContent);
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
-                });
-
-            var output = new TagHelperOutput(originalTagName, originalAttributes)
+                })
             {
                 TagMode = TagMode.StartTagAndEndTag,
             };
@@ -559,7 +565,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         private static TagHelperOutput GetTagHelperOutput(
             string tagName, TagHelperAttributeList attributes, string content)
         {
-            var tagHelperOutput = new TagHelperOutput(tagName, attributes);
+            var tagHelperOutput = new TagHelperOutput(
+                tagName,
+                attributes,
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
             tagHelperOutput.Content.SetContent(content);
 
             return tagHelperOutput;

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/RenderAtEndOfFormTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/RenderAtEndOfFormTagHelperTest.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc.Rendering;
+using Microsoft.AspNet.Mvc.ViewFeatures;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 using Xunit;
 
@@ -32,7 +33,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                             GetTagBuilder("input", "SomeName", "hidden", "false", TagRenderMode.SelfClosing),
                             GetTagBuilder("input", "SomeOtherName", "hidden", "false", TagRenderMode.SelfClosing)
                         },
-                        @"<input name=""SomeName"" type=""hidden"" value=""false"" />" + 
+                        @"<input name=""SomeName"" type=""hidden"" value=""false"" />" +
                         @"<input name=""SomeOtherName"" type=""hidden"" value=""false"" />"
                     }
                 };
@@ -41,19 +42,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
         [Theory]
         [MemberData(nameof(RenderAtEndOfFormTagHelperData))]
-        public async Task Process_AddsHiddenInputTag_FromEndOfFormContent(List<TagBuilder> tagBuilderList, string expectedOutput)
+        public async Task Process_AddsHiddenInputTag_FromEndOfFormContent(
+            List<TagBuilder> tagBuilderList,
+            string expectedOutput)
         {
             // Arrange
             var viewContext = new ViewContext();
             var tagHelperOutput = new TagHelperOutput(
                 tagName: "form",
-                attributes: new TagHelperAttributeList());
-
-            var tagHelperContext = new TagHelperContext(
-                Enumerable.Empty<IReadOnlyTagHelperAttribute>(),
-                new Dictionary<object, object>(),
-                "someId",
-                (useCachedResult) =>
+                attributes: new TagHelperAttributeList(),
+                getChildContentAsync: (useCachedResult) =>
                 {
                     Assert.True(viewContext.FormContext.CanRenderAtEndOfForm);
                     foreach (var item in tagBuilderList)
@@ -64,16 +62,62 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     return Task.FromResult<TagHelperContent>(new DefaultTagHelperContent());
                 });
 
+            var tagHelperContext = new TagHelperContext(
+                Enumerable.Empty<IReadOnlyTagHelperAttribute>(),
+                new Dictionary<object, object>(),
+                "someId");
+
             var tagHelper = new RenderAtEndOfFormTagHelper
             {
                 ViewContext = viewContext
             };
+            tagHelper.Init(tagHelperContext);
 
             // Act
             await tagHelper.ProcessAsync(context: tagHelperContext, output: tagHelperOutput);
 
             // Assert
             Assert.Equal(expectedOutput, tagHelperOutput.PostContent.GetContent());
+        }
+
+        [Theory]
+        [MemberData(nameof(RenderAtEndOfFormTagHelperData))]
+        public async Task Process_AddsHiddenInputTag_FromEndOfFormContent_WithCachedBody(
+            List<TagBuilder> tagBuilderList,
+            string expectedOutput)
+        {
+            // Arrange
+            var viewContext = new ViewContext();
+            var runner = new TagHelperRunner();
+            var tagHelperExecutionContext = new TagHelperExecutionContext(
+                "form",
+                TagMode.StartTagAndEndTag,
+                items: new Dictionary<object, object>(),
+                uniqueId: string.Empty,
+                executeChildContentAsync: () =>
+                {
+                    foreach (var item in tagBuilderList)
+                    {
+                        viewContext.FormContext.EndOfFormContent.Add(item);
+                    }
+
+                    return Task.FromResult(true);
+                },
+                startTagHelperWritingScope: () => { },
+                endTagHelperWritingScope: () => new DefaultTagHelperContent());
+
+            // This TagHelper will pre-execute the child content forcing the body to be cached.
+            tagHelperExecutionContext.Add(new ChildContentInvoker());
+            tagHelperExecutionContext.Add(new RenderAtEndOfFormTagHelper
+            {
+                ViewContext = viewContext
+            });
+
+            // Act
+            var output = await runner.RunAsync(tagHelperExecutionContext);
+
+            // Assert
+            Assert.Equal(expectedOutput, output.PostContent.GetContent());
         }
 
         private static TagBuilder GetTagBuilder(string tag, string name, string type, string value, TagRenderMode mode)
@@ -85,6 +129,22 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             tagBuilder.TagRenderMode = mode;
 
             return tagBuilder;
+        }
+
+        private class ChildContentInvoker : TagHelper
+        {
+            public override int Order
+            {
+                get
+                {
+                    return int.MinValue;
+                }
+            }
+
+            public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+            {
+                await output.GetChildContentAsync();
+            }
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ScriptTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ScriptTagHelperTest.cs
@@ -906,13 +906,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             return new TagHelperContext(
                 attributes,
                 items: new Dictionary<object, object>(),
-                uniqueId: Guid.NewGuid().ToString("N"),
-                getChildContentAsync: useCachedResult =>
-                {
-                    var tagHelperContent = new DefaultTagHelperContent();
-                    tagHelperContent.SetContent(content);
-                    return Task.FromResult<TagHelperContent>(tagHelperContent);
-                });
+                uniqueId: Guid.NewGuid().ToString("N"));
         }
 
         private static ViewContext MakeViewContext(string requestPathBase = null)
@@ -940,7 +934,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             attributes = attributes ?? new TagHelperAttributeList();
 
-            return new TagHelperOutput(tagName, attributes);
+            return new TagHelperOutput(
+                tagName,
+                attributes,
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
         }
 
         private TagHelperLogger<ScriptTagHelper> CreateLogger()

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/SelectTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/SelectTagHelperTest.cs
@@ -203,14 +203,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                uniqueId: "test");
+            var output = new TagHelperOutput(
+                expectedTagName,
+                originalAttributes,
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
-                });
-            var output = new TagHelperOutput(expectedTagName, originalAttributes)
+                })
             {
                 TagMode = TagMode.SelfClosing,
             };
@@ -290,14 +292,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                uniqueId: "test");
+            var output = new TagHelperOutput(
+                expectedTagName,
+                originalAttributes,
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.AppendEncoded("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
-                });
-            var output = new TagHelperOutput(expectedTagName, originalAttributes)
+                })
             {
                 TagMode = TagMode.SelfClosing,
             };
@@ -392,14 +396,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                uniqueId: "test");
+            var output = new TagHelperOutput(
+                expectedTagName,
+                originalAttributes,
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.AppendEncoded("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
-                });
-            var output = new TagHelperOutput(expectedTagName, originalAttributes)
+                })
             {
                 TagMode = TagMode.SelfClosing,
             };
@@ -478,15 +484,17 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var tagHelperContext = new TagHelperContext(
                 contextAttributes,
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                uniqueId: "test");
+
+            var output = new TagHelperOutput(
+                expectedTagName,
+                originalAttributes,
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-
-            var output = new TagHelperOutput(expectedTagName, originalAttributes);
             var metadataProvider = new EmptyModelMetadataProvider();
             string model = null;
             var modelExplorer = metadataProvider.GetModelExplorerForType(typeof(string), model);
@@ -557,14 +565,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var tagHelperContext = new TagHelperContext(
                 contextAttributes,
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                uniqueId: "test");
+            var output = new TagHelperOutput(
+                tagName,
+                originalAttributes,
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-            var output = new TagHelperOutput(tagName, originalAttributes);
             var metadataProvider = new EmptyModelMetadataProvider();
             var modelExplorer = metadataProvider.GetModelExplorerForType(modelType, model);
             var modelExpression = new ModelExpression(propertyName, modelExplorer);

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TagHelperOutputExtensionsTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TagHelperOutputExtensionsTest.cs
@@ -333,12 +333,14 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             IEnumerable<TagHelperAttribute> expectedAttributes)
         {
             // Arrange
-            var output = new TagHelperOutput("p", attributes: new TagHelperAttributeList(outputAttributes));
+            var output = new TagHelperOutput(
+                tagName: "p",
+                attributes: new TagHelperAttributeList(outputAttributes),
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
             var context = new TagHelperContext(
                 allAttributes,
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
-                getChildContentAsync: useCachedResult => Task.FromResult<TagHelperContent>(result: null));
+                uniqueId: "test");
 
             // Act
             output.CopyHtmlAttribute(attributeNameToCopy, context);
@@ -431,12 +433,14 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             IEnumerable<TagHelperAttribute> expectedAttributes)
         {
             // Arrange
-            var output = new TagHelperOutput("p", attributes: new TagHelperAttributeList());
+            var output = new TagHelperOutput(
+                tagName: "p",
+                attributes: new TagHelperAttributeList(),
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
             var context = new TagHelperContext(
                 allAttributes,
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
-                getChildContentAsync: useCachedResult => Task.FromResult<TagHelperContent>(result: null));
+                uniqueId: "test");
 
             // Act
             output.CopyHtmlAttribute(attributeNameToCopy, context);
@@ -453,20 +457,20 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new TagHelperAttributeList());
-            var tagHelperContext = new TagHelperContext(
-                allAttributes: new TagHelperAttributeList
-                {
-                    { attributeName, attributeValue }
-                },
-                items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                attributes: new TagHelperAttributeList(),
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.Append("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
+            var tagHelperContext = new TagHelperContext(
+                allAttributes: new TagHelperAttributeList
+                {
+                    { attributeName, attributeValue }
+                },
+                items: new Dictionary<object, object>(),
+                uniqueId: "test");
             var expectedAttribute = new TagHelperAttribute(attributeName, attributeValue);
 
             // Act
@@ -487,6 +491,12 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 attributes: new TagHelperAttributeList()
                 {
                     { attributeName, "world2" }
+                },
+                getChildContentAsync: useCachedResult =>
+                {
+                    var tagHelperContent = new DefaultTagHelperContent();
+                    tagHelperContent.Append("Something Else");
+                    return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
             var expectedAttribute = new TagHelperAttribute(attributeName, "world2");
             var tagHelperContext = new TagHelperContext(
@@ -495,13 +505,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     { attributeName, "world" }
                 },
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
-                getChildContentAsync: useCachedResult =>
-                {
-                    var tagHelperContent = new DefaultTagHelperContent();
-                    tagHelperContent.Append("Something Else");
-                    return Task.FromResult<TagHelperContent>(tagHelperContent);
-                });
+                uniqueId: "test");
 
             // Act
             tagHelperOutput.CopyHtmlAttribute(attributeName, tagHelperContext);
@@ -518,20 +522,20 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var invalidAttributeName = "hello2";
             var tagHelperOutput = new TagHelperOutput(
                 "p",
-                attributes: new TagHelperAttributeList());
-            var tagHelperContext = new TagHelperContext(
-                allAttributes: new TagHelperAttributeList
-                {
-                    { "hello", "world" }
-                },
-                items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                attributes: new TagHelperAttributeList(),
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.Append("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
+            var tagHelperContext = new TagHelperContext(
+                allAttributes: new TagHelperAttributeList
+                {
+                    { "hello", "world" }
+                },
+                items: new Dictionary<object, object>(),
+                uniqueId: "test");
 
             // Act & Assert
             ExceptionAssert.ThrowsArgument(
@@ -545,12 +549,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
-                "p",
+                tagName: "p",
                 attributes: new TagHelperAttributeList()
                 {
                     { "route-Hello", "World" },
                     { "Route-I", "Am" }
-                });
+                },
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
             var expectedAttribute = new TagHelperAttribute("type", "btn");
             tagHelperOutput.Attributes.Add(expectedAttribute);
 
@@ -571,12 +576,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
-                "p",
+                tagName: "p",
                 attributes: new TagHelperAttributeList()
                 {
                     { "route-Hello", "World" },
                     { "Route-I", "Am" }
-                });
+                },
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
             var expectedAttribute = new TagHelperAttribute("type", "btn");
             tagHelperOutput.Attributes.Add(expectedAttribute);
             var attributes = tagHelperOutput.Attributes
@@ -595,12 +601,13 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
-                "p",
+                tagName: "p",
                 attributes: new TagHelperAttributeList()
                 {
                     { "route-Hello", "World" },
                     { "Route-I", "Am" }
-                });
+                },
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
             var expectedAttribute = new TagHelperAttribute("type", "btn");
             tagHelperOutput.Attributes.Add(expectedAttribute);
 
@@ -755,7 +762,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             TagHelperAttributeList expectedAttributes)
         {
             // Arrange
-            var tagHelperOutput = new TagHelperOutput("p", outputAttributes);
+            var tagHelperOutput = new TagHelperOutput(
+                "p",
+                outputAttributes,
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
 
             var tagBuilder = new TagBuilder("p");
             foreach (var attr in tagBuilderAttributes)
@@ -778,8 +788,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
-                "p",
-                attributes: new TagHelperAttributeList());
+                tagName: "p",
+                attributes: new TagHelperAttributeList(),
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
             var expectedAttribute = new TagHelperAttribute("type", "btn");
             tagHelperOutput.Attributes.Add(expectedAttribute);
 
@@ -799,8 +810,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
-                "p",
-                attributes: new TagHelperAttributeList());
+                tagName: "p",
+                attributes: new TagHelperAttributeList(),
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
             tagHelperOutput.Attributes.Add("class", "Hello");
 
             var tagBuilder = new TagBuilder("p");
@@ -825,8 +837,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
-                "p",
-                attributes: new TagHelperAttributeList());
+                tagName: "p",
+                attributes: new TagHelperAttributeList(),
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
             tagHelperOutput.Attributes.Add(originalName, "Hello");
 
             var tagBuilder = new TagBuilder("p");
@@ -845,8 +858,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
-                "p",
-                attributes: new TagHelperAttributeList());
+                tagName: "p",
+                attributes: new TagHelperAttributeList(),
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
 
             var tagBuilder = new TagBuilder("p");
             var expectedAttribute = new TagHelperAttribute("visible", "val < 3");
@@ -865,8 +879,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
-                "p",
-                attributes: new TagHelperAttributeList());
+                tagName: "p",
+                attributes: new TagHelperAttributeList(),
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
 
             var tagBuilder = new TagBuilder("p");
             var expectedAttribute1 = new TagHelperAttribute("class", "btn");
@@ -890,8 +905,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
-                "p",
-                attributes: new TagHelperAttributeList());
+                tagName: "p",
+                attributes: new TagHelperAttributeList(),
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
             var expectedAttribute = new TagHelperAttribute("class", "btn");
             tagHelperOutput.Attributes.Add(expectedAttribute);
 
@@ -910,8 +926,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput(
-                "p",
-                attributes: new TagHelperAttributeList());
+                tagName: "p",
+                attributes: new TagHelperAttributeList(),
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
             var expectedOutputAttribute = new TagHelperAttribute("class", "btn");
             tagHelperOutput.Attributes.Add(expectedOutputAttribute);
 

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TextAreaTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TextAreaTagHelperTest.cs
@@ -127,18 +127,20 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                uniqueId: "test");
+            var htmlAttributes = new TagHelperAttributeList
+            {
+                { "class", "form-control" },
+            };
+            var output = new TagHelperOutput(
+                expectedTagName,
+                htmlAttributes,
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
-                });
-            var htmlAttributes = new TagHelperAttributeList
-            {
-                { "class", "form-control" },
-            };
-            var output = new TagHelperOutput(expectedTagName, htmlAttributes)
+                })
             {
                 TagMode = TagMode.SelfClosing,
             };

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ValidationMessageTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ValidationMessageTagHelperTest.cs
@@ -46,18 +46,18 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     { "for", modelExpression },
                 },
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
-                getChildContentAsync: useCachedResult =>
-                {
-                    var tagHelperContent = new DefaultTagHelperContent();
-                    tagHelperContent.SetContent("Something");
-                    return Task.FromResult<TagHelperContent>(tagHelperContent);
-                });
+                uniqueId: "test");
             var output = new TagHelperOutput(
                 expectedTagName,
                 attributes: new TagHelperAttributeList
                 {
                     { "id", "myvalidationmessage" }
+                },
+                getChildContentAsync: useCachedResult =>
+                {
+                    var tagHelperContent = new DefaultTagHelperContent();
+                    tagHelperContent.SetContent("Something");
+                    return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
             output.PreContent.SetContent(expectedPreContent);
             output.Content.SetContent(expectedContent);
@@ -110,16 +110,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                uniqueId: "test");
+            var output = new TagHelperOutput(
+                "span",
+                attributes: new TagHelperAttributeList(),
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-            var output = new TagHelperOutput(
-                "span",
-                attributes: new TagHelperAttributeList());
             output.PreContent.SetContent(expectedPreContent);
             output.Content.SetContent(expectedContent);
             output.PostContent.SetContent(expectedPostContent);
@@ -166,20 +166,20 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             };
             var output = new TagHelperOutput(
                 "span",
-                attributes: new TagHelperAttributeList());
-            output.Content.AppendEncoded(outputContent);
-
-            var context = new TagHelperContext(
-                allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
-                    Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
-                items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                attributes: new TagHelperAttributeList(),
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.AppendEncoded(childContent);
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
+            output.Content.AppendEncoded(outputContent);
+
+            var context = new TagHelperContext(
+                allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
+                    Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
+                items: new Dictionary<object, object>(),
+                uniqueId: "test");
 
             var viewContext = CreateViewContext();
             validationMessageTagHelper.ViewContext = viewContext;
@@ -225,19 +225,19 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             };
             var output = new TagHelperOutput(
                 "span",
-                attributes: new TagHelperAttributeList());
-
-            var context = new TagHelperContext(
-                allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
-                    Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
-                items: new Dictionary<object, object>(),
-                uniqueId: "test",
+                attributes: new TagHelperAttributeList(),
                 getChildContentAsync: useCachedResult =>
                 {
                     var tagHelperContent = new DefaultTagHelperContent();
                     tagHelperContent.SetContent(childContent);
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
+
+            var context = new TagHelperContext(
+                allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
+                    Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
+                items: new Dictionary<object, object>(),
+                uniqueId: "test");
 
             var viewContext = CreateViewContext();
             validationMessageTagHelper.ViewContext = viewContext;
@@ -265,8 +265,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var expectedContent = "original content";
             var expectedPostContent = "original post-content";
             var output = new TagHelperOutput(
-                "span",
-                attributes: new TagHelperAttributeList());
+                tagName: "span",
+                attributes: new TagHelperAttributeList(),
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
             output.PreContent.SetContent(expectedPreContent);
             output.Content.SetContent(expectedContent);
             output.PostContent.SetContent(expectedPostContent);
@@ -275,8 +276,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
-                getChildContentAsync: _ => Task.FromResult<TagHelperContent>(null));
+                uniqueId: "test");
 
             var viewContext = CreateViewContext();
             validationMessageTagHelper.ViewContext = viewContext;

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ValidationSummaryTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ValidationSummaryTagHelperTest.cs
@@ -42,18 +42,18 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
-                getChildContentAsync: useCachedResult =>
-                {
-                    var tagHelperContent = new DefaultTagHelperContent();
-                    tagHelperContent.SetContent("Something");
-                    return Task.FromResult<TagHelperContent>(tagHelperContent);
-                });
+                uniqueId: "test");
             var output = new TagHelperOutput(
                 expectedTagName,
                 attributes: new TagHelperAttributeList
                 {
                     { "class", "form-control" }
+                },
+                getChildContentAsync: useCachedResult =>
+                {
+                    var tagHelperContent = new DefaultTagHelperContent();
+                    tagHelperContent.SetContent("Something");
+                    return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
             output.PreContent.SetContent(expectedPreContent);
             output.Content.SetContent(expectedContent);
@@ -109,8 +109,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var expectedContent = "original content";
             var expectedPostContent = "original post-content";
             var output = new TagHelperOutput(
-                "div",
-                attributes: new TagHelperAttributeList());
+                tagName: "div",
+                attributes: new TagHelperAttributeList(),
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
             output.PreContent.SetContent(expectedPreContent);
             output.Content.SetContent(expectedContent);
             output.PostContent.SetContent(expectedPostContent);
@@ -121,8 +122,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
-                getChildContentAsync: _ => Task.FromResult<TagHelperContent>(null));
+                uniqueId: "test");
 
             // Act & Assert
             await validationSummaryTagHelper.ProcessAsync(context, output);
@@ -163,8 +163,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var expectedPreContent = "original pre-content";
             var expectedContent = "original content";
             var output = new TagHelperOutput(
-                "div",
-                attributes: new TagHelperAttributeList());
+                tagName: "div",
+                attributes: new TagHelperAttributeList(),
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
             output.PreContent.SetContent(expectedPreContent);
             output.Content.SetContent(expectedContent);
             output.PostContent.SetContent("Content of validation summary");
@@ -176,8 +177,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
-                getChildContentAsync: _ => Task.FromResult<TagHelperContent>(null));
+                uniqueId: "test");
 
             // Act
             await validationSummaryTagHelper.ProcessAsync(context, output);
@@ -211,8 +211,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var expectedContent = "original content";
             var expectedPostContent = "original post-content";
             var output = new TagHelperOutput(
-                "div",
-                attributes: new TagHelperAttributeList());
+                tagName: "div",
+                attributes: new TagHelperAttributeList(),
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
             output.PreContent.SetContent(expectedPreContent);
             output.Content.SetContent(expectedContent);
             output.PostContent.SetContent(expectedPostContent);
@@ -224,8 +225,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
-                getChildContentAsync: _ => Task.FromResult<TagHelperContent>(null));
+                uniqueId: "test");
 
             // Act
             await validationSummaryTagHelper.ProcessAsync(context, output);
@@ -266,8 +266,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var expectedPreContent = "original pre-content";
             var expectedContent = "original content";
             var output = new TagHelperOutput(
-                "div",
-                attributes: new TagHelperAttributeList());
+                tagName: "div",
+                attributes: new TagHelperAttributeList(),
+                getChildContentAsync: (_) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
             output.PreContent.SetContent(expectedPreContent);
             output.Content.SetContent(expectedContent);
             output.PostContent.SetContent("Content of validation message");
@@ -279,8 +280,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 allAttributes: new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                     Enumerable.Empty<IReadOnlyTagHelperAttribute>()),
                 items: new Dictionary<object, object>(),
-                uniqueId: "test",
-                getChildContentAsync: _ => Task.FromResult<TagHelperContent>(null));
+                uniqueId: "test");
 
             // Act
             await validationSummaryTagHelper.ProcessAsync(context, output);

--- a/test/WebSites/ActivatorWebSite/TagHelpers/HiddenTagHelper.cs
+++ b/test/WebSites/ActivatorWebSite/TagHelpers/HiddenTagHelper.cs
@@ -33,7 +33,7 @@ namespace ActivatorWebSite.TagHelpers
         {
             (HtmlHelper as ICanHasViewContext)?.Contextualize(ViewContext);
 
-            var content = await context.GetChildContentAsync();
+            var content = await output.GetChildContentAsync();
             output.Content.SetContent(HtmlHelper.Hidden(Name, content.GetContent(HtmlEncoder)));
         }
     }

--- a/test/WebSites/ActivatorWebSite/TagHelpers/RepeatContentTagHelper.cs
+++ b/test/WebSites/ActivatorWebSite/TagHelpers/RepeatContentTagHelper.cs
@@ -31,7 +31,7 @@ namespace ActivatorWebSite.TagHelpers
         {
             (HtmlHelper as ICanHasViewContext)?.Contextualize(ViewContext);
 
-            var content = await context.GetChildContentAsync();
+            var content = await output.GetChildContentAsync();
             var repeatContent = HtmlHelper.Encode(Expression.Model.ToString());
 
             if (string.IsNullOrEmpty(repeatContent))

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/AutoLinkerTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/AutoLinkerTagHelper.cs
@@ -12,7 +12,7 @@ namespace TagHelpersWebSite.TagHelpers
     {
         public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
-            var childContent = await context.GetChildContentAsync();
+            var childContent = await output.GetChildContentAsync();
 
             // Find Urls in the content and replace them with their anchor tag equivalent.
             output.Content.AppendEncoded(Regex.Replace(

--- a/test/WebSites/TagHelpersWebSite/TagHelpers/TagCloudViewComponentTagHelper.cs
+++ b/test/WebSites/TagHelpersWebSite/TagHelpers/TagCloudViewComponentTagHelper.cs
@@ -33,6 +33,10 @@ namespace MvcSample.Web.Components
 
         public int Order { get; } = 0;
 
+        public void Init(TagHelperContext context)
+        {
+        }
+
         public async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
             var result = await InvokeAsync(Count);


### PR DESCRIPTION
- Changed all `GetChildContentAsync` calls to come from `TagHelperOutput` instead of `TagHelperContext`.
- Updated `ReaderAtEndOfFormTagHelper` to properly detect changes inside of a `Form`s body by calling the `Init` method.
- Add test to `RenderAtEndOfFormTagHelperTest`.

aspnet/Razor#571