### PR TITLE
Make `ModelBinderAttribute.BindingSource` setter `protected`

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinderAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinderAttribute.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNet.Mvc
         public Type BinderType { get; set; }
 
         /// <inheritdoc />
-        public BindingSource BindingSource
+        public virtual BindingSource BindingSource
         {
             get
             {
@@ -43,7 +43,7 @@ namespace Microsoft.AspNet.Mvc
 
                 return _bindingSource;
             }
-            set
+            protected set
             {
                 _bindingSource = value;
             }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/Metadata/DefaultBindingMetadataProviderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/Metadata/DefaultBindingMetadataProviderTest.cs
@@ -108,8 +108,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
             // Arrange
             var attributes = new object[]
             {
-                new ModelBinderAttribute() { BindingSource = BindingSource.Body },
-                new ModelBinderAttribute() { BindingSource = BindingSource.Query },
+                new BindingSourceModelBinderAttribute(BindingSource.Body),
+                new BindingSourceModelBinderAttribute(BindingSource.Query),
             };
 
             var context = new BindingMetadataProviderContext(
@@ -132,8 +132,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
             var attributes = new object[]
             {
                 new ModelBinderAttribute(),
-                new ModelBinderAttribute() { BindingSource = BindingSource.Body },
-                new ModelBinderAttribute() { BindingSource = BindingSource.Query },
+                new BindingSourceModelBinderAttribute(BindingSource.Body),
+                new BindingSourceModelBinderAttribute(BindingSource.Query),
             };
 
             var context = new BindingMetadataProviderContext(
@@ -544,6 +544,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         [BindRequired]
         private class BindRequiredOverridesInheritedBindNever : BindNeverOnClass
         {
+        }
+
+        private class BindingSourceModelBinderAttribute : ModelBinderAttribute
+        {
+            public BindingSourceModelBinderAttribute(BindingSource bindingSource)
+            {
+                BindingSource = bindingSource;
+            }
         }
     }
 }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/Metadata/ModelBinderAttributeTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/Metadata/ModelBinderAttributeTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Xunit;
 
 namespace Microsoft.AspNet.Mvc.ModelBinding
@@ -39,15 +38,20 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         public void BinderType_SettingBindingSource_OverridesDefaultCustomBindingSource()
         {
             // Arrange
-            var attribute = new ModelBinderAttribute();
-            attribute.BindingSource = BindingSource.Query;
-            attribute.BinderType = typeof(ByteArrayModelBinder);
+            var attribute = new FromQueryModelBinderAttribute();
 
             // Act
             var source = attribute.BindingSource;
 
             // Assert
             Assert.Equal(BindingSource.Query, source);
+        }
+
+        private class FromQueryModelBinderAttribute : ModelBinderAttribute
+        {
+            // Not the perfect way to override this property since setting its value (possible when not using the class
+            // as an attribute) has no effect. base.BindingSource && BindingSource.Query may be right for some cases.
+            public override BindingSource BindingSource => BindingSource.Query;
         }
     }
 }


### PR DESCRIPTION
- #3428
- the `public` setter was not useful when this class is used as an attribute
- make property `virtual` to support other override patterns
- update existing test to use both override patterns