### PR TITLE
Adds ActionContext to Validation contexts

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/Validation/ClientModelValidationContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/Validation/ClientModelValidationContext.cs
@@ -8,10 +8,15 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
     public class ClientModelValidationContext
     {
         public ClientModelValidationContext(
+            ActionContext actionContext,
             ModelMetadata metadata,
-            IModelMetadataProvider metadataProvider,
-            IServiceProvider requestServices)
+            IModelMetadataProvider metadataProvider)
         {
+            if (actionContext == null)
+            {
+                throw new ArgumentNullException(nameof(actionContext));
+            }
+
             if (metadata == null)
             {
                 throw new ArgumentNullException(nameof(metadata));
@@ -22,20 +27,14 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
                 throw new ArgumentNullException(nameof(metadataProvider));
             }
 
-            if (requestServices == null)
-            {
-                throw new ArgumentNullException(nameof(requestServices));
-            }
-
             ModelMetadata = metadata;
             MetadataProvider = metadataProvider;
-            RequestServices = requestServices;
         }
+
+        public ActionContext ActionContext { get; }
 
         public ModelMetadata ModelMetadata { get; }
 
         public IModelMetadataProvider MetadataProvider { get; }
-
-        public IServiceProvider RequestServices { get; }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/Validation/ModelValidationContext.cs
+++ b/src/Microsoft.AspNet.Mvc.Abstractions/ModelBinding/Validation/ModelValidationContext.cs
@@ -9,6 +9,11 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
     public class ModelValidationContext
     {
         /// <summary>
+        /// Gets or sets the <see cref="Mvc.ActionContext"/>
+        /// </summary>
+        public ActionContext ActionContext { get; set; }
+
+        /// <summary>
         /// Gets or sets the model object.
         /// </summary>
         public object Model { get; set; }

--- a/src/Microsoft.AspNet.Mvc.Core/Controllers/DefaultControllerActionArgumentBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Controllers/DefaultControllerActionArgumentBinder.cs
@@ -82,7 +82,6 @@ namespace Microsoft.AspNet.Mvc.Controllers
             var controllerProperties = new Dictionary<string, object>(StringComparer.Ordinal);
             await PopulateArgumentsAsync(
                 operationBindingContext,
-                context.ModelState,
                 controllerProperties,
                 actionDescriptor.BoundProperties);
             var controllerType = actionDescriptor.ControllerTypeInfo.AsType();
@@ -91,7 +90,6 @@ namespace Microsoft.AspNet.Mvc.Controllers
             var actionArguments = new Dictionary<string, object>(StringComparer.Ordinal);
             await PopulateArgumentsAsync(
                 operationBindingContext,
-                context.ModelState,
                 actionArguments,
                 actionDescriptor.Parameters);
             return actionArguments;
@@ -99,17 +97,11 @@ namespace Microsoft.AspNet.Mvc.Controllers
 
         public async Task<ModelBindingResult> BindModelAsync(
             ParameterDescriptor parameter,
-            ModelStateDictionary modelState,
             OperationBindingContext operationContext)
         {
             if (parameter == null)
             {
                 throw new ArgumentNullException(nameof(parameter));
-            }
-
-            if (modelState == null)
-            {
-                throw new ArgumentNullException(nameof(modelState));
             }
 
             if (operationContext == null)
@@ -120,7 +112,7 @@ namespace Microsoft.AspNet.Mvc.Controllers
             var metadata = _modelMetadataProvider.GetMetadataForType(parameter.ParameterType);
             var modelBindingContext = ModelBindingContext.CreateBindingContext(
                 operationContext,
-                modelState,
+                operationContext.ActionContext.ModelState,
                 metadata,
                 parameter.BindingInfo,
                 parameter.Name);
@@ -129,8 +121,8 @@ namespace Microsoft.AspNet.Mvc.Controllers
             if (modelBindingResult.IsModelSet)
             {
                 _validator.Validate(
+                    operationContext.ActionContext,
                     operationContext.ValidatorProvider,
-                    modelState,
                     modelBindingContext.ValidationState,
                     modelBindingResult.Key,
                     modelBindingResult.Model);
@@ -204,7 +196,6 @@ namespace Microsoft.AspNet.Mvc.Controllers
 
         private async Task PopulateArgumentsAsync(
             OperationBindingContext operationContext,
-            ModelStateDictionary modelState,
             IDictionary<string, object> arguments,
             IList<ParameterDescriptor> parameterMetadata)
         {
@@ -212,7 +203,7 @@ namespace Microsoft.AspNet.Mvc.Controllers
             for (var i = 0; i < parameterMetadata.Count; i++)
             {
                 var parameter = parameterMetadata[i];
-                var modelBindingResult = await BindModelAsync(parameter, modelState, operationContext);
+                var modelBindingResult = await BindModelAsync(parameter, operationContext);
                 if (modelBindingResult.IsModelSet)
                 {
                     arguments[parameter.Name] = modelBindingResult.Model;

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/ModelBindingHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/ModelBindingHelper.cs
@@ -583,8 +583,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             if (modelBindingResult.IsModelSet)
             {
                 objectModelValidator.Validate(
+                    operationBindingContext.ActionContext,
                     operationBindingContext.ValidatorProvider,
-                    modelState,
                     modelBindingContext.ValidationState,
                     modelBindingResult.Key,
                     modelBindingResult.Model);

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Validation/DefaultObjectValidator.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Validation/DefaultObjectValidator.cs
@@ -40,26 +40,26 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
 
         /// <inheritdoc />
         public void Validate(
+            ActionContext actionContext,
             IModelValidatorProvider validatorProvider,
-            ModelStateDictionary modelState,
             ValidationStateDictionary validationState,
             string prefix,
             object model)
         {
+            if (actionContext == null)
+            {
+                throw new ArgumentNullException(nameof(actionContext));
+            }
+
             if (validatorProvider == null)
             {
                 throw new ArgumentNullException(nameof(validatorProvider));
             }
 
-            if (modelState == null)
-            {
-                throw new ArgumentNullException(nameof(modelState));
-            }
-
             var visitor = new ValidationVisitor(
+                actionContext,
                 validatorProvider,
                 _excludeFilters,
-                modelState,
                 validationState);
 
             var metadata = model == null ? null : _modelMetadataProvider.GetMetadataForType(model.GetType());

--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Validation/IObjectModelValidator.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Validation/IObjectModelValidator.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Extensions.Internal;
-
 namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
 {
     /// <summary>
@@ -13,16 +11,16 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         /// <summary>
         /// Validates the provided object.
         /// </summary>
+        /// <param name="actionContext">The <see cref="ActionContext"/> associated with the current request.</param>
         /// <param name="validatorProvider">The <see cref="IModelValidatorProvider"/>.</param>
-        /// <param name="modelState">The <see cref="ModelStateDictionary"/>.</param>
         /// <param name="validationState">The <see cref="ValidationStateDictionary"/>. May be null.</param>
         /// <param name="prefix">
         /// The model prefix. Used to map the model object to entries in <paramref name="modelState"/>.
         /// </param>
         /// <param name="model">The model object.</param>
         void Validate(
+            ActionContext actionContext,
             IModelValidatorProvider validatorProvider,
-            ModelStateDictionary modelState,
             ValidationStateDictionary validationState,
             string prefix,
             object model);

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Controller.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Controller.cs
@@ -1773,8 +1773,8 @@ namespace Microsoft.AspNet.Mvc
                 modelName);
 
             ObjectValidator.Validate(
+                ControllerContext,
                 new CompositeModelValidatorProvider(ControllerContext.ValidatorProviders),
-                ModelState,
                 validationState: null,
                 prefix: prefix,
                 model: model);

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/RemoteAttribute.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/RemoteAttribute.cs
@@ -198,7 +198,8 @@ namespace Microsoft.AspNet.Mvc
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var urlHelper = context.RequestServices.GetRequiredService<IUrlHelper>();
+            var services = context.ActionContext.HttpContext.RequestServices;
+            var urlHelper = services.GetRequiredService<IUrlHelper>();
             var url = urlHelper.RouteUrl(new UrlRouteContext()
             {
                 RouteName = this.RouteName,

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/DefaultHtmlGenerator.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/ViewFeatures/DefaultHtmlGenerator.cs
@@ -858,9 +858,9 @@ namespace Microsoft.AspNet.Mvc.ViewFeatures
             modelExplorer = modelExplorer ??
                 ExpressionMetadataProvider.FromStringExpression(expression, viewContext.ViewData, _metadataProvider);
             var validationContext = new ClientModelValidationContext(
+                viewContext,
                 modelExplorer.Metadata,
-                _metadataProvider,
-                viewContext.HttpContext.RequestServices);
+                _metadataProvider);
 
             var validatorProviderContext = new ClientValidatorProviderContext(modelExplorer.Metadata);
             _clientModelValidatorProvider.GetValidators(validatorProviderContext);

--- a/src/Microsoft.AspNet.Mvc.WebApiCompatShim/ApiController.cs
+++ b/src/Microsoft.AspNet.Mvc.WebApiCompatShim/ApiController.cs
@@ -572,8 +572,8 @@ namespace System.Web.Http
         {
             var validatidationState = new ValidationStateDictionary();
             ObjectValidator.Validate(
+                ControllerContext,
                 new CompositeModelValidatorProvider(ControllerContext.ValidatorProviders),
-                ModelState,
                 validatidationState,
                 keyPrefix,
                 entity);

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Controllers/ControllerActionArgumentBinderTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Controllers/ControllerActionArgumentBinderTests.cs
@@ -143,8 +143,8 @@ namespace Microsoft.AspNet.Mvc.Controllers
             var mockValidator = new Mock<IObjectModelValidator>(MockBehavior.Strict);
             mockValidator
                 .Setup(o => o.Validate(
+                    It.IsAny<ActionContext>(),
                     It.IsAny<IModelValidatorProvider>(),
-                    It.IsAny<ModelStateDictionary>(),
                     It.IsAny<ValidationStateDictionary>(),
                     It.IsAny<string>(),
                     It.IsAny<object>()));
@@ -157,12 +157,12 @@ namespace Microsoft.AspNet.Mvc.Controllers
             // Assert
             mockValidator
                 .Verify(o => o.Validate(
+                    It.IsAny<ActionContext>(),
                     It.IsAny<IModelValidatorProvider>(),
-                    It.IsAny<ModelStateDictionary>(),
                     It.IsAny<ValidationStateDictionary>(),
                     It.IsAny<string>(),
                     It.IsAny<object>()),
-                Times.Once());
+            Times.Once());
         }
 
         [Fact]
@@ -191,8 +191,8 @@ namespace Microsoft.AspNet.Mvc.Controllers
             var mockValidator = new Mock<IObjectModelValidator>(MockBehavior.Strict);
             mockValidator
                 .Setup(o => o.Validate(
+                    It.IsAny<ActionContext>(),
                     It.IsAny<IModelValidatorProvider>(),
-                    It.IsAny<ModelStateDictionary>(),
                     It.IsAny<ValidationStateDictionary>(),
                     It.IsAny<string>(),
                     It.IsAny<object>()));
@@ -205,8 +205,8 @@ namespace Microsoft.AspNet.Mvc.Controllers
             // Assert
             mockValidator
                 .Verify(o => o.Validate(
+                    It.IsAny<ActionContext>(),
                     It.IsAny<IModelValidatorProvider>(),
-                    It.IsAny<ModelStateDictionary>(),
                     It.IsAny<ValidationStateDictionary>(),
                     It.IsAny<string>(),
                     It.IsAny<object>()),
@@ -230,8 +230,8 @@ namespace Microsoft.AspNet.Mvc.Controllers
             var mockValidator = new Mock<IObjectModelValidator>(MockBehavior.Strict);
             mockValidator
                 .Setup(o => o.Validate(
+                    It.IsAny<ActionContext>(),
                     It.IsAny<IModelValidatorProvider>(),
-                    It.IsAny<ModelStateDictionary>(),
                     It.IsAny<ValidationStateDictionary>(),
                     It.IsAny<string>(),
                     It.IsAny<object>()));
@@ -244,8 +244,8 @@ namespace Microsoft.AspNet.Mvc.Controllers
             // Assert
             mockValidator
                 .Verify(o => o.Validate(
+                    It.IsAny<ActionContext>(),
                     It.IsAny<IModelValidatorProvider>(),
-                    It.IsAny<ModelStateDictionary>(),
                     It.IsAny<ValidationStateDictionary>(),
                     It.IsAny<string>(),
                     It.IsAny<object>()),
@@ -277,8 +277,8 @@ namespace Microsoft.AspNet.Mvc.Controllers
             var mockValidator = new Mock<IObjectModelValidator>(MockBehavior.Strict);
             mockValidator
                 .Setup(o => o.Validate(
+                    It.IsAny<ActionContext>(),
                     It.IsAny<IModelValidatorProvider>(),
-                    It.IsAny<ModelStateDictionary>(),
                     It.IsAny<ValidationStateDictionary>(),
                     It.IsAny<string>(),
                     It.IsAny<object>()));
@@ -291,8 +291,8 @@ namespace Microsoft.AspNet.Mvc.Controllers
             // Assert
             mockValidator
                 .Verify(o => o.Validate(
+                    It.IsAny<ActionContext>(),
                     It.IsAny<IModelValidatorProvider>(),
-                    It.IsAny<ModelStateDictionary>(),
                     It.IsAny<ValidationStateDictionary>(),
                     It.IsAny<string>(),
                     It.IsAny<object>()),
@@ -635,8 +635,8 @@ namespace Microsoft.AspNet.Mvc.Controllers
             var mockValidator = new Mock<IObjectModelValidator>(MockBehavior.Strict);
             mockValidator
                 .Setup(o => o.Validate(
-                    It.IsAny<IModelValidatorProvider>(), 
-                    It.IsAny<ModelStateDictionary>(),
+                    It.IsAny<ActionContext>(),
+                    It.IsAny<IModelValidatorProvider>(),
                     It.IsAny<ValidationStateDictionary>(),
                     It.IsAny<string>(),
                     It.IsAny<object>()));

--- a/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/Validation/DefaultObjectValidatorTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ModelBinding/Validation/DefaultObjectValidatorTests.cs
@@ -21,7 +21,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator();
@@ -32,7 +33,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             validationState.Add(model, new ValidationStateEntry() { Key = "parameter" });
 
             // Act
-            validator.Validate(validatorProvider, modelState, validationState, "parameter", model);
+            validator.Validate(actionContext, validatorProvider, validationState, "parameter", model);
 
             // Assert
             AssertKeysEqual(modelState, "parameter");
@@ -47,7 +48,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator();
@@ -58,7 +60,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             validationState.Add(model, new ValidationStateEntry() { Key = "parameter" });
 
             // Act
-            validator.Validate(validatorProvider, modelState, validationState, "parameter", model);
+            validator.Validate(actionContext, validatorProvider, validationState, "parameter", model);
 
             // Assert
             Assert.True(modelState.IsValid);
@@ -74,7 +76,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator();
@@ -87,7 +90,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             validationState.Add(model, new ValidationStateEntry() { Key = "parameter" });
 
             // Act
-            validator.Validate(validatorProvider, modelState, validationState, "parameter", model);
+            validator.Validate(actionContext, validatorProvider, validationState, "parameter", model);
 
             // Assert
             Assert.False(modelState.IsValid);
@@ -103,7 +106,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator();
@@ -114,7 +118,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             validationState.Add(model, new ValidationStateEntry() { Key = "parameter", SuppressValidation = true });
 
             // Act
-            validator.Validate(validatorProvider, modelState, validationState, "parameter", model);
+            validator.Validate(actionContext, validatorProvider, validationState, "parameter", model);
 
             // Assert
             Assert.True(modelState.IsValid);
@@ -131,7 +135,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator();
@@ -143,7 +148,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             validationState.Add(model, new ValidationStateEntry() { Key = "parameter" });
 
             // Act
-            validator.Validate(validatorProvider, modelState, validationState, "parameter", model);
+            validator.Validate(actionContext, validatorProvider, validationState, "parameter", model);
 
             // Assert
             Assert.True(modelState.IsValid);
@@ -163,7 +168,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator();
@@ -175,7 +181,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             validationState.Add(model, new ValidationStateEntry() { Key = "parameter" });
 
             // Act
-            validator.Validate(validatorProvider, modelState, validationState, "parameter", model);
+            validator.Validate(actionContext, validatorProvider, validationState, "parameter", model);
 
             // Assert
             Assert.True(modelState.IsValid);
@@ -195,7 +201,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator();
@@ -205,7 +212,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             validationState.Add(model, new ValidationStateEntry() { Key = string.Empty });
 
             // Act
-            validator.Validate(validatorProvider, modelState, validationState, string.Empty, model);
+            validator.Validate(actionContext, validatorProvider, validationState, string.Empty, model);
 
             // Assert
             Assert.False(modelState.IsValid);
@@ -227,7 +234,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator();
@@ -248,7 +256,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             });
 
             // Act
-            validator.Validate(validatorProvider, modelState, validationState, "person", model);
+            validator.Validate(actionContext, validatorProvider, validationState, "person", model);
 
             // Assert
             Assert.True(modelState.IsValid);
@@ -269,7 +277,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator();
@@ -280,7 +289,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             validationState.Add(model, new ValidationStateEntry() { Key = "parameter" });
 
             // Act
-            validator.Validate(validatorProvider, modelState, validationState, "parameter", model);
+            validator.Validate(actionContext, validatorProvider, validationState, "parameter", model);
 
             // Assert
             Assert.False(modelState.IsValid);
@@ -301,7 +310,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator();
@@ -312,7 +322,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             validationState.Add(model, new ValidationStateEntry() { Key = string.Empty });
 
             // Act
-            validator.Validate(validatorProvider, modelState, validationState, string.Empty, model);
+            validator.Validate(actionContext, validatorProvider, validationState, string.Empty, model);
 
             // Assert
             Assert.False(modelState.IsValid);
@@ -333,7 +343,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator();
@@ -344,7 +355,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             validationState.Add(model, new ValidationStateEntry() { Key = string.Empty });
 
             // Act
-            validator.Validate(validatorProvider, modelState, validationState, string.Empty, model);
+            validator.Validate(actionContext, validatorProvider, validationState, string.Empty, model);
 
             // Assert
             Assert.False(modelState.IsValid);
@@ -377,7 +388,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator();
@@ -389,7 +401,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             validationState.Add(model, new ValidationStateEntry() { Key = "parameter" });
 
             // Act
-            validator.Validate(validatorProvider, modelState, validationState, "parameter", model);
+            validator.Validate(actionContext, validatorProvider, validationState, "parameter", model);
 
             // Assert
             Assert.False(modelState.IsValid);
@@ -422,7 +434,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator();
@@ -433,7 +446,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             validationState.Add(model, new ValidationStateEntry() { Key = "parameter" });
 
             // Act
-            validator.Validate(validatorProvider, modelState, validationState, "parameter", model);
+            validator.Validate(actionContext, validatorProvider, validationState, "parameter", model);
 
             // Assert
             Assert.True(modelState.IsValid);
@@ -450,7 +463,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator();
@@ -464,7 +478,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             validationState.Add(model, new ValidationStateEntry() { Key = "parameter" });
 
             // Act
-            validator.Validate(validatorProvider, modelState, validationState, "parameter", model);
+            validator.Validate(actionContext, validatorProvider, validationState, "parameter", model);
 
             // Assert
             Assert.False(modelState.IsValid);
@@ -485,7 +499,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator(typeof(string));
@@ -504,7 +519,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             validationState.Add(model, new ValidationStateEntry() { Key = "user", });
 
             // Act
-            validator.Validate(validatorProvider, modelState, validationState, "user", model);
+            validator.Validate(actionContext, validatorProvider, validationState, "user", model);
 
             // Assert
             Assert.False(modelState.IsValid);
@@ -522,7 +537,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator();
@@ -534,7 +550,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             validationState.Add(model, new ValidationStateEntry() { Key = "parameter" });
 
             // Act
-            validator.Validate(validatorProvider, modelState, validationState, "parameter", model);
+            validator.Validate(actionContext, validatorProvider, validationState, "parameter", model);
 
             // Assert
             Assert.True(modelState.IsValid);
@@ -555,7 +571,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator();
@@ -565,7 +582,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             validationState.Add(model, new ValidationStateEntry() { Key = string.Empty });
 
             // Act
-            validator.Validate(validatorProvider, modelState, validationState, string.Empty, model);
+            validator.Validate(actionContext, validatorProvider, validationState, string.Empty, model);
 
             // Assert
             Assert.False(modelState.IsValid);
@@ -598,7 +615,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator();
@@ -608,7 +626,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             validationState.Add(model, new ValidationStateEntry() { Key = string.Empty });
 
             // Act
-            validator.Validate(validatorProvider, modelState, validationState, string.Empty, model);
+            validator.Validate(actionContext, validatorProvider, validationState, string.Empty, model);
 
             // Assert
             Assert.False(modelState.IsValid);
@@ -646,7 +664,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator(new SimpleTypesExcludeFilter());
@@ -663,7 +682,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             });
 
             // Act
-            validator.Validate(validatorProvider, modelState, validationState, "items", model);
+            validator.Validate(actionContext, validatorProvider, validationState, "items", model);
 
             // Assert
             Assert.True(modelState.IsValid);
@@ -687,7 +706,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator(new SimpleTypesExcludeFilter());
@@ -705,7 +725,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             validationState.Add(model, new ValidationStateEntry() { Key = "items" });
 
             // Act
-            validator.Validate(validatorProvider, modelState, validationState, "items", model);
+            validator.Validate(actionContext, validatorProvider, validationState, "items", model);
 
             // Assert
             Assert.True(modelState.IsValid);
@@ -734,7 +754,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator();
@@ -746,7 +767,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             validationState.Add(model, new ValidationStateEntry() { Key = string.Empty });
 
             // Act
-            validator.Validate(validatorProvider, modelState, validationState, string.Empty, model);
+            validator.Validate(actionContext, validatorProvider, validationState, string.Empty, model);
 
             // Assert
             Assert.False(modelState.IsValid);
@@ -794,7 +815,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator();
@@ -806,7 +828,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
                 typeof(InvalidTimeZoneException),
                 () =>
                 {
-                    validator.Validate(validatorProvider, modelState, validationState, string.Empty, model);
+                    validator.Validate(actionContext, validatorProvider, validationState, string.Empty, model);
                 });
         }
 
@@ -816,7 +838,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator();
@@ -828,7 +851,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             };
 
             // Act & Assert (does not throw)
-            validator.Validate(validatorProvider, modelState, validationState, string.Empty, model);
+            validator.Validate(actionContext, validatorProvider, validationState, string.Empty, model);
         }
 
         [Fact]
@@ -836,7 +859,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
         {
             // Arrange
             var validatorProvider = CreateValidatorProvider();
-            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext();
+            var modelState = actionContext.ModelState;
             var validationState = new ValidationStateDictionary();
 
             var validator = CreateValidator(typeof(User));
@@ -853,7 +877,7 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             validationState.Add(model, new ValidationStateEntry() { Key = "user", });
 
             // Act
-            validator.Validate(validatorProvider, modelState, validationState, "user", model);
+            validator.Validate(actionContext, validatorProvider, validationState, "user", model);
 
             // Assert
             Assert.Equal(ModelValidationState.Valid, modelState.ValidationState);

--- a/test/Microsoft.AspNet.Mvc.DataAnnotations.Test/CompareAttributeAdapterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.DataAnnotations.Test/CompareAttributeAdapterTest.cs
@@ -22,10 +22,8 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             var attribute = new CompareAttribute("OtherProperty");
             var adapter = new CompareAttributeAdapter(attribute, stringLocalizer: null);
 
-            var serviceCollection = new ServiceCollection();
-            var requestServices = serviceCollection.BuildServiceProvider();
-
-            var context = new ClientModelValidationContext(metadata, metadataProvider, requestServices);
+            var actionContext = new ActionContext();
+            var context = new ClientModelValidationContext(actionContext, metadata, metadataProvider);
 
             // Act
             var rules = adapter.GetClientValidationRules(context);
@@ -46,11 +44,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             // Arrange
             var metadataProvider = TestModelMetadataProvider.CreateDefaultProvider();
             var metadata = metadataProvider.GetMetadataForProperty(typeof(PropertyNameModel), "MyProperty");
+
             var attribute = new CompareAttribute("OtherProperty");
-            var serviceCollection = new ServiceCollection();
-            var requestServices = serviceCollection.BuildServiceProvider();
-            var context = new ClientModelValidationContext(metadata, metadataProvider, requestServices);
             var adapter = new CompareAttributeAdapter(attribute, stringLocalizer: null);
+
+            var actionContext = new ActionContext();
+            var context = new ClientModelValidationContext(actionContext, metadata, metadataProvider);
 
             // Act
             var rules = adapter.GetClientValidationRules(context);
@@ -69,14 +68,15 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             // Arrange
             var metadataProvider = TestModelMetadataProvider.CreateDefaultProvider();
             var metadata = metadataProvider.GetMetadataForProperty( typeof(PropertyNameModel), "MyProperty");
+
             var attribute = new CompareAttribute("OtherProperty")
             {
                 ErrorMessage = "Hello '{0}', goodbye '{1}'."
             };
-            var serviceCollection = new ServiceCollection();
-            var requestServices = serviceCollection.BuildServiceProvider();
-            var context = new ClientModelValidationContext(metadata, metadataProvider, requestServices);
             var adapter = new CompareAttributeAdapter(attribute, stringLocalizer: null);
+
+            var actionContext = new ActionContext();
+            var context = new ClientModelValidationContext(actionContext, metadata, metadataProvider);
 
             // Act
             var rules = adapter.GetClientValidationRules(context);
@@ -94,15 +94,16 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             // Arrange
             var metadataProvider = TestModelMetadataProvider.CreateDefaultProvider();
             var metadata = metadataProvider.GetMetadataForProperty(typeof(PropertyNameModel), "MyProperty");
+
             var attribute = new CompareAttribute("OtherProperty")
             {
                 ErrorMessageResourceName = "CompareAttributeTestResource",
                 ErrorMessageResourceType = typeof(DataAnnotations.Test.Resources),
             };
-            var serviceCollection = new ServiceCollection();
-            var requestServices = serviceCollection.BuildServiceProvider();
-            var context = new ClientModelValidationContext(metadata, metadataProvider, requestServices);
             var adapter = new CompareAttributeAdapter(attribute, stringLocalizer: null);
+
+            var actionContext = new ActionContext();
+            var context = new ClientModelValidationContext(actionContext, metadata, metadataProvider);
 
             // Act
             var rules = adapter.GetClientValidationRules(context);

--- a/test/Microsoft.AspNet.Mvc.DataAnnotations.Test/MaxLengthAttributeAdapterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.DataAnnotations.Test/MaxLengthAttributeAdapterTest.cs
@@ -19,11 +19,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             // Arrange
             var provider = TestModelMetadataProvider.CreateDefaultProvider();
             var metadata = provider.GetMetadataForProperty(typeof(string), "Length");
+
             var attribute = new MaxLengthAttribute(10);
             var adapter = new MaxLengthAttributeAdapter(attribute, stringLocalizer: null);
-            var serviceCollection = new ServiceCollection();
-            var requestServices = serviceCollection.BuildServiceProvider();
-            var context = new ClientModelValidationContext(metadata, provider, requestServices);
+
+            var actionContext = new ActionContext();
+            var context = new ClientModelValidationContext(actionContext, metadata, provider);
 
             // Act
             var rules = adapter.GetClientValidationRules(context);
@@ -45,11 +46,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             var message = "{0} must be at most {1}";
             var provider = TestModelMetadataProvider.CreateDefaultProvider();
             var metadata = provider.GetMetadataForProperty(typeof(string), propertyName);
+
             var attribute = new MaxLengthAttribute(5) { ErrorMessage = message };
             var adapter = new MaxLengthAttributeAdapter(attribute, stringLocalizer: null);
-            var serviceCollection = new ServiceCollection();
-            var requestServices = serviceCollection.BuildServiceProvider();
-            var context = new ClientModelValidationContext(metadata, provider, requestServices);
+
+            var actionContext = new ActionContext();
+            var context = new ClientModelValidationContext(actionContext, metadata, provider);
 
             // Act
             var rules = adapter.GetClientValidationRules(context);
@@ -70,18 +72,17 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             // Arrange
             var provider = TestModelMetadataProvider.CreateDefaultProvider();
             var metadata = provider.GetMetadataForProperty(typeof(string), "Length");
+
             var errorKey = metadata.GetDisplayName();
             var attribute = new MaxLengthAttribute(10);
             attribute.ErrorMessage = errorKey;
-
             var localizedString = new LocalizedString(errorKey, "Longueur est invalide");
             var stringLocalizer = new Mock<IStringLocalizer>();
             stringLocalizer.Setup(s => s[errorKey]).Returns(localizedString);
-
             var adapter = new MaxLengthAttributeAdapter(attribute, stringLocalizer.Object);
-            var serviceCollection = new ServiceCollection();
-            var requestServices = serviceCollection.BuildServiceProvider();
-            var context = new ClientModelValidationContext(metadata, provider, requestServices);
+
+            var actionContext = new ActionContext();
+            var context = new ClientModelValidationContext(actionContext, metadata, provider);
 
             // Act
             var rules = adapter.GetClientValidationRules(context);

--- a/test/Microsoft.AspNet.Mvc.DataAnnotations.Test/MinLengthAttributeAdapterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.DataAnnotations.Test/MinLengthAttributeAdapterTest.cs
@@ -3,7 +3,6 @@
 
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNet.Testing;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
@@ -17,11 +16,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             // Arrange
             var provider = TestModelMetadataProvider.CreateDefaultProvider();
             var metadata = provider.GetMetadataForProperty(typeof(string), "Length");
+
             var attribute = new MinLengthAttribute(6);
             var adapter = new MinLengthAttributeAdapter(attribute, stringLocalizer: null);
-            var serviceCollection = new ServiceCollection();
-            var requestServices = serviceCollection.BuildServiceProvider();
-            var context = new ClientModelValidationContext(metadata, provider, requestServices);
+
+            var actionContext = new ActionContext();
+            var context = new ClientModelValidationContext(actionContext, metadata, provider);
 
             // Act
             var rules = adapter.GetClientValidationRules(context);
@@ -43,11 +43,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             var message = "Array must have at least {1} items.";
             var provider = TestModelMetadataProvider.CreateDefaultProvider();
             var metadata = provider.GetMetadataForProperty(typeof(string), propertyName);
+
             var attribute = new MinLengthAttribute(2) { ErrorMessage = message };
             var adapter = new MinLengthAttributeAdapter(attribute, stringLocalizer: null);
-            var serviceCollection = new ServiceCollection();
-            var requestServices = serviceCollection.BuildServiceProvider();
-            var context = new ClientModelValidationContext(metadata, provider, requestServices);
+
+            var actionContext = new ActionContext();
+            var context = new ClientModelValidationContext(actionContext, metadata, provider);
 
             // Act
             var rules = adapter.GetClientValidationRules(context);

--- a/test/Microsoft.AspNet.Mvc.DataAnnotations.Test/NumericClientModelValidatorTest.cs
+++ b/test/Microsoft.AspNet.Mvc.DataAnnotations.Test/NumericClientModelValidatorTest.cs
@@ -3,7 +3,6 @@
 
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNet.Testing;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
@@ -17,10 +16,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             // Arrange
             var provider = TestModelMetadataProvider.CreateDefaultProvider();
             var metadata = provider.GetMetadataForProperty(typeof(TypeWithNumericProperty), "Id");
+
             var adapter = new NumericClientModelValidator();
-            var serviceCollection = new ServiceCollection();
-            var requestServices = serviceCollection.BuildServiceProvider();
-            var context = new ClientModelValidationContext(metadata, provider, requestServices);
+
+            var actionContext = new ActionContext();
+            var context = new ClientModelValidationContext(actionContext, metadata, provider);
+
             var expectedMessage = "The field DisplayId must be a number.";
 
             // Act

--- a/test/Microsoft.AspNet.Mvc.DataAnnotations.Test/RangeAttributeAdapterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.DataAnnotations.Test/RangeAttributeAdapterTest.cs
@@ -3,7 +3,6 @@
 
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNet.Testing;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
@@ -17,11 +16,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             // Arrange
             var provider = TestModelMetadataProvider.CreateDefaultProvider();
             var metadata = provider.GetMetadataForProperty(typeof(string), "Length");
+
             var attribute = new RangeAttribute(typeof(decimal), "0", "100");
             var adapter = new RangeAttributeAdapter(attribute, stringLocalizer: null);
-            var serviceCollection = new ServiceCollection();
-            var requestServices = serviceCollection.BuildServiceProvider();
-            var context = new ClientModelValidationContext(metadata, provider, requestServices);
+
+            var actionContext = new ActionContext();
+            var context = new ClientModelValidationContext(actionContext, metadata, provider);
 
             // Act
             var rules = adapter.GetClientValidationRules(context);

--- a/test/Microsoft.AspNet.Mvc.DataAnnotations.Test/RequiredAttributeAdapterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.DataAnnotations.Test/RequiredAttributeAdapterTest.cs
@@ -3,7 +3,6 @@
 
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNet.Testing;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
@@ -18,11 +17,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             var expected = ValidationAttributeUtil.GetRequiredErrorMessage("Length");
             var provider = TestModelMetadataProvider.CreateDefaultProvider();
             var metadata = provider.GetMetadataForProperty(typeof(string), "Length");
+
             var attribute = new RequiredAttribute();
             var adapter = new RequiredAttributeAdapter(attribute, stringLocalizer: null);
-            var serviceCollection = new ServiceCollection();
-            var requestServices = serviceCollection.BuildServiceProvider();
-            var context = new ClientModelValidationContext(metadata, provider, requestServices);
+
+            var actionContext = new ActionContext();
+            var context = new ClientModelValidationContext(actionContext, metadata, provider);
 
             // Act
             var rules = adapter.GetClientValidationRules(context);

--- a/test/Microsoft.AspNet.Mvc.DataAnnotations.Test/StringLengthAttributeAdapterTest.cs
+++ b/test/Microsoft.AspNet.Mvc.DataAnnotations.Test/StringLengthAttributeAdapterTest.cs
@@ -3,7 +3,6 @@
 
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNet.Testing;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
@@ -17,11 +16,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             // Arrange
             var provider = TestModelMetadataProvider.CreateDefaultProvider();
             var metadata = provider.GetMetadataForProperty(typeof(string), "Length");
+
             var attribute = new StringLengthAttribute(8);
             var adapter = new StringLengthAttributeAdapter(attribute, stringLocalizer: null);
-            var serviceCollection = new ServiceCollection();
-            var requestServices = serviceCollection.BuildServiceProvider();
-            var context = new ClientModelValidationContext(metadata, provider, requestServices);
+
+            var actionContext = new ActionContext();
+            var context = new ClientModelValidationContext(actionContext, metadata, provider);
 
             // Act
             var rules = adapter.GetClientValidationRules(context);
@@ -41,11 +41,12 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Validation
             // Arrange
             var provider = TestModelMetadataProvider.CreateDefaultProvider();
             var metadata = provider.GetMetadataForProperty(typeof(string), "Length");
+
             var attribute = new StringLengthAttribute(10) { MinimumLength = 3 };
             var adapter = new StringLengthAttributeAdapter(attribute, stringLocalizer: null);
-            var serviceCollection = new ServiceCollection();
-            var requestServices = serviceCollection.BuildServiceProvider();
-            var context = new ClientModelValidationContext(metadata, provider, requestServices);
+
+            var actionContext = new ActionContext();
+            var context = new ClientModelValidationContext(actionContext, metadata, provider);
 
             // Act
             var rules = adapter.GetClientValidationRules(context);

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/ActionParametersIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/ActionParametersIntegrationTest.cs
@@ -53,11 +53,11 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = QueryString.Create("Address[0].Street", "SomeStreet");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
             var model = new Person3();
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -104,10 +104,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = QueryString.Create("Address[0].Street", "SomeStreet");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -157,10 +157,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = QueryString.Create("Address[0].Street", "SomeStreet");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
             var model = new Person4();
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -209,9 +209,9 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = QueryString.Create("Address[0].Street", "SomeStreet");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -254,10 +254,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = QueryString.Create("prefix.Address[0].Street", "SomeStreet");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -303,10 +303,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = QueryString.Create("prefix.Address[0].Street", "SomeStreet");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -355,10 +355,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = QueryString.Create("prefix.Address[0].Street", "SomeStreet");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -405,10 +405,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = QueryString.Create("prefix.Address[0].Street", "SomeStreet");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/ArrayModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/ArrayModelBinderIntegrationTest.cs
@@ -28,10 +28,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter[0]=10&parameter[1]=11");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -72,10 +72,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?prefix[0]=10&prefix[1]=11");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -112,10 +112,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?[0]=10&[1]=11");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -152,10 +152,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -187,10 +187,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter[0].Name=bill&parameter[1].Name=lang");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -232,10 +232,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?prefix[0].Name=bill&prefix[1].Name=lang");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -273,10 +273,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?[0].Name=bill&[1].Name=lang");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -314,10 +314,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/BinderTypeBasedModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/BinderTypeBasedModelBinderIntegrationTest.cs
@@ -31,10 +31,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             // No data is passed.
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext();
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 
@@ -69,10 +69,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             // No data is passed.
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext();
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.Equal(ModelBindingResult.NoResult, modelBindingResult);
@@ -104,10 +104,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             // No data is passed.
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext();
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 
@@ -140,10 +140,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             // No data is passed.
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext();
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 
@@ -175,10 +175,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             };
 
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext();
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 
@@ -218,10 +218,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             };
 
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext();
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 
@@ -259,10 +259,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             };
 
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext();
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/BodyValidationIntegrationTests.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/BodyValidationIntegrationTests.cs
@@ -47,10 +47,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                   request.ContentType = "application/json";
               });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -88,10 +88,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 });
 
             var httpContext = operationContext.HttpContext;
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -132,10 +132,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                     request.ContentType = "application/json";
                 });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -191,10 +191,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                     request.ContentType = "application/json";
                 });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -234,10 +234,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                     request.ContentType = "application/json";
                 });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -304,10 +304,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                     request.ContentType = "application/json";
                 });
             var httpContext = operationContext.HttpContext;
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -363,10 +363,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                     request.Body = new MemoryStream(Encoding.UTF8.GetBytes(inputText));
                     request.ContentType = "application/json";
                 });
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/ByteArrayModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/ByteArrayModelBinderIntegrationTest.cs
@@ -50,10 +50,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 {
                     request.QueryString = QueryString.Create(queryStringKey, value);
                 });
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 
@@ -95,10 +95,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             // No data is passed.
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext();
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 
@@ -134,10 +134,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                     request.QueryString = QueryString.Create("CustomParameter", value);
                 });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/CancellationTokenModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/CancellationTokenModelBinderIntegrationTest.cs
@@ -37,10 +37,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             };
 
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext();
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 
@@ -71,10 +71,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             };
 
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext();
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 
@@ -108,10 +108,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             };
 
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext();
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/CollectionModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/CollectionModelBinderIntegrationTest.cs
@@ -37,10 +37,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter[0]=10&parameter[1]=11");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -83,10 +83,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString(queryString);
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -117,10 +117,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString(queryString);
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -149,10 +149,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -188,10 +188,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString(queryString);
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -227,10 +227,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString(queryString);
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -260,10 +260,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -298,10 +298,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter[0].Id=10&parameter[1].Id=11");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -357,10 +357,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?prefix[0].Id=10&prefix[1].Id=11");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -408,10 +408,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?[0].Id=10&[1].Id=11");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -460,10 +460,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                     new QueryString("?parameter.index=low&parameter.index=high&parameter[low]=10&parameter[high]=11");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -503,10 +503,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?index=low&index=high&[high].Id=11&[low].Id=10");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -554,10 +554,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -604,10 +604,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.ContentType = "application/x-www-form-urlencoded";
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -661,10 +661,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.ContentType = "application/x-www-form-urlencoded";
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -700,10 +700,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString(queryString);
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -920,14 +920,14 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             };
 
             var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
-            var modelState = new ModelStateDictionary();
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
             {
                 request.Form = new FormCollection(formContent);
             });
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/DictionaryModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/DictionaryModelBinderIntegrationTest.cs
@@ -32,10 +32,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter[0].Key=key0&parameter[0].Value=10");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -72,10 +72,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter[key0]=10");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -110,10 +110,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                     new QueryString("?parameter.index=low&parameter[low].Key=key0&parameter[low].Value=10");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -163,10 +163,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString(queryString);
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -198,10 +198,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString(queryString);
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -230,10 +230,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -291,10 +291,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString(queryString);
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -331,10 +331,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString(queryString);
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -370,10 +370,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString(queryString);
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -410,10 +410,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -517,14 +517,14 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             };
 
             var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
-            var modelState = new ModelStateDictionary();
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext(request =>
             {
                 request.QueryString = new QueryString(queryString);
             });
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/FormCollectionModelBindingIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/FormCollectionModelBindingIntegrationTest.cs
@@ -49,10 +49,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                     UpdateRequest(request, data, "Address.File");
                 });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 
@@ -99,10 +99,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                     UpdateRequest(request, data, "CustomParameter");
                 });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             // ModelBindingResult
@@ -139,10 +139,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             // No data is passed.
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext();
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/FormFileModelBindingIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/FormFileModelBindingIntegrationTest.cs
@@ -49,10 +49,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                     UpdateRequest(request, data, "Address.File");
                 });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 
@@ -100,10 +100,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                     UpdateRequest(request, data, "CustomParameter");
                 });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             // ModelBindingResult
@@ -146,10 +146,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext(
                 request => UpdateRequest(request, data: null, name: null));
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.Equal(ModelBindingResult.NoResult, modelBindingResult);

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/GenericModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/GenericModelBinderIntegrationTest.cs
@@ -37,10 +37,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter.index=10");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -75,10 +75,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?index=10");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -114,10 +114,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -183,10 +183,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request => request.QueryString = new QueryString("?parameter.index=0"),
                 options => options.ModelBinders.Add(new AddressBinder()));
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -217,10 +217,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext(
                 request => request.QueryString = new QueryString("?parameter.index=0"));
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -252,10 +252,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter[0][0].Key=key0&parameter[0][0].Value=10");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -297,10 +297,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?[0][0].Key=key0&[0][0].Value=10");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -342,10 +342,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -377,10 +377,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter[0].Key=key0&parameter[0].Value=10");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -421,10 +421,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?[0].Key=key0&[0].Value=10");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -465,10 +465,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -501,10 +501,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                     "?parameter[0].Key=key0&parameter[0].Value[0]=10&parameter[0].Value[1]=11");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -549,10 +549,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?[0].Key=key0&[0].Value[0]=10&[0].Value[1]=11");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -597,10 +597,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/HeaderModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/HeaderModelBinderIntegrationTest.cs
@@ -43,10 +43,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             // Do not add any headers.
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext();
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 
@@ -86,10 +86,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.Headers.Add("Header", new[] { "someValue" });
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 
@@ -128,10 +128,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext(
                 request => request.Headers.Add("Header", new[] { "someValue" }));
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 
@@ -190,10 +190,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
 
             // Do not add any headers.
             var httpContext = operationContext.HttpContext;
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/KeyValuePairModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/KeyValuePairModelBinderIntegrationTest.cs
@@ -30,10 +30,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter.Key=key0&parameter.Value=10");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -68,10 +68,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             {
                 request.QueryString = new QueryString("?parameter.Value=10");
             });
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.False(modelBindingResult.IsModelSet);
@@ -116,10 +116,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             {
                 request.QueryString = new QueryString("?parameter.Value=10");
             });
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.False(modelBindingResult.IsModelSet);
@@ -153,10 +153,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             {
                 request.QueryString = new QueryString("?parameter.Key=10");
             });
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.False(modelBindingResult.IsModelSet);
@@ -201,10 +201,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             {
                 request.QueryString = new QueryString("?parameter.Key=10");
             });
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.False(modelBindingResult.IsModelSet);
@@ -244,10 +244,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?prefix.Key=key0&prefix.Value=10");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -284,10 +284,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?Key=key0&Value=10");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -324,10 +324,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -360,10 +360,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter.Key=key0&parameter.Value.Id=10");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -405,10 +405,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?prefix.Key=key0&prefix.Value.Id=10");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -446,10 +446,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?Key=key0&Value.Id=10");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -487,10 +487,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/ModelPrefixSelectionIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/ModelPrefixSelectionIntegrationTest.cs
@@ -45,10 +45,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 });
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -95,10 +95,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 });
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -135,10 +135,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?Name=");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -185,10 +185,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 });
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -232,10 +232,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 });
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/MutableObjectModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/MutableObjectModelBinderIntegrationTest.cs
@@ -66,10 +66,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 SetJsonBodyContent(request, AddressBodyContent);
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -111,10 +111,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 SetJsonBodyContent(request, AddressBodyContent);
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -156,10 +156,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.ContentType = "application/json";
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -201,10 +201,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 SetJsonBodyContent(request, AddressBodyContent);
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -242,10 +242,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 SetJsonBodyContent(request, AddressBodyContent);
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -290,10 +290,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                     new QueryString("?parameter.Customer.Name=bill&parameter.Customer.Token=" + ByteArrayEncoded);
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -333,10 +333,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?Customer.Name=bill&Customer.Token=" + ByteArrayEncoded);
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -376,10 +376,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter.Customer.Name=bill");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -430,10 +430,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 SetFormFileBodyContent(request, "Hello, World!", "parameter.Customer.Documents");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -474,10 +474,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 SetFormFileBodyContent(request, "Hello, World!", "Customer.Documents");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -519,10 +519,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 // Deliberately leaving out any form data.
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -565,10 +565,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 SetFormFileBodyContent(request, "Hello, World!", "parameter.Customer.Documents");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -606,10 +606,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 SetFormFileBodyContent(request, "Hello, World!", "parameter.Customer.Documents");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -647,10 +647,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                     new QueryString("?parameter.Name=bill&parameter.ProductIds[0]=10&parameter.ProductIds[1]=11");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -693,10 +693,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?Name=bill&ProductIds[0]=10&ProductIds[1]=11");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -739,10 +739,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter.Name=bill");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -777,10 +777,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -819,10 +819,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                     new QueryString("?parameter.Name=bill&parameter.ProductIds[0]=10&parameter.ProductIds[1]=11");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -865,10 +865,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?Name=bill&ProductIds[0]=10&ProductIds[1]=11");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -911,10 +911,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter.Name=bill");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -949,10 +949,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -991,10 +991,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                     new QueryString("?parameter.Name=bill&parameter.ProductIds[0].Key=key0&parameter.ProductIds[0].Value=10");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1037,10 +1037,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?Name=bill&ProductIds[0].Key=key0&ProductIds[0].Value=10");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1083,10 +1083,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter.Name=bill");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1121,10 +1121,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1163,10 +1163,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                     new QueryString("?parameter.Name=bill&parameter.ProductId.Key=key0&parameter.ProductId.Value=10");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1209,10 +1209,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?Name=bill&ProductId.Key=key0&ProductId.Value=10");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1255,10 +1255,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter.Name=bill");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1293,10 +1293,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1341,10 +1341,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 SetJsonBodyContent(request, AddressBodyContent);
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1389,10 +1389,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             // No Data
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext();
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1436,10 +1436,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             // No Data
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext();
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1488,10 +1488,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter.Customer.Id=123");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1533,10 +1533,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?Customer.Id=123");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1582,10 +1582,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?customParameter.Customer.Id=123");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1633,10 +1633,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1676,10 +1676,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1715,10 +1715,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?ProductName=abc");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1758,10 +1758,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1801,10 +1801,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1840,10 +1840,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?OrderIds[0]=123");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1884,10 +1884,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter.ProductId=");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1928,10 +1928,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter.ProductId");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/ServicesModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/ServicesModelBinderIntegrationTest.cs
@@ -32,10 +32,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             };
 
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext();
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 
@@ -69,10 +69,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             };
 
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext();
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             // ModelBindingResult
@@ -105,10 +105,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             };
 
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext();
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             // ModelBindingResult
@@ -141,10 +141,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             };
 
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext();
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             // ModelBindingResult
@@ -177,11 +177,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             };
 
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext();
-            var modelState = new ModelStateDictionary();
 
             // Act & Assert
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                () => argumentBinder.BindModelAsync(parameter, modelState, operationContext));
+                () => argumentBinder.BindModelAsync(parameter, operationContext));
             Assert.Contains(typeof(IActionResult).FullName, exception.Message);
         }
     }

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/SimpleTypeModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/SimpleTypeModelBinderIntegrationTest.cs
@@ -42,10 +42,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = QueryString.Create("CustomParameter.Address.Zip", "1");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 
@@ -86,10 +86,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = QueryString.Create("Address.Zip", "1");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 
@@ -131,10 +131,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = QueryString.Create("Parameter1", "someValue");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 
@@ -175,10 +175,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?Parameter1=someValue&Parameter1=otherValue");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 
@@ -219,10 +219,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = QueryString.Create("Parameter1", "abcd");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 
@@ -273,10 +273,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             {
                 request.QueryString = QueryString.Create("Parameter1", "  ");
             });
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 
@@ -326,10 +326,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             {
                 request.QueryString = QueryString.Create("Parameter1", string.Empty);
             });
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             // ModelBindingResult
@@ -369,10 +369,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             {
                 request.QueryString = QueryString.Create("Parameter1", string.Empty);
             });
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 
@@ -407,10 +407,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             // No Data.
             var operationContext = ModelBindingTestHelper.GetOperationBindingContext();
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
 
@@ -461,10 +461,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
             {
                 request.Form = new FormCollection(personStore);
             });
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             // ModelBindingResult

--- a/test/Microsoft.AspNet.Mvc.IntegrationTests/ValidationIntegrationTests.cs
+++ b/test/Microsoft.AspNet.Mvc.IntegrationTests/ValidationIntegrationTests.cs
@@ -37,10 +37,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter.CustomerName=bill");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -74,10 +74,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -125,10 +125,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter.Customer.Name=bill");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -163,10 +163,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -216,10 +216,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter.Customer.Name=bill");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -255,10 +255,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter.Customer.Age=17");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -308,10 +308,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?Items[0].ItemId=17");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -347,10 +347,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -395,10 +395,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter[0].ProductId=17");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -433,10 +433,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter[0].Name=bill");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -481,10 +481,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter.Name=bill");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -518,10 +518,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter.Name=billybob");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -569,10 +569,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter.Customer.Name=bill");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -606,10 +606,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter.Customer.Name=billybob");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -646,10 +646,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -704,10 +704,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter.Customer.Name=bill");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -741,10 +741,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter.Customer.Name=billybob");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -811,10 +811,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter.Products[0].Name=bill");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -848,10 +848,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter.Products[0].Name=billybob");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -899,10 +899,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter[0].Name=bill");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -936,10 +936,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?parameter[0].Name=billybob");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -976,10 +976,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1016,10 +1016,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?Id=bill");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1056,10 +1056,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 request.QueryString = new QueryString("?Zip=-123");
             });
 
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
@@ -1134,10 +1134,10 @@ namespace Microsoft.AspNet.Mvc.IntegrationTests
                 });
 
             var argumentBinder = ModelBindingTestHelper.GetArgumentBinder(testOptions);
-            var modelState = new ModelStateDictionary();
+            var modelState = operationContext.ActionContext.ModelState;
 
             // Act
-            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, modelState, operationContext);
+            var modelBindingResult = await argumentBinder.BindModelAsync(parameter, operationContext);
 
             Assert.Equal(4, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/RemoteAttributeTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/RemoteAttributeTest.cs
@@ -446,7 +446,15 @@ namespace Microsoft.AspNet.Mvc
             serviceCollection.AddSingleton<IUrlHelper>(urlHelper);
             var serviceProvider = serviceCollection.BuildServiceProvider();
 
-            return new ClientModelValidationContext(_metadata, _metadataProvider, serviceProvider);
+            var actionContext = new ActionContext()
+            {
+                HttpContext = new DefaultHttpContext()
+                {
+                    RequestServices = serviceProvider,
+                },
+            };
+
+            return new ClientModelValidationContext(actionContext, _metadata, _metadataProvider);
         }
 
         private static ClientModelValidationContext GetValidationContextWithArea(string currentArea)
@@ -476,7 +484,15 @@ namespace Microsoft.AspNet.Mvc
             serviceCollection.AddSingleton<IUrlHelper>(urlHelper);
             serviceProvider = serviceCollection.BuildServiceProvider();
 
-            return new ClientModelValidationContext(_metadata, _metadataProvider, serviceProvider);
+            var actionContext = new ActionContext()
+            {
+                HttpContext = new DefaultHttpContext()
+                {
+                    RequestServices = serviceProvider,
+                },
+            };
+
+            return new ClientModelValidationContext(actionContext, _metadata, _metadataProvider);
         }
 
         private static ClientModelValidationContext GetValidationContextWithNoController()
@@ -495,9 +511,9 @@ namespace Microsoft.AspNet.Mvc
             var contextAccessor = GetContextAccessor(serviceProvider, routeData);
             var urlHelper = new UrlHelper(contextAccessor);
             serviceCollection.AddSingleton<IUrlHelper>(urlHelper);
-            serviceProvider = serviceCollection.BuildServiceProvider();
+            contextAccessor.ActionContext.HttpContext.RequestServices = serviceCollection.BuildServiceProvider();
 
-            return new ClientModelValidationContext(_metadata, _metadataProvider, serviceProvider);
+            return new ClientModelValidationContext(contextAccessor.ActionContext, _metadata, _metadataProvider);
         }
 
         private static IRouter GetRouteCollectionWithArea(IServiceProvider serviceProvider)


### PR DESCRIPTION
This change makes it possible to access the ActionContext/ActionDescriptor
from inside of validators and client validators.