### PR TITLE
Change PhysicalFileResult and VirtualFileResult to use SendFileAsync

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/VirtualFileResult.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/VirtualFileResult.cs
@@ -106,14 +106,9 @@ namespace Microsoft.AspNet.Mvc
             if (fileInfo.Exists)
             {
                 var physicalPath = fileInfo.PhysicalPath;
-                var sendFile = response.HttpContext.Features.Get<IHttpSendFileFeature>();
-                if (sendFile != null && !string.IsNullOrEmpty(physicalPath))
+                if (!string.IsNullOrEmpty(physicalPath))
                 {
-                    await sendFile.SendFileAsync(
-                        physicalPath,
-                        offset: 0,
-                        length: null,
-                        cancellation: default(CancellationToken));
+                    await response.SendFileAsync(physicalPath);
                 }
                 else
                 {


### PR DESCRIPTION
- SendFileAsync does the proper fallback to stream copy when the feature
isn't available. Take advantage of it in MVC. There are plans to use the
buffer pool as part of the stream copy so MVC will get that benefit for
free.
- Left CopyToAsync in SendFileAsync when the file doesn't have a
physical path