### PR TITLE
Using IsDefined over GetCustomAttribute<T>

### DIFF
--- a/src/Microsoft.AspNet.Mvc.DataAnnotations/DataAnnotationsMetadataProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.DataAnnotations/DataAnnotationsMetadataProvider.cs
@@ -112,8 +112,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
                 displayMetadata.IsEnum = true;
 
                 // IsFlagsEnum
-                displayMetadata.IsFlagsEnum =
-                    underlyingTypeInfo.GetCustomAttribute<FlagsAttribute>(inherit: false) != null;
+                displayMetadata.IsFlagsEnum = underlyingTypeInfo.IsDefined(typeof(FlagsAttribute), inherit: false);
 
                 // EnumDisplayNamesAndValues and EnumNamesAndValues
                 //

--- a/src/Microsoft.AspNet.Mvc.Formatters.Xml/ModelBinding/DataMemberRequiredBindingMetadataProvider.cs
+++ b/src/Microsoft.AspNet.Mvc.Formatters.Xml/ModelBinding/DataMemberRequiredBindingMetadataProvider.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
 
             // isDataContract == true iff the container type has at least one DataContractAttribute
             var containerType = context.Key.ContainerType.GetTypeInfo();
-            var isDataContract = containerType.GetCustomAttribute<DataContractAttribute>() != null;
+            var isDataContract = containerType.IsDefined(typeof(DataContractAttribute));
             if (isDataContract)
             {
                 // We don't need to add a validator, just to set IsRequired = true. The validation

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewComponents/ViewComponentConventions.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewComponents/ViewComponentConventions.cs
@@ -89,7 +89,7 @@ namespace Microsoft.AspNet.Mvc.ViewComponents
 
             return
                 typeInfo.Name.EndsWith(ViewComponentSuffix, StringComparison.OrdinalIgnoreCase) ||
-                typeInfo.GetCustomAttribute<ViewComponentAttribute>() != null;
+                typeInfo.IsDefined(typeof(ViewComponentAttribute));
         }
     }
 }


### PR DESCRIPTION
Replaced Type.GetCustomAttribute<T> with Type.IsDefined where the attribute instance is only used to check if it's defined, to increase performance.

Resolves #3416