### PR TITLE
Fixing local parameter usage

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/RazorView.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorView.cs
@@ -177,7 +177,7 @@ namespace Microsoft.AspNet.Mvc.Razor
             {
                 for (var i = 0; i < viewStartPages.Count; i++)
                 {
-                    var viewStart = ViewStartPages[i];
+                    var viewStart = viewStartPages[i];
                     context.ExecutingFilePath = viewStart.Path;
 
                     // Copy the layout value from the previous view start (if any) to the current.


### PR DESCRIPTION
The argument should be used instead of the property.