### PR TITLE
Removed unused private method in DefaultActionSelector

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/Controllers/ControllerActionDescriptorBuilder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Controllers/ControllerActionDescriptorBuilder.cs
@@ -316,7 +316,6 @@ namespace Microsoft.AspNet.Mvc.Controllers
             ControllerModel controller,
             ActionModel action)
         {
-            
             var isVisible = 
                 action.ApiExplorer?.IsVisible ?? 
                 controller.ApiExplorer?.IsVisible ?? 

--- a/src/Microsoft.AspNet.Mvc.Core/Infrastructure/DefaultActionSelector.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Infrastructure/DefaultActionSelector.cs
@@ -235,20 +235,6 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             return matchingRouteConstraints.Count > 0;
         }
 
-        private IReadOnlyList<ActionDescriptor> GetActions()
-        {
-            var descriptors = _actionDescriptorsCollectionProvider.ActionDescriptors;
-
-            if (descriptors == null)
-            {
-                throw new InvalidOperationException(
-                    Resources.FormatPropertyOfTypeCannotBeNull("ActionDescriptors",
-                                                               _actionDescriptorsCollectionProvider.GetType()));
-            }
-
-            return descriptors.Items;
-        }
-
         private IReadOnlyList<IActionConstraint> GetConstraints(HttpContext httpContext, ActionDescriptor action)
         {
             if (action.ActionConstraints == null || action.ActionConstraints.Count == 0)

--- a/src/Microsoft.AspNet.Mvc.Core/Infrastructure/ObjectResultExecutor.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Infrastructure/ObjectResultExecutor.cs
@@ -101,7 +101,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             if (objectType == null || objectType == typeof(object))
             {
                 objectType = result.Value?.GetType();
-            };
+            }
 
             var formatterContext = new OutputFormatterWriteContext(
                 context.HttpContext,

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Infrastructure/DefaultActionSelectorTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Infrastructure/DefaultActionSelectorTests.cs
@@ -642,9 +642,9 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
 
             serviceContainer.AddSingleton(typeof(IEnumerable<IActionDescriptorProvider>), list);
 
-            var actionCollectionDescriptorProvider = new DefaultActionDescriptorsCollectionProvider(
+            var actionDescriptorsCollectionProvider = new DefaultActionDescriptorsCollectionProvider(
                 serviceContainer.BuildServiceProvider());
-            var decisionTreeProvider = new ActionSelectorDecisionTreeProvider(actionCollectionDescriptorProvider);
+            var decisionTreeProvider = new ActionSelectorDecisionTreeProvider(actionDescriptorsCollectionProvider);
 
             var actionConstraintProviders = new[]
             {
@@ -652,7 +652,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             };
 
             var defaultActionSelector = new DefaultActionSelector(
-                actionCollectionDescriptorProvider,
+                actionDescriptorsCollectionProvider,
                 decisionTreeProvider,
                 actionConstraintProviders,
                 NullLoggerFactory.Instance);


### PR DESCRIPTION
DefaultActionSelector contained GetActions private method, which is not used anywhere.

Additionally added some small fixes:
 - One of the method in ControllerActionDescriptorBuilder contained blank empty line, which was not consistent with all other method stylings.
 - ObjectResultExecutor contained unnecessary semicolon after one conditional statement.
 - In DefaultActionSelectorTests one of the variables was named backwards - actionCollectionDescriptorProvider while it should be actionDescriptorsCollectionProvider.