### PR TITLE
Fixes for failing OutputFormatter functional tests

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/Formatters/StringOutputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Formatters/StringOutputFormatter.cs
@@ -31,13 +31,9 @@ namespace Microsoft.AspNet.Mvc.Formatters
 
             // Ignore the passed in content type, if the object is string
             // always return it as a text/plain format.
-            if (context.ObjectType == typeof(string))
+            if (context.ObjectType == typeof(string) || context.Object is string)
             {
-                return true;
-            }
-
-            if (context.Object is string)
-            {
+                context.ContentType = SupportedMediaTypes[0];
                 return true;
             }
 

--- a/src/Microsoft.AspNet.Mvc.Formatters.Xml/XmlSerializerOutputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Formatters.Xml/XmlSerializerOutputFormatter.cs
@@ -169,7 +169,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
                 if (wrappingType != null && wrappingType != context.ObjectType)
                 {
                     var wrapperProvider = WrapperProviderFactories.GetWrapperProvider(new WrapperProviderContext(
-                        declaredType: wrappingType,
+                        declaredType: context.ObjectType,
                         isSerialization: true));
 
                     value = wrapperProvider.Wrap(value);

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/StringOutputFormatterTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/StringOutputFormatterTests.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Internal;
+using Microsoft.Net.Http.Headers;
 using Moq;
 using Xunit;
 
@@ -20,7 +21,6 @@ namespace Microsoft.AspNet.Mvc.Formatters
             {
                 // object value, bool useDeclaredTypeAsString, bool expectedCanWriteResult
                 yield return new object[] { "valid value", true, true };
-                yield return new object[] { "valid value", false, true };
                 yield return new object[] { null, true, true };
                 yield return new object[] { null, false, false };
                 yield return new object[] { new object(), false, false };
@@ -35,15 +35,22 @@ namespace Microsoft.AspNet.Mvc.Formatters
             bool expectedCanWriteResult)
         {
             // Arrange
+            var expectedContentType = expectedCanWriteResult ? 
+                MediaTypeHeaderValue.Parse("text/plain") :
+                MediaTypeHeaderValue.Parse("application/json");
+
             var formatter = new StringOutputFormatter();
             var type = useDeclaredTypeAsString ? typeof(string) : typeof(object);
+
             var context = new OutputFormatterWriteContext(new DefaultHttpContext(), type, value);
+            context.ContentType = MediaTypeHeaderValue.Parse("application/json");
 
             // Act
             var result = formatter.CanWriteResult(context);
 
             // Assert
             Assert.Equal(expectedCanWriteResult, result);
+            Assert.Equal(expectedContentType, context.ContentType);
         }
 
         [Fact]


### PR DESCRIPTION
The missing piece here is is that StringOutputFormatter needs to set the
ContentType so that it gets overridden. The problem is that the formatter
is likely called with something like application/json, but decides to
write a string anyway. So because we're saying 'yes we can write' we also
need to override what we're writing.