### PR TITLE
Add `AddDataAnnotationsLocalization` parameterless overload.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.DataAnnotations/DependencyInjection/MvcDataAnnotationsMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.DataAnnotations/DependencyInjection/MvcDataAnnotationsMvcCoreBuilderExtensions.cs
@@ -32,6 +32,21 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
+        /// Adds MVC data annotations localization to the application.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcCoreBuilder"/>.</param>
+        /// <returns>The <see cref="IMvcCoreBuilder"/>.</returns>
+        public static IMvcCoreBuilder AddDataAnnotationsLocalization(this IMvcCoreBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return AddDataAnnotationsLocalization(builder, setupAction: null);
+        }
+
+        /// <summary>
         /// Registers an action to configure <see cref="MvcDataAnnotationsLocalizationOptions"/> for MVC data
         /// annotations localization.
         /// </summary>


### PR DESCRIPTION
- The `IMvcBuilder` extension methods already had this overload, just adding it to `IMvcCoreBuilder`.

#3517