### PR TITLE
Delete unused config.json file from MvcSample.Web project

### DIFF
--- a/samples/MvcSample.Web/config.json
+++ b/samples/MvcSample.Web/config.json
@@ -1,3 +1,0 @@
-﻿{
-    "DependencyInjection": "AutoFac"
-}


### PR DESCRIPTION
It was determined that the `config.json` file isn't being used in the MvcSample.Web project (see [here](https://github.com/aspnet/Mvc/pull/3421)). This PR will delete that file.