### PR TITLE
Revert "Fixing tests" and remove references to `Microsoft.Extensions.WebEncoders.Testing` package

### DIFF
--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/TagBuilder.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Rendering/TagBuilder.cs
@@ -206,10 +206,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                     writer.Write(" ");
                     writer.Write(key);
                     writer.Write("=\"");
-                    if (!string.IsNullOrEmpty(attribute.Value))
-                    {
-                        encoder.Encode(writer, attribute.Value);
-                    }
+                    encoder.Encode(writer, attribute.Value);
                     writer.Write("\"");
                 }
             }

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/StringHtmlContent.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/StringHtmlContent.cs
@@ -39,10 +39,7 @@ namespace Microsoft.AspNet.Mvc.ViewFeatures
                 throw new ArgumentNullException(nameof(encoder));
             }
 
-            if (!string.IsNullOrEmpty(_input))
-            {
-                encoder.Encode(writer, _input);
-            }
+            encoder.Encode(writer, _input);
         }
 
         private string DebuggerToString()

--- a/test/Microsoft.AspNet.Mvc.ApiExplorer.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.ApiExplorer.Test/project.json
@@ -3,12 +3,14 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "Microsoft.AspNet.Mvc" : "6.0.0-*",
-    "Microsoft.AspNet.Mvc.TestCommon": { "version": "6.0.0-*", "type": "build" },
+    "Microsoft.AspNet.Mvc": "6.0.0-*",
     "Microsoft.AspNet.Mvc.Formatters.Xml": "6.0.0-*",
+    "Microsoft.AspNet.Mvc.TestCommon": {
+      "version": "6.0.0-*",
+      "type": "build"
+    },
     "Microsoft.AspNet.Testing": "1.0.0-*",
     "Microsoft.Extensions.Logging.Testing": "1.0.0-*",
-    "Microsoft.Extensions.WebEncoders.Testing": "1.0.0-*",
     "Moq": "4.2.1312.1622",
     "xunit.runner.aspnet": "2.0.0-aspnet-*"
   },

--- a/test/Microsoft.AspNet.Mvc.Core.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/project.json
@@ -5,20 +5,19 @@
   "dependencies": {
     "Microsoft.AspNet.Http": "1.0.0-*",
     "Microsoft.AspNet.Mvc": "6.0.0-*",
+    "Microsoft.AspNet.Mvc.Formatters.Xml": "6.0.0-*",
     "Microsoft.AspNet.Mvc.TestCommon": {
       "version": "6.0.0-*",
       "type": "build"
     },
-    "Microsoft.AspNet.Mvc.Formatters.Xml": "6.0.0-*",
     "Microsoft.AspNet.Mvc.TestDiagnosticListener.Sources": {
       "version": "6.0.0-*",
       "type": "build"
     },
     "Microsoft.AspNet.Testing": "1.0.0-*",
     "Microsoft.Extensions.DependencyInjection": "1.0.0-*",
-    "Microsoft.Extensions.Logging.Testing": "1.0.0-*",
     "Microsoft.Extensions.DiagnosticAdapter": "1.0.0-*",
-    "Microsoft.Extensions.WebEncoders.Testing": "1.0.0-*",
+    "Microsoft.Extensions.Logging.Testing": "1.0.0-*",
     "Moq": "4.2.1312.1622",
     "xunit.runner.aspnet": "2.0.0-aspnet-*"
   },

--- a/test/Microsoft.AspNet.Mvc.Cors.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.Cors.Test/project.json
@@ -10,7 +10,6 @@
         "Microsoft.AspNet.Testing": "1.0.0-*",
         "Microsoft.Extensions.DependencyInjection": "1.0.0-*",
         "Microsoft.Extensions.Logging.Testing": "1.0.0-*",
-        "Microsoft.Extensions.WebEncoders.Testing": "1.0.0-*",
         "Moq": "4.2.1312.1622",
         "xunit.runner.aspnet": "2.0.0-aspnet-*"
     },

--- a/test/Microsoft.AspNet.Mvc.DataAnnotations.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.DataAnnotations.Test/project.json
@@ -9,7 +9,6 @@
         "Microsoft.AspNet.Testing": "1.0.0-*",
         "Microsoft.Extensions.DependencyInjection": "1.0.0-*",
         "Microsoft.Extensions.Logging.Testing": "1.0.0-*",
-        "Microsoft.Extensions.WebEncoders.Testing": "1.0.0-*",
         "Moq": "4.2.1312.1622",
         "xunit.runner.aspnet": "2.0.0-aspnet-*"
     },

--- a/test/Microsoft.AspNet.Mvc.Formatters.Json.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.Formatters.Json.Test/project.json
@@ -10,7 +10,6 @@
         "Microsoft.AspNet.Testing": "1.0.0-*",
         "Microsoft.Extensions.DependencyInjection": "1.0.0-*",
         "Microsoft.Extensions.Logging.Testing": "1.0.0-*",
-        "Microsoft.Extensions.WebEncoders.Testing": "1.0.0-*",
         "Moq": "4.2.1312.1622",
         "xunit.runner.aspnet": "2.0.0-aspnet-*"
     },

--- a/test/Microsoft.AspNet.Mvc.Formatters.Xml.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.Formatters.Xml.Test/project.json
@@ -8,7 +8,6 @@
     "Microsoft.AspNet.Mvc.Formatters.Xml" : "6.0.0-*",
     "Microsoft.AspNet.Mvc.TestCommon": { "type": "build", "version": "6.0.0-*" },
     "Microsoft.AspNet.Testing": "1.0.0-*",
-    "Microsoft.Extensions.WebEncoders.Testing": "1.0.0-*",
     "Moq": "4.2.1312.1622",
     "xunit.runner.aspnet": "2.0.0-aspnet-*"
   },

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Script.Encoded.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Script.Encoded.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html>
 <head>
     <meta charset="utf-8" />
@@ -62,10 +62,10 @@
     </script>
 
     <!-- Globbed script tag with existing file -->
-    HtmlEncode[[]]<script src="HtmlEncode[[/styles/site.js]]"></script>
+    <script src="HtmlEncode[[/styles/site.js]]"></script>
 
     <!-- Globbed script tag with existing file and exclude -->
-    HtmlEncode[[]]<script src="HtmlEncode[[/styles/site.js]]"></script><script src="HtmlEncode[[/styles/sub/site2.js]]"></script>
+    <script src="HtmlEncode[[/styles/site.js]]"></script><script src="HtmlEncode[[/styles/sub/site2.js]]"></script>
 
     <script>
         // Globbed script tag missing include
@@ -76,16 +76,16 @@
     </script>
 
     <!-- Globbed script tag with comma separated include pattern -->
-    HtmlEncode[[]]<script src="HtmlEncode[[/styles/site.js]]"></script><script src="HtmlEncode[[/styles/sub/site2.js]]"></script><script src="HtmlEncode[[/styles/sub/site3.js]]"></script>
+    <script src="HtmlEncode[[/styles/site.js]]"></script><script src="HtmlEncode[[/styles/sub/site2.js]]"></script><script src="HtmlEncode[[/styles/sub/site3.js]]"></script>
 
     <!-- Globbed script tag with missing file -->
-    HtmlEncode[[]]
+    
 
     <!-- Globbed script tag with file outside of webroot -->
-    HtmlEncode[[]]
+    
 
     <!-- Globbed script tag with file outside of webroot -->
-    HtmlEncode[[]]
+    
 
     <script src="HtmlEncode[[/styles/site.js]]">
         // Globbed script tag with existing file and static src
@@ -110,9 +110,9 @@
     </script>
 
     <!-- Globbed script tag with existing files and version -->
-    HtmlEncode[[]]<script src="HtmlEncode[[/styles/site.js?v=jx1PJjLX32-xgQQx2BxnckU9QH9DVKkm4-M5bSK869I]]"></script><script src="HtmlEncode[[/styles/sub/site2.js?v=pwJaxaQxnb-rPAdF2JlAp4xiPNq1XuJFd6TyOOfNF-0]]"></script><script src="HtmlEncode[[/styles/sub/site3.js?v=lmeAMiqm76lnGyqHhu6PIBHAC0Vt46mgVB_KaG_gGdA]]"></script>
+    <script src="HtmlEncode[[/styles/site.js?v=jx1PJjLX32-xgQQx2BxnckU9QH9DVKkm4-M5bSK869I]]"></script><script src="HtmlEncode[[/styles/sub/site2.js?v=pwJaxaQxnb-rPAdF2JlAp4xiPNq1XuJFd6TyOOfNF-0]]"></script><script src="HtmlEncode[[/styles/sub/site3.js?v=lmeAMiqm76lnGyqHhu6PIBHAC0Vt46mgVB_KaG_gGdA]]"></script>
 
     <!-- Globbed script tag with existing file, exclude and version -->
-    HtmlEncode[[]]<script src="HtmlEncode[[/styles/site.js?v=jx1PJjLX32-xgQQx2BxnckU9QH9DVKkm4-M5bSK869I]]"></script><script src="HtmlEncode[[/styles/sub/site2.js?v=pwJaxaQxnb-rPAdF2JlAp4xiPNq1XuJFd6TyOOfNF-0]]"></script>
+    <script src="HtmlEncode[[/styles/site.js?v=jx1PJjLX32-xgQQx2BxnckU9QH9DVKkm4-M5bSK869I]]"></script><script src="HtmlEncode[[/styles/sub/site2.js?v=pwJaxaQxnb-rPAdF2JlAp4xiPNq1XuJFd6TyOOfNF-0]]"></script>
 </body>
 </html>

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/project.json
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/project.json
@@ -44,7 +44,6 @@
     "Microsoft.AspNet.WebUtilities": "1.0.0-*",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-*",
     "Microsoft.Extensions.Logging.Testing": "1.0.0-*",
-    "Microsoft.Extensions.WebEncoders.Testing": "1.0.0-*",
     "ModelBindingWebSite": "1.0.0",
     "MvcSample.Web": "1.0.0",
     "PrecompilationWebSite": "1.0.0",

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/project.json
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/project.json
@@ -11,7 +11,6 @@
             "type": "build"
         },
         "Microsoft.AspNet.Testing": "1.0.0-*",
-        "Microsoft.Extensions.WebEncoders.Testing": "1.0.0-*",
         "xunit.runner.aspnet": "2.0.0-aspnet-*"
     },
     "commands": {

--- a/test/Microsoft.AspNet.Mvc.Localization.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.Localization.Test/project.json
@@ -4,11 +4,13 @@
   },
   "dependencies": {
     "Microsoft.AspNet.Mvc": "6.0.0-*",
-    "Microsoft.AspNet.Mvc.Localization": "6.0.0-*",
-    "Microsoft.AspNet.Mvc.TestCommon": { "version": "6.0.0-*", "type": "build" },
-    "Microsoft.AspNet.Testing": "1.0.0-*",
     "Microsoft.AspNet.Mvc.Formatters.Xml": "6.0.0-*",
-    "Microsoft.Extensions.WebEncoders.Testing": "1.0.0-*",
+    "Microsoft.AspNet.Mvc.Localization": "6.0.0-*",
+    "Microsoft.AspNet.Mvc.TestCommon": {
+      "version": "6.0.0-*",
+      "type": "build"
+    },
+    "Microsoft.AspNet.Testing": "1.0.0-*",
     "xunit.runner.aspnet": "2.0.0-aspnet-*"
   },
   "commands": {

--- a/test/Microsoft.AspNet.Mvc.Razor.Host.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.Razor.Host.Test/project.json
@@ -6,10 +6,12 @@
     "Microsoft.AspNet.Mvc.Formatters.Xml": "6.0.0-*",
     "Microsoft.AspNet.Mvc.Razor": "6.0.0-*",
     "Microsoft.AspNet.Mvc.Razor.Host": "6.0.0-*",
+    "Microsoft.AspNet.Mvc.TestCommon": {
+      "version": "6.0.0-*",
+      "type": "build"
+    },
     "Microsoft.AspNet.Mvc.ViewFeatures": "6.0.0-*",
-    "Microsoft.AspNet.Mvc.TestCommon": { "version": "6.0.0-*", "type": "build" },
     "Microsoft.AspNet.Testing": "1.0.0-*",
-    "Microsoft.Extensions.WebEncoders.Testing": "1.0.0-*",
     "xunit.runner.aspnet": "2.0.0-aspnet-*"
   },
   "commands": {

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/RazorViewTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/RazorViewTest.cs
@@ -914,7 +914,6 @@ namespace Microsoft.AspNet.Mvc.Razor
                            "]]BodyContent" +
                            "foo-content" +
                            Environment.NewLine +
-                           "HtmlEncode[[]]" +
                            Environment.NewLine;
 
             var page = new TestableRazorPage(v =>

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/project.json
@@ -14,9 +14,8 @@
       "type": "build"
     },
     "Microsoft.AspNet.Testing": "1.0.0-*",
-    "Microsoft.Extensions.DependencyInjection": "1.0.0-*",
-    "Microsoft.Extensions.WebEncoders.Testing": "1.0.0-*",
     "Microsoft.Dnx.Runtime": "1.0.0-*",
+    "Microsoft.Extensions.DependencyInjection": "1.0.0-*",
     "xunit.runner.aspnet": "2.0.0-aspnet-*"
   },
     "commands": {

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/SelectTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/SelectTagHelperTest.cs
@@ -45,15 +45,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                     modelWithNull,
                     modelWithText,
                 };
-                var noneSelected = "<option>HtmlEncode[[]]</option>" + Environment.NewLine +
+                var noneSelected = "<option></option>" + Environment.NewLine +
                     "<option>HtmlEncode[[outer text]]</option>" + Environment.NewLine +
                     "<option>HtmlEncode[[inner text]]</option>" + Environment.NewLine +
                     "<option>HtmlEncode[[other text]]</option>" + Environment.NewLine;
-                var innerSelected = "<option>HtmlEncode[[]]</option>" + Environment.NewLine +
+                var innerSelected = "<option></option>" + Environment.NewLine +
                     "<option>HtmlEncode[[outer text]]</option>" + Environment.NewLine +
                     "<option selected=\"HtmlEncode[[selected]]\">HtmlEncode[[inner text]]</option>" + Environment.NewLine +
                     "<option>HtmlEncode[[other text]]</option>" + Environment.NewLine;
-                var outerSelected = "<option>HtmlEncode[[]]</option>" + Environment.NewLine +
+                var outerSelected = "<option></option>" + Environment.NewLine +
                     "<option selected=\"HtmlEncode[[selected]]\">HtmlEncode[[outer text]]</option>" + Environment.NewLine +
                     "<option>HtmlEncode[[inner text]]</option>" + Environment.NewLine +
                     "<option>HtmlEncode[[other text]]</option>" + Environment.NewLine;

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TextAreaTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/TextAreaTagHelperTest.cs
@@ -48,35 +48,32 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 {
                     { null, typeof(Model), null,
                         new NameAndId("Text", "Text"),
-                        Environment.NewLine + "HtmlEncode[[]]" },
+                        Environment.NewLine },
 
                     { modelWithNull, typeof(Model), modelWithNull.Text,
                         new NameAndId("Text", "Text"),
-                        Environment.NewLine + "HtmlEncode[[]]"},
+                        Environment.NewLine },
                     { modelWithText, typeof(Model), modelWithText.Text,
                         new NameAndId("Text", "Text"),
                         Environment.NewLine + "HtmlEncode[[outer text]]" },
 
                     { modelWithNull, typeof(NestedModel), modelWithNull.NestedModel.Text,
                         new NameAndId("NestedModel.Text", "NestedModel_Text"),
-                        Environment.NewLine  + "HtmlEncode[[]]" },
-
+                        Environment.NewLine },
                     { modelWithText, typeof(NestedModel), modelWithText.NestedModel.Text,
                         new NameAndId("NestedModel.Text", "NestedModel_Text"),
                         Environment.NewLine + "HtmlEncode[[inner text]]" },
 
                     { models, typeof(Model), models[0].Text,
                         new NameAndId("[0].Text", "z0__Text"),
-                        Environment.NewLine  + "HtmlEncode[[]]" },
-
+                        Environment.NewLine },
                     { models, typeof(Model), models[1].Text,
                         new NameAndId("[1].Text", "z1__Text"),
                         Environment.NewLine + "HtmlEncode[[outer text]]" },
 
                     { models, typeof(NestedModel), models[0].NestedModel.Text,
                         new NameAndId("[0].NestedModel.Text", "z0__NestedModel_Text"),
-                        Environment.NewLine  + "HtmlEncode[[]]" },
-
+                        Environment.NewLine },
                     { models, typeof(NestedModel), models[1].NestedModel.Text,
                         new NameAndId("[1].NestedModel.Text", "z1__NestedModel_Text"),
                         Environment.NewLine + "HtmlEncode[[inner text]]" },

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/project.json
@@ -10,7 +10,6 @@
     },
     "Microsoft.AspNet.Testing": "1.0.0-*",
     "Microsoft.Extensions.Logging.Abstractions": "1.0.0-*",
-    "Microsoft.Extensions.WebEncoders.Testing": "1.0.0-*",
     "xunit.runner.aspnet": "2.0.0-aspnet-*"
   },
   "commands": {

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/Rendering/HtmlHelperLinkGenerationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/Rendering/HtmlHelperLinkGenerationTest.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                                                                 GetRouteValuesAsString(routeValues),
                                                                 fragment,
                                                                 GetHtmlAttributesAsString(htmlAttributes));
-            expectedLink = expectedLink.Replace("HtmlEncode[[]]", "");
+            expectedLink = expectedLink.Replace("HtmlEncode[[]]", string.Empty);
 
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(h => h.Action(It.IsAny<UrlActionContext>()))
@@ -122,7 +122,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                                                                     GetRouteValuesAsString(routeValues),
                                                                     fragment,
                                                                     GetHtmlAttributesAsString(htmlAttributes));
-            expectedLink = expectedLink.Replace("HtmlEncode[[]]", "");
+            expectedLink = expectedLink.Replace("HtmlEncode[[]]", string.Empty);
 
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/Rendering/HtmlHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/Rendering/HtmlHelperTest.cs
@@ -72,8 +72,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
                 var data = new TheoryData<object, string>
                 {
                     { null, string.Empty },
-                    // Object overload does not special case the empty string.
-                    { string.Empty, "HtmlEncode[[]]" },
+                    { string.Empty, string.Empty },
                     { "<\">", "HtmlEncode[[<\">]]" },
                     { "<br />", "HtmlEncode[[<br />]]" },
                     { "<b>bold</b>", "HtmlEncode[[<b>bold</b>]]" },

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/project.json
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/project.json
@@ -16,9 +16,8 @@
     },
     "Microsoft.AspNet.Testing": "1.0.0-*",
     "Microsoft.Extensions.DependencyInjection": "1.0.0-*",
-    "Microsoft.Extensions.Logging.Testing": "1.0.0-*",
     "Microsoft.Extensions.DiagnosticAdapter": "1.0.0-*",
-    "Microsoft.Extensions.WebEncoders.Testing": "1.0.0-*",
+    "Microsoft.Extensions.Logging.Testing": "1.0.0-*",
     "xunit.runner.aspnet": "2.0.0-aspnet-*"
   },
   "commands": {


### PR DESCRIPTION
- wrong fix especially now that test encoders work as expected
- also touch up `HtmlHelperTest` and `RazorViewTest` since test encoders are now consistent

This reverts commit a9d5876.
- but leave `FormTagHelperTest` and `ValidationMessageTagHelperTest` cleanup alone

nit: use `string.Empty` in `HtmlHelperLinkGenerationTest`