### PR TITLE
Remove FormatFilter dependency on IActionContextAccessor

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/DependencyInjection/MvcCoreMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/DependencyInjection/MvcCoreMvcCoreBuilderExtensions.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Extensions.DependencyInjection
         // Internal for testing.
         internal static void AddFormatterMappingsServices(IServiceCollection services)
         {
-            services.TryAddTransient<FormatFilter, FormatFilter>();
+            services.TryAddSingleton<FormatFilter, FormatFilter>();
         }
 
         public static IMvcCoreBuilder AddAuthorization(this IMvcCoreBuilder builder)

--- a/src/Microsoft.AspNet.Mvc.Core/Formatters/IFormatFilter.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Formatters/IFormatFilter.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNet.Mvc.Filters;
-using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNet.Mvc.Formatters
 {
@@ -12,18 +11,10 @@ namespace Microsoft.AspNet.Mvc.Formatters
     public interface IFormatFilter : IFilterMetadata
     {
         /// <summary>
-        /// format value in the current request. <c>null</c> if format not present in the current request.
+        /// Gets the format value for the request associated with the provided <see cref="ActionContext"/>. 
         /// </summary>
-        string Format { get; }
-
-        /// <summary>
-        /// <see cref="MediaTypeHeaderValue"/> for the format value in the current request.
-        /// </summary>
-        MediaTypeHeaderValue ContentType { get; }
-
-        /// <summary>
-        /// <c>true</c> if the current <see cref="FormatFilter"/> is active and will execute. 
-        /// </summary>
-        bool IsActive { get; }
+        /// <param name="context">The <see cref="ActionContext"/> associated with the current request.</param>
+        /// <returns>A format value, or <c>null</c> if a format cannot be determined for the request.</returns>
+        string GetFormat(ActionContext context);
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/ProducesAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ProducesAttribute.cs
@@ -67,7 +67,7 @@ namespace Microsoft.AspNet.Mvc
             {
                 // Check if there are any IFormatFilter in the pipeline, and if any of them is active. If there is one,
                 // do not override the content type value.
-                if (context.Filters.OfType<IFormatFilter>().All(f => !f.IsActive))
+                if (context.Filters.OfType<IFormatFilter>().All(f => f.GetFormat(context) == null))
                 {
                     SetContentTypes(objectResult.ContentTypes);
                 }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/FormatFilterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Formatters/FormatFilterTest.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
             var resultExecutingContext = mockObjects.CreateResultExecutingContext();
             var resourceExecutingContext = mockObjects.CreateResourceExecutingContext(new IFilterMetadata[] { });
 
-            var filter = new FormatFilter(mockObjects.OptionsManager, mockObjects.ActionContextAccessor);
+            var filter = new FormatFilter(mockObjects.OptionsManager);
 
             // Act
             filter.OnResourceExecuting(resourceExecutingContext);
@@ -90,7 +90,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
                 ac,
                 new IFilterMetadata[] { });
 
-            var filter = new FormatFilter(mockObjects.OptionsManager, mockObjects.ActionContextAccessor);
+            var filter = new FormatFilter(mockObjects.OptionsManager);
 
             // Act
             filter.OnResourceExecuting(resourceExecutingContext);
@@ -122,7 +122,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
                 format,
                 MediaTypeHeaderValue.Parse(contentType));
 
-            var filter = new FormatFilter(mockObjects.OptionsManager, mockObjects.ActionContextAccessor);
+            var filter = new FormatFilter(mockObjects.OptionsManager);
 
             // Act
             filter.OnResourceExecuting(resourceExecutingContext);
@@ -145,7 +145,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
             var mockObjects = new MockObjects(format, place);
             var resourceExecutingContext = mockObjects.CreateResourceExecutingContext(new IFilterMetadata[] { });
 
-            var filter = new FormatFilter(mockObjects.OptionsManager, mockObjects.ActionContextAccessor);
+            var filter = new FormatFilter(mockObjects.OptionsManager);
 
             // Act
             filter.OnResourceExecuting(resourceExecutingContext);
@@ -162,7 +162,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
             var mockObjects = new MockObjects();
             var resourceExecutingContext = mockObjects.CreateResourceExecutingContext(new IFilterMetadata[] { });
 
-            var filter = new FormatFilter(mockObjects.OptionsManager, mockObjects.ActionContextAccessor);
+            var filter = new FormatFilter(mockObjects.OptionsManager);
 
             // Act
             filter.OnResourceExecuting(resourceExecutingContext);
@@ -184,7 +184,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
             var mockObjects = new MockObjects(format, place);
             var resourceExecutingContext = mockObjects.CreateResourceExecutingContext(new IFilterMetadata[] { produces });
 
-            var filter = new FormatFilter(mockObjects.OptionsManager, mockObjects.ActionContextAccessor);
+            var filter = new FormatFilter(mockObjects.OptionsManager);
 
             // Act
             filter.OnResourceExecuting(resourceExecutingContext);
@@ -205,7 +205,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
                 "xml",
                 MediaTypeHeaderValue.Parse("application/xml"));
 
-            var filter = new FormatFilter(mockObjects.OptionsManager, mockObjects.ActionContextAccessor);
+            var filter = new FormatFilter(mockObjects.OptionsManager);
 
             // Act
             filter.OnResourceExecuting(resourceExecutingContext);
@@ -226,7 +226,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
                 "xml",
                 MediaTypeHeaderValue.Parse("application/xml;version=1"));
 
-            var filter = new FormatFilter(mockObjects.OptionsManager, mockObjects.ActionContextAccessor);
+            var filter = new FormatFilter(mockObjects.OptionsManager);
 
             // Act
             filter.OnResourceExecuting(resourceExecutingContext);
@@ -252,7 +252,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
                 "xml",
                 MediaTypeHeaderValue.Parse("application/xml"));
 
-            var filter = new FormatFilter(mockObjects.OptionsManager, mockObjects.ActionContextAccessor);
+            var filter = new FormatFilter(mockObjects.OptionsManager);
 
             // Act
             filter.OnResourceExecuting(resourceExecutingContext);
@@ -271,7 +271,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
             // Arrange
             var mockObjects = new MockObjects(format, place);
             var resourceExecutingContext = mockObjects.CreateResourceExecutingContext(new IFilterMetadata[] { });
-            var filter = new FormatFilter(mockObjects.OptionsManager, mockObjects.ActionContextAccessor);
+            var filter = new FormatFilter(mockObjects.OptionsManager);
 
             // Act
             filter.OnResourceExecuting(resourceExecutingContext);
@@ -281,23 +281,26 @@ namespace Microsoft.AspNet.Mvc.Formatters
         }
 
         [Theory]
-        [InlineData("json", FormatSource.RouteData, true)]
-        [InlineData("json", FormatSource.QueryData, true)]
-        [InlineData("", FormatSource.RouteAndQueryData, false)]
-        [InlineData(null, FormatSource.RouteAndQueryData, false)]
-        public void FormatFilter_IsActive(
-            string format,
+        [InlineData("json", FormatSource.RouteData, "json")]
+        [InlineData("json", FormatSource.QueryData, "json")]
+        [InlineData("", FormatSource.RouteAndQueryData, null)]
+        [InlineData(null, FormatSource.RouteAndQueryData, null)]
+        public void FormatFilter_GetFormat(
+            string input,
             FormatSource place,
-            bool expected)
+            string expected)
         {
             // Arrange
-            var mockObjects = new MockObjects(format, place);
-            var resultExecutingContext = mockObjects.CreateResultExecutingContext();
+            var mockObjects = new MockObjects(input, place);
+            var context = mockObjects.CreateResultExecutingContext();
             var filterAttribute = new FormatFilterAttribute();
-            var filter = new FormatFilter(mockObjects.OptionsManager, mockObjects.ActionContextAccessor);
+            var filter = new FormatFilter(mockObjects.OptionsManager);
 
-            // Act and Assert
-            Assert.Equal(expected, filter.IsActive);
+            // Act
+            var format = filter.GetFormat(context);
+
+            // Assert
+            Assert.Equal(expected, filter.GetFormat(context));
         }
 
         private static void AssertMediaTypesEqual(
@@ -322,7 +325,6 @@ namespace Microsoft.AspNet.Mvc.Formatters
             public HttpContext MockHttpContext { get; private set; }
             public ActionContext MockActionContext { get; private set; }
 
-            public IActionContextAccessor ActionContextAccessor { get; private set; }
             public IOptions<MvcOptions> OptionsManager { get; private set; }
 
             public MockObjects(string format = null, FormatSource? place = null)
@@ -399,10 +401,6 @@ namespace Microsoft.AspNet.Mvc.Formatters
 
                 // Setup MVC services on mock service provider
                 MockActionContext = CreateMockActionContext(httpContext, format, place);
-                ActionContextAccessor = new ActionContextAccessor()
-                {
-                    ActionContext = MockActionContext,
-                };
             }
         }
 #endif

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ProducesAttributeTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ProducesAttributeTests.cs
@@ -47,8 +47,9 @@ namespace Microsoft.AspNet.Mvc.Test
             var producesContentAttribute = new ProducesAttribute("application/xml");
 
             var formatFilter = new Mock<IFormatFilter>();
-            formatFilter.Setup(f => f.IsActive)
-                .Returns(false);
+            formatFilter
+                .Setup(f => f.GetFormat(It.IsAny<ActionContext>()))
+                .Returns((string)null);
 
             var filters = new IFilterMetadata[] { producesContentAttribute, formatFilter.Object };
             var resultExecutingContext = CreateResultExecutingContext(filters);
@@ -71,8 +72,9 @@ namespace Microsoft.AspNet.Mvc.Test
             var producesContentAttribute = new ProducesAttribute("application/xml");
 
             var formatFilter = new Mock<IFormatFilter>();
-            formatFilter.Setup(f => f.IsActive)
-                .Returns(true);
+            formatFilter
+                .Setup(f => f.GetFormat(It.IsAny<ActionContext>()))
+                .Returns("xml");
 
             var filters = new IFilterMetadata[] { producesContentAttribute, formatFilter.Object };
             var resultExecutingContext = CreateResultExecutingContext(filters);


### PR DESCRIPTION
This change simplifies IFormatFilter's API and removes the dependency on
IActionContext accessor.

The old API for IFormatFilter required computing state based on the
current request as part of the constructor, which in turn implied the use
of a context accessor. This isn't really needed. I didn't preserve caching of
the 'format' as that seems like an early optimization.