### PR TITLE
Remove dependency on ICompilationOptionsProvider

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Razor/Compilation/RoslynCompilationService.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Compilation/RoslynCompilationService.cs
@@ -38,7 +38,6 @@ namespace Microsoft.AspNet.Mvc.Razor.Compilation
         private readonly IFileProvider _fileProvider;
         private readonly Lazy<List<MetadataReference>> _applicationReferences;
         private readonly string _classPrefix;
-        private readonly string _configuration;
         private readonly Action<RoslynCompilationContext> _compilationCallback;
         private readonly CSharpParseOptions _parseOptions;
         private readonly CSharpCompilationOptions _compilationOptions;

--- a/src/Microsoft.AspNet.Mvc.Razor/Compilation/RoslynCompilationService.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Compilation/RoslynCompilationService.cs
@@ -70,8 +70,8 @@ namespace Microsoft.AspNet.Mvc.Razor.Compilation
             _fileProvider = optionsAccessor.Value.FileProvider;
             _classPrefix = host.MainClassNamePrefix;
             _compilationCallback = optionsAccessor.Value.CompilationCallback;
-            _parseOptions = optionsAccessor.Value.ParseOptions ?? new CSharpParseOptions(LanguageVersion.CSharp6);
-            _compilationOptions = optionsAccessor.Value.CompilationOptions ?? new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+            _parseOptions = optionsAccessor.Value.ParseOptions;
+            _compilationOptions = optionsAccessor.Value.CompilationOptions;
 
 
 #if DOTNET5_5

--- a/src/Microsoft.AspNet.Mvc.Razor/Compilation/RoslynCompilationService.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Compilation/RoslynCompilationService.cs
@@ -35,12 +35,13 @@ namespace Microsoft.AspNet.Mvc.Razor.Compilation
 
         private readonly ILibraryExporter _libraryExporter;
         private readonly IApplicationEnvironment _environment;
-        private readonly ICompilerOptionsProvider _compilerOptionsProvider;
         private readonly IFileProvider _fileProvider;
         private readonly Lazy<List<MetadataReference>> _applicationReferences;
         private readonly string _classPrefix;
         private readonly string _configuration;
-        private Action<RoslynCompilationContext> _compilationCallback;
+        private readonly Action<RoslynCompilationContext> _compilationCallback;
+        private readonly CSharpParseOptions _parseOptions;
+        private readonly CSharpCompilationOptions _compilationOptions;
 
 #if DOTNET5_5
         private readonly RazorLoadContext _razorLoadContext;
@@ -61,18 +62,18 @@ namespace Microsoft.AspNet.Mvc.Razor.Compilation
         public RoslynCompilationService(
             IApplicationEnvironment environment,
             ILibraryExporter libraryExporter,
-            ICompilerOptionsProvider compilerOptionsProvider,
             IMvcRazorHost host,
             IOptions<RazorViewEngineOptions> optionsAccessor)
         {
             _environment = environment;
             _libraryExporter = libraryExporter;
             _applicationReferences = new Lazy<List<MetadataReference>>(GetApplicationReferences);
-            _compilerOptionsProvider = compilerOptionsProvider;
             _fileProvider = optionsAccessor.Value.FileProvider;
             _classPrefix = host.MainClassNamePrefix;
-            _configuration = optionsAccessor.Value.Configuration;
             _compilationCallback = optionsAccessor.Value.CompilationCallback;
+            _parseOptions = optionsAccessor.Value.ParseOptions ?? new CSharpParseOptions(LanguageVersion.CSharp6);
+            _compilationOptions = optionsAccessor.Value.CompilationOptions ?? new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+
 
 #if DOTNET5_5
             _razorLoadContext = new RazorLoadContext();
@@ -93,21 +94,17 @@ namespace Microsoft.AspNet.Mvc.Razor.Compilation
             }
 
             var assemblyName = Path.GetRandomFileName();
-            var compilationSettings = _compilerOptionsProvider.GetCompilationSettings(_environment, _configuration);
+
             var syntaxTree = SyntaxTreeGenerator.Generate(
                 compilationContent,
                 assemblyName,
-                compilationSettings);
+                _parseOptions);
 
             var references = _applicationReferences.Value;
 
-            var compilationOptions = compilationSettings
-                .CompilationOptions
-                .WithOutputKind(OutputKind.DynamicallyLinkedLibrary);
-
             var compilation = CSharpCompilation.Create(
                 assemblyName,
-                options: compilationOptions,
+                options: _compilationOptions,
                 syntaxTrees: new[] { syntaxTree },
                 references: references);
 
@@ -258,13 +255,16 @@ namespace Microsoft.AspNet.Mvc.Razor.Compilation
             }
 
             var export = _libraryExporter.GetAllExports(_environment.ApplicationName);
-            foreach (var metadataReference in export.MetadataReferences)
+            if (export != null)
             {
-                // Taken from https://github.com/aspnet/KRuntime/blob/757ba9bfdf80bd6277e715d6375969a7f44370ee/src/...
-                // Microsoft.Extensions.Runtime.Roslyn/RoslynCompiler.cs#L164
-                // We don't want to take a dependency on the Roslyn bit directly since it pulls in more dependencies
-                // than the view engine needs (Microsoft.Extensions.Runtime) for example
-                references.Add(ConvertMetadataReference(metadataReference));
+                foreach (var metadataReference in export.MetadataReferences)
+                {
+                    // Taken from https://github.com/aspnet/KRuntime/blob/757ba9bfdf80bd6277e715d6375969a7f44370ee/src/...
+                    // Microsoft.Extensions.Runtime.Roslyn/RoslynCompiler.cs#L164
+                    // We don't want to take a dependency on the Roslyn bit directly since it pulls in more dependencies
+                    // than the view engine needs (Microsoft.Extensions.Runtime) for example
+                    references.Add(ConvertMetadataReference(metadataReference));
+                }
             }
 
             return references;

--- a/src/Microsoft.AspNet.Mvc.Razor/Compilation/SyntaxTreeGenerator.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/Compilation/SyntaxTreeGenerator.cs
@@ -17,6 +17,19 @@ namespace Microsoft.AspNet.Mvc.Razor.Compilation
             string path,
             CompilationSettings compilationSettings)
         {
+            if (compilationSettings == null)
+            {
+                throw new ArgumentNullException(nameof(compilationSettings));
+            }
+
+            return Generate(text, path, GetParseOptions(compilationSettings));
+        }
+
+        public static SyntaxTree Generate(
+            string text,
+            string path,
+            CSharpParseOptions parseOptions)
+        {
             if (text == null)
             {
                 throw new ArgumentNullException(nameof(text));
@@ -27,15 +40,15 @@ namespace Microsoft.AspNet.Mvc.Razor.Compilation
                 throw new ArgumentNullException(nameof(path));
             }
 
-            if (compilationSettings == null)
+            if (parseOptions == null)
             {
-                throw new ArgumentNullException(nameof(compilationSettings));
+                throw new ArgumentNullException(nameof(parseOptions));
             }
 
             var sourceText = SourceText.From(text, Encoding.UTF8);
             var syntaxTree = CSharpSyntaxTree.ParseText(sourceText,
                 path: path,
-                options: GetParseOptions(compilationSettings));
+                options: parseOptions);
 
             return syntaxTree;
         }

--- a/src/Microsoft.AspNet.Mvc.Razor/DependencyInjection/MvcRazorMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/DependencyInjection/MvcRazorMvcCoreBuilderExtensions.cs
@@ -123,7 +123,6 @@ namespace Microsoft.Extensions.DependencyInjection
             if (CompilationServices.Default != null)
             {
                 services.TryAdd(ServiceDescriptor.Instance(CompilationServices.Default.LibraryExporter));
-                services.TryAdd(ServiceDescriptor.Instance(CompilationServices.Default.CompilerOptionsProvider));
             }
 
             services.TryAddEnumerable(

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorViewEngineOptions.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorViewEngineOptions.cs
@@ -16,9 +16,9 @@ namespace Microsoft.AspNet.Mvc.Razor
     {
         private IFileProvider _fileProvider;
 
-        private CSharpParseOptions _parseOptions;
+        private CSharpParseOptions _parseOptions = new CSharpParseOptions(LanguageVersion.CSharp6);
 
-        private CSharpCompilationOptions _compilationOptions;
+        private CSharpCompilationOptions _compilationOptions = new CSharpCompilationOptions(CodeAnalysis.OutputKind.DynamicallyLinkedLibrary);
 
         private Action<RoslynCompilationContext> _compilationCallback = c => { };
 

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorViewEngineOptions.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorViewEngineOptions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.AspNet.FileProviders;
 using Microsoft.AspNet.Mvc.Razor.Compilation;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.AspNet.Mvc.Razor
 {
@@ -16,6 +17,10 @@ namespace Microsoft.AspNet.Mvc.Razor
         private IFileProvider _fileProvider;
 
         private string _configuration;
+
+        private CSharpParseOptions _parseOptions;
+
+        private CSharpCompilationOptions _compilationOptions;
 
         private Action<RoslynCompilationContext> _compilationCallback = c => { };
 
@@ -49,27 +54,6 @@ namespace Microsoft.AspNet.Mvc.Razor
         }
 
         /// <summary>
-        /// Gets or sets the configuration name used by <see cref="RazorViewEngine"/> to compile razor views.
-        /// </summary>
-        /// <remarks>
-        /// At startup, this is initialized to "Debug" if <see cref="Microsoft.AspNet.Hosting.IHostingEnvironment"/> service is
-        /// registred and environment is development (<see cref="Microsoft.AspNet.Hosting.HostingEnvironmentExtensions.IsDevelopment"/>) else it is set to
-        /// "Release".
-        /// </remarks>
-        public string Configuration
-        {
-            get { return _configuration; }
-            set
-            {
-                if (string.IsNullOrEmpty(value))
-                {
-                    throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(value));
-                }
-                _configuration = value;
-            }
-        }
-
-        /// <summary>
         /// Gets or sets the callback that is used to customize Razor compilation
         /// to change compilation settings you can update <see cref="RoslynCompilationContext.Compilation"/> property.
         /// Customizations made here would not reflect in tooling (Intellisense).
@@ -86,5 +70,38 @@ namespace Microsoft.AspNet.Mvc.Razor
                 _compilationCallback = value;
             }
         }
+
+        /// <summary>
+        /// Gets or sets the <see cref="CSharpParseOptions"/> options used by Razor view compilation.
+        /// </summary>
+        public CSharpParseOptions ParseOptions
+        {
+            get { return _parseOptions; }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+                _parseOptions = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="CSharpCompilationOptions"/> used by Razor view compilation.
+        /// </summary>
+        public CSharpCompilationOptions CompilationOptions
+        {
+            get { return _compilationOptions; }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+                _compilationOptions = value;
+            }
+        }
+
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorViewEngineOptions.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorViewEngineOptions.cs
@@ -16,8 +16,6 @@ namespace Microsoft.AspNet.Mvc.Razor
     {
         private IFileProvider _fileProvider;
 
-        private string _configuration;
-
         private CSharpParseOptions _parseOptions;
 
         private CSharpCompilationOptions _compilationOptions;

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorViewEngineOptionsSetup.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorViewEngineOptionsSetup.cs
@@ -4,8 +4,8 @@
 using Microsoft.AspNet.FileProviders;
 using Microsoft.AspNet.Hosting;
 using Microsoft.AspNet.Mvc.Razor;
-using Microsoft.AspNet.Mvc.Razor.Compilation;
-using Microsoft.Extensions.CompilationAbstractions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.OptionsModel;
 using Microsoft.Extensions.PlatformAbstractions;
 
@@ -22,7 +22,7 @@ namespace Microsoft.AspNet.Mvc
         /// <param name="applicationEnvironment"><see cref="IApplicationEnvironment"/> for the application.</param>
         /// <param name="hostingEnvironment"><see cref="IHostingEnvironment"/> for the application.</param>
         public RazorViewEngineOptionsSetup(IApplicationEnvironment applicationEnvironment,
-            IHostingEnvironment hostingEnvironment)
+                                           IHostingEnvironment hostingEnvironment)
             : base(options => ConfigureRazor(options, applicationEnvironment, hostingEnvironment))
         {
         }
@@ -32,13 +32,19 @@ namespace Microsoft.AspNet.Mvc
             IHostingEnvironment hostingEnvironment)
         {
             razorOptions.FileProvider = new PhysicalFileProvider(applicationEnvironment.ApplicationBasePath);
+
+            var parseOptions = new CSharpParseOptions(LanguageVersion.CSharp6);
+            var compilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+
             if (hostingEnvironment.IsDevelopment())
             {
-                razorOptions.Configuration = "Debug";
+                razorOptions.ParseOptions = parseOptions.WithPreprocessorSymbols("DEBUG");
+                razorOptions.CompilationOptions = compilationOptions.WithOptimizationLevel(OptimizationLevel.Debug);
             }
             else
             {
-                razorOptions.Configuration = "Release";
+                razorOptions.ParseOptions = parseOptions.WithPreprocessorSymbols("RELEASE");
+                razorOptions.CompilationOptions = compilationOptions.WithOptimizationLevel(OptimizationLevel.Release);
             }
         }
     }

--- a/test/Microsoft.AspNet.Mvc.Razor.Test/Compilation/RoslynCompilationServiceTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Razor.Test/Compilation/RoslynCompilationServiceTest.cs
@@ -27,14 +27,6 @@ namespace Microsoft.AspNet.Mvc.Razor.Compilation
 public class MyTestType  {}";
             var applicationEnvironment = PlatformServices.Default.Application;
             var libraryExporter = CompilationServices.Default.LibraryExporter;
-
-            var compilerOptionsProvider = new Mock<ICompilerOptionsProvider>();
-            compilerOptionsProvider
-                .Setup(p => p.GetCompilerOptions(
-                    applicationEnvironment.ApplicationName,
-                    applicationEnvironment.RuntimeFramework,
-                    ConfigurationName))
-                .Returns(new CompilerOptions());
             var mvcRazorHost = new Mock<IMvcRazorHost>();
             mvcRazorHost.SetupGet(m => m.MainClassNamePrefix)
                         .Returns(string.Empty);
@@ -42,7 +34,6 @@ public class MyTestType  {}";
             var compilationService = new RoslynCompilationService(
                 applicationEnvironment,
                 libraryExporter,
-                compilerOptionsProvider.Object,
                 mvcRazorHost.Object,
                 GetOptions());
             var relativeFileInfo = new RelativeFileInfo(
@@ -67,14 +58,6 @@ public class MyTestType  {}";
 this should fail";
             var applicationEnvironment = PlatformServices.Default.Application;
             var libraryExporter = CompilationServices.Default.LibraryExporter;
-
-            var compilerOptionsProvider = new Mock<ICompilerOptionsProvider>();
-            compilerOptionsProvider
-                .Setup(p => p.GetCompilerOptions(
-                    applicationEnvironment.ApplicationName,
-                    applicationEnvironment.RuntimeFramework,
-                    ConfigurationName))
-                .Returns(new CompilerOptions());
             var mvcRazorHost = Mock.Of<IMvcRazorHost>();
             var fileProvider = new TestFileProvider();
             var fileInfo = fileProvider.AddFile(viewPath, fileContent);
@@ -82,7 +65,6 @@ this should fail";
             var compilationService = new RoslynCompilationService(
                 applicationEnvironment,
                 libraryExporter,
-                compilerOptionsProvider.Object,
                 mvcRazorHost,
                 GetOptions(fileProvider));
             var relativeFileInfo = new RelativeFileInfo(fileInfo, "some-relative-path");
@@ -106,20 +88,11 @@ this should fail";
             var content = @"this should fail";
             var applicationEnvironment = PlatformServices.Default.Application;
             var libraryExporter = CompilationServices.Default.LibraryExporter;
-
-            var compilerOptionsProvider = new Mock<ICompilerOptionsProvider>();
-            compilerOptionsProvider
-                .Setup(p => p.GetCompilerOptions(
-                    applicationEnvironment.ApplicationName,
-                    applicationEnvironment.RuntimeFramework,
-                    ConfigurationName))
-                .Returns(new CompilerOptions());
             var mvcRazorHost = Mock.Of<IMvcRazorHost>();
 
             var compilationService = new RoslynCompilationService(
                 applicationEnvironment,
                 libraryExporter,
-                compilerOptionsProvider.Object,
                 mvcRazorHost,
                 GetOptions());
             var relativeFileInfo = new RelativeFileInfo(
@@ -148,14 +121,6 @@ this should fail";
 this should fail";
             var applicationEnvironment = PlatformServices.Default.Application;
             var libraryExporter = CompilationServices.Default.LibraryExporter;
-
-            var compilerOptionsProvider = new Mock<ICompilerOptionsProvider>();
-            compilerOptionsProvider
-                .Setup(p => p.GetCompilerOptions(
-                    applicationEnvironment.ApplicationName,
-                    applicationEnvironment.RuntimeFramework,
-                    ConfigurationName))
-                .Returns(new CompilerOptions());
             var mvcRazorHost = Mock.Of<IMvcRazorHost>();
 
             var mockFileInfo = new Mock<IFileInfo>();
@@ -167,7 +132,6 @@ this should fail";
             var compilationService = new RoslynCompilationService(
                 applicationEnvironment,
                 libraryExporter,
-                compilerOptionsProvider.Object,
                 mvcRazorHost,
                 GetOptions(fileProvider));
 
@@ -197,24 +161,18 @@ public class MyNonCustomDefinedClass {}
 ";
             var applicationEnvironment = PlatformServices.Default.Application;
             var libraryExporter = CompilationServices.Default.LibraryExporter;
-
-            var compilerOptionsProvider = new Mock<ICompilerOptionsProvider>();
-            compilerOptionsProvider
-                .Setup(p => p.GetCompilerOptions(
-                    applicationEnvironment.ApplicationName,
-                    applicationEnvironment.RuntimeFramework,
-                    ConfigurationName))
-                .Returns(new CompilerOptions { Defines = new[] { "MY_CUSTOM_DEFINE" } });
             var mvcRazorHost = new Mock<IMvcRazorHost>();
             mvcRazorHost.SetupGet(m => m.MainClassNamePrefix)
                         .Returns("My");
 
+            var options = GetOptions();
+            options.Value.ParseOptions = options.Value.ParseOptions.WithPreprocessorSymbols("MY_CUSTOM_DEFINE");
+
             var compilationService = new RoslynCompilationService(
                 applicationEnvironment,
                 libraryExporter,
-                compilerOptionsProvider.Object,
                 mvcRazorHost.Object,
-                GetOptions());
+                options);
             var relativeFileInfo = new RelativeFileInfo(
                 new TestFileInfo { PhysicalPath = "SomePath" },
                 "some-relative-path");
@@ -236,14 +194,6 @@ public class RazorPrefixType  {}
 public class NotRazorPrefixType {}";
             var applicationEnvironment = PlatformServices.Default.Application;
             var libraryExporter = CompilationServices.Default.LibraryExporter;
-
-            var compilerOptionsProvider = new Mock<ICompilerOptionsProvider>();
-            compilerOptionsProvider
-                .Setup(p => p.GetCompilerOptions(
-                    applicationEnvironment.ApplicationName,
-                    applicationEnvironment.RuntimeFramework,
-                    ConfigurationName))
-                .Returns(new CompilerOptions());
             var mvcRazorHost = new Mock<IMvcRazorHost>();
             mvcRazorHost.SetupGet(m => m.MainClassNamePrefix)
                         .Returns("RazorPrefix");
@@ -251,7 +201,6 @@ public class NotRazorPrefixType {}";
             var compilationService = new RoslynCompilationService(
                 applicationEnvironment,
                 libraryExporter,
-                compilerOptionsProvider.Object,
                 mvcRazorHost.Object,
                 GetOptions());
 
@@ -284,7 +233,6 @@ public class NotRazorPrefixType {}";
             var compilationService = new RoslynCompilationService(
                 PlatformServices.Default.Application,
                 CompilationServices.Default.LibraryExporter,
-                Mock.Of<ICompilerOptionsProvider>(),
                 Mock.Of<IMvcRazorHost>(),
                 options.Object);
 
@@ -368,15 +316,6 @@ public class NotRazorPrefixType {}";
             var content = "public class MyTestType  {}";
             var applicationEnvironment = PlatformServices.Default.Application;
             var libraryExporter = CompilationServices.Default.LibraryExporter;
-
-            var compilerOptionsProvider = new Mock<ICompilerOptionsProvider>();
-            compilerOptionsProvider
-                .Setup(p => p.GetCompilerOptions(
-                    applicationEnvironment.ApplicationName,
-                    applicationEnvironment.RuntimeFramework,
-                    ConfigurationName))
-                .Returns(new CompilerOptions());
-
             RoslynCompilationContext usedCompilation = null;
             var mvcRazorHost = new Mock<IMvcRazorHost>();
             mvcRazorHost.SetupGet(m => m.MainClassNamePrefix)
@@ -385,7 +324,6 @@ public class NotRazorPrefixType {}";
             var compilationService = new RoslynCompilationService(
                 applicationEnvironment,
                 libraryExporter,
-                compilerOptionsProvider.Object,
                 mvcRazorHost.Object,
                 GetOptions(callback: c => usedCompilation = c));
 
@@ -418,7 +356,6 @@ public class NotRazorPrefixType {}";
             var razorViewEngineOptions = new RazorViewEngineOptions
             {
                 FileProvider = fileProvider ?? new TestFileProvider(),
-                Configuration = ConfigurationName,
                 CompilationCallback = callback ?? (c => { })
             };
             var options = new Mock<IOptions<RazorViewEngineOptions>>();

--- a/test/WebSites/RazorWebSite/Startup.cs
+++ b/test/WebSites/RazorWebSite/Startup.cs
@@ -20,9 +20,9 @@ namespace RazorWebSite
                 {
                     options.ViewLocationExpanders.Add(new NonMainPageViewLocationExpander());
 #if DNX451
-					options.ParseOptions = options.ParseOptions.WithPreprocessorSymbols("DNX451", "DNX451_CUSTOM_DEFINE");
+                    options.ParseOptions = options.ParseOptions.WithPreprocessorSymbols("DNX451", "DNX451_CUSTOM_DEFINE");
 #else
-					options.ParseOptions = options.ParseOptions.WithPreprocessorSymbols("DNCORE50", "DNXCORE50_CUSTOM_DEFINE");
+                    options.ParseOptions = options.ParseOptions.WithPreprocessorSymbols("DNCORE50", "DNXCORE50_CUSTOM_DEFINE");
 #endif
                 })
                 .AddViewOptions(options =>

--- a/test/WebSites/RazorWebSite/Startup.cs
+++ b/test/WebSites/RazorWebSite/Startup.cs
@@ -19,6 +19,11 @@ namespace RazorWebSite
                 .AddRazorOptions(options =>
                 {
                     options.ViewLocationExpanders.Add(new NonMainPageViewLocationExpander());
+#if DNX451
+					options.ParseOptions = options.ParseOptions.WithPreprocessorSymbols("DNX451", "DNX451_CUSTOM_DEFINE");
+#else
+					options.ParseOptions = options.ParseOptions.WithPreprocessorSymbols("DNCORE50", "DNXCORE50_CUSTOM_DEFINE");
+#endif
                 })
                 .AddViewOptions(options =>
                 {

--- a/test/WebSites/RazorWebSite/Startup.cs
+++ b/test/WebSites/RazorWebSite/Startup.cs
@@ -22,7 +22,7 @@ namespace RazorWebSite
 #if DNX451
                     options.ParseOptions = options.ParseOptions.WithPreprocessorSymbols("DNX451", "DNX451_CUSTOM_DEFINE");
 #else
-                    options.ParseOptions = options.ParseOptions.WithPreprocessorSymbols("DNCORE50", "DNXCORE50_CUSTOM_DEFINE");
+                    options.ParseOptions = options.ParseOptions.WithPreprocessorSymbols("DNXCORE50", "DNXCORE50_CUSTOM_DEFINE");
 #endif
                 })
                 .AddViewOptions(options =>


### PR DESCRIPTION
- Removed Configuration from RazorViewEngineOptions
- Added ParseOptions and CompilationOptions to RazorViewEngineOptions

#3633

/cc @pranavkm @pakrym 

There's a broken test that shows flowing compilation options from the project file. I can update the functional test project to support passing setting the right preprocessor symbols at runtime.

EDIT:

Update the test