### PR TITLE
Remove the use of `Linq` and unneeded enumerators from Mvc `TagHelper`s.

### DIFF
--- a/src/Microsoft.AspNet.Mvc.TagHelpers/AnchorTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/AnchorTagHelper.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Mvc.ViewFeatures;
 using Microsoft.AspNet.Razor.TagHelpers;
@@ -32,6 +31,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         private const string RouteValuesDictionaryName = "asp-all-route-data";
         private const string RouteValuesPrefix = "asp-route-";
         private const string Href = "href";
+        private IDictionary<string, string> _routeValues;
 
         /// <summary>
         /// Creates a new <see cref="AnchorTagHelper"/>.
@@ -98,8 +98,22 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         /// Additional parameters for the route.
         /// </summary>
         [HtmlAttributeName(RouteValuesDictionaryName, DictionaryAttributePrefix = RouteValuesPrefix)]
-        public IDictionary<string, string> RouteValues { get; set; } =
-            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        public IDictionary<string, string> RouteValues
+        {
+            get
+            {
+                if (_routeValues == null)
+                {
+                    _routeValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                }
+
+                return _routeValues;
+            }
+            set
+            {
+                _routeValues = value;
+            }
+        }
 
         /// <inheritdoc />
         /// <remarks>Does nothing if user provides an <c>href</c> attribute.</remarks>
@@ -148,11 +162,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             }
             else
             {
-                // Convert from Dictionary<string, string> to Dictionary<string, object>.
-                var routeValues = RouteValues.ToDictionary(
-                    kvp => kvp.Key,
-                    kvp => (object)kvp.Value,
-                    StringComparer.OrdinalIgnoreCase);
+                IDictionary<string, object> routeValues = null;
+                if (_routeValues != null && _routeValues.Count > 0)
+                {
+                    // Convert from Dictionary<string, string> to Dictionary<string, object>.
+                    routeValues = new Dictionary<string, object>(_routeValues.Count, StringComparer.OrdinalIgnoreCase);
+                    foreach (var routeValue in _routeValues)
+                    {
+                        routeValues.Add(routeValue.Key, routeValue.Value);
+                    }
+                }
 
                 TagBuilder tagBuilder;
                 if (Route == null)
@@ -180,13 +199,14 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 }
                 else
                 {
-                    tagBuilder = Generator.GenerateRouteLink(linkText: string.Empty,
-                                                             routeName: Route,
-                                                             protocol: Protocol,
-                                                             hostName: Host,
-                                                             fragment: Fragment,
-                                                             routeValues: routeValues,
-                                                             htmlAttributes: null);
+                    tagBuilder = Generator.GenerateRouteLink(
+                        linkText: string.Empty,
+                        routeName: Route,
+                        protocol: Protocol,
+                        hostName: Host,
+                        fragment: Fragment,
+                        routeValues: routeValues,
+                        htmlAttributes: null);
                 }
 
                 if (tagBuilder != null)

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/EnvironmentTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/EnvironmentTagHelper.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
+using System.Collections.Generic;
 using Microsoft.AspNet.Hosting;
 using Microsoft.AspNet.Razor.TagHelpers;
 
@@ -67,28 +67,39 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 return;
             }
 
-            var environments = Names.Split(NameSeparator, StringSplitOptions.RemoveEmptyEntries)
-                                    .Where(name => !string.IsNullOrWhiteSpace(name));
-
-            if (!environments.Any())
-            {
-                // Names contains only commas or empty entries, do nothing
-                return;
-            }
-
             var currentEnvironmentName = HostingEnvironment.EnvironmentName?.Trim();
-
-            if (string.IsNullOrWhiteSpace(currentEnvironmentName))
+            if (string.IsNullOrEmpty(currentEnvironmentName))
             {
                 // No current environment name, do nothing
                 return;
             }
 
-            if (environments.Any(name =>
-                string.Equals(name.Trim(), currentEnvironmentName, StringComparison.OrdinalIgnoreCase)))
+            var values = Names.Split(NameSeparator, StringSplitOptions.RemoveEmptyEntries);
+            var environments = new List<string>();
+
+            for (var i = 0; i < values.Length; i++)
             {
-                // Matching environment name found, do nothing
+                var trimmedValue = values[i].Trim();
+
+                if (trimmedValue.Length > 0)
+                {
+                    environments.Add(trimmedValue);
+                }
+            }
+
+            if (environments.Count == 0)
+            {
+                // Names contains only commas or empty entries, do nothing
                 return;
+            }
+
+            for (var i = 0; i < environments.Count; i++)
+            {
+                if (string.Equals(environments[i], currentEnvironmentName, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Matching environment name found, do nothing
+                    return;
+                }
             }
 
             // No matching environment name found, suppress all output

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/FormTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/FormTagHelper.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.AspNet.Mvc.Rendering;
 using Microsoft.AspNet.Mvc.ViewFeatures;
 using Microsoft.AspNet.Razor.TagHelpers;
@@ -28,6 +27,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         private const string RouteValuesDictionaryName = "asp-all-route-data";
         private const string RouteValuesPrefix = "asp-route-";
         private const string HtmlActionAttributeName = "action";
+        private IDictionary<string, string> _routeValues;
 
         /// <summary>
         /// Creates a new <see cref="FormTagHelper"/>.
@@ -85,8 +85,22 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
         /// Additional parameters for the route.
         /// </summary>
         [HtmlAttributeName(RouteValuesDictionaryName, DictionaryAttributePrefix = RouteValuesPrefix)]
-        public IDictionary<string, string> RouteValues { get; set; } =
-            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        public IDictionary<string, string> RouteValues
+        {
+            get
+            {
+                if (_routeValues == null)
+                {
+                    _routeValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                }
+
+                return _routeValues;
+            }
+            set
+            {
+                _routeValues = value;
+            }
+        }
 
         /// <inheritdoc />
         /// <remarks>
@@ -133,11 +147,16 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             }
             else
             {
-                // Convert from Dictionary<string, string> to Dictionary<string, object>.
-                var routeValues = RouteValues.ToDictionary(
-                    kvp => kvp.Key,
-                    kvp => (object)kvp.Value,
-                    StringComparer.OrdinalIgnoreCase);
+                IDictionary<string, object> routeValues = null;
+                if (_routeValues != null && _routeValues.Count > 0)
+                {
+                    // Convert from Dictionary<string, string> to Dictionary<string, object>.
+                    routeValues = new Dictionary<string, object>(_routeValues.Count, StringComparer.OrdinalIgnoreCase);
+                    foreach (var routeValue in _routeValues)
+                    {
+                        routeValues.Add(routeValue.Key, routeValue.Value);
+                    }
+                }
 
                 TagBuilder tagBuilder;
                 if (Route == null)

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/GlobbingUrlBuilder.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/GlobbingUrlBuilder.cs
@@ -73,7 +73,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
         /// <param name="includePattern">The file globbing include pattern.</param>
         /// <param name="excludePattern">The file globbing exclude pattern.</param>
         /// <returns>The list of URLs</returns>
-        public virtual IEnumerable<string> BuildUrlList(string staticUrl, string includePattern, string excludePattern)
+        public virtual ICollection<string> BuildUrlList(string staticUrl, string includePattern, string excludePattern)
         {
             var urls = new HashSet<string>(StringComparer.Ordinal);
 
@@ -112,9 +112,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
                 if (!Cache.TryGetValue(cacheKey, out files))
                 {
                     var options = new MemoryCacheEntryOptions();
-                    foreach (var pattern in includePatterns)
+
+                    for (var i = 0; i < includePatterns.Length; i++)
                     {
-                        var changeToken = FileProvider.Watch(pattern);
+                        var changeToken = FileProvider.Watch(includePatterns[i]);
                         options.AddExpirationToken(changeToken);
                     }
 
@@ -128,15 +129,24 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
             return FindFiles(includePatterns, excludePatterns);
         }
 
-        private IEnumerable<string> FindFiles(IEnumerable<string> includePatterns, IEnumerable<string> excludePatterns)
+        private IEnumerable<string> FindFiles(string[] includePatterns, string[] excludePatterns)
         {
             var matcher = MatcherBuilder != null ? MatcherBuilder() : new Matcher();
-
-            matcher.AddIncludePatterns(includePatterns.Select(pattern => TrimLeadingTildeSlash(pattern)));
+            var trimmedIncludePatterns = new List<string>();
+            for (var i = 0; i < includePatterns.Length; i++)
+            {
+                trimmedIncludePatterns.Add(TrimLeadingTildeSlash(includePatterns[i]));
+            }
+            matcher.AddIncludePatterns(trimmedIncludePatterns);
 
             if (excludePatterns != null)
             {
-                matcher.AddExcludePatterns(excludePatterns.Select(pattern => TrimLeadingTildeSlash(pattern)));
+                var trimmedExcludePatterns = new List<string>();
+                for (var i = 0; i < excludePatterns.Length; i++)
+                {
+                    trimmedExcludePatterns.Add(TrimLeadingTildeSlash(excludePatterns[i]));
+                }
+                matcher.AddExcludePatterns(trimmedExcludePatterns);
             }
 
             var matches = matcher.Execute(_baseGlobbingDirectory);

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/JavaScriptStringArrayEncoder.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/JavaScriptStringArrayEncoder.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
         /// <summary>
         /// Encodes a .NET string array for safe use as a JavaScript array literal, including inline in an HTML file.
         /// </summary>
-        public static string Encode(JavaScriptEncoder encoder, IEnumerable<string> values)
+        public static string Encode(JavaScriptEncoder encoder, string[] values)
         {
             var writer = new StringWriter();
 
@@ -23,14 +23,15 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
 
             writer.Write('[');
 
-            foreach (var value in values)
+            // Perf: Avoid allocating enumerator
+            for (var i = 0; i < values.Length; i++)
             {
                 if (firstAdded)
                 {
                     writer.Write(',');
                 }
                 writer.Write('"');
-                encoder.Encode(writer, value);
+                encoder.Encode(writer, values[i]);
                 writer.Write('"');
                 firstAdded = true;
             }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/ModeAttributes.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/ModeAttributes.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
         /// <summary>
         /// Creates an <see cref="ModeAttributes{TMode}"/>/
         /// </summary>
-        public static ModeAttributes<TMode> Create<TMode>(TMode mode, IEnumerable<string> attributes)
+        public static ModeAttributes<TMode> Create<TMode>(TMode mode, string[] attributes)
         {
             return new ModeAttributes<TMode>
             {

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/ModeAttributesOfT.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/ModeAttributesOfT.cs
@@ -1,25 +1,22 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using Microsoft.AspNet.Razor.TagHelpers;
-
 namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
 {
     /// <summary>
-    /// A mapping of a <see cref="ITagHelper"/> mode to its required attributes.
+    /// A mapping of a <see cref="AspNet.Razor.TagHelpers.ITagHelper"/> mode to its required attributes.
     /// </summary>
-    /// <typeparam name="TMode">The type representing the <see cref="ITagHelper"/>'s mode.</typeparam>
+    /// <typeparam name="TMode">The type representing the <see cref="AspNet.Razor.TagHelpers.ITagHelper"/>'s mode.</typeparam>
     public class ModeAttributes<TMode>
     {
         /// <summary>
-        /// The <see cref="ITagHelper"/>'s mode.
+        /// The <see cref="AspNet.Razor.TagHelpers.ITagHelper"/>'s mode.
         /// </summary>
         public TMode Mode { get; set; }
 
         /// <summary>
         /// The names of attributes required for this mode.
         /// </summary>
-        public IEnumerable<string> Attributes { get; set; }
+        public string[] Attributes { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/ModeMatchAttributes.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/ModeMatchAttributes.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
         /// </summary>
         public static ModeMatchAttributes<TMode> Create<TMode>(
            TMode mode,
-           IEnumerable<string> presentAttributes)
+           IList<string> presentAttributes)
         {
             return Create(mode, presentAttributes, missingAttributes: null);
         }
@@ -25,8 +25,8 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
         /// </summary>
         public static ModeMatchAttributes<TMode> Create<TMode>(
             TMode mode,
-            IEnumerable<string> presentAttributes,
-            IEnumerable<string> missingAttributes)
+            IList<string> presentAttributes,
+            IList<string> missingAttributes)
         {
             return new ModeMatchAttributes<TMode>
             {

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/ModeMatchAttributesOfT.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/ModeMatchAttributesOfT.cs
@@ -2,29 +2,28 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using Microsoft.AspNet.Razor.TagHelpers;
 
 namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
 {
     /// <summary>
-    /// A mapping of a <see cref="ITagHelper"/> mode to its missing and present attributes.
+    /// A mapping of a <see cref="AspNet.Razor.TagHelpers.ITagHelper"/> mode to its missing and present attributes.
     /// </summary>
-    /// <typeparam name="TMode">The type representing the <see cref="ITagHelper"/>'s mode.</typeparam>
+    /// <typeparam name="TMode">The type representing the <see cref="AspNet.Razor.TagHelpers.ITagHelper"/>'s mode.</typeparam>
     public class ModeMatchAttributes<TMode>
     {
         /// <summary>
-        /// The <see cref="ITagHelper"/>'s mode.
+        /// The <see cref="AspNet.Razor.TagHelpers.ITagHelper"/>'s mode.
         /// </summary>
         public TMode Mode { get; set; }
 
         /// <summary>
         /// The names of attributes that were present in this match.
         /// </summary>
-        public IEnumerable<string> PresentAttributes { get; set; }
+        public IList<string> PresentAttributes { get; set; }
 
         /// <summary>
         /// The names of attributes that were missing in this match.
         /// </summary>
-        public IEnumerable<string> MissingAttributes { get; set; }
+        public IList<string> MissingAttributes { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/ModeMatchResult.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/Internal/ModeMatchResult.cs
@@ -1,20 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using Microsoft.AspNet.Mvc.Logging;
-using Microsoft.AspNet.Mvc.TagHelpers.Logging;
-using Microsoft.AspNet.Razor.TagHelpers;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
 {
     /// <summary>
-    /// Result of determining the mode an <see cref="ITagHelper"/> will run in.
+    /// Result of determining the mode an <see cref="AspNet.Razor.TagHelpers.ITagHelper"/> will run in.
     /// </summary>
-    /// <typeparam name="TMode">The type representing the <see cref="ITagHelper"/>'s mode.</typeparam>
+    /// <typeparam name="TMode">The type representing the <see cref="AspNet.Razor.TagHelpers.ITagHelper"/>'s mode.</typeparam>
     public class ModeMatchResult<TMode>
     {
         /// <summary>
@@ -32,47 +26,5 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
         /// <see cref="FullMatches"/>.
         /// </summary>
         public IList<string> PartiallyMatchedAttributes { get; } = new List<string>();
-
-        /// <summary>
-        /// Logs the details of the <see cref="ModeMatchResult{TMode}"/>.
-        /// </summary>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        /// <param name="tagHelper">The <see cref="ITagHelper"/>.</param>
-        /// <param name="uniqueId">The value of <see cref="TagHelperContext.UniqueId"/>.</param>
-        /// <param name="viewPath">The path to the view the <see cref="ITagHelper"/> is on.</param>
-        public void LogDetails<TTagHelper>(
-            ILogger logger,
-            TTagHelper tagHelper,
-            string uniqueId,
-            string viewPath)
-            where TTagHelper : ITagHelper
-        {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            if (tagHelper == null)
-            {
-                throw new ArgumentNullException(nameof(tagHelper));
-            }
-
-            if (logger.IsEnabled(LogLevel.Warning) && PartiallyMatchedAttributes.Any())
-            {
-                // Build the list of partial matches that contain attributes not appearing in at least one full match
-                var partialOnlyMatches = PartialMatches.Where(
-                    match => match.PresentAttributes.Any(
-                        attribute => PartiallyMatchedAttributes.Contains(
-                            attribute, StringComparer.OrdinalIgnoreCase)));
-                logger.TagHelperPartialMatches<TMode>(uniqueId, viewPath, partialOnlyMatches);
-            }
-
-            if (logger.IsEnabled(LogLevel.Verbose) && !FullMatches.Any())
-            {
-                logger.TagHelperSkippingProcessing(
-                    tagHelper,
-                    uniqueId);
-            }
-        }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.TagHelpers/RenderAtEndOfFormTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/RenderAtEndOfFormTagHelper.cs
@@ -57,9 +57,10 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             var formContext = ViewContext.FormContext;
             if (formContext.HasEndOfFormContent)
             {
-                foreach (var content in formContext.EndOfFormContent)
+                // Perf: Avoid allocating enumerator
+                for (var i = 0; i < formContext.EndOfFormContent.Count; i++)
                 {
-                    output.PostContent.Append(content);
+                    output.PostContent.Append(formContext.EndOfFormContent[i]);
                 }
             }
 

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/Internal/ModeMatchResultTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/Internal/ModeMatchResultTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNet.Mvc.TagHelpers.Logging;
 using Microsoft.AspNet.Razor.TagHelpers;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -22,7 +23,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
             var viewPath = "Views/Home/Index.cshtml";
 
             // Act
-            modeMatchResult.LogDetails(logger, tagHelper.Object, uniqueId, viewPath);
+            logger.TagHelperModeMatchResult(modeMatchResult, uniqueId, viewPath, tagHelper.Object);
 
             // Assert
             Mock.Get(logger).Verify(l => l.Log(
@@ -48,7 +49,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
             var viewPath = "Views/Home/Index.cshtml";
 
             // Act
-            modeMatchResult.LogDetails(logger, tagHelper.Object, uniqueId, viewPath);
+            logger.TagHelperModeMatchResult(modeMatchResult, uniqueId, viewPath, tagHelper.Object);
 
             // Assert
             Mock.Get(logger).Verify(l => l.Log(
@@ -79,7 +80,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
             var viewPath = "Views/Home/Index.cshtml";
 
             // Act
-            modeMatchResult.LogDetails(logger, tagHelper.Object, uniqueId, viewPath);
+            logger.TagHelperModeMatchResult(modeMatchResult, uniqueId, viewPath, tagHelper.Object);
 
             // Assert
             Mock.Get(logger).Verify(l => l.Log(
@@ -110,7 +111,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers.Internal
             var viewPath = "Views/Home/Index.cshtml";
 
             // Act
-            modeMatchResult.LogDetails(logger, tagHelper.Object, uniqueId, viewPath);
+            logger.TagHelperModeMatchResult(modeMatchResult, uniqueId, viewPath, tagHelper.Object);
 
             // Assert
             Mock.Get(logger).Verify(l => l.Log(


### PR DESCRIPTION
- Prior to this change we were using `Linq` throughout our `TagHelper`s which resulted excess allocations.
- Also went through our data structures and changed some from `Enumerable<T>` to `IList<T>` where we were just not exposing the more accessible types (list).
- Changed several locations of `foreach` to `for` to remove the enumerator allocation.

**Before:**
![image](https://cloud.githubusercontent.com/assets/2008729/11411009/f778a0da-9380-11e5-9b16-bc76d2088a60.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/2008729/11411078/81e0ce6e-9381-11e5-9ef7-3873534d680f.png)

**Result:** Roughly a 2.5% reduction in overall allocations.

#3599