### PR TITLE
Transition from `IAssemblyLoadContext` to `AssemblyLoadContext`.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/project.json
+++ b/src/Microsoft.AspNet.Mvc.Razor/project.json
@@ -41,6 +41,7 @@
     "dotnet5.4": {
       "dependencies": {
         "System.Text.Encoding": "4.0.11-*",
+        "System.Runtime.Loader": "4.0.0-*",
         "System.Threading.Tasks.Parallel": "4.0.1-beta-*"
       }
     }


### PR DESCRIPTION
- `IAssemblyLoadContext` is a DNX defined type that will eventually go away.

#3365