### PR TITLE
Partial fix for #3676 - fix race in ElementMetadata

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Metadata/DefaultModelMetadata.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/ModelBinding/Metadata/DefaultModelMetadata.cs
@@ -25,7 +25,6 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
 
         private ReadOnlyDictionary<object, object> _additionalValues;
         private ModelMetadata _elementMetadata;
-        private bool _haveCalculatedElementMetadata;
         private bool? _isBindingRequired;
         private bool? _isReadOnly;
         private bool? _isRequired;
@@ -248,38 +247,9 @@ namespace Microsoft.AspNet.Mvc.ModelBinding.Metadata
         {
             get
             {
-                if (!_haveCalculatedElementMetadata)
+                if (_elementMetadata == null && ElementType != null)
                 {
-                    _haveCalculatedElementMetadata = true;
-                    if (!IsEnumerableType)
-                    {
-                        // Short-circuit checks below. If not IsEnumerableType, ElementMetadata is null.
-                        // For example, as in IsEnumerableType, do not consider strings collections.
-                        return null;
-                    }
-
-                    Type elementType = null;
-                    if (ModelType.IsArray)
-                    {
-                        elementType = ModelType.GetElementType();
-                    }
-                    else
-                    {
-                        elementType = ClosedGenericMatcher.ExtractGenericInterface(ModelType, typeof(IEnumerable<>))
-                            ?.GenericTypeArguments[0];
-                        if (elementType == null && typeof(IEnumerable).IsAssignableFrom(ModelType))
-                        {
-                            // ModelType implements IEnumerable but not IEnumerable<T>.
-                            elementType = typeof(object);
-                        }
-                    }
-
-                    Debug.Assert(
-                        elementType != null,
-                        $"Unable to find element type for '{ ModelType.FullName }' though IsEnumerableType is true.");
-
-                    // Success
-                    _elementMetadata = _provider.GetMetadataForType(elementType);
+                    _elementMetadata = _provider.GetMetadataForType(ElementType);
                 }
 
                 return _elementMetadata;

--- a/test/Microsoft.AspNet.Mvc.Abstractions.Test/ModelBinding/ModelMetadataTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Abstractions.Test/ModelBinding/ModelMetadataTest.cs
@@ -217,6 +217,45 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             Assert.Equal(expected, modelMetadata.UnderlyingOrModelType);
         }
 
+        [Theory]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(NonCollectionType))]
+        [InlineData(typeof(string))]
+        public void ElementType_ReturnsNull_ForNonCollections(Type modelType)
+        {
+            // Arrange
+            var metadata = new TestModelMetadata(modelType);
+
+            // Act
+            var elementType = metadata.ElementType;
+
+            // Assert
+            Assert.Null(elementType);
+        }
+
+        [Theory]
+        [InlineData(typeof(int[]), typeof(int))]
+        [InlineData(typeof(List<string>), typeof(string))]
+        [InlineData(typeof(DerivedList), typeof(int))]
+        [InlineData(typeof(IEnumerable), typeof(object))]
+        [InlineData(typeof(IEnumerable<string>), typeof(string))]
+        [InlineData(typeof(Collection<int>), typeof(int))]
+        [InlineData(typeof(Dictionary<object, object>), typeof(KeyValuePair<object, object>))]
+        [InlineData(typeof(DerivedDictionary), typeof(KeyValuePair<string, int>))]
+        public void ElementType_ReturnsExpectedMetadata(Type modelType, Type expected)
+        {
+            // Arrange
+            var metadata = new TestModelMetadata(modelType);
+
+            // Act
+            var elementType = metadata.ElementType;
+
+            // Assert
+            Assert.NotNull(elementType);
+            Assert.Equal(expected, elementType);
+        }
+
         // GetDisplayName()
 
         [Fact]
@@ -606,6 +645,10 @@ namespace Microsoft.AspNet.Mvc.ModelBinding
             {
                 throw new NotImplementedException();
             }
+        }
+
+        private class DerivedDictionary : Dictionary<string, int>
+        {
         }
     }
 }


### PR DESCRIPTION
The accessor for ElementMetadata can sometimes return null when
concurrently accessed. This change solves this issue by precomputing all
type-related facets of ModelMetadata. This also adds a ElementType
property to ModelMetadata to maintain the current separation of concerns
as ModelMetadata is unaware of the metadata provider.