### PR TITLE
Learn the one wierd trick that really works to shed pounds of allocations

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/TagHelperContentWrapperTextWriter.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/TagHelperContentWrapperTextWriter.cs
@@ -2,16 +2,17 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.IO;
 using System.Text;
+using Microsoft.AspNet.Html.Abstractions;
+using Microsoft.AspNet.Mvc.ViewFeatures;
 using Microsoft.AspNet.Razor.TagHelpers;
 
 namespace Microsoft.AspNet.Mvc.Razor
 {
     /// <summary>
-    /// <see cref="TextWriter"/> implementation which writes to a <see cref="TagHelperContent"/> instance.
+    /// <see cref="HtmlTextWriter"/> implementation which writes to a <see cref="TagHelperContent"/> instance.
     /// </summary>
-    public class TagHelperContentWrapperTextWriter : TextWriter
+    public class TagHelperContentWrapperTextWriter : HtmlTextWriter
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TagHelperContentWrapperTextWriter"/> class.
@@ -61,6 +62,12 @@ namespace Microsoft.AspNet.Mvc.Razor
         public override void Write(char value)
         {
             Content.AppendHtml(value.ToString());
+        }
+
+        /// <inheritdoc />
+        public override void Write(IHtmlContent value)
+        {
+            Content.Append(value);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/StringCollectionTextWriter.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/StringCollectionTextWriter.cs
@@ -176,17 +176,17 @@ namespace Microsoft.AspNet.Mvc.ViewFeatures
         }
 
         /// <summary>
-        /// If the specified <paramref name="writer"/> is a <see cref="StringCollectionTextWriter"/> the contents
+        /// If the specified <paramref name="writer"/> is a <see cref="HtmlTextWriter"/> the contents
         /// are copied. It is just written to the <paramref name="writer"/> otherwise.
         /// </summary>
         /// <param name="writer">The <see cref="TextWriter"/> to which the content must be copied/written.</param>
         /// <param name="encoder">The <see cref="HtmlEncoder"/> to encode the copied/written content.</param>
         public void CopyTo(TextWriter writer, HtmlEncoder encoder)
         {
-            var targetStringCollectionWriter = writer as StringCollectionTextWriter;
-            if (targetStringCollectionWriter != null)
+            var htmlTextWriter = writer as HtmlTextWriter;
+            if (htmlTextWriter != null)
             {
-                targetStringCollectionWriter._content.Append(Content);
+                htmlTextWriter.Write(Content);
             }
             else
             {
@@ -195,7 +195,7 @@ namespace Microsoft.AspNet.Mvc.ViewFeatures
         }
 
         /// <summary>
-        /// If the specified <paramref name="writer"/> is a <see cref="StringCollectionTextWriter"/> the contents
+        /// If the specified <paramref name="writer"/> is a <see cref="HtmlTextWriter"/> the contents
         /// are copied. It is just written to the <paramref name="writer"/> otherwise.
         /// </summary>
         /// <param name="writer">The <see cref="TextWriter"/> to which the content must be copied/written.</param>


### PR DESCRIPTION
Doctors **hate** him

This textwriter needs to inherit HtmlTextWriter and the
StringCollectionTextWriter needs to have the right conditional test.

This allows us to 'pass-through' any IHtmlContent instances without
writing out intermediate strings.

Here's some allocation data from 3000 requests to a simple page doing model binding and using TagHelpers to render an HTML form. 

**Before**
![image](https://cloud.githubusercontent.com/assets/1430011/11070442/87ca331c-8790-11e5-9a57-ef0b96170a5a.png)


**After**
![image](https://cloud.githubusercontent.com/assets/1430011/11070453/9c085138-8790-11e5-991d-a840bf398d6b.png)

This change is worth about 10mb based on current numbers, and isn't a design change, it was already supposed to do this :laughing: 