### PR TITLE
React to aspnet/Razor#196.

### DIFF
--- a/samples/TagHelperSample.Web/Views/Home/Create.cshtml
+++ b/samples/TagHelperSample.Web/Views/Home/Create.cshtml
@@ -21,7 +21,7 @@
         @* - should helper remove the <div/> if list isn't generated? *@
         @* - (Html.ValidationSummary returns empty string despite non-empty message parameter) *@
         @* Acceptable values are: "None", "ModelOnly" and "All" *@
-        <div asp-validation-summary="ValidationSummary.All" style="color:blue" id="validation_day" class="form-group">
+        <div asp-validation-summary="@ValidationSummary.All" style="color:blue" id="validation_day" class="form-group">
             <span style="color:red">This is my message</span>
         </div>
 

--- a/samples/TagHelperSample.Web/Views/Home/Edit.cshtml
+++ b/samples/TagHelperSample.Web/Views/Home/Edit.cshtml
@@ -6,7 +6,7 @@
 
 <form>
     <div class="form-horizontal">
-        <div asp-validation-summary="ValidationSummary.All"></div>
+        <div asp-validation-summary="All"></div>
         <input type="hidden" asp-for="Id" />
 
         <div class="form-group">

--- a/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/CreateWarehouse.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/CreateWarehouse.cshtml
@@ -20,7 +20,7 @@
             <select asp-for="Product" asp-items="(IEnumerable<SelectListItem>)ViewBag.Items"></select>
             <span asp-validation-for="Product"></span>
         </div>
-        <div asp-validation-summary="ValidationSummary.All" class="warehouse"></div>
+        <div asp-validation-summary="All" class="warehouse"></div>
         <input type="submit" />
     }
 </body>

--- a/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Order.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Order.cshtml
@@ -84,7 +84,7 @@
             @Html.EditorFor(model => model.Customer.Gender)
             <span asp-validation-for="Customer.Gender"></span>
         </div>
-        <div asp-validation-summary="ValidationSummary.All" class="order"></div>
+        <div asp-validation-summary="All" class="order"></div>
         <input type="hidden" asp-for="Customer.Key" />
         <input type="submit" />
     </form>

--- a/test/WebSites/HtmlGenerationWebSite/Views/Shared/Customer.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/Shared/Customer.cshtml
@@ -38,8 +38,8 @@
             <input asp-for="Gender" type="radio" value="Female" /> Female
             <span asp-validation-for="Gender"></span>
         </div>
-        <div asp-validation-summary="ValidationSummary.All" class="order"></div>
-        <div asp-validation-summary="ValidationSummary.ModelOnly" class="order"></div>
+        <div asp-validation-summary="All" class="order"></div>
+        <div asp-validation-summary="ModelOnly" class="order"></div>
         <input type="submit"/>
     </form>
 </body>

--- a/test/WebSites/TagHelpersWebSite/Views/Employee/Create.cshtml
+++ b/test/WebSites/TagHelpersWebSite/Views/Employee/Create.cshtml
@@ -22,7 +22,7 @@
         <div class="form-horizontal">
             <h4>Employee</h4>
             <hr />
-            <div asp-validation-summary="ValidationSummary.All" class="text-danger">
+            <div asp-validation-summary="All" class="text-danger">
             </div>
             <div class="form-group">
                 <label asp-for="Age" class="control-label col-md-2"></label>


### PR DESCRIPTION
- Razor `TagHelper`s now special case `enum` values so you don't need to provide the entire `enum` prefix.