### PR TITLE
Fix missing dependency to System.Reflection.Metadata

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/project.json
+++ b/src/Microsoft.AspNet.Mvc.Razor/project.json
@@ -27,6 +27,7 @@
     },
     "Microsoft.Dnx.Compilation.CSharp.Common": "1.0.0-*",
     "Microsoft.Dnx.Compilation.CSharp.Abstractions": "1.0.0-*"
+    "System.Reflection.Metadata": "1.1.0-*"
   },
   "frameworks": {
     "net451": {


### PR DESCRIPTION
The file `RoslynCompilationService.cs` of `Microsoft.AspNet.Mvc.Razor` contains the reference `using System.Reflection.PortableExecutable;` in [the line](https://github.com/aspnet/Mvc/blob/dev/src/Microsoft.AspNet.Mvc.Razor/Compilation/RoslynCompilationService.cs#L11) of code. As the result `Microsoft.AspNet.Mvc.Razor` have dependence to [System.Reflection.Metadata](https://www.nuget.org/packages/System.Reflection.Metadata) NuGet package. One can examine `project.lock.json` to verify that `System.Reflection.Metadata` in version `1.1.0-alpha-00014` or higher (starting with Oktober 27 2015 is released 1.1.0 final) is required.