### PR TITLE
Use buffer pooling in IOutputFormatters

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Abstractions/Formatters/OutputFormatterWriteContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/Formatters/OutputFormatterWriteContext.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
+using System.Text;
 using Microsoft.AspNet.Http;
 
 namespace Microsoft.AspNet.Mvc.Formatters
@@ -15,13 +17,19 @@ namespace Microsoft.AspNet.Mvc.Formatters
         /// Creates a new <see cref="OutputFormatterWriteContext"/>.
         /// </summary>
         /// <param name="httpContext">The <see cref="Http.HttpContext"/> for the current request.</param>
+        /// <param name="writerFactory">The delegate used to create a <see cref="TextWriter"/> for writing the response.
         /// <param name="objectType">The <see cref="Type"/> of the object to write to the response.</param>
         /// <param name="@object">The object to write to the response.</param>
-        public OutputFormatterWriteContext(HttpContext httpContext, Type objectType, object @object)
+        public OutputFormatterWriteContext(HttpContext httpContext, Func<Stream, Encoding, TextWriter> writerFactory, Type objectType, object @object)
         {
             if (httpContext == null)
             {
                 throw new ArgumentNullException(nameof(httpContext));
+            }
+
+            if (writerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(writerFactory));
             }
 
             HttpContext = httpContext;
@@ -33,5 +41,10 @@ namespace Microsoft.AspNet.Mvc.Formatters
         /// Gets or sets the <see cref="HttpContext"/> context associated with the current operation.
         /// </summary>
         public virtual HttpContext HttpContext { get; protected set; }
+
+        /// <summary>
+        /// Gets or sets a delegate used to create a <see cref="TextWriter"/> for writing the response.
+        /// </summary>
+        public virtual Func<Stream, Encoding, TextWriter> WriterFactory { get; protected set; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Abstractions/IActionResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/IActionResult.cs
@@ -5,8 +5,18 @@ using System.Threading.Tasks;
 
 namespace Microsoft.AspNet.Mvc
 {
+    /// <summary>
+    /// Defines a contract that represents the result of an action method.
+    /// </summary>
     public interface IActionResult
     {
+        /// <summary>
+        /// Executes the result operation of the action method asynchronously. This method is called by MVC to process
+        /// the result of an action method.
+        /// </summary>
+        /// <param name="context">The context in which the result is executed. The context information includes
+        /// information about the action that was executed and request information.</param>
+        /// <returns>A task that represents the asynchronous execute operation.</returns>
         Task ExecuteResultAsync(ActionContext context);
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ActionResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ActionResult.cs
@@ -5,14 +5,32 @@ using System.Threading.Tasks;
 
 namespace Microsoft.AspNet.Mvc
 {
+    /// <summary>
+    /// A default implementation of <see cref="IActionResult"/>.
+    /// </summary>
     public abstract class ActionResult : IActionResult
     {
+        /// <summary>
+        /// Executes the result operation of the action method asynchronously. This method is called by MVC to process
+        /// the result of an action method.
+        /// The default implementation of this method calls the <see cref="ExecuteResult(ActionContext)"/> method and
+        /// returns a completed task.
+        /// </summary>
+        /// <param name="context">The context in which the result is executed. The context information includes
+        /// information about the action that was executed and request information.</param>
+        /// <returns>A task that represents the asynchronous execute operation.</returns>
         public virtual Task ExecuteResultAsync(ActionContext context)
         {
             ExecuteResult(context);
             return Task.FromResult(true);
         }
 
+        /// <summary>
+        /// Executes the result operation of the action method synchronously. This method is called by MVC to process
+        /// the result of an action method.
+        /// </summary>
+        /// <param name="context">The context in which the result is executed. The context information includes
+        /// information about the action that was executed and request information.</param>
         public virtual void ExecuteResult(ActionContext context)
         {
         }

--- a/src/Microsoft.AspNet.Mvc.Core/ApiExplorer/IApiResponseFormatMetadataProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ApiExplorer/IApiResponseFormatMetadataProvider.cs
@@ -11,13 +11,13 @@ namespace Microsoft.AspNet.Mvc.ApiExplorer
     /// Provides metadata information about the response format to an <c>IApiDescriptionProvider</c>.
     /// </summary>
     /// <remarks>
-    /// An <see cref="IOutputFormatter"/> should implement this interface to expose metadata information
+    /// An <see cref="Formatters.IOutputFormatter"/> should implement this interface to expose metadata information
     /// to an <c>IApiDescriptionProvider</c>.
     /// </remarks>
     public interface IApiResponseFormatMetadataProvider
     {
         /// <summary>
-        /// Gets a filtered list of content types which are supported by the <see cref="IOutputFormatter"/>
+        /// Gets a filtered list of content types which are supported by the <see cref="Formatters.IOutputFormatter"/>
         /// for the <paramref name="declaredType"/> and <paramref name="contentType"/>.
         /// </summary>
         /// <param name="contentType">
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.Mvc.ApiExplorer
         /// <param name="objectType">
         /// The <see cref="Type"/> for which the supported content types are desired.
         /// </param>
-        /// <returns>Content types which are supported by the <see cref="IOutputFormatter"/>.</returns>
+        /// <returns>Content types which are supported by the <see cref="Formatters.IOutputFormatter"/>.</returns>
         IReadOnlyList<MediaTypeHeaderValue> GetSupportedContentTypes(
             MediaTypeHeaderValue contentType,
             Type objectType);

--- a/src/Microsoft.AspNet.Mvc.Core/Builder/MvcApplicationBuilderExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Builder/MvcApplicationBuilderExtensions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNet.Builder
         /// Adds MVC to the <see cref="IApplicationBuilder"/> request execution pipeline.
         /// </summary>
         /// <param name="app">The <see cref="IApplicationBuilder"/>.</param>
-        /// <returns>The <paramref name="app"/>.</returns>
+        /// <returns>A reference to this instance after the operation has completed.</returns>
         /// <remarks>This method only supports attribute routing. To add conventional routes use
         /// <see cref="UseMvc(IApplicationBuilder, Action{IRouteBuilder})"/>.</remarks>
         public static IApplicationBuilder UseMvc(this IApplicationBuilder app)
@@ -39,7 +39,7 @@ namespace Microsoft.AspNet.Builder
         /// '{controller=Home}/{action=Index}/{id?}'.
         /// </summary>
         /// <param name="app">The <see cref="IApplicationBuilder"/>.</param>
-        /// <returns>The <paramref name="app"/>.</returns>
+        /// <returns>A reference to this instance after the operation has completed.</returns>
         public static IApplicationBuilder UseMvcWithDefaultRoute(this IApplicationBuilder app)
         {
             if (app == null)
@@ -60,7 +60,7 @@ namespace Microsoft.AspNet.Builder
         /// </summary>
         /// <param name="app">The <see cref="IApplicationBuilder"/>.</param>
         /// <param name="configureRoutes">A callback to configure MVC routes.</param>
-        /// <returns>The <paramref name="app"/>.</returns>
+        /// <returns>A reference to this instance after the operation has completed.</returns>
         public static IApplicationBuilder UseMvc(
             this IApplicationBuilder app,
             Action<IRouteBuilder> configureRoutes)

--- a/src/Microsoft.AspNet.Mvc.Core/Formatters/StringOutputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Formatters/StringOutputFormatter.cs
@@ -31,13 +31,9 @@ namespace Microsoft.AspNet.Mvc.Formatters
 
             // Ignore the passed in content type, if the object is string
             // always return it as a text/plain format.
-            if (context.ObjectType == typeof(string))
+            if (context.ObjectType == typeof(string) || context.Object is string)
             {
-                return true;
-            }
-
-            if (context.Object is string)
-            {
+                context.ContentType = SupportedMediaTypes[0];
                 return true;
             }
 

--- a/src/Microsoft.AspNet.Mvc.Formatters.Json/JsonOutputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Formatters.Json/JsonOutputFormatter.cs
@@ -108,7 +108,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
             var response = context.HttpContext.Response;
             var selectedEncoding = context.ContentType?.Encoding ?? Encoding.UTF8;
 
-            using (var writer = new HttpResponseStreamWriter(response.Body, selectedEncoding))
+            using (var writer = context.WriterFactory(response.Body, selectedEncoding))
             {
                 WriteObject(writer, context.Object);
             }

--- a/src/Microsoft.AspNet.Mvc.Formatters.Xml/XmlDataContractSerializerOutputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Formatters.Xml/XmlDataContractSerializerOutputFormatter.cs
@@ -148,17 +148,20 @@ namespace Microsoft.AspNet.Mvc.Formatters
         }
 
         /// <summary>
-        /// Creates a new instance of <see cref="XmlWriter"/> using the given stream and the <see cref="WriterSettings"/>.
+        /// Creates a new instance of <see cref="XmlWriter"/> using the given <see cref="TextWriter"/> and
+        /// <see cref="WriterSettings"/>.
         /// </summary>
-        /// <param name="writeStream">The stream on which the XmlWriter should operate on.</param>
+        /// <param name="writer">
+        /// The underlying <see cref="TextWriter"/> which the <see cref="XmlWriter"/> should write to.
+        /// </param>
         /// <returns>A new instance of <see cref="XmlWriter"/></returns>
         public virtual XmlWriter CreateXmlWriter(
-            Stream writeStream,
+            TextWriter writer,
             XmlWriterSettings xmlWriterSettings)
         {
-            if (writeStream == null)
+            if (writer == null)
             {
-                throw new ArgumentNullException(nameof(writeStream));
+                throw new ArgumentNullException(nameof(writer));
             }
 
             if (xmlWriterSettings == null)
@@ -166,9 +169,10 @@ namespace Microsoft.AspNet.Mvc.Formatters
                 throw new ArgumentNullException(nameof(xmlWriterSettings));
             }
 
-            return XmlWriter.Create(
-                new HttpResponseStreamWriter(writeStream, xmlWriterSettings.Encoding),
-                xmlWriterSettings);
+            // We always close the TextWriter, so the XmlWriter shouldn't.
+            xmlWriterSettings.CloseOutput = false;
+
+            return XmlWriter.Create(writer, xmlWriterSettings);
         }
 
         /// <inheritdoc />
@@ -182,24 +186,26 @@ namespace Microsoft.AspNet.Mvc.Formatters
             var writerSettings = WriterSettings.Clone();
             writerSettings.Encoding = context.ContentType?.Encoding ?? Encoding.UTF8;
 
+            // Wrap the object only if there is a wrapping type.
             var value = context.Object;
-
-            using (var xmlWriter = CreateXmlWriter(context.HttpContext.Response.Body, writerSettings))
+            var wrappingType = GetSerializableType(context.ObjectType);
+            if (wrappingType != null && wrappingType != context.ObjectType)
             {
-                var wrappingType = GetSerializableType(context.ObjectType);
+                var wrapperProvider = WrapperProviderFactories.GetWrapperProvider(new WrapperProviderContext(
+                    declaredType: context.ObjectType,
+                    isSerialization: true));
 
-                // Wrap the object only if there is a wrapping type.
-                if (wrappingType != null && wrappingType != context.ObjectType)
+                value = wrapperProvider.Wrap(value);
+            }
+
+            var dataContractSerializer = GetCachedSerializer(wrappingType);
+
+            using (var textWriter = context.WriterFactory(context.HttpContext.Response.Body, writerSettings.Encoding))
+            {
+                using (var xmlWriter = CreateXmlWriter(textWriter, writerSettings))
                 {
-                    var wrapperProvider = WrapperProviderFactories.GetWrapperProvider(new WrapperProviderContext(
-                        declaredType: context.ObjectType,
-                        isSerialization: true));
-
-                    value = wrapperProvider.Wrap(value);
+                    dataContractSerializer.WriteObject(xmlWriter, value);
                 }
-
-                var dataContractSerializer = GetCachedSerializer(wrappingType);
-                dataContractSerializer.WriteObject(xmlWriter, value);
             }
 
             return TaskCache.CompletedTask;

--- a/src/Microsoft.AspNet.Mvc.Formatters.Xml/XmlSerializerOutputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Formatters.Xml/XmlSerializerOutputFormatter.cs
@@ -123,17 +123,20 @@ namespace Microsoft.AspNet.Mvc.Formatters
         }
 
         /// <summary>
-        /// Creates a new instance of <see cref="XmlWriter"/> using the given stream and the <see cref="WriterSettings"/>.
+        /// Creates a new instance of <see cref="XmlWriter"/> using the given <see cref="TextWriter"/> and
+        /// <see cref="WriterSettings"/>.
         /// </summary>
-        /// <param name="writeStream">The stream on which the XmlWriter should operate on.</param>
+        /// <param name="writer">
+        /// The underlying <see cref="TextWriter"/> which the <see cref="XmlWriter"/> should write to.
+        /// </param>
         /// <returns>A new instance of <see cref="XmlWriter"/></returns>
         public virtual XmlWriter CreateXmlWriter(
-            Stream writeStream,
+            TextWriter writer,
             XmlWriterSettings xmlWriterSettings)
         {
-            if (writeStream == null)
+            if (writer == null)
             {
-                throw new ArgumentNullException(nameof(writeStream));
+                throw new ArgumentNullException(nameof(writer));
             }
 
             if (xmlWriterSettings == null)
@@ -141,9 +144,10 @@ namespace Microsoft.AspNet.Mvc.Formatters
                 throw new ArgumentNullException(nameof(xmlWriterSettings));
             }
 
-            return XmlWriter.Create(
-                new HttpResponseStreamWriter(writeStream, xmlWriterSettings.Encoding),
-                xmlWriterSettings);
+            // We always close the TextWriter, so the XmlWriter shouldn't.
+            xmlWriterSettings.CloseOutput = false;
+
+            return XmlWriter.Create(writer, xmlWriterSettings);
         }
 
         /// <inheritdoc />
@@ -159,24 +163,26 @@ namespace Microsoft.AspNet.Mvc.Formatters
             var writerSettings = WriterSettings.Clone();
             writerSettings.Encoding = context.ContentType.Encoding ?? Encoding.UTF8;
 
+            // Wrap the object only if there is a wrapping type.
             var value = context.Object;
-
-            using (var xmlWriter = CreateXmlWriter(context.HttpContext.Response.Body, writerSettings))
+            var wrappingType = GetSerializableType(context.ObjectType);
+            if (wrappingType != null && wrappingType != context.ObjectType)
             {
-                var wrappingType = GetSerializableType(context.ObjectType);
+                var wrapperProvider = WrapperProviderFactories.GetWrapperProvider(new WrapperProviderContext(
+                    declaredType: context.ObjectType,
+                    isSerialization: true));
 
-                // Wrap the object only if there is a wrapping type.
-                if (wrappingType != null && wrappingType != context.ObjectType)
+                value = wrapperProvider.Wrap(value);
+            }
+
+            var xmlSerializer = GetCachedSerializer(wrappingType);
+
+            using (var textWriter = context.WriterFactory(context.HttpContext.Response.Body, writerSettings.Encoding))
+            {
+                using (var xmlWriter = CreateXmlWriter(textWriter, writerSettings))
                 {
-                    var wrapperProvider = WrapperProviderFactories.GetWrapperProvider(new WrapperProviderContext(
-                        declaredType: context.ObjectType,
-                        isSerialization: true));
-
-                    value = wrapperProvider.Wrap(value);
+                    xmlSerializer.Serialize(xmlWriter, value);
                 }
-
-                var xmlSerializer = GetCachedSerializer(wrappingType);
-                xmlSerializer.Serialize(xmlWriter, value);
             }
 
             return TaskCache.CompletedTask;

--- a/src/Microsoft.AspNet.Mvc.Formatters.Xml/XmlSerializerOutputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Formatters.Xml/XmlSerializerOutputFormatter.cs
@@ -169,7 +169,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
                 if (wrappingType != null && wrappingType != context.ObjectType)
                 {
                     var wrapperProvider = WrapperProviderFactories.GetWrapperProvider(new WrapperProviderContext(
-                        declaredType: wrappingType,
+                        declaredType: context.ObjectType,
                         isSerialization: true));
 
                     value = wrapperProvider.Wrap(value);

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
@@ -46,6 +46,9 @@ namespace Microsoft.AspNet.Mvc.Razor
             _writerScopes = new Stack<TextWriter>();
         }
 
+        /// <summary>
+        /// An <see cref="HttpContext"/> representing the current request execution.
+        /// </summary>
         public HttpContext Context
         {
             get
@@ -81,7 +84,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         public IPageExecutionContext PageExecutionContext { get; set; }
 
         /// <summary>
-        /// Gets the TextWriter that the page is writing output to.
+        /// Gets the <see cref="TextWriter"/> that the page is writing output to.
         /// </summary>
         public virtual TextWriter Output
         {
@@ -97,6 +100,9 @@ namespace Microsoft.AspNet.Mvc.Razor
             }
         }
 
+        /// <summary>
+        /// Gets the <see cref="ClaimsPrincipal"/> of the current logged in user.
+        /// </summary>
         public virtual ClaimsPrincipal User
         {
             get
@@ -110,6 +116,9 @@ namespace Microsoft.AspNet.Mvc.Razor
             }
         }
 
+        /// <summary>
+        /// Gets the dynamic view data dictionary.
+        /// </summary>
         public dynamic ViewBag
         {
             get
@@ -821,6 +830,10 @@ namespace Microsoft.AspNet.Mvc.Razor
             EndContext();
         }
 
+        /// <summary>
+        /// In a Razor layout page, renders the portion of a content page that is not within a named section.
+        /// </summary>
+        /// <returns>The HTML content to render.</returns>
         protected virtual HelperResult RenderBody()
         {
             if (RenderBodyDelegateAsync == null)
@@ -858,6 +871,11 @@ namespace Microsoft.AspNet.Mvc.Razor
             SectionWriters[name] = section;
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether the specified section is defined in the content page.
+        /// </summary>
+        /// <param name="name">The section name to search for.</param>
+        /// <returns><c>true</c> if the specified section is defined in the content page; otherwise, <c>false</c>.</returns>
         public bool IsSectionDefined(string name)
         {
             if (name == null)

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorPageOfT.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorPageOfT.cs
@@ -19,6 +19,9 @@ namespace Microsoft.AspNet.Mvc.Razor
     {
         private IModelMetadataProvider _provider;
 
+        /// <summary>
+        /// Gets the Model property of the <see cref="ViewData"/> property.
+        /// </summary>
         public TModel Model
         {
             get
@@ -27,6 +30,9 @@ namespace Microsoft.AspNet.Mvc.Razor
             }
         }
 
+        /// <summary>
+        /// Gets or sets the dictionary for view data.
+        /// </summary>
         [RazorInject]
         public ViewDataDictionary<TModel> ViewData { get; set; }
 

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/MultiSelectList.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/MultiSelectList.cs
@@ -10,6 +10,11 @@ using Microsoft.AspNet.Mvc.ViewFeatures;
 
 namespace Microsoft.AspNet.Mvc.Rendering
 {
+    /// <summary>
+    /// Represents a list that lets users select multiple items.
+    /// This class is typically rendered as an HTML <code>&lt;select multiple="multiple"&gt;</code> element with the specified collection
+    /// of <see cref="SelectListItem"/> objects.
+    /// </summary>
     public class MultiSelectList : IEnumerable<SelectListItem>
     {
         private IList<SelectListGroup> _groups;

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/SelectList.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/SelectList.cs
@@ -6,6 +6,11 @@ using System.Collections;
 
 namespace Microsoft.AspNet.Mvc.Rendering
 {
+    /// <summary>
+    /// Represents a list that lets users select a single item.
+    /// This class is typically rendered as an HTML <code>&lt;select&gt;</code> element with the specified collection
+    /// of <see cref="SelectListItem"/> objects.
+    /// </summary>
     public class SelectList : MultiSelectList
     {
         public SelectList(IEnumerable items)

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/SelectListItem.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/SelectListItem.cs
@@ -3,10 +3,17 @@
 
 namespace Microsoft.AspNet.Mvc.Rendering
 {
+    /// <summary>
+    /// Represents an item in a <see cref="SelectList"/> or <see cref="MultiSelectList"/>.
+    /// This class is typically rendered as an HTML <code>&lt;option&gt;</code> element with the specified
+    /// attribute values.
+    /// </summary>
     public class SelectListItem
     {
         /// <summary>
         /// Gets or sets a value that indicates whether this <see cref="SelectListItem"/> is disabled.
+        /// This property is typically rendered as a <code>disabled="disabled"</code> attribute in the HTML
+        /// <code>&lt;option&gt;</code> element.
         /// </summary>
         public bool Disabled { get; set; }
 
@@ -17,10 +24,24 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// </summary>
         public SelectListGroup Group { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value that indicates whether this <see cref="SelectListItem"/> is selected.
+        /// This property is typically rendered as a <code>selected="selected"</code> attribute in the HTML
+        /// <code>&lt;option&gt;</code> element.
+        /// </summary>
         public bool Selected { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value that indicates the display text of this <see cref="SelectListItem"/>.
+        /// This property is typically rendered as the inner HTML in the HTML <code>&lt;option&gt;</code> element.
+        /// </summary>
         public string Text { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value that indicates the value of this <see cref="SelectListItem"/>.
+        /// This property is typically rendered as a <code>value="..."</code> attribute in the HTML
+        /// <code>&lt;option&gt;</code> element.
+        /// </summary>
         public string Value { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/TagBuilder.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/TagBuilder.cs
@@ -14,11 +14,19 @@ using Microsoft.Extensions.WebEncoders;
 
 namespace Microsoft.AspNet.Mvc.Rendering
 {
+    /// <summary>
+    /// Contains methods and properties that are used to create HTML elements. This class is often used to write HTML
+    /// helpers and tag helpers.
+    /// </summary>
     [DebuggerDisplay("{DebuggerToString()}")]
     public class TagBuilder : IHtmlContent
     {
         private AttributeDictionary _attributes;
 
+        /// <summary>
+        /// Creates a new HTML tag that has the specified tag name.
+        /// </summary>
+        /// <param name="tagName">An HTML tag name.</param>
         public TagBuilder(string tagName)
         {
             if (string.IsNullOrEmpty(tagName))
@@ -47,8 +55,14 @@ namespace Microsoft.AspNet.Mvc.Rendering
             }
         }
 
+        /// <summary>
+        /// Gets the inner HTML content of the element.
+        /// </summary>
         public IHtmlContentBuilder InnerHtml { get; }
 
+        /// <summary>
+        /// Gets the tag name for this tag.
+        /// </summary>
         public string TagName { get; }
 
         /// <summary>
@@ -57,6 +71,12 @@ namespace Microsoft.AspNet.Mvc.Rendering
         /// <remarks>Defaults to <see cref="TagRenderMode.Normal"/>.</remarks>
         public TagRenderMode TagRenderMode { get; set; } = TagRenderMode.Normal;
 
+        /// <summary>
+        /// Adds a CSS class to the list of CSS classes in the tag.
+        /// If there are already CSS classes on the tag then a space character and the new class will be appended to
+        /// the existing list.
+        /// </summary>
+        /// <param name="value">The CSS class name to add.</param>
         public void AddCssClass(string value)
         {
             string currentValue;
@@ -144,16 +164,24 @@ namespace Microsoft.AspNet.Mvc.Rendering
             return stringBuffer.ToString();
         }
 
-        public void GenerateId(string name, string idAttributeDotReplacement)
+        /// <summary>
+        /// Generates a sanitized ID attribute for the tag by using the specified name.
+        /// </summary>
+        /// <param name="name">The name to use to generate an ID attribute.</param>
+        /// <param name="invalidCharReplacement">
+        /// The <see cref="string"/> (normally a single <see cref="char"/>) to substitute for invalid characters in
+        /// <paramref name="name"/>.
+        /// </param>
+        public void GenerateId(string name, string invalidCharReplacement)
         {
-            if (idAttributeDotReplacement == null)
+            if (invalidCharReplacement == null)
             {
-                throw new ArgumentNullException(nameof(idAttributeDotReplacement));
+                throw new ArgumentNullException(nameof(invalidCharReplacement));
             }
 
             if (!Attributes.ContainsKey("id"))
             {
-                var sanitizedId = CreateSanitizedId(name, idAttributeDotReplacement);
+                var sanitizedId = CreateSanitizedId(name, invalidCharReplacement);
                 if (!string.IsNullOrEmpty(sanitizedId))
                 {
                     Attributes["id"] = sanitizedId;

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ValidateAntiForgeryTokenAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ValidateAntiForgeryTokenAttribute.cs
@@ -9,6 +9,14 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNet.Mvc
 {
+    /// <summary>
+    /// Specifies that the class or method that this attribute is applied validates the anti-forgery token.
+    /// If the anti-forgery token is not available, or if the token is invalid, the validation will fail
+    /// and the action method will not execute.
+    /// </summary>
+    /// <remarks>
+    /// This attribute helps defend against cross-site request forgery. It won't prevent other forgery or tampering attacks.
+    /// </remarks>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public class ValidateAntiForgeryTokenAttribute : Attribute, IFilterFactory, IOrderedFilter
     {

--- a/src/Microsoft.AspNet.Mvc/MvcServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc/MvcServiceCollectionExtensions.cs
@@ -7,8 +7,16 @@ using Microsoft.AspNet.Mvc.Internal;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
+    /// <summary>
+    /// Extension methods for setting up MVC services in an <see cref="IServiceCollection" />.
+    /// </summary>
     public static class MvcServiceCollectionExtensions
     {
+        /// <summary>
+        /// Adds MVC services to the specified <see cref="IServiceCollection" />.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+        /// <returns>A reference to this instance after the operation has completed.</returns>
         public static IMvcBuilder AddMvc(this IServiceCollection services)
         {
             if (services == null)
@@ -19,6 +27,12 @@ namespace Microsoft.Extensions.DependencyInjection
             return AddMvc(services, setupAction: null);
         }
 
+        /// <summary>
+        /// Adds MVC services to the specified <see cref="IServiceCollection" />.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+        /// <param name="setupAction">An action delegate to configure the provided <see cref="MvcOptions"/>.</param>
+        /// <returns>A reference to this instance after the operation has completed.</returns>
         public static IMvcBuilder AddMvc(this IServiceCollection services, Action<MvcOptions> setupAction)
         {
             if (services == null)

--- a/test/Microsoft.AspNet.Mvc.Core.Test/CreatedAtActionResultTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/CreatedAtActionResultTests.cs
@@ -98,6 +98,7 @@ namespace Microsoft.AspNet.Mvc
             services.AddInstance(new ObjectResultExecutor(
                 options,
                 new ActionBindingContextAccessor(),
+                new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));
 
             return services.BuildServiceProvider();

--- a/test/Microsoft.AspNet.Mvc.Core.Test/CreatedAtRouteResultTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/CreatedAtRouteResultTests.cs
@@ -112,6 +112,7 @@ namespace Microsoft.AspNet.Mvc
             services.AddInstance(new ObjectResultExecutor(
                 options,
                 new ActionBindingContextAccessor(),
+                new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));
 
             return services.BuildServiceProvider();

--- a/test/Microsoft.AspNet.Mvc.Core.Test/CreatedResultTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/CreatedResultTests.cs
@@ -99,6 +99,7 @@ namespace Microsoft.AspNet.Mvc
             services.AddInstance(new ObjectResultExecutor(
                 options,
                 new ActionBindingContextAccessor(),
+                new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));
 
             return services.BuildServiceProvider();

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/NoContentFormatterTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/NoContentFormatterTests.cs
@@ -43,7 +43,11 @@ namespace Microsoft.AspNet.Mvc.Formatters
             var type = declaredTypeAsString ? typeof(string) : typeof(object);
             var contentType = useNonNullContentType ? MediaTypeHeaderValue.Parse("text/plain") : null;
 
-            var context = new OutputFormatterWriteContext(new DefaultHttpContext(), type, value)
+            var context = new OutputFormatterWriteContext(
+                new DefaultHttpContext(),
+                new TestHttpResponseStreamWriterFactory().CreateWriter,
+                type,
+                value)
             {
                 ContentType = contentType,
             };
@@ -65,6 +69,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
             // Arrange
             var context = new OutputFormatterWriteContext(
                 new DefaultHttpContext(),
+                new TestHttpResponseStreamWriterFactory().CreateWriter,
                 declaredType,
                 "Something non null.")
             {
@@ -92,6 +97,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
             // Arrange
             var context = new OutputFormatterWriteContext(
                 new DefaultHttpContext(),
+                new TestHttpResponseStreamWriterFactory().CreateWriter,
                 typeof(string),
                 value)
             {
@@ -114,7 +120,11 @@ namespace Microsoft.AspNet.Mvc.Formatters
         public async Task WriteAsync_WritesTheStatusCode204()
         {
             // Arrange
-            var context = new OutputFormatterWriteContext(new DefaultHttpContext(), typeof(string), @object: null);
+            var context = new OutputFormatterWriteContext(
+                new DefaultHttpContext(),
+                new TestHttpResponseStreamWriterFactory().CreateWriter,
+                typeof(string),
+                @object: null);
 
             var formatter = new HttpNoContentOutputFormatter();
 
@@ -132,7 +142,11 @@ namespace Microsoft.AspNet.Mvc.Formatters
             var httpContext = new DefaultHttpContext();
             httpContext.Response.StatusCode = StatusCodes.Status201Created;
 
-            var context = new OutputFormatterWriteContext(httpContext, typeof(string), @object: null);
+            var context = new OutputFormatterWriteContext(
+                httpContext,
+                new TestHttpResponseStreamWriterFactory().CreateWriter,
+                typeof(string),
+                @object: null);
 
             var formatter = new HttpNoContentOutputFormatter();
 

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/OutputFormatterTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/OutputFormatterTests.cs
@@ -53,7 +53,11 @@ namespace Microsoft.AspNet.Mvc.Formatters
                 formatter.SupportedEncodings.Add(Encoding.GetEncoding(supportedEncoding));
             }
 
-            var context = new OutputFormatterWriteContext(httpContext.Object, typeof(string), "someValue")
+            var context = new OutputFormatterWriteContext(
+                httpContext.Object,
+                new TestHttpResponseStreamWriterFactory().CreateWriter,
+                typeof(string),
+                "someValue")
             {
                 ContentType = MediaTypeHeaderValue.Parse(httpRequest.Headers[HeaderNames.Accept]),
             };
@@ -77,7 +81,11 @@ namespace Microsoft.AspNet.Mvc.Formatters
             formatter.SupportedMediaTypes.Clear();
             formatter.SupportedMediaTypes.Add(testContentType);
 
-            var context = new OutputFormatterWriteContext(new DefaultHttpContext(), objectType: null, @object: null)
+            var context = new OutputFormatterWriteContext(
+                new DefaultHttpContext(),
+                new TestHttpResponseStreamWriterFactory().CreateWriter,
+                objectType: null,
+                @object: null)
             {
                 ContentType = testContentType,
             };
@@ -102,7 +110,11 @@ namespace Microsoft.AspNet.Mvc.Formatters
             var mediaType = new MediaTypeHeaderValue("image/png");
             formatter.SupportedMediaTypes.Add(mediaType);
 
-            var context = new OutputFormatterWriteContext(new DefaultHttpContext(), objectType: null, @object: null);
+            var context = new OutputFormatterWriteContext(
+                new DefaultHttpContext(),
+                new TestHttpResponseStreamWriterFactory().CreateWriter,
+                objectType: null,
+                @object: null);
 
             // Act
             await formatter.WriteAsync(context);
@@ -117,7 +129,12 @@ namespace Microsoft.AspNet.Mvc.Formatters
         public void CanWriteResult_ForNullContentType_UsesFirstEntryInSupportedContentTypes()
         {
             // Arrange
-            var context = new OutputFormatterWriteContext(new DefaultHttpContext(), objectType: null, @object: null);
+            var context = new OutputFormatterWriteContext(
+                new DefaultHttpContext(),
+                new TestHttpResponseStreamWriterFactory().CreateWriter,
+                objectType: null,
+                @object: null);
+
             var formatter = new TestOutputFormatter();
 
             // Act

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/StringOutputFormatterTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/StringOutputFormatterTests.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Internal;
+using Microsoft.Net.Http.Headers;
 using Moq;
 using Xunit;
 
@@ -20,7 +21,6 @@ namespace Microsoft.AspNet.Mvc.Formatters
             {
                 // object value, bool useDeclaredTypeAsString, bool expectedCanWriteResult
                 yield return new object[] { "valid value", true, true };
-                yield return new object[] { "valid value", false, true };
                 yield return new object[] { null, true, true };
                 yield return new object[] { null, false, false };
                 yield return new object[] { new object(), false, false };
@@ -35,15 +35,22 @@ namespace Microsoft.AspNet.Mvc.Formatters
             bool expectedCanWriteResult)
         {
             // Arrange
+            var expectedContentType = expectedCanWriteResult ? 
+                MediaTypeHeaderValue.Parse("text/plain") :
+                MediaTypeHeaderValue.Parse("application/json");
+
             var formatter = new StringOutputFormatter();
             var type = useDeclaredTypeAsString ? typeof(string) : typeof(object);
+
             var context = new OutputFormatterWriteContext(new DefaultHttpContext(), type, value);
+            context.ContentType = MediaTypeHeaderValue.Parse("application/json");
 
             // Act
             var result = formatter.CanWriteResult(context);
 
             // Assert
             Assert.Equal(expectedCanWriteResult, result);
+            Assert.Equal(expectedContentType, context.ContentType);
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Mvc.Core.Test/HttpNotFoundObjectResultTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/HttpNotFoundObjectResultTest.cs
@@ -75,6 +75,7 @@ namespace Microsoft.AspNet.Mvc
             services.AddInstance(new ObjectResultExecutor(
                 options,
                 new ActionBindingContextAccessor(),
+                new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));
 
             return services.BuildServiceProvider();

--- a/test/Microsoft.AspNet.Mvc.Core.Test/HttpOkObjectResultTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/HttpOkObjectResultTest.cs
@@ -79,6 +79,7 @@ namespace Microsoft.AspNet.Mvc
             services.AddInstance(new ObjectResultExecutor(
                 options,
                 new ActionBindingContextAccessor(),
+                new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));
 
             return services.BuildServiceProvider();

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Infrastructure/ObjectResultExecutorTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Infrastructure/ObjectResultExecutorTest.cs
@@ -31,7 +31,12 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
                 new TestJsonOutputFormatter(), // This will be chosen based on the accept header
             };
 
-            var context = new OutputFormatterWriteContext(new DefaultHttpContext(), objectType: null, @object: null);
+            var context = new OutputFormatterWriteContext(
+                new DefaultHttpContext(),
+                new TestHttpResponseStreamWriterFactory().CreateWriter,
+                objectType: null,
+                @object: null);
+
             context.HttpContext.Request.Headers[HeaderNames.Accept] = "application/json";
 
             // Act
@@ -57,7 +62,12 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
                 new TestJsonOutputFormatter(), // This will be chosen based on the content type
             };
 
-            var context = new OutputFormatterWriteContext(new DefaultHttpContext(), objectType: null, @object: null);
+            var context = new OutputFormatterWriteContext(
+                new DefaultHttpContext(),
+                new TestHttpResponseStreamWriterFactory().CreateWriter,
+                objectType: null,
+                @object: null);
+
             context.HttpContext.Request.Headers[HeaderNames.Accept] = "application/xml"; // This will not be used
 
             // Act
@@ -82,7 +92,12 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
                 new TestXmlOutputFormatter(),
             };
 
-            var context = new OutputFormatterWriteContext(new DefaultHttpContext(), objectType: null, @object: null);
+            var context = new OutputFormatterWriteContext(
+                new DefaultHttpContext(),
+                new TestHttpResponseStreamWriterFactory().CreateWriter,
+                objectType: null,
+                @object: null);
+
             context.HttpContext.Request.Headers[HeaderNames.Accept] = "application/xml"; // This will not be used
 
             // Act
@@ -149,7 +164,12 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
                 new TestJsonOutputFormatter(),
             };
 
-            var context = new OutputFormatterWriteContext(new DefaultHttpContext(), objectType: null, @object: null);
+            var context = new OutputFormatterWriteContext(
+                new DefaultHttpContext(),
+                new TestHttpResponseStreamWriterFactory().CreateWriter,
+                objectType: null,
+                @object: null);
+
             context.HttpContext.Request.Headers[HeaderNames.Accept] = acceptHeader;
 
             // Act
@@ -176,7 +196,11 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
                 new TestXmlOutputFormatter(),
             };
 
-            var context = new OutputFormatterWriteContext(new DefaultHttpContext(), objectType: null, @object: null);
+            var context = new OutputFormatterWriteContext(
+                new DefaultHttpContext(),
+                new TestHttpResponseStreamWriterFactory().CreateWriter,
+                objectType: null,
+                @object: null);
 
             // Act
             var formatter = executor.SelectFormatter(
@@ -202,7 +226,12 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
                 new TestJsonOutputFormatter(),
             };
 
-            var context = new OutputFormatterWriteContext(new DefaultHttpContext(), objectType: null, @object: null);
+            var context = new OutputFormatterWriteContext(
+                new DefaultHttpContext(),
+                new TestHttpResponseStreamWriterFactory().CreateWriter, 
+                objectType: null,
+                @object: null);
+
             context.HttpContext.Request.Headers[HeaderNames.Accept] = "text/custom, application/custom";
 
             // Act
@@ -414,6 +443,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             return new TestObjectResultExecutor(
                 options ?? new TestOptionsManager<MvcOptions>(),
                 bindingContextAccessor,
+                new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance);
         }
 
@@ -466,9 +496,10 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
         {
             public TestObjectResultExecutor(
                 IOptions<MvcOptions> options, 
-                IActionBindingContextAccessor bindingContextAccessor, 
+                IActionBindingContextAccessor bindingContextAccessor,
+                IHttpResponseStreamWriterFactory writerFactory,
                 ILoggerFactory loggerFactory) 
-                : base(options, bindingContextAccessor, loggerFactory)
+                : base(options, bindingContextAccessor, writerFactory, loggerFactory)
             {
             }
 

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ObjectResultTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ObjectResultTests.cs
@@ -67,6 +67,7 @@ namespace Microsoft.AspNet.Mvc
             services.AddInstance(new ObjectResultExecutor(
                 new TestOptionsManager<MvcOptions>(),
                 new ActionBindingContextAccessor(),
+                new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));
 
             return services.BuildServiceProvider();

--- a/test/Microsoft.AspNet.Mvc.Formatters.Json.Test/JsonOutputFormatterTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Formatters.Json.Test/JsonOutputFormatterTests.cs
@@ -175,6 +175,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
 
             var outputFormatterContext = new OutputFormatterWriteContext(
                 actionContext.HttpContext,
+                new TestHttpResponseStreamWriterFactory().CreateWriter,
                 typeof(string),
                 content)
             {
@@ -218,7 +219,11 @@ namespace Microsoft.AspNet.Mvc.Formatters
             var mediaTypeHeaderValue = MediaTypeHeaderValue.Parse(contentType);
 
             var actionContext = GetActionContext(mediaTypeHeaderValue, responseStream);
-            return new OutputFormatterWriteContext(actionContext.HttpContext, outputType, outputValue)
+            return new OutputFormatterWriteContext(
+                actionContext.HttpContext,
+                new TestHttpResponseStreamWriterFactory().CreateWriter,
+                outputType,
+                outputValue)
             {
                 ContentType = mediaTypeHeaderValue,
             };

--- a/test/Microsoft.AspNet.Mvc.Formatters.Xml.Test/XmlDataContractSerializerOutputFormatterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Formatters.Xml.Test/XmlDataContractSerializerOutputFormatterTest.cs
@@ -599,7 +599,11 @@ namespace Microsoft.AspNet.Mvc.Formatters.Xml
             Type outputType,
             string contentType = "application/xml; charset=utf-8")
         {
-            return new OutputFormatterWriteContext(GetHttpContext(contentType), outputType, outputValue);
+            return new OutputFormatterWriteContext(
+                GetHttpContext(contentType),
+                new TestHttpResponseStreamWriterFactory().CreateWriter,
+                outputType,
+                outputValue);
         }
 
         private static HttpContext GetHttpContext(string contentType)

--- a/test/Microsoft.AspNet.Mvc.Formatters.Xml.Test/XmlSerializerOutputFormatterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Formatters.Xml.Test/XmlSerializerOutputFormatterTest.cs
@@ -360,7 +360,11 @@ namespace Microsoft.AspNet.Mvc.Formatters.Xml
             Type outputType,
             string contentType = "application/xml; charset=utf-8")
         {
-            return new OutputFormatterWriteContext(GetHttpContext(contentType), outputType, outputValue);
+            return new OutputFormatterWriteContext(
+                GetHttpContext(contentType),
+                new TestHttpResponseStreamWriterFactory().CreateWriter,
+                outputType,
+                outputValue);
         }
 
         private static HttpContext GetHttpContext(string contentType)

--- a/test/Microsoft.AspNet.Mvc.Formatters.Xml.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.Formatters.Xml.Test/project.json
@@ -4,9 +4,11 @@
   },
   "dependencies": {
     "Microsoft.AspNet.Http": "1.0.0-*",
-    "Microsoft.AspNet.Mvc" : "6.0.0-*",
+    "Microsoft.AspNet.Mvc": "6.0.0-*",
     "Microsoft.AspNet.Mvc.Formatters.Xml" : "6.0.0-*",
+    "Microsoft.AspNet.Mvc.TestCommon": { "type": "build", "version": "6.0.0-*" },
     "Microsoft.AspNet.Testing": "1.0.0-*",
+    "Microsoft.Extensions.WebEncoders.Testing": "1.0.0-*",
     "Moq": "4.2.1312.1622",
     "xunit.runner.aspnet": "2.0.0-aspnet-*"
   },

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/Rendering/TagBuilderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/Rendering/TagBuilderTest.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNet.Mvc.Core.Rendering
             tagBuilder.Attributes.Add("ID", "something");
 
             // Act
-            tagBuilder.GenerateId("else", idAttributeDotReplacement: "-");
+            tagBuilder.GenerateId("else", invalidCharReplacement: "-");
 
             // Assert
             var attribute = Assert.Single(tagBuilder.Attributes);

--- a/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/BadRequestErrorMessageResultTest.cs
+++ b/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/BadRequestErrorMessageResultTest.cs
@@ -77,6 +77,7 @@ namespace System.Web.Http
             services.AddInstance(new ObjectResultExecutor(
                 options,
                 new ActionBindingContextAccessor(),
+                new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));
 
             return services.BuildServiceProvider();

--- a/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/ExceptionResultTest.cs
+++ b/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/ExceptionResultTest.cs
@@ -77,6 +77,7 @@ namespace System.Web.Http
             services.AddInstance(new ObjectResultExecutor(
                 options,
                 new ActionBindingContextAccessor(),
+                new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));
 
             return services.BuildServiceProvider();

--- a/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/HttpResponseMessageOutputFormatterTests.cs
+++ b/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/HttpResponseMessageOutputFormatterTests.cs
@@ -151,7 +151,11 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShimTest
             Type outputType,
             HttpContext httpContext)
         {
-            return new OutputFormatterWriteContext(httpContext, outputType, outputValue);
+            return new OutputFormatterWriteContext(
+                httpContext,
+                new TestHttpResponseStreamWriterFactory().CreateWriter,
+                outputType,
+                outputValue);
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/InvalidModelStateResultTest.cs
+++ b/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/InvalidModelStateResultTest.cs
@@ -90,6 +90,7 @@ namespace System.Web.Http
             services.AddInstance(new ObjectResultExecutor(
                 options,
                 new ActionBindingContextAccessor(),
+                new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));
 
             return services.BuildServiceProvider();

--- a/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/NegotiatedContentResultTest.cs
+++ b/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/NegotiatedContentResultTest.cs
@@ -77,6 +77,7 @@ namespace System.Web.Http
             services.AddInstance(new ObjectResultExecutor(
                 options,
                 new ActionBindingContextAccessor(),
+                new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));
 
             return services.BuildServiceProvider();

--- a/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/TestHttpResponseStreamWriterFactory.cs
+++ b/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/TestHttpResponseStreamWriterFactory.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Text;
+using Microsoft.AspNet.Mvc.Infrastructure;
+
+namespace Microsoft.AspNet.Mvc
+{
+    public class TestHttpResponseStreamWriterFactory : IHttpResponseStreamWriterFactory
+    {
+        public TextWriter CreateWriter(Stream stream, Encoding encoding)
+        {
+            return new HttpResponseStreamWriter(stream, encoding);
+        }
+    }
+}


### PR DESCRIPTION
Allocation data from 3000 request to a simple API site. Post JSON -> Return 201 Created with JSON.

**Before**
![image](https://cloud.githubusercontent.com/assets/1430011/10614166/9c0ab72c-770d-11e5-9992-6dd1bbce7064.png)

**After**
![image](https://cloud.githubusercontent.com/assets/1430011/10614173/ab128dbc-770d-11e5-98f9-14a2b5824ce2.png)

The overall reduction in allocations here is about 16mb - based on a total of 106mb. The vast majority of the remaining `char[]` and `byte[]` allocations come from input formatters, which I'll address next.