### PR TITLE
Adds ActionContext to OperationBindingContext

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/OperationBindingContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/OperationBindingContext.cs
@@ -15,9 +15,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
     public class OperationBindingContext
     {
         /// <summary>
-        /// Gets or sets the <see cref="HttpContext"/> for the current request.
+        /// Gets or sets the <see cref="Mvc.ActionContext"/> for the current request.
         /// </summary>
-        public HttpContext HttpContext { get; set; }
+        public ActionContext ActionContext { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="Http.HttpContext"/> for the current request.
+        /// </summary>
+        public HttpContext HttpContext => ActionContext.HttpContext;
 
         /// <summary>
         /// Gets or sets the set of <see cref="IInputFormatter"/> instances associated with this context.

--- a/src/Microsoft.AspNet.Mvc.Core/Controllers/DefaultControllerActionArgumentBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Controllers/DefaultControllerActionArgumentBinder.cs
@@ -224,11 +224,11 @@ namespace Microsoft.AspNet.Mvc.Controllers
         {
             return new OperationBindingContext
             {
+                ActionContext = context,
                 InputFormatters = context.InputFormatters,
                 ModelBinder = new CompositeModelBinder(context.ModelBinders),
                 ValidatorProvider = new CompositeModelValidatorProvider(context.ValidatorProviders),
                 MetadataProvider = _modelMetadataProvider,
-                HttpContext = context.HttpContext,
                 ValueProvider = new CompositeValueProvider(context.ValueProviders),
             };
         }

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/ModelBindingHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/ModelBindingHelper.cs
@@ -11,7 +11,6 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Mvc.Core;
 using Microsoft.AspNet.Mvc.Formatters;
 using Microsoft.AspNet.Mvc.ModelBinding.Validation;
@@ -29,7 +28,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// <param name="model">The model instance to update and validate.</param>
         /// <param name="prefix">The prefix to use when looking up values in the <paramref name="valueProvider"/>.
         /// </param>
-        /// <param name="httpContext">The <see cref="HttpContext"/> for the current executing request.</param>
+        /// <param name="actionContext">The <see cref="ActionContext"/> for the current executing request.</param>
         /// <param name="modelState">The <see cref="ModelStateDictionary"/> used for maintaining state and
         /// results of model-binding validation.</param>
         /// <param name="metadataProvider">The provider used for reading metadata for the model type.</param>
@@ -44,16 +43,16 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// on the model instance.</param>
         /// <returns>A <see cref="Task"/> that on completion returns <c>true</c> if the update is successful</returns>
         public static Task<bool> TryUpdateModelAsync<TModel>(
-                TModel model,
-                string prefix,
-                HttpContext httpContext,
-                ModelStateDictionary modelState,
-                IModelMetadataProvider metadataProvider,
-                IModelBinder modelBinder,
-                IValueProvider valueProvider,
-                IList<IInputFormatter> inputFormatters,
-                IObjectModelValidator objectModelValidator,
-                IModelValidatorProvider validatorProvider)
+            TModel model,
+            string prefix,
+            ActionContext actionContext,
+            ModelStateDictionary modelState,
+            IModelMetadataProvider metadataProvider,
+            IModelBinder modelBinder,
+            IValueProvider valueProvider,
+            IList<IInputFormatter> inputFormatters,
+            IObjectModelValidator objectModelValidator,
+            IModelValidatorProvider validatorProvider)
             where TModel : class
         {
             if (model == null)
@@ -66,9 +65,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 throw new ArgumentNullException(nameof(prefix));
             }
 
-            if (httpContext == null)
+            if (actionContext == null)
             {
-                throw new ArgumentNullException(nameof(httpContext));
+                throw new ArgumentNullException(nameof(actionContext));
             }
 
             if (modelState == null)
@@ -110,7 +109,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             return TryUpdateModelAsync(
                 model,
                 prefix,
-                httpContext,
+                actionContext,
                 modelState,
                 metadataProvider,
                 modelBinder,
@@ -130,7 +129,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// <param name="model">The model instance to update and validate.</param>
         /// <param name="prefix">The prefix to use when looking up values in the <paramref name="valueProvider"/>.
         /// </param>
-        /// <param name="httpContext">The <see cref="HttpContext"/> for the current executing request.</param>
+        /// <param name="actionContext">The <see cref="ActionContext"/> for the current executing request.</param>
         /// <param name="modelState">The <see cref="ModelStateDictionary"/> used for maintaining state and
         /// results of model-binding validation.</param>
         /// <param name="metadataProvider">The provider used for reading metadata for the model type.</param>
@@ -150,7 +149,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         public static Task<bool> TryUpdateModelAsync<TModel>(
                TModel model,
                string prefix,
-               HttpContext httpContext,
+               ActionContext actionContext,
                ModelStateDictionary modelState,
                IModelMetadataProvider metadataProvider,
                IModelBinder modelBinder,
@@ -171,9 +170,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 throw new ArgumentNullException(nameof(prefix));
             }
 
-            if (httpContext == null)
+            if (actionContext == null)
             {
-                throw new ArgumentNullException(nameof(httpContext));
+                throw new ArgumentNullException(nameof(actionContext));
             }
 
             if (modelState == null)
@@ -222,7 +221,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             return TryUpdateModelAsync(
                model,
                prefix,
-               httpContext,
+               actionContext,
                modelState,
                metadataProvider,
                modelBinder,
@@ -242,7 +241,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// <param name="model">The model instance to update and validate.</param>
         /// <param name="prefix">The prefix to use when looking up values in the <paramref name="valueProvider"/>.
         /// </param>
-        /// <param name="httpContext">The <see cref="HttpContext"/> for the current executing request.</param>
+        /// <param name="actionContext">The <see cref="ActionContext"/> for the current executing request.</param>
         /// <param name="modelState">The <see cref="ModelStateDictionary"/> used for maintaining state and
         /// results of model-binding validation.</param>
         /// <param name="metadataProvider">The provider used for reading metadata for the model type.</param>
@@ -261,7 +260,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         public static Task<bool> TryUpdateModelAsync<TModel>(
                TModel model,
                string prefix,
-               HttpContext httpContext,
+               ActionContext actionContext,
                ModelStateDictionary modelState,
                IModelMetadataProvider metadataProvider,
                IModelBinder modelBinder,
@@ -282,9 +281,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 throw new ArgumentNullException(nameof(prefix));
             }
 
-            if (httpContext == null)
+            if (actionContext == null)
             {
-                throw new ArgumentNullException(nameof(httpContext));
+                throw new ArgumentNullException(nameof(actionContext));
             }
 
             if (modelState == null)
@@ -331,7 +330,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                model,
                typeof(TModel),
                prefix,
-               httpContext,
+               actionContext,
                modelState,
                metadataProvider,
                modelBinder,
@@ -351,7 +350,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// <param name="modelType">The type of model instance to update and validate.</param>
         /// <param name="prefix">The prefix to use when looking up values in the <paramref name="valueProvider"/>.
         /// </param>
-        /// <param name="httpContext">The <see cref="HttpContext"/> for the current executing request.</param>
+        /// <param name="actionContext">The <see cref="ActionContext"/> for the current executing request.</param>
         /// <param name="modelState">The <see cref="ModelStateDictionary"/> used for maintaining state and
         /// results of model-binding validation.</param>
         /// <param name="metadataProvider">The provider used for reading metadata for the model type.</param>
@@ -369,7 +368,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 object model,
                 Type modelType,
                 string prefix,
-                HttpContext httpContext,
+                ActionContext actionContext,
                 ModelStateDictionary modelState,
                 IModelMetadataProvider metadataProvider,
                 IModelBinder modelBinder,
@@ -393,9 +392,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 throw new ArgumentNullException(nameof(prefix));
             }
 
-            if (httpContext == null)
+            if (actionContext == null)
             {
-                throw new ArgumentNullException(nameof(httpContext));
+                throw new ArgumentNullException(nameof(actionContext));
             }
 
             if (modelState == null)
@@ -438,7 +437,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 model,
                 modelType,
                 prefix,
-                httpContext,
+                actionContext,
                 modelState,
                 metadataProvider,
                 modelBinder,
@@ -458,7 +457,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
         /// <param name="modelType">The type of model instance to update and validate.</param>
         /// <param name="prefix">The prefix to use when looking up values in the <paramref name="valueProvider"/>.
         /// </param>
-        /// <param name="httpContext">The <see cref="HttpContext"/> for the current executing request.</param>
+        /// <param name="actionContext">The <see cref="ActionContext"/> for the current executing request.</param>
         /// <param name="modelState">The <see cref="ModelStateDictionary"/> used for maintaining state and
         /// results of model-binding validation.</param>
         /// <param name="metadataProvider">The provider used for reading metadata for the model type.</param>
@@ -478,7 +477,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                object model,
                Type modelType,
                string prefix,
-               HttpContext httpContext,
+               ActionContext actionContext,
                ModelStateDictionary modelState,
                IModelMetadataProvider metadataProvider,
                IModelBinder modelBinder,
@@ -503,9 +502,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 throw new ArgumentNullException(nameof(prefix));
             }
 
-            if (httpContext == null)
+            if (actionContext == null)
             {
-                throw new ArgumentNullException(nameof(httpContext));
+                throw new ArgumentNullException(nameof(actionContext));
             }
 
             if (modelState == null)
@@ -567,7 +566,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 ModelBinder = modelBinder,
                 ValidatorProvider = validatorProvider,
                 MetadataProvider = metadataProvider,
-                HttpContext = httpContext,
+                ActionContext = actionContext,
                 ValueProvider = valueProvider,
             };
 

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Controller.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Controller.cs
@@ -1446,7 +1446,7 @@ namespace Microsoft.AspNet.Mvc
             return ModelBindingHelper.TryUpdateModelAsync(
                 model,
                 prefix,
-                HttpContext,
+                ControllerContext,
                 ModelState,
                 MetadataProvider,
                 new CompositeModelBinder(ControllerContext.ModelBinders),
@@ -1487,7 +1487,7 @@ namespace Microsoft.AspNet.Mvc
             return ModelBindingHelper.TryUpdateModelAsync(
                 model,
                 prefix,
-                HttpContext,
+                ControllerContext,
                 ModelState,
                 MetadataProvider,
                 new CompositeModelBinder(ControllerContext.ModelBinders),
@@ -1528,7 +1528,7 @@ namespace Microsoft.AspNet.Mvc
             return ModelBindingHelper.TryUpdateModelAsync(
                 model,
                 prefix,
-                HttpContext,
+                ControllerContext,
                 ModelState,
                 MetadataProvider,
                 new CompositeModelBinder(ControllerContext.ModelBinders),
@@ -1577,7 +1577,7 @@ namespace Microsoft.AspNet.Mvc
             return ModelBindingHelper.TryUpdateModelAsync(
                 model,
                 prefix,
-                HttpContext,
+                ControllerContext,
                 ModelState,
                 MetadataProvider,
                 new CompositeModelBinder(ControllerContext.ModelBinders),
@@ -1625,7 +1625,7 @@ namespace Microsoft.AspNet.Mvc
             return ModelBindingHelper.TryUpdateModelAsync(
                 model,
                 prefix,
-                HttpContext,
+                ControllerContext,
                 ModelState,
                 MetadataProvider,
                 new CompositeModelBinder(ControllerContext.ModelBinders),
@@ -1665,7 +1665,7 @@ namespace Microsoft.AspNet.Mvc
                 model,
                 modelType,
                 prefix,
-                HttpContext,
+                ControllerContext,
                 ModelState,
                 MetadataProvider,
                 new CompositeModelBinder(ControllerContext.ModelBinders),
@@ -1718,7 +1718,7 @@ namespace Microsoft.AspNet.Mvc
                 model,
                 modelType,
                 prefix,
-                HttpContext,
+                ControllerContext,
                 ModelState,
                 MetadataProvider,
                 new CompositeModelBinder(ControllerContext.ModelBinders),

--- a/test/Microsoft.AspNet.Mvc.Core.Test/BindAttributeTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/BindAttributeTest.cs
@@ -76,7 +76,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var context = new ModelBindingContext();
             context.OperationBindingContext = new OperationBindingContext()
             {
-                HttpContext = new DefaultHttpContext(),
+                ActionContext = new ActionContext()
+                {
+                    HttpContext = new DefaultHttpContext(),
+                },
             };
             var services = new Mock<IServiceProvider>();
 
@@ -100,7 +103,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var context = new ModelBindingContext();
             context.OperationBindingContext = new OperationBindingContext()
             {
-                HttpContext = new DefaultHttpContext(),
+                ActionContext = new ActionContext()
+                {
+                    HttpContext = new DefaultHttpContext(),
+                },
             };
 
             var services = new Mock<IServiceProvider>(MockBehavior.Strict);

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/ArrayModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/ArrayModelBinderTest.cs
@@ -209,7 +209,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             {
                 OperationBindingContext = new OperationBindingContext()
                 {
-                    HttpContext = new DefaultHttpContext(),
+                    ActionContext = new ActionContext()
+                    {
+                        HttpContext = new DefaultHttpContext(),
+                    },
                     MetadataProvider = new TestModelMetadataProvider(),
                 }
             };

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BinderTypeBasedModelBinderModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BinderTypeBasedModelBinderModelBinderTest.cs
@@ -94,8 +94,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
 
             var operationBindingContext = new OperationBindingContext
             {
+                ActionContext = new ActionContext()
+                {
+                    HttpContext = new DefaultHttpContext(),
+                },
                 MetadataProvider = metadataProvider,
-                HttpContext = new DefaultHttpContext(),
                 ValidatorProvider = Mock.Of<IModelValidatorProvider>(),
             };
 

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BodyModelBinderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/BodyModelBinderTests.cs
@@ -256,10 +256,13 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             var operationBindingContext = new OperationBindingContext
             {
+                ActionContext = new ActionContext()
+                {
+                    HttpContext = httpContext,
+                },
                 InputFormatters = inputFormatters.ToList(),
                 ModelBinder = new BodyModelBinder(new TestHttpRequestStreamReaderFactory()),
                 MetadataProvider = metadataProvider,
-                HttpContext = httpContext,
             };
 
             var bindingContext = new ModelBindingContext

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CancellationTokenModelBinderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CancellationTokenModelBinderTests.cs
@@ -54,9 +54,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
                 ValueProvider = new SimpleValueProvider(),
                 OperationBindingContext = new OperationBindingContext
                 {
+                    ActionContext = new ActionContext()
+                    {
+                        HttpContext = new DefaultHttpContext(),
+                    },
                     ModelBinder = new CancellationTokenModelBinder(),
                     MetadataProvider = metadataProvider,
-                    HttpContext = new DefaultHttpContext(),
                 }
             };
 

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CollectionModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/CollectionModelBinderTest.cs
@@ -426,7 +426,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             {
                 OperationBindingContext = new OperationBindingContext()
                 {
-                    HttpContext = new DefaultHttpContext(),
+                    ActionContext = new ActionContext()
+                    {
+                        HttpContext = new DefaultHttpContext(),
+                    },
                     MetadataProvider = new TestModelMetadataProvider(),
                 }
             };

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/DictionaryModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/DictionaryModelBinderTest.cs
@@ -416,7 +416,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
                 ModelState = new ModelStateDictionary(),
                 OperationBindingContext = new OperationBindingContext()
                 {
-                    HttpContext = new DefaultHttpContext(),
+                    ActionContext = new ActionContext()
+                    {
+                        HttpContext = new DefaultHttpContext(),
+                    },
                     MetadataProvider = new TestModelMetadataProvider(),
                 },
                 ValidationState = new ValidationStateDictionary(),

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/FormCollectionModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/FormCollectionModelBinderTest.cs
@@ -125,9 +125,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 ModelName = "file",
                 OperationBindingContext = new OperationBindingContext
                 {
+                    ActionContext = new ActionContext()
+                    {
+                        HttpContext = httpContext,
+                    },
                     ModelBinder = new FormCollectionModelBinder(),
                     MetadataProvider = metadataProvider,
-                    HttpContext = httpContext,
                 },
                 ValidationState = new ValidationStateDictionary(),
             };

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/FormFileModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/FormFileModelBinderTest.cs
@@ -221,9 +221,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 ModelState = new ModelStateDictionary(),
                 OperationBindingContext = new OperationBindingContext
                 {
+                    ActionContext = new ActionContext()
+                    {
+                        HttpContext = httpContext,
+                    },
                     ModelBinder = new FormFileModelBinder(),
                     MetadataProvider = metadataProvider,
-                    HttpContext = httpContext,
                 },
                 ValidationState = new ValidationStateDictionary(),
             };

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/HeaderModelBinderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/HeaderModelBinderTests.cs
@@ -129,9 +129,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
                 ModelState = new ModelStateDictionary(),
                 OperationBindingContext = new OperationBindingContext
                 {
+                    ActionContext = new ActionContext()
+                    {
+                        HttpContext = new DefaultHttpContext(),
+                    },
                     ModelBinder = new HeaderModelBinder(),
                     MetadataProvider = metadataProvider,
-                    HttpContext = new DefaultHttpContext()
                 },
                 BinderModelName = modelMetadata.BinderModelName,
                 BindingSource = modelMetadata.BindingSource,

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/KeyValuePairModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/KeyValuePairModelBinderTest.cs
@@ -200,7 +200,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Test
             {
                 OperationBindingContext = new OperationBindingContext()
                 {
-                    HttpContext = new DefaultHttpContext(),
+                    ActionContext = new ActionContext()
+                    {
+                        HttpContext = new DefaultHttpContext(),
+                    },
                     MetadataProvider = new TestModelMetadataProvider(),
                     ModelBinder = new SimpleTypeModelBinder(),
                 },

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/ModelBindingHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/ModelBindingHelperTest.cs
@@ -8,7 +8,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Http;
+using Microsoft.AspNet.Http.Internal;
 using Microsoft.AspNet.Mvc.Formatters;
 using Microsoft.AspNet.Mvc.ModelBinding.Validation;
 using Moq;
@@ -46,7 +46,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var result = await ModelBindingHelper.TryUpdateModelAsync(
                 model,
                 string.Empty,
-                Mock.Of<HttpContext>(),
+                new ActionContext() { HttpContext = new DefaultHttpContext() },
                 new ModelStateDictionary(),
                 metadataProvider,
                 GetCompositeBinder(binder.Object),
@@ -88,7 +88,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var result = await ModelBindingHelper.TryUpdateModelAsync(
                 model,
                 "",
-                Mock.Of<HttpContext>(),
+                new ActionContext() { HttpContext = new DefaultHttpContext() },
                 modelStateDictionary,
                 modelMetadataProvider,
                 GetCompositeBinder(binders),
@@ -130,7 +130,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var result = await ModelBindingHelper.TryUpdateModelAsync(
                 model,
                 "",
-                Mock.Of<HttpContext>(),
+                new ActionContext() { HttpContext = new DefaultHttpContext() },
                 modelStateDictionary,
                 metadataProvider,
                 GetCompositeBinder(binders),
@@ -162,7 +162,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var result = await ModelBindingHelper.TryUpdateModelAsync(
                 model,
                 string.Empty,
-                Mock.Of<HttpContext>(),
+                new ActionContext() { HttpContext = new DefaultHttpContext() },
                 new ModelStateDictionary(),
                 metadataProvider,
                 GetCompositeBinder(binder.Object),
@@ -218,7 +218,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var result = await ModelBindingHelper.TryUpdateModelAsync(
                 model,
                 "",
-                Mock.Of<HttpContext>(),
+                new ActionContext() { HttpContext = new DefaultHttpContext() },
                 modelStateDictionary,
                 metadataProvider,
                 GetCompositeBinder(binders),
@@ -252,7 +252,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var result = await ModelBindingHelper.TryUpdateModelAsync(
                 model,
                 string.Empty,
-                Mock.Of<HttpContext>(),
+                new ActionContext() { HttpContext = new DefaultHttpContext() },
                 new ModelStateDictionary(),
                 metadataProvider,
                 GetCompositeBinder(binder.Object),
@@ -305,7 +305,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var result = await ModelBindingHelper.TryUpdateModelAsync(
                 model,
                 "",
-                Mock.Of<HttpContext>(),
+                new ActionContext() { HttpContext = new DefaultHttpContext() },
                 modelStateDictionary,
                 TestModelMetadataProvider.CreateDefaultProvider(),
                 GetCompositeBinder(binders),
@@ -359,7 +359,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             var result = await ModelBindingHelper.TryUpdateModelAsync(
                 model,
                 "",
-                Mock.Of<HttpContext>(),
+                new ActionContext() { HttpContext = new DefaultHttpContext() },
                 modelStateDictionary,
                 metadataProvider,
                 GetCompositeBinder(binders),
@@ -514,7 +514,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 model,
                 model.GetType(),
                 prefix: "",
-                httpContext: Mock.Of<HttpContext>(),
+                actionContext: new ActionContext() { HttpContext = new DefaultHttpContext() },
                 modelState: new ModelStateDictionary(),
                 metadataProvider: metadataProvider,
                 modelBinder: GetCompositeBinder(binder.Object),
@@ -570,20 +570,20 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             // Act
             var result = await ModelBindingHelper.TryUpdateModelAsync(
-                                                    model,
-                                                    model.GetType(),
-                                                    "",
-                                                    Mock.Of<HttpContext>(),
-                                                    modelStateDictionary,
-                                                    metadataProvider,
-                                                    GetCompositeBinder(binders),
-                                                    valueProvider,
-                                                    new List<IInputFormatter>(),
-                                                    new DefaultObjectValidator(
-                                                        new IExcludeTypeValidationFilter[0],
-                                                        metadataProvider),
-                                                    validator,
-                                                    includePredicate);
+                model,
+                model.GetType(),
+                "",
+                new ActionContext() { HttpContext = new DefaultHttpContext() },
+                modelStateDictionary,
+                metadataProvider,
+                GetCompositeBinder(binders),
+                valueProvider,
+                new List<IInputFormatter>(),
+                new DefaultObjectValidator(
+                    new IExcludeTypeValidationFilter[0],
+                    metadataProvider),
+                validator,
+                includePredicate);
 
             // Assert
             Assert.True(result);
@@ -610,7 +610,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 model,
                 modelType: model.GetType(),
                 prefix: "",
-                httpContext: Mock.Of<HttpContext>(),
+                actionContext: new ActionContext() { HttpContext = new DefaultHttpContext() },
                 modelState: new ModelStateDictionary(),
                 metadataProvider: metadataProvider,
                 modelBinder: GetCompositeBinder(binder.Object),
@@ -649,19 +649,19 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
 
             // Act
             var result = await ModelBindingHelper.TryUpdateModelAsync(
-                                                    model,
-                                                    model.GetType(),
-                                                    "",
-                                                    Mock.Of<HttpContext>(),
-                                                    modelStateDictionary,
-                                                    TestModelMetadataProvider.CreateDefaultProvider(),
-                                                    GetCompositeBinder(binders),
-                                                    valueProvider,
-                                                    new List<IInputFormatter>(),
-                                                    new DefaultObjectValidator(
-                                                        new IExcludeTypeValidationFilter[0],
-                                                        metadataProvider),
-                                                    validator);
+                model,
+                model.GetType(),
+                "",
+                new ActionContext() { HttpContext = new DefaultHttpContext() },
+                modelStateDictionary,
+                TestModelMetadataProvider.CreateDefaultProvider(),
+                GetCompositeBinder(binders),
+                valueProvider,
+                new List<IInputFormatter>(),
+                new DefaultObjectValidator(
+                    new IExcludeTypeValidationFilter[0],
+                    metadataProvider),
+                validator);
 
             // Assert
             Assert.True(result);
@@ -687,7 +687,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                     model,
                     typeof(User),
                     "",
-                    Mock.Of<HttpContext>(),
+                    new ActionContext() { HttpContext = new DefaultHttpContext() },
                     new ModelStateDictionary(),
                     metadataProvider,
                     GetCompositeBinder(binder.Object),

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/MutableObjectModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/MutableObjectModelBinderTest.cs
@@ -681,9 +681,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 ModelMetadata = GetMetadataForType(typeof(TypeWithExcludedPropertiesUsingBindAttribute)),
                 OperationBindingContext = new OperationBindingContext
                 {
-                    HttpContext = new DefaultHttpContext
+                    ActionContext = new ActionContext()
                     {
-                        RequestServices = CreateServices()
+                        HttpContext = new DefaultHttpContext()
+                        {
+                            RequestServices = CreateServices(),
+                        },
                     },
                     ValidatorProvider = Mock.Of<IModelValidatorProvider>(),
                     MetadataProvider = TestModelMetadataProvider.CreateDefaultProvider(),

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/ServicesModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/ServicesModelBinderTest.cs
@@ -88,12 +88,15 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
                 ModelState = new ModelStateDictionary(),
                 OperationBindingContext = new OperationBindingContext
                 {
+                    ActionContext = new ActionContext()
+                    {
+                        HttpContext = new DefaultHttpContext()
+                        {
+                            RequestServices = services.BuildServiceProvider(),
+                        }
+                    },
                     ModelBinder = new HeaderModelBinder(),
                     MetadataProvider = metadataProvider,
-                    HttpContext = new DefaultHttpContext()
-                    {
-                        RequestServices = services.BuildServiceProvider(),
-                    },
                 },
                 BinderModelName = modelMetadata.BinderModelName,
                 BindingSource = modelMetadata.BindingSource,

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/ModelBindingTestHelper.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/ModelBindingTestHelper.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             return new OperationBindingContext()
             {
-                HttpContext = httpContext,
+                ActionContext = controllerContext,
                 InputFormatters = controllerContext.InputFormatters,
                 MetadataProvider = TestModelMetadataProvider.CreateDefaultProvider(),
                 ValidatorProvider = new CompositeModelValidatorProvider(controllerContext.ValidatorProviders),

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/TryUpdateModelIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/TryUpdateModelIntegrationTest.cs
@@ -1105,7 +1105,7 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                model,
                model.GetType(),
                prefix,
-               operationContext.HttpContext,
+               operationContext.ActionContext,
                modelState,
                operationContext.MetadataProvider,
                operationContext.ModelBinder,

--- a/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/HttpRequestMessage/HttpRequestMessageModelBinderTest.cs
+++ b/test/Microsoft.AspNet.Mvc.WebApiCompatShimTest/HttpRequestMessage/HttpRequestMessageModelBinderTest.cs
@@ -61,7 +61,10 @@ namespace Microsoft.AspNet.Mvc.WebApiCompatShim
                 ModelName = "someName",
                 OperationBindingContext = new OperationBindingContext
                 {
-                    HttpContext = new DefaultHttpContext(),
+                    ActionContext = new ActionContext()
+                    {
+                        HttpContext = new DefaultHttpContext(),
+                    },
                     MetadataProvider = metadataProvider,
                 },
                 ValidationState = new ValidationStateDictionary(),


### PR DESCRIPTION
This change makes it possible to access the ActionContext/ActionDescriptor
from inside of modelbinding.