### PR TITLE
Tweak CacheTagHelper sample to use a token provider service for

### DIFF
--- a/test/WebSites/HtmlGenerationWebSite/CancellableChangeToken.cs
+++ b/test/WebSites/HtmlGenerationWebSite/CancellableChangeToken.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Primitives;
+
+namespace HtmlGenerationWebSite
+{
+    public class CancellableChangeToken : IChangeToken
+    {
+        public bool HasChanged { get; set; }
+
+        public bool ActiveChangeCallbacks => false;
+
+        public IDisposable RegisterChangeCallback(Action<object> callback, object state)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/test/WebSites/HtmlGenerationWebSite/Controllers/Catalog_CacheTagHelperController.cs
+++ b/test/WebSites/HtmlGenerationWebSite/Controllers/Catalog_CacheTagHelperController.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Security.Claims;
+using HtmlGenerationWebSite.Models;
 using Microsoft.AspNet.Mvc;
 
 namespace HtmlGenerationWebSite.Controllers
@@ -72,9 +73,10 @@ namespace HtmlGenerationWebSite.Controllers
         }
 
         [HttpPost("/categories/update-products")]
-        public void UpdateCategories([FromServices] ProductsService productsService)
+        public void UpdateCategories([FromServices] TokenProviderService tokenService)
         {
-            productsService.UpdateProducts();
+            var key = typeof(Product);
+            tokenService.ExpireToken(key);
         }
 
         [HttpGet("/catalog/GetDealPercentage/{dealPercentage}")]

--- a/test/WebSites/HtmlGenerationWebSite/ProductsService.cs
+++ b/test/WebSites/HtmlGenerationWebSite/ProductsService.cs
@@ -1,20 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Threading;
-using Microsoft.Extensions.Primitives;
-
 namespace HtmlGenerationWebSite
 {
     public class ProductsService
     {
-        private readonly CancellationTokenSource _tokenSource = new CancellationTokenSource();
-
-        public string GetProducts(string category, out IChangeToken changeToken)
+        public string GetProducts(string category)
         {
-            var token = _tokenSource.IsCancellationRequested ?
-                CancellationToken.None : _tokenSource.Token;
-            changeToken = new CancellationChangeToken(token);
             if (category == "Books")
             {
                 return "Book1, Book2";
@@ -23,11 +15,6 @@ namespace HtmlGenerationWebSite
             {
                 return "Laptops";
             }
-        }
-
-        public void UpdateProducts()
-        {
-            _tokenSource.Cancel();
         }
     }
 }

--- a/test/WebSites/HtmlGenerationWebSite/Startup.cs
+++ b/test/WebSites/HtmlGenerationWebSite/Startup.cs
@@ -16,7 +16,8 @@ namespace HtmlGenerationWebSite
             // null which is interpreted as true unless element includes an action attribute.
             services.AddMvc().InitializeTagHelper<FormTagHelper>((helper, _) => helper.Antiforgery = false);
 
-            services.AddSingleton<ProductsService>();
+            services.AddSingleton<TokenProviderService>();
+            services.AddTransient<ProductsService>();
         }
 
         public void Configure(IApplicationBuilder app)

--- a/test/WebSites/HtmlGenerationWebSite/TokenProviderService.cs
+++ b/test/WebSites/HtmlGenerationWebSite/TokenProviderService.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+
+namespace HtmlGenerationWebSite
+{
+    public class TokenProviderService
+    {
+        private readonly ConcurrentDictionary<object, CancellableChangeToken> _changeTokens
+            = new ConcurrentDictionary<object, CancellableChangeToken>();
+
+        public CancellableChangeToken GetToken(object key)
+        {
+            return _changeTokens.GetOrAdd(key, new CancellableChangeToken());
+        }
+
+        public void ExpireToken(object key)
+        {
+            CancellableChangeToken changeToken;
+            if (_changeTokens.TryRemove(key, out changeToken))
+            {
+                changeToken.HasChanged = true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
cache expiration.

Fixes #3573