### PR TITLE
Transition `SelectTagHelper` and `OptionTagHelper` to use `context.Items`.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.TagHelpers/OptionTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/OptionTagHelper.cs
@@ -54,8 +54,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 
         /// <inheritdoc />
         /// <remarks>
-        /// Does nothing unless <see cref="FormContext.FormData"/> contains a
-        /// <see cref="SelectTagHelper.SelectedValuesFormDataKey"/> entry and that entry is a non-empty
+        /// Does nothing unless <see cref="TagHelperContext.Items"/> contains a
+        /// <see cref="SelectTagHelper"/> <see cref="Type"/> entry and that entry is a non-empty
         /// <see cref="ICollection{string}"/> instance. Also does nothing if the associated &lt;option&gt; is already
         /// selected.
         /// </remarks>
@@ -82,9 +82,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             {
                 // Is this <option/> element a child of a <select/> element the SelectTagHelper targeted?
                 object formDataEntry;
-                ViewContext.FormContext.FormData.TryGetValue(
-                    SelectTagHelper.SelectedValuesFormDataKey,
-                    out formDataEntry);
+                context.Items.TryGetValue(typeof(SelectTagHelper), out formDataEntry);
 
                 // ... And did the SelectTagHelper determine any selected values?
                 var selectedValues = formDataEntry as ICollection<string>;

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/RenderAtEndOfFormTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/RenderAtEndOfFormTagHelper.cs
@@ -27,6 +27,11 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         /// <inheritdoc />
         public override void Init(TagHelperContext context)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
             // Push the new FormContext.
             ViewContext.FormContext = new FormContext
             {

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Order.Encoded.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Order.Encoded.html
@@ -41,6 +41,9 @@
                 <option value="HtmlEncode[[Credit]]">Credit</option>
                 <option value="HtmlEncode[[Check]]" selected="HtmlEncode[[selected]]">Check</option>
             </select>
+            <select>
+                <option value="HtmlEncode[[Check]]">Check</option>
+            </select>
         </div>
         <div>
             <label class="order" for="HtmlEncode[[Customer_Number]]">HtmlEncode[[Number]]</label>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Order.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Order.html
@@ -41,6 +41,9 @@
                 <option value="Credit">Credit</option>
                 <option value="Check" selected="selected">Check</option>
             </select>
+            <select>
+                <option value="Check">Check</option>
+            </select>
         </div>
         <div>
             <label class="order" for="Customer_Number">Number</label>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.OrderUsingHtmlHelpers.Encoded.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.OrderUsingHtmlHelpers.Encoded.html
@@ -40,6 +40,9 @@
             <select id="HtmlEncode[[PaymentMethod]]" multiple="HtmlEncode[[multiple]]" name="HtmlEncode[[PaymentMethod]]"><option value="HtmlEncode[[Credit]]">HtmlEncode[[Credit]]</option>
 <option selected="HtmlEncode[[selected]]" value="HtmlEncode[[Check]]">HtmlEncode[[Check]]</option>
 </select>
+            <select>
+                <option value="Check">Check</option>
+            </select>
         </div>
         <div>
             <label class="HtmlEncode[[order]]" for="HtmlEncode[[Customer_Number]]">HtmlEncode[[Number]]</label>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.OrderUsingHtmlHelpers.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.OrderUsingHtmlHelpers.html
@@ -40,6 +40,9 @@
             <select id="PaymentMethod" multiple="multiple" name="PaymentMethod"><option value="Credit">Credit</option>
 <option selected="selected" value="Check">Check</option>
 </select>
+            <select>
+                <option value="Check">Check</option>
+            </select>
         </div>
         <div>
             <label class="order" for="Customer_Number">Number</label>

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/OptionTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/OptionTagHelperTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
 {
     public class OptionTagHelperTest
     {
-        // Original content, selected attribute, value attribute, selected values (to place in FormContext.FormData)
+        // Original content, selected attribute, value attribute, selected values (to place in TagHelperContext.Items)
         // and expected tag helper output.
         public static TheoryData<string, string, string, IEnumerable<string>, TagHelperOutput> GeneratesExpectedDataSet
         {
@@ -346,7 +346,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             }
         }
 
-        // Original content, selected attribute, value attribute, selected values (to place in FormContext.FormData)
+        // Original content, selected attribute, value attribute, selected values (to place in TagHelperContext.Items)
         // and expected output (concatenation of TagHelperOutput generations). Excludes non-null selected attribute,
         // null selected values, and empty selected values cases.
         public static IEnumerable<object[]> DoesNotUseGeneratorDataSet
@@ -358,7 +358,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             }
         }
 
-        // Original content, selected attribute, value attribute, selected values (to place in FormContext.FormData)
+        // Original content, selected attribute, value attribute, selected values (to place in TagHelperContext.Items)
         // and expected output (concatenation of TagHelperOutput generations). Excludes non-null selected attribute
         // cases.
         public static IEnumerable<object[]> DoesNotUseViewContextDataSet
@@ -420,7 +420,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 model: null,
                 htmlGenerator: htmlGenerator,
                 metadataProvider: metadataProvider);
-            viewContext.FormContext.FormData[SelectTagHelper.SelectedValuesFormDataKey] = selectedValues;
+            tagHelperContext.Items[typeof(SelectTagHelper)] = selectedValues;
             var tagHelper = new OptionTagHelper(htmlGenerator)
             {
                 Value = value,
@@ -491,7 +491,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 model: null,
                 htmlGenerator: htmlGenerator,
                 metadataProvider: metadataProvider);
-            viewContext.FormContext.FormData[SelectTagHelper.SelectedValuesFormDataKey] = selectedValues;
+            tagHelperContext.Items[typeof(SelectTagHelper)] = selectedValues;
             var tagHelper = new OptionTagHelper(htmlGenerator)
             {
                 Value = value,

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/SelectTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/SelectTagHelperTest.cs
@@ -235,6 +235,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             };
 
             // Act
+            tagHelper.Init(tagHelperContext);
             await tagHelper.ProcessAsync(tagHelperContext, output);
 
             // Assert
@@ -245,10 +246,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal(expectedPostContent, output.PostContent.GetContent());
             Assert.Equal(expectedTagName, output.TagName);
 
-            Assert.NotNull(viewContext.FormContext?.FormData);
             Assert.Single(
-                viewContext.FormContext.FormData,
-                entry => entry.Key == SelectTagHelper.SelectedValuesFormDataKey);
+                tagHelperContext.Items,
+                entry => (Type)entry.Key == typeof(SelectTagHelper));
         }
 
         [Theory]
@@ -333,6 +333,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             };
 
             // Act
+            tagHelper.Init(tagHelperContext);
             await tagHelper.ProcessAsync(tagHelperContext, output);
 
             // Assert
@@ -343,10 +344,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal(expectedPostContent, HtmlContentUtilities.HtmlContentToString(output.PostContent));
             Assert.Equal(expectedTagName, output.TagName);
 
-            Assert.NotNull(viewContext.FormContext?.FormData);
             Assert.Single(
-                viewContext.FormContext.FormData,
-                entry => entry.Key == SelectTagHelper.SelectedValuesFormDataKey);
+                tagHelperContext.Items,
+                entry => (Type)entry.Key == typeof(SelectTagHelper));
 
             Assert.Equal(savedDisabled, items.Select(item => item.Disabled));
             Assert.Equal(savedGroup, items.Select(item => item.Group));
@@ -429,7 +429,6 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var savedSelected = items.Select(item => item.Selected).ToList();
             var savedText = items.Select(item => item.Text).ToList();
             var savedValue = items.Select(item => item.Value).ToList();
-
             var tagHelper = new SelectTagHelper(htmlGenerator)
             {
                 For = modelExpression,
@@ -438,6 +437,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             };
 
             // Act
+            tagHelper.Init(tagHelperContext);
             await tagHelper.ProcessAsync(tagHelperContext, output);
 
             // Assert
@@ -448,10 +448,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             Assert.Equal(expectedPostContent, HtmlContentUtilities.HtmlContentToString(output.PostContent));
             Assert.Equal(expectedTagName, output.TagName);
 
-            Assert.NotNull(viewContext.FormContext?.FormData);
             Assert.Single(
-                viewContext.FormContext.FormData,
-                entry => entry.Key == SelectTagHelper.SelectedValuesFormDataKey);
+                tagHelperContext.Items,
+                entry => (Type)entry.Key == typeof(SelectTagHelper));
 
             Assert.Equal(savedDisabled, items.Select(item => item.Disabled));
             Assert.Equal(savedGroup, items.Select(item => item.Group));
@@ -536,15 +535,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             };
 
             // Act
+            tagHelper.Init(tagHelperContext);
             await tagHelper.ProcessAsync(tagHelperContext, output);
 
             // Assert
             htmlGenerator.Verify();
 
-            Assert.NotNull(viewContext.FormContext?.FormData);
             var keyValuePair = Assert.Single(
-                viewContext.FormContext.FormData,
-                entry => entry.Key == SelectTagHelper.SelectedValuesFormDataKey);
+                tagHelperContext.Items,
+                entry => (Type)entry.Key == typeof(SelectTagHelper));
             Assert.Same(currentValues, keyValuePair.Value);
         }
 
@@ -610,15 +609,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             };
 
             // Act
+            tagHelper.Init(tagHelperContext);
             await tagHelper.ProcessAsync(tagHelperContext, output);
 
             // Assert
             htmlGenerator.Verify();
 
-            Assert.NotNull(viewContext.FormContext?.FormData);
             var keyValuePair = Assert.Single(
-                viewContext.FormContext.FormData,
-                entry => entry.Key == SelectTagHelper.SelectedValuesFormDataKey);
+                tagHelperContext.Items,
+                entry => (Type)entry.Key == typeof(SelectTagHelper));
             Assert.Same(currentValues, keyValuePair.Value);
         }
 

--- a/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Order.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Order.cshtml
@@ -52,6 +52,9 @@
                 <option value="Credit">Credit</option>
                 <option value="Check">Check</option>
             </select>
+            <select>
+                <option value="Check">Check</option>
+            </select>
         </div>
         <div>
             <label asp-for="Customer.Number" class="order"></label>

--- a/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/OrderUsingHtmlHelpers.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/OrderUsingHtmlHelpers.cshtml
@@ -43,6 +43,9 @@ Html.BeginForm(actionName: "Submit", controllerName: "HtmlGeneration_Order"))
         <div>
             @Html.LabelFor(m => m.PaymentMethod, htmlAttributes: new { @class = "order" })
             @Html.ListBoxFor(m => m.PaymentMethod, selectList: new SelectList(new[] { new { value = "Credit" }, new { value = "Check" } }, dataValueField: "value", dataTextField: "value"))
+            <select>
+                <option value="Check">Check</option>
+            </select>
         </div>
         <div>
             @Html.LabelFor(m => m.Customer.Number, htmlAttributes: new { @class = "order" })


### PR DESCRIPTION
- Added functional tests to validate data created from a `SelectTagHelper` does not impact following `<select>` tags.

#3347