### PR TITLE
Update NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,7 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="AspNetVNext" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+    <clear />
+    <add key="AspNetCiDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
 </configuration>


### PR DESCRIPTION
Make it very straightforward to do an initial build. Example: I had an `AspNetVNext` package source configured in my global NuGet.config file, and I had also placed an entry for it under `disabledPackageSources`. When I cloned the Mvc repository and tried to build, I was getting errors that dependencies could not be resolved. Either adding explicit `remove` entries to the `disabledPackageSources` element in this file or changing the key in this file from `AspNetVNext` to `AspNetCiDev` would prevent that from happening; the approach I took here was to just completely tighten the local NuGet configuration to only use these two feeds and clear all disabled package source entries.