### PR TITLE
Modify RazorPage to use DiagnosticSource for page instrumentation \ BrowserLink.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/IRazorPage.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/IRazorPage.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc.Rendering;
-using Microsoft.AspNet.PageExecutionInstrumentation;
 
 namespace Microsoft.AspNet.Mvc.Razor
 {
@@ -52,9 +52,9 @@ namespace Microsoft.AspNet.Mvc.Razor
         bool IsPartial { get; set; }
 
         /// <summary>
-        /// Gets or sets a <see cref="IPageExecutionContext"/> instance used to instrument the page execution.
+        /// Gets or sets a <see cref="DiagnosticSource"/> instance used to instrument the page execution.
         /// </summary>
-        IPageExecutionContext PageExecutionContext { get; set; }
+        DiagnosticSource DiagnosticSource { get; set; }
 
         /// <summary>
         /// Gets or sets the sections that can be rendered by this page.

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
@@ -16,7 +16,6 @@ using Microsoft.AspNet.Mvc.Infrastructure;
 using Microsoft.AspNet.Mvc.Razor.Internal;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Mvc.ViewFeatures;
-using Microsoft.AspNet.PageExecutionInstrumentation;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 using Microsoft.AspNet.Razor.TagHelpers;
 using Microsoft.Extensions.DependencyInjection;
@@ -82,7 +81,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         public IHtmlEncoder HtmlEncoder { get; set; }
 
         /// <inheritdoc />
-        public IPageExecutionContext PageExecutionContext { get; set; }
+        public DiagnosticSource DiagnosticSource { get; set; }
 
         /// <summary>
         /// Gets the <see cref="TextWriter"/> that the page is writing output to.
@@ -1063,12 +1062,37 @@ namespace Microsoft.AspNet.Mvc.Razor
 
         public void BeginContext(int position, int length, bool isLiteral)
         {
-            PageExecutionContext?.BeginContext(position, length, isLiteral);
+            const string BeginContextEvent = "Microsoft.AspNet.Mvc.Razor.BeginInstrumentationContext";
+            if (DiagnosticSource != null && DiagnosticSource.IsEnabled(BeginContextEvent))
+            {
+                DiagnosticSource.Write(
+                    BeginContextEvent,
+                    new
+                    {
+                        httpContext = Context,
+                        path = Path,
+                        isPartial = IsPartial,
+                        position = position,
+                        length = length,
+                        isLiteral = isLiteral,
+                    });
+            }
         }
 
         public void EndContext()
         {
-            PageExecutionContext?.EndContext();
+            const string EndContextEvent = "Microsoft.AspNet.Mvc.Razor.EndInstrumentationContext";
+            if (DiagnosticSource != null && DiagnosticSource.IsEnabled(EndContextEvent))
+            {
+                DiagnosticSource.Write(
+                    EndContextEvent,
+                    new
+                    {
+                        httpContext = Context,
+                        path = Path,
+                        isPartial = IsPartial,
+                    });
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorTextWriter.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorTextWriter.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNet.Mvc.Razor
     /// This type is designed to avoid creating large in-memory strings when buffering and supporting the contract that
     /// <see cref="RazorPage.FlushAsync"/> expects.
     /// </remarks>
-    public class RazorTextWriter : HtmlTextWriter, IBufferedTextWriter
+    public class RazorTextWriter : HtmlTextWriter
     {
         /// <summary>
         /// Creates a new instance of <see cref="RazorTextWriter"/>.

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorViewFactory.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorViewFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using Microsoft.AspNet.Mvc.ViewEngines;
 using Microsoft.Extensions.WebEncoders;
 
@@ -16,6 +17,7 @@ namespace Microsoft.AspNet.Mvc.Razor
         private readonly IHtmlEncoder _htmlEncoder;
         private readonly IRazorPageActivator _pageActivator;
         private readonly IViewStartProvider _viewStartProvider;
+        private readonly DiagnosticSource _diagnosticSource;
 
         /// <summary>
         /// Initializes a new instance of RazorViewFactory
@@ -26,11 +28,13 @@ namespace Microsoft.AspNet.Mvc.Razor
         public RazorViewFactory(
             IRazorPageActivator pageActivator,
             IViewStartProvider viewStartProvider,
-            IHtmlEncoder htmlEncoder)
+            IHtmlEncoder htmlEncoder,
+            DiagnosticSource diagnosticSource)
         {
             _pageActivator = pageActivator;
             _viewStartProvider = viewStartProvider;
             _htmlEncoder = htmlEncoder;
+            _diagnosticSource = diagnosticSource;
         }
 
         /// <inheritdoc />
@@ -55,6 +59,7 @@ namespace Microsoft.AspNet.Mvc.Razor
                 _viewStartProvider,
                 page,
                 _htmlEncoder,
+                _diagnosticSource,
                 isPartial);
             return razorView;
         }

--- a/src/Microsoft.AspNet.Mvc.Razor/project.json
+++ b/src/Microsoft.AspNet.Mvc.Razor/project.json
@@ -12,7 +12,6 @@
     "Microsoft.AspNet.Mvc.Razor.Host": "6.0.0-*",
     "Microsoft.AspNet.Mvc.ViewFeatures": "6.0.0-*",
     "Microsoft.AspNet.Razor.Runtime.Precompilation": "4.0.0-*",
-    "Microsoft.AspNet.PageExecutionInstrumentation.Interfaces": "1.0.0-*",
     "Microsoft.Extensions.HashCodeCombiner.Sources": {
       "version": "1.0.0-*",
       "type": "build"

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/RazorViewFactoryTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/RazorViewFactoryTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using Microsoft.Extensions.WebEncoders.Testing;
 using Moq;
 using Xunit;
@@ -18,7 +19,8 @@ namespace Microsoft.AspNet.Mvc.Razor
             var factory = new RazorViewFactory(
                 Mock.Of<IRazorPageActivator>(),
                 Mock.Of<IViewStartProvider>(),
-                new CommonTestEncoder());
+                new CommonTestEncoder(),
+                Mock.Of<DiagnosticSource>());
             var page = Mock.Of<IRazorPage>();
             var viewEngine = Mock.Of<IRazorViewEngine>();
 
@@ -38,7 +40,8 @@ namespace Microsoft.AspNet.Mvc.Razor
             var factory = new RazorViewFactory(
                 Mock.Of<IRazorPageActivator>(),
                 Mock.Of<IViewStartProvider>(),
-                new CommonTestEncoder());
+                new CommonTestEncoder(),
+                Mock.Of<DiagnosticSource>());
 
             var page = Mock.Of<IRazorPage>();
             var viewEngine = Mock.Of<IRazorViewEngine>();

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/project.json
@@ -13,8 +13,13 @@
       "version": "6.0.0-*",
       "type": "build"
     },
+    "Microsoft.AspNet.Mvc.TestDiagnosticListener.Sources": {
+      "version": "6.0.0-*",
+      "type": "build"
+    },
     "Microsoft.AspNet.Testing": "1.0.0-*",
     "Microsoft.Extensions.DependencyInjection": "1.0.0-*",
+    "Microsoft.Extensions.DiagnosticAdapter":  "1.0.0-*",
     "Microsoft.Extensions.WebEncoders.Testing": "1.0.0-*",
     "Microsoft.Dnx.Runtime": "1.0.0-*",
     "xunit.runner.aspnet": "2.0.0-aspnet-*"

--- a/test/Microsoft.AspNet.Mvc.TestDiagnosticListener.Sources/TestDiagnosticListener.cs
+++ b/test/Microsoft.AspNet.Mvc.TestDiagnosticListener.Sources/TestDiagnosticListener.cs
@@ -324,5 +324,69 @@ namespace Microsoft.AspNet.Mvc
                 View = view
             };
         }
+
+        public class BeginPageInstrumentationData
+        {
+            public IProxyHttpContext HttpContext { get; set; }
+
+            public string Path { get; set; }
+
+            public bool IsPartial { get; set; }
+
+            public int Position { get; set; }
+
+            public int Length { get; set; }
+
+            public bool IsLiteral { get; set; }
+        }
+
+        public class EndPageInstrumentationData
+        {
+            public IProxyHttpContext HttpContext { get; set; }
+
+            public string Path { get; set; }
+
+            public bool IsPartial { get; set; }
+        }
+
+        public List<object> PageInstrumentationData { get; set; } =
+            new List<object>();
+
+        [DiagnosticName("Microsoft.AspNet.Mvc.Razor.BeginInstrumentationContext")]
+        public virtual void OnBeginPageInstrumentationContext(
+            IProxyHttpContext httpContext,
+            string path,
+            bool isPartial,
+            int position,
+            int length,
+            bool isLiteral)
+        {
+            PageInstrumentationData.Add(new BeginPageInstrumentationData
+            {
+                HttpContext = httpContext,
+                Path = path,
+                IsPartial = isPartial,
+                Position = position,
+                Length = length,
+                IsLiteral = isLiteral,
+            });
+        }
+
+        [DiagnosticName("Microsoft.AspNet.Mvc.Razor.EndInstrumentationContext")]
+        public virtual void OnEndPageInstrumentationContext(
+            IProxyHttpContext httpContext,
+            string path,
+            bool isPartial,
+            int position,
+            int length,
+            bool isLiteral)
+        {
+            PageInstrumentationData.Add(new EndPageInstrumentationData
+            {
+                HttpContext = httpContext,
+                Path = path,
+                IsPartial = isPartial,
+            });
+        }
     }
 }


### PR DESCRIPTION
Fixes #3281