### PR TITLE
Argument binder

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/Controllers/DefaultControllerActionArgumentBinder.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Controllers/DefaultControllerActionArgumentBinder.cs
@@ -64,35 +64,47 @@ namespace Microsoft.AspNet.Mvc.Controllers
                 return Task.FromResult<IDictionary<string, object>>(
                     new Dictionary<string, object>(StringComparer.Ordinal));
             }
-            else
+            else if (actionDescriptor.BoundProperties.Count == 0)
             {
                 return BindActionArgumentsCoreAsync(
                     context,
                     controller,
                     actionDescriptor);
             }
+            else
+            {
+                return BindActionArgumentsAndPropertiesCoreAsync(
+                    context,
+                    controller,
+                    actionDescriptor);
+            }
         }
 
-        private async Task<IDictionary<string, object>> BindActionArgumentsCoreAsync(
+        private async Task<IDictionary<string, object>> BindActionArgumentsAndPropertiesCoreAsync(
             ControllerContext context,
             object controller,
             ControllerActionDescriptor actionDescriptor)
         {
             var operationBindingContext = GetOperationBindingContext(context);
-            var controllerProperties = new Dictionary<string, object>(StringComparer.Ordinal);
-            await PopulateArgumentsAsync(
-                operationBindingContext,
-                controllerProperties,
-                actionDescriptor.BoundProperties);
-            var controllerType = actionDescriptor.ControllerTypeInfo.AsType();
-            ActivateProperties(controller, controllerType, controllerProperties);
 
-            var actionArguments = new Dictionary<string, object>(StringComparer.Ordinal);
-            await PopulateArgumentsAsync(
+            var controllerProperties = await PopulateArgumentsAsync(
                 operationBindingContext,
-                actionArguments,
+                actionDescriptor.BoundProperties);
+            ActivateProperties(actionDescriptor, controller, controllerProperties);
+
+            var actionArguments = await PopulateArgumentsAsync(
+                operationBindingContext,
                 actionDescriptor.Parameters);
             return actionArguments;
+        }
+
+        private Task<IDictionary<string, object>> BindActionArgumentsCoreAsync(
+            ControllerContext context,
+            object controller,
+            ControllerActionDescriptor actionDescriptor)
+        {
+            var operationBindingContext = GetOperationBindingContext(context);
+            return PopulateArgumentsAsync(operationBindingContext, actionDescriptor.Parameters);
         }
 
         public async Task<ModelBindingResult> BindModelAsync(
@@ -145,22 +157,31 @@ namespace Microsoft.AspNet.Mvc.Controllers
             }
         }
 
-        private void ActivateProperties(object controller, Type containerType, Dictionary<string, object> properties)
+        private void ActivateProperties(
+            ControllerActionDescriptor actionDescriptor,
+            object controller,
+            IDictionary<string, object> properties)
         {
             var propertyHelpers = PropertyHelper.GetProperties(controller);
-            foreach (var property in properties)
+            foreach (var property in actionDescriptor.BoundProperties)
             {
                 var propertyHelper = propertyHelpers.First(helper =>
-                    string.Equals(helper.Name, property.Key, StringComparison.Ordinal));
+                    string.Equals(helper.Name, property.Name, StringComparison.Ordinal));
                 var propertyType = propertyHelper.Property.PropertyType;
                 var metadata = _modelMetadataProvider.GetMetadataForType(propertyType);
-                var source = property.Value;
+
+                object value;
+                if (!properties.TryGetValue(property.Name, out value))
+                {
+                    continue;
+                }
+
                 if (propertyHelper.Property.CanWrite && propertyHelper.Property.SetMethod?.IsPublic == true)
                 {
                     // Handle settable property. Do not set the property to null if the type is a non-nullable type.
-                    if (source != null || metadata.IsReferenceOrNullableType)
+                    if (value != null || metadata.IsReferenceOrNullableType)
                     {
-                        propertyHelper.SetValue(controller, source);
+                        propertyHelper.SetValue(controller, value);
                     }
 
                     continue;
@@ -174,7 +195,7 @@ namespace Microsoft.AspNet.Mvc.Controllers
                 }
 
                 var target = propertyHelper.GetValue(controller);
-                if (source == null || target == null)
+                if (value == null || target == null)
                 {
                     // Nothing to do when source or target is null.
                     continue;
@@ -189,15 +210,16 @@ namespace Microsoft.AspNet.Mvc.Controllers
                 // Handle a read-only collection property.
                 var propertyAddRange = CallPropertyAddRangeOpenGenericMethod.MakeGenericMethod(
                     metadata.ElementMetadata.ModelType);
-                propertyAddRange.Invoke(obj: null, parameters: new[] { target, source });
+                propertyAddRange.Invoke(obj: null, parameters: new[] { target, value });
             }
         }
 
-        private async Task PopulateArgumentsAsync(
+        private async Task<IDictionary<string, object>> PopulateArgumentsAsync(
             OperationBindingContext operationContext,
-            IDictionary<string, object> arguments,
             IList<ParameterDescriptor> parameterMetadata)
         {
+            var arguments = new Dictionary<string, object>(StringComparer.Ordinal);
+
             // Perf: Avoid allocations
             for (var i = 0; i < parameterMetadata.Count; i++)
             {
@@ -208,6 +230,8 @@ namespace Microsoft.AspNet.Mvc.Controllers
                     arguments[parameter.Name] = modelBindingResult.Model;
                 }
             }
+
+            return arguments;
         }
 
         private OperationBindingContext GetOperationBindingContext(ControllerContext context)


### PR DESCRIPTION
**Before**
![image](https://cloud.githubusercontent.com/assets/1430011/12028959/14f094d2-ad95-11e5-9713-b77c9aa761d0.png)

**After**
![image](https://cloud.githubusercontent.com/assets/1430011/12028957/0a96c81c-ad95-11e5-93d4-3186941fbdca.png)

This change optimizes out an (empty) dictionary per request, and the highlighted async state machine.

Think of 30.0mb as your big-picture number. That's where we are with JSON.NET buffer pooling on CoreCLR.