### PR TITLE
Remove per-instance string.Concat

### DIFF
--- a/src/Microsoft.AspNet.Mvc.TagHelpers/LinkTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/LinkTagHelper.cs
@@ -35,6 +35,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
     public class LinkTagHelper : UrlResolutionTagHelper
     {
         private static readonly string Namespace = typeof(LinkTagHelper).Namespace;
+        private static readonly string FallbackJavaScriptResourceName = 
+            Namespace + ".compiler.resources.LinkTagHelper_FallbackJavaScript.js";
 
         private const string HrefIncludeAttributeName = "asp-href-include";
         private const string HrefExcludeAttributeName = "asp-href-exclude";
@@ -44,7 +46,6 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         private const string FallbackTestClassAttributeName = "asp-fallback-test-class";
         private const string FallbackTestPropertyAttributeName = "asp-fallback-test-property";
         private const string FallbackTestValueAttributeName = "asp-fallback-test-value";
-        private readonly string FallbackJavaScriptResourceName = Namespace + ".compiler.resources.LinkTagHelper_FallbackJavaScript.js";
         private const string AppendVersionAttributeName = "asp-append-version";
         private const string HrefAttributeName = "href";
 


### PR DESCRIPTION
This is allocating per request, and at 500kb / 3000 req this is definitely something we want to fix.

![image](https://cloud.githubusercontent.com/assets/1430011/11315991/c704dd8e-8fb0-11e5-9249-0453cebf110d.png)
