### PR TITLE
MVC companion to aspnet/Routing#238

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/CreatedAtActionResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/CreatedAtActionResult.cs
@@ -2,11 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Mvc.Core;
+using Microsoft.AspNet.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Internal;
 using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNet.Mvc
@@ -33,7 +32,7 @@ namespace Microsoft.AspNet.Mvc
         {
             ActionName = actionName;
             ControllerName = controllerName;
-            RouteValues = PropertyHelper.ObjectToDictionary(routeValues);
+            RouteValues = routeValues == null ? null : new RouteValueDictionary(routeValues);
             StatusCode = StatusCodes.Status201Created;
         }
 
@@ -55,7 +54,7 @@ namespace Microsoft.AspNet.Mvc
         /// <summary>
         /// Gets or sets the route data to use for generating the URL.
         /// </summary>
-        public IDictionary<string, object> RouteValues { get; set; }
+        public RouteValueDictionary RouteValues { get; set; }
 
         /// <inheritdoc />
         public override void OnFormatting(ActionContext context)

--- a/src/Microsoft.AspNet.Mvc.Core/CreatedAtRouteResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/CreatedAtRouteResult.cs
@@ -2,11 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Mvc.Core;
+using Microsoft.AspNet.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Internal;
 using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNet.Mvc
@@ -41,7 +40,7 @@ namespace Microsoft.AspNet.Mvc
             : base(value)
         {
             RouteName = routeName;
-            RouteValues = PropertyHelper.ObjectToDictionary(routeValues);
+            RouteValues = routeValues == null ? null : new RouteValueDictionary(routeValues);
             StatusCode = StatusCodes.Status201Created;
         }
 
@@ -58,7 +57,7 @@ namespace Microsoft.AspNet.Mvc
         /// <summary>
         /// Gets or sets the route data to use for generating the URL.
         /// </summary>
-        public IDictionary<string, object> RouteValues { get; set; }
+        public RouteValueDictionary RouteValues { get; set; }
 
         /// <inheritdoc />
         public override void OnFormatting(ActionContext context)

--- a/src/Microsoft.AspNet.Mvc.Core/RedirectToActionResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/RedirectToActionResult.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.AspNet.Mvc.Core;
 using Microsoft.AspNet.Mvc.Logging;
 using Microsoft.AspNet.Mvc.ViewFeatures;
+using Microsoft.AspNet.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.Mvc
         public RedirectToActionResult(
             string actionName,
             string controllerName,
-            IDictionary<string, object> routeValues)
+            object routeValues)
             : this(actionName, controllerName, routeValues, permanent: false)
         {
         }
@@ -24,25 +24,38 @@ namespace Microsoft.AspNet.Mvc
         public RedirectToActionResult(
             string actionName,
             string controllerName,
-            IDictionary<string, object> routeValues,
+            object routeValues,
             bool permanent)
         {
             ActionName = actionName;
             ControllerName = controllerName;
-            RouteValues = routeValues;
+            RouteValues = routeValues == null ? null : new RouteValueDictionary(routeValues);
             Permanent = permanent;
         }
 
+        /// <summary>
+        /// Gets or sets the <see cref="IUrlHelper" /> used to generate URLs.
+        /// </summary>
         public IUrlHelper UrlHelper { get; set; }
 
+        /// <summary>
+        /// Gets or sets the name of the action to use for generating the URL.
+        /// </summary>
         public string ActionName { get; set; }
 
+        /// <summary>
+        /// Gets or sets the name of the controller to use for generating the URL.
+        /// </summary>
         public string ControllerName { get; set; }
 
-        public IDictionary<string, object> RouteValues { get; set; }
+        /// <summary>
+        /// Gets or sets the route data to use for generating the URL.
+        /// </summary>
+        public RouteValueDictionary RouteValues { get; set; }
 
         public bool Permanent { get; set; }
 
+        /// <inheritdoc />
         public override void ExecuteResult(ActionContext context)
         {
             if (context == null)

--- a/src/Microsoft.AspNet.Mvc.Core/RedirectToRouteResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/RedirectToRouteResult.cs
@@ -2,12 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.AspNet.Mvc.Core;
 using Microsoft.AspNet.Mvc.Logging;
 using Microsoft.AspNet.Mvc.ViewFeatures;
+using Microsoft.AspNet.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNet.Mvc
@@ -32,18 +31,28 @@ namespace Microsoft.AspNet.Mvc
             bool permanent)
         {
             RouteName = routeName;
-            RouteValues = PropertyHelper.ObjectToDictionary(routeValues);
+            RouteValues = routeValues == null ? null : new RouteValueDictionary(routeValues);
             Permanent = permanent;
         }
 
+        /// <summary>
+        /// Gets or sets the <see cref="IUrlHelper" /> used to generate URLs.
+        /// </summary>
         public IUrlHelper UrlHelper { get; set; }
 
+        /// <summary>
+        /// Gets or sets the name of the route to use for generating the URL.
+        /// </summary>
         public string RouteName { get; set; }
 
-        public IDictionary<string, object> RouteValues { get; set; }
+        /// <summary>
+        /// Gets or sets the route data to use for generating the URL.
+        /// </summary>
+        public RouteValueDictionary RouteValues { get; set; }
 
         public bool Permanent { get; set; }
 
+        /// <inheritdoc />
         public override void ExecuteResult(ActionContext context)
         {
             if (context == null)

--- a/src/Microsoft.AspNet.Mvc.Core/Routing/UrlHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Routing/UrlHelper.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNet.Mvc.Routing
             _actionContextAccessor = actionContextAccessor;
         }
 
-        protected IDictionary<string, object> AmbientValues => ActionContext.RouteData.Values;
+        protected RouteValueDictionary AmbientValues => ActionContext.RouteData.Values;
 
         protected ActionContext ActionContext => _actionContextAccessor.ActionContext;
 
@@ -46,7 +46,7 @@ namespace Microsoft.AspNet.Mvc.Routing
                 throw new ArgumentNullException(nameof(actionContext));
             }
 
-            var valuesDictionary = PropertyHelper.ObjectToDictionary(actionContext.Values);
+            var valuesDictionary = new RouteValueDictionary(actionContext.Values);
 
             if (actionContext.Action == null)
             {
@@ -106,7 +106,7 @@ namespace Microsoft.AspNet.Mvc.Routing
                 throw new ArgumentNullException(nameof(routeContext));
             }
 
-            var valuesDictionary = PropertyHelper.ObjectToDictionary(routeContext.Values);
+            var valuesDictionary = new RouteValueDictionary(routeContext.Values);
 
             var path = GeneratePathFromRoute(routeContext.RouteName, valuesDictionary);
             if (path == null)
@@ -117,7 +117,7 @@ namespace Microsoft.AspNet.Mvc.Routing
             return GenerateUrl(routeContext.Protocol, routeContext.Host, path, routeContext.Fragment);
         }
 
-        private string GeneratePathFromRoute(IDictionary<string, object> values)
+        private string GeneratePathFromRoute(RouteValueDictionary values)
         {
             return GeneratePathFromRoute(routeName: null, values: values);
         }
@@ -129,7 +129,7 @@ namespace Microsoft.AspNet.Mvc.Routing
         /// <param name="routeName">The name of the route that is used to generate the URL.</param>
         /// <param name="values">A dictionary that contains the parameters for a route.</param>
         /// <returns>The absolute path of the URL.</returns>
-        protected virtual string GeneratePathFromRoute(string routeName, IDictionary<string, object> values)
+        protected virtual string GeneratePathFromRoute(string routeName, RouteValueDictionary values)
         {
             var context = new VirtualPathContext(HttpContext, AmbientValues, values, routeName);
             var pathData = Router.GetVirtualPath(context);

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Controller.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Controller.cs
@@ -1101,7 +1101,7 @@ namespace Microsoft.AspNet.Mvc
         /// </summary>
         /// <param name="actionName">The name of the action to use for generating the URL.</param>
         /// <param name="value">The content value to format in the entity body.</param>
-        /// <returns>The created <see cref="CreatedAtRouteResult"/> for the response.</returns>
+        /// <returns>The created <see cref="CreatedAtActionResult"/> for the response.</returns>
         [NonAction]
         public virtual CreatedAtActionResult CreatedAtAction(string actionName, object value)
         {
@@ -1114,7 +1114,7 @@ namespace Microsoft.AspNet.Mvc
         /// <param name="actionName">The name of the action to use for generating the URL.</param>
         /// <param name="routeValues">The route data to use for generating the URL.</param>
         /// <param name="value">The content value to format in the entity body.</param>
-        /// <returns>The created <see cref="CreatedAtRouteResult"/> for the response.</returns>
+        /// <returns>The created <see cref="CreatedAtActionResult"/> for the response.</returns>
         [NonAction]
         public virtual CreatedAtActionResult CreatedAtAction(string actionName, object routeValues, object value)
         {
@@ -1128,7 +1128,7 @@ namespace Microsoft.AspNet.Mvc
         /// <param name="controllerName">The name of the controller to use for generating the URL.</param>
         /// <param name="routeValues">The route data to use for generating the URL.</param>
         /// <param name="value">The content value to format in the entity body.</param>
-        /// <returns>The created <see cref="CreatedAtRouteResult"/> for the response.</returns>
+        /// <returns>The created <see cref="CreatedAtActionResult"/> for the response.</returns>
         [NonAction]
         public virtual CreatedAtActionResult CreatedAtAction(
             string actionName,


### PR DESCRIPTION
This is a companion change to make the RouteValueDictionary type more
promient. Using the concrete type here allows to avoid allocations in a
lot of common scenarios.