### PR TITLE
Enhance javascript fallback-test

### DIFF
--- a/src/Microsoft.AspNet.Mvc.TagHelpers/ScriptTagHelper.cs
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/ScriptTagHelper.cs
@@ -299,7 +299,9 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
                 // Build the <script> tag that checks the test method and if it fails, renders the extra script.
                 builder.AppendHtml(Environment.NewLine)
                        .AppendHtml("<script>(")
+                       .AppendHtml("(function(){try {return ")
                        .AppendHtml(FallbackTestExpression)
+                       .AppendHtml("} catch(e) {return false}}())")
                        .AppendHtml("||document.write(\"");
 
                 // May have no "src" attribute in the dictionary e.g. if Src and SrcInclude were not bound.

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Script.Encoded.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Script.Encoded.html
@@ -13,27 +13,27 @@
     <script src="HtmlEncode[[/blank.js?a=b&c=d]]" data-foo="foo-data2" title="&lt;the title>">
         // TagHelper script with comment in body, and extra properties.
     </script>
-<script>(false||document.write("<script src=\"JavaScriptEncode[[/styles/site.js?a=b&c=d]]\" JavaScriptEncode[[data-foo]]=\"JavaScriptEncode[[foo-data2]]\" JavaScriptEncode[[title]]=\"JavaScriptEncode[[&lt;the title>]]\"><\/script>"));</script>
+<script>((function(){try {return false} catch(e) {return false}}())||document.write("<script src=\"JavaScriptEncode[[/styles/site.js?a=b&c=d]]\" JavaScriptEncode[[data-foo]]=\"JavaScriptEncode[[foo-data2]]\" JavaScriptEncode[[title]]=\"JavaScriptEncode[[&lt;the title>]]\"><\/script>"));</script>
 
     <script src="HtmlEncode[[/blank.js]]" title="&quot;the&quot; title">
         // Fallback to globbed src
     </script>
-<script>(false||document.write("<script src=\"JavaScriptEncode[[/styles/site.js]]\" JavaScriptEncode[[title]]=\"JavaScriptEncode[["the" title]]\"><\/script>"));</script>
+<script>((function(){try {return false} catch(e) {return false}}())||document.write("<script src=\"JavaScriptEncode[[/styles/site.js]]\" JavaScriptEncode[[title]]=\"JavaScriptEncode[["the" title]]\"><\/script>"));</script>
 
     <script src="HtmlEncode[[/blank.js]]">
         // Fallback to globbed src with exclude
     </script>
-<script>(false||document.write("<script src=\"JavaScriptEncode[[/styles/site.js]]\"><\/script><script src=\"JavaScriptEncode[[/styles/sub/site2.js]]\"><\/script>"));</script>
+<script>((function(){try {return false} catch(e) {return false}}())||document.write("<script src=\"JavaScriptEncode[[/styles/site.js]]\"><\/script><script src=\"JavaScriptEncode[[/styles/sub/site2.js]]\"><\/script>"));</script>
 
     <script src="HtmlEncode[[/blank.js]]">
         // Fallback to globbed and static src
     </script>
-<script>(false||document.write("<script src=\"JavaScriptEncode[[/styles/site.js]]\"><\/script><script src=\"JavaScriptEncode[[/styles/sub/site2.js]]\"><\/script>"));</script>
+<script>((function(){try {return false} catch(e) {return false}}())||document.write("<script src=\"JavaScriptEncode[[/styles/site.js]]\"><\/script><script src=\"JavaScriptEncode[[/styles/sub/site2.js]]\"><\/script>"));</script>
 
     <script src="HtmlEncode[[/blank.js]]">
         // Fallback to globbed and static src should de-dupe
     </script>
-<script>(false||document.write("<script src=\"JavaScriptEncode[[/styles/site.js]]\"><\/script>"));</script>
+<script>((function(){try {return false} catch(e) {return false}}())||document.write("<script src=\"JavaScriptEncode[[/styles/site.js]]\"><\/script>"));</script>
 
     <script src="HtmlEncode[[/blank.js]]">
         // Fallback to globbed src with missing include
@@ -42,7 +42,7 @@
     <script src="HtmlEncode[[/blank.js]]">
         // Fallback to static and globbed src with missing include
     </script>
-<script>(false||document.write("<script src=\"JavaScriptEncode[[/styles/site.js]]\"><\/script>"));</script>
+<script>((function(){try {return false} catch(e) {return false}}())||document.write("<script src=\"JavaScriptEncode[[/styles/site.js]]\"><\/script>"));</script>
 
     <script src="HtmlEncode[[/blank.js]]">
         // Fallback to globbed src outside of webroot
@@ -55,7 +55,7 @@
     <script data-foo="foo-data3">
         // Valid TagHelper (although no src is provided) script with comment in body, and extra properties.
     </script>
-<script>(false||document.write("<script JavaScriptEncode[[data-foo]]=\"JavaScriptEncode[[foo-data3]]\" src=\"JavaScriptEncode[[/styles/site.js]]\"><\/script>"));</script>
+<script>((function(){try {return false} catch(e) {return false}}())||document.write("<script JavaScriptEncode[[data-foo]]=\"JavaScriptEncode[[foo-data3]]\" src=\"JavaScriptEncode[[/styles/site.js]]\"><\/script>"));</script>
 
     <script src="HtmlEncode[[/blank.js]]">
         // Invalid TagHelper script with comment in body.
@@ -98,12 +98,12 @@
     <script src="HtmlEncode[[/blank.js]]">
         // TagHelper script with comment in body, and file version.
     </script>
-<script>(false||document.write("<script src=\"JavaScriptEncode[[/styles/site.js?v=jx1PJjLX32-xgQQx2BxnckU9QH9DVKkm4-M5bSK869I]]\"><\/script>"));</script>
+<script>((function(){try {return false} catch(e) {return false}}())||document.write("<script src=\"JavaScriptEncode[[/styles/site.js?v=jx1PJjLX32-xgQQx2BxnckU9QH9DVKkm4-M5bSK869I]]\"><\/script>"));</script>
 
     <script src="HtmlEncode[[/blank.js]]">
         // Fallback to globbed src with file version.
     </script>
-<script>(false||document.write("<script src=\"JavaScriptEncode[[/styles/site.js?v=jx1PJjLX32-xgQQx2BxnckU9QH9DVKkm4-M5bSK869I]]\"><\/script>"));</script>
+<script>((function(){try {return false} catch(e) {return false}}())||document.write("<script src=\"JavaScriptEncode[[/styles/site.js?v=jx1PJjLX32-xgQQx2BxnckU9QH9DVKkm4-M5bSK869I]]\"><\/script>"));</script>
 
     <script src="HtmlEncode[[/styles/site.js?v=jx1PJjLX32-xgQQx2BxnckU9QH9DVKkm4-M5bSK869I]]">
         // Regular script with comment in body, and file version.

--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Script.html
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Script.html
@@ -13,27 +13,27 @@
     <script src="/blank.js?a=b&amp;c=d" data-foo="foo-data2" title="&lt;the title>">
         // TagHelper script with comment in body, and extra properties.
     </script>
-<script>(false||document.write("<script src=\"\/styles\/site.js?a=b\u0026c=d\" data-foo=\"foo-data2\" title=\"\u0026lt;the title\u003E\"><\/script>"));</script>
+<script>((function(){try {return false} catch(e) {return false}}())||document.write("<script src=\"\/styles\/site.js?a=b\u0026c=d\" data-foo=\"foo-data2\" title=\"\u0026lt;the title\u003E\"><\/script>"));</script>
 
     <script src="/blank.js" title="&quot;the&quot; title">
         // Fallback to globbed src
     </script>
-<script>(false||document.write("<script src=\"\/styles\/site.js\" title=\"\u0022the\u0022 title\"><\/script>"));</script>
+<script>((function(){try {return false} catch(e) {return false}}())||document.write("<script src=\"\/styles\/site.js\" title=\"\u0022the\u0022 title\"><\/script>"));</script>
 
     <script src="/blank.js">
         // Fallback to globbed src with exclude
     </script>
-<script>(false||document.write("<script src=\"\/styles\/site.js\"><\/script><script src=\"\/styles\/sub\/site2.js\"><\/script>"));</script>
+<script>((function(){try {return false} catch(e) {return false}}())||document.write("<script src=\"\/styles\/site.js\"><\/script><script src=\"\/styles\/sub\/site2.js\"><\/script>"));</script>
 
     <script src="/blank.js">
         // Fallback to globbed and static src
     </script>
-<script>(false||document.write("<script src=\"\/styles\/site.js\"><\/script><script src=\"\/styles\/sub\/site2.js\"><\/script>"));</script>
+<script>((function(){try {return false} catch(e) {return false}}())||document.write("<script src=\"\/styles\/site.js\"><\/script><script src=\"\/styles\/sub\/site2.js\"><\/script>"));</script>
 
     <script src="/blank.js">
         // Fallback to globbed and static src should de-dupe
     </script>
-<script>(false||document.write("<script src=\"\/styles\/site.js\"><\/script>"));</script>
+<script>((function(){try {return false} catch(e) {return false}}())||document.write("<script src=\"\/styles\/site.js\"><\/script>"));</script>
 
     <script src="/blank.js">
         // Fallback to globbed src with missing include
@@ -42,7 +42,7 @@
     <script src="/blank.js">
         // Fallback to static and globbed src with missing include
     </script>
-<script>(false||document.write("<script src=\"\/styles\/site.js\"><\/script>"));</script>
+<script>((function(){try {return false} catch(e) {return false}}())||document.write("<script src=\"\/styles\/site.js\"><\/script>"));</script>
 
     <script src="/blank.js">
         // Fallback to globbed src outside of webroot
@@ -55,7 +55,7 @@
     <script data-foo="foo-data3">
         // Valid TagHelper (although no src is provided) script with comment in body, and extra properties.
     </script>
-<script>(false||document.write("<script data-foo=\"foo-data3\" src=\"\/styles\/site.js\"><\/script>"));</script>
+<script>((function(){try {return false} catch(e) {return false}}())||document.write("<script data-foo=\"foo-data3\" src=\"\/styles\/site.js\"><\/script>"));</script>
 
     <script src="/blank.js">
         // Invalid TagHelper script with comment in body.
@@ -98,12 +98,12 @@
     <script src="/blank.js">
         // TagHelper script with comment in body, and file version.
     </script>
-<script>(false||document.write("<script src=\"\/styles\/site.js?v=jx1PJjLX32-xgQQx2BxnckU9QH9DVKkm4-M5bSK869I\"><\/script>"));</script>
+<script>((function(){try {return false} catch(e) {return false}}())||document.write("<script src=\"\/styles\/site.js?v=jx1PJjLX32-xgQQx2BxnckU9QH9DVKkm4-M5bSK869I\"><\/script>"));</script>
 
     <script src="/blank.js">
         // Fallback to globbed src with file version.
     </script>
-<script>(false||document.write("<script src=\"\/styles\/site.js?v=jx1PJjLX32-xgQQx2BxnckU9QH9DVKkm4-M5bSK869I\"><\/script>"));</script>
+<script>((function(){try {return false} catch(e) {return false}}())||document.write("<script src=\"\/styles\/site.js?v=jx1PJjLX32-xgQQx2BxnckU9QH9DVKkm4-M5bSK869I\"><\/script>"));</script>
 
     <script src="/styles/site.js?v=jx1PJjLX32-xgQQx2BxnckU9QH9DVKkm4-M5bSK869I">
         // Regular script with comment in body, and file version.

--- a/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ScriptTagHelperTest.cs
+++ b/test/Microsoft.AspNet.Mvc.TagHelpers.Test/ScriptTagHelperTest.cs
@@ -853,7 +853,7 @@ namespace Microsoft.AspNet.Mvc.TagHelpers
             // Assert
             Assert.Equal("script", output.TagName);
             Assert.Equal("/js/site.js?v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk", output.Attributes["src"].Value);
-            Assert.Equal(Environment.NewLine + "<script>(isavailable()||document.write(\"<script " +
+            Assert.Equal(Environment.NewLine + "<script>((function(){try {return isavailable()} catch(e) {return false}}())||document.write(\"<script " +
                 "src=\\\"JavaScriptEncode[[fallback.js?v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk]]\\\">" +
                 "<\\/script>\"));</script>", output.PostElement.GetContent());
         }


### PR DESCRIPTION
If there is error while evaluating the test then use the fallback source instead of throwing error.