### PR TITLE
Optimize MvcRouteHandler

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/Infrastructure/DefaultActionSelector.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Infrastructure/DefaultActionSelector.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Mvc.Abstractions;
 using Microsoft.AspNet.Mvc.ActionConstraints;
@@ -32,7 +31,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             _logger = loggerFactory.CreateLogger<DefaultActionSelector>();
         }
 
-        public Task<ActionDescriptor> SelectAsync(RouteContext context)
+        public ActionDescriptor SelectAsync(RouteContext context)
         {
             if (context == null)
             {
@@ -71,13 +70,13 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
 
             if (finalMatches == null || finalMatches.Count == 0)
             {
-                return Task.FromResult<ActionDescriptor>(null);
+                return null;
             }
             else if (finalMatches.Count == 1)
             {
                 var selectedAction = finalMatches[0];
 
-                return Task.FromResult(selectedAction);
+                return selectedAction;
             }
             else
             {

--- a/src/Microsoft.AspNet.Mvc.Core/Infrastructure/DefaultActionSelector.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Infrastructure/DefaultActionSelector.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             _logger = loggerFactory.CreateLogger<DefaultActionSelector>();
         }
 
-        public ActionDescriptor SelectAsync(RouteContext context)
+        public ActionDescriptor Select(RouteContext context)
         {
             if (context == null)
             {

--- a/src/Microsoft.AspNet.Mvc.Core/Infrastructure/IActionSelector.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Infrastructure/IActionSelector.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc.Abstractions;
 using Microsoft.AspNet.Routing;
 
@@ -9,6 +8,6 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
 {
     public interface IActionSelector
     {
-        Task<ActionDescriptor> SelectAsync(RouteContext context);
+        ActionDescriptor SelectAsync(RouteContext context);
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/Infrastructure/IActionSelector.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Infrastructure/IActionSelector.cs
@@ -8,6 +8,6 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
 {
     public interface IActionSelector
     {
-        ActionDescriptor SelectAsync(RouteContext context);
+        ActionDescriptor Select(RouteContext context);
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Core/Infrastructure/MvcRouteHandler.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Infrastructure/MvcRouteHandler.cs
@@ -38,25 +38,20 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             return null;
         }
 
-        public async Task RouteAsync(RouteContext context)
+        public Task RouteAsync(RouteContext context)
         {
             if (context == null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var services = context.HttpContext.RequestServices;
-
-            // Verify if AddMvc was done before calling UseMvc
-            // We use the MvcMarkerService to make sure if all the services were added.
-            MvcServicesHelper.ThrowIfMvcNotRegistered(services);
             EnsureServices(context.HttpContext);
 
-            var actionDescriptor = await _actionSelector.SelectAsync(context);
+            var actionDescriptor = _actionSelector.SelectAsync(context);
             if (actionDescriptor == null)
             {
                 _logger.NoActionsMatched();
-                return;
+                return TaskCache.CompletedTask;
             }
 
             if (actionDescriptor.RouteValueDefaults != null)
@@ -68,12 +63,13 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
                         context.RouteData.Values.Add(kvp.Key, kvp.Value);
                     }
                 }
+
+                // Removing RouteGroup from RouteValues to simulate the result of conventional routing
+                context.RouteData.Values.Remove(TreeRouter.RouteGroupKey);
             }
 
-            // Removing RouteGroup from RouteValues to simulate the result of conventional routing
-            context.RouteData.Values.Remove(TreeRouter.RouteGroupKey);
-
             context.Handler = (c) => InvokeActionAsync(c, actionDescriptor);
+            return TaskCache.CompletedTask;
         }
 
         private async Task InvokeActionAsync(HttpContext httpContext, ActionDescriptor actionDescriptor)
@@ -121,15 +117,22 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
                 return;
             }
 
+            var services = context.RequestServices;
+
+            // Verify if AddMvc was done before calling UseMvc
+            // We use the MvcMarkerService to make sure if all the services were added.
+            MvcServicesHelper.ThrowIfMvcNotRegistered(services);
+
+
             // The IActionContextAccessor is optional. We want to avoid the overhead of using CallContext
             // if possible.
-            _actionContextAccessor = context.RequestServices.GetService<IActionContextAccessor>();
+            _actionContextAccessor = services.GetService<IActionContextAccessor>();
 
-            _actionInvokerFactory = context.RequestServices.GetRequiredService<IActionInvokerFactory>();
-            _actionSelector = context.RequestServices.GetRequiredService<IActionSelector>();
-            _diagnosticSource = context.RequestServices.GetRequiredService<DiagnosticSource>();
+            _actionInvokerFactory = services.GetRequiredService<IActionInvokerFactory>();
+            _actionSelector = services.GetRequiredService<IActionSelector>();
+            _diagnosticSource = services.GetRequiredService<DiagnosticSource>();
 
-            var factory = context.RequestServices.GetRequiredService<ILoggerFactory>();
+            var factory = services.GetRequiredService<ILoggerFactory>();
             _logger = factory.CreateLogger<MvcRouteHandler>();
 
             _servicesRetrieved = true;

--- a/src/Microsoft.AspNet.Mvc.Core/Infrastructure/MvcRouteHandler.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Infrastructure/MvcRouteHandler.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
 
             EnsureServices(context.HttpContext);
 
-            var actionDescriptor = _actionSelector.SelectAsync(context);
+            var actionDescriptor = _actionSelector.Select(context);
             if (actionDescriptor == null)
             {
                 _logger.NoActionsMatched();

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Infrastructure/DefaultActionSelectorTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Infrastructure/DefaultActionSelectorTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Internal;
 using Microsoft.AspNet.Mvc.Abstractions;
@@ -25,7 +24,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
     public class DefaultActionSelectorTests
     {
         [Fact]
-        public async void SelectAsync_AmbiguousActions_LogIsCorrect()
+        public void SelectAsync_AmbiguousActions_LogIsCorrect()
         {
             // Arrange
             var sink = new TestSink();
@@ -44,9 +43,9 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
                 $"ambiguity. Matching actions: {actionNames}";
 
             // Act
-            await Assert.ThrowsAsync<AmbiguousActionException>(async () =>
+            Assert.Throws<AmbiguousActionException>(() =>
             {
-                await selector.SelectAsync(routeContext);
+                selector.SelectAsync(routeContext);
             });
 
             // Assert
@@ -56,7 +55,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
         }
 
         [Fact]
-        public async Task SelectAsync_PrefersActionWithConstraints()
+        public void SelectAsync_PrefersActionWithConstraints()
         {
             // Arrange
             var actionWithConstraints = new ActionDescriptor()
@@ -79,14 +78,14 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             var context = CreateRouteContext("POST");
 
             // Act
-            var action = await selector.SelectAsync(context);
+            var action = selector.SelectAsync(context);
 
             // Assert
             Assert.Same(action, actionWithConstraints);
         }
 
         [Fact]
-        public async Task SelectAsync_ConstraintsRejectAll()
+        public void SelectAsync_ConstraintsRejectAll()
         {
             // Arrange
             var action1 = new ActionDescriptor()
@@ -111,14 +110,14 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             var context = CreateRouteContext("POST");
 
             // Act
-            var action = await selector.SelectAsync(context);
+            var action = selector.SelectAsync(context);
 
             // Assert
             Assert.Null(action);
         }
 
         [Fact]
-        public async Task SelectAsync_ConstraintsRejectAll_DifferentStages()
+        public void SelectAsync_ConstraintsRejectAll_DifferentStages()
         {
             // Arrange
             var action1 = new ActionDescriptor()
@@ -145,14 +144,14 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             var context = CreateRouteContext("POST");
 
             // Act
-            var action = await selector.SelectAsync(context);
+            var action = selector.SelectAsync(context);
 
             // Assert
             Assert.Null(action);
         }
 
         [Fact]
-        public async Task SelectAsync_ActionConstraintFactory()
+        public void SelectAsync_ActionConstraintFactory()
         {
             // Arrange
             var actionWithConstraints = new ActionDescriptor()
@@ -177,14 +176,14 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             var context = CreateRouteContext("POST");
 
             // Act
-            var action = await selector.SelectAsync(context);
+            var action = selector.SelectAsync(context);
 
             // Assert
             Assert.Same(action, actionWithConstraints);
         }
 
         [Fact]
-        public async Task SelectAsync_ActionConstraintFactory_ReturnsNull()
+        public void SelectAsync_ActionConstraintFactory_ReturnsNull()
         {
             // Arrange
             var nullConstraint = new ActionDescriptor()
@@ -203,7 +202,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             var context = CreateRouteContext("POST");
 
             // Act
-            var action = await selector.SelectAsync(context);
+            var action = selector.SelectAsync(context);
 
             // Assert
             Assert.Same(action, nullConstraint);
@@ -211,7 +210,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
 
         // There's a custom constraint provider registered that only understands BooleanConstraintMarker
         [Fact]
-        public async Task SelectAsync_CustomProvider()
+        public void SelectAsync_CustomProvider()
         {
             // Arrange
             var actionWithConstraints = new ActionDescriptor()
@@ -233,7 +232,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             var context = CreateRouteContext("POST");
 
             // Act
-            var action = await selector.SelectAsync(context);
+            var action = selector.SelectAsync(context);
 
             // Assert
             Assert.Same(action, actionWithConstraints);
@@ -241,7 +240,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
 
         // Due to ordering of stages, the first action will be better.
         [Fact]
-        public async Task SelectAsync_ConstraintsInOrder()
+        public void SelectAsync_ConstraintsInOrder()
         {
             // Arrange
             var best = new ActionDescriptor()
@@ -266,7 +265,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             var context = CreateRouteContext("POST");
 
             // Act
-            var action = await selector.SelectAsync(context);
+            var action = selector.SelectAsync(context);
 
             // Assert
             Assert.Same(action, best);
@@ -274,7 +273,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
 
         // Due to ordering of stages, the first action will be better.
         [Fact]
-        public async Task SelectAsync_ConstraintsInOrder_MultipleStages()
+        public void SelectAsync_ConstraintsInOrder_MultipleStages()
         {
             // Arrange
             var best = new ActionDescriptor()
@@ -303,14 +302,14 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             var context = CreateRouteContext("POST");
 
             // Act
-            var action = await selector.SelectAsync(context);
+            var action = selector.SelectAsync(context);
 
             // Assert
             Assert.Same(action, best);
         }
 
         [Fact]
-        public async Task SelectAsync_Fallback_ToActionWithoutConstraints()
+        public void SelectAsync_Fallback_ToActionWithoutConstraints()
         {
             // Arrange
             var nomatch1 = new ActionDescriptor()
@@ -341,14 +340,14 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             var context = CreateRouteContext("POST");
 
             // Act
-            var action = await selector.SelectAsync(context);
+            var action = selector.SelectAsync(context);
 
             // Assert
             Assert.Same(action, best);
         }
 
         [Fact]
-        public async Task SelectAsync_Ambiguous()
+        public void SelectAsync_Ambiguous()
         {
             // Arrange
             var expectedMessage =
@@ -375,9 +374,9 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             context.RouteData.Values.Add("action", "Buy");
 
             // Act
-            var ex = await Assert.ThrowsAsync<AmbiguousActionException>(async () =>
+            var ex = Assert.Throws<AmbiguousActionException>(() =>
             {
-                await selector.SelectAsync(context);
+                selector.SelectAsync(context);
             });
 
             // Assert
@@ -390,7 +389,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
         [InlineData("POST")]
         [InlineData("DELETE")]
         [InlineData("PATCH")]
-        public async Task HttpMethodAttribute_ActionWithMultipleHttpMethodAttributeViaAcceptVerbs_ORsMultipleHttpMethods(string verb)
+        public void HttpMethodAttribute_ActionWithMultipleHttpMethodAttributeViaAcceptVerbs_ORsMultipleHttpMethods(string verb)
         {
             // Arrange
             var routeContext = new RouteContext(GetHttpContext(verb));
@@ -398,7 +397,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             routeContext.RouteData.Values.Add("action", "Patch");
 
             // Act
-            var result = await InvokeActionSelector(routeContext);
+            var result = InvokeActionSelector(routeContext);
 
             // Assert
             Assert.Equal("Patch", result.Name);
@@ -411,7 +410,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
         [InlineData("DELETE")]
         [InlineData("PATCH")]
         [InlineData("HEAD")]
-        public async Task HttpMethodAttribute_ActionWithMultipleHttpMethodAttributes_ORsMultipleHttpMethods(string verb)
+        public void HttpMethodAttribute_ActionWithMultipleHttpMethodAttributes_ORsMultipleHttpMethods(string verb)
         {
             // Arrange
             var routeContext = new RouteContext(GetHttpContext(verb));
@@ -419,7 +418,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             routeContext.RouteData.Values.Add("action", "Put");
 
             // Act
-            var result = await InvokeActionSelector(routeContext);
+            var result = InvokeActionSelector(routeContext);
 
             // Assert
             Assert.Equal("Put", result.Name);
@@ -428,7 +427,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
         [Theory]
         [InlineData("GET")]
         [InlineData("PUT")]
-        public async Task HttpMethodAttribute_ActionDecoratedWithHttpMethodAttribute_OverridesConvention(string verb)
+        public void HttpMethodAttribute_ActionDecoratedWithHttpMethodAttribute_OverridesConvention(string verb)
         {
             // Arrange
             // Note no action name is passed, hence should return a null action descriptor.
@@ -436,7 +435,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             routeContext.RouteData.Values.Add("controller", "HttpMethodAttributeTests_RestOnly");
 
             // Act
-            var result = await InvokeActionSelector(routeContext);
+            var result = InvokeActionSelector(routeContext);
 
             // Assert
             Assert.Null(result);
@@ -466,7 +465,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
         [InlineData("POST")]
         [InlineData("DELETE")]
         [InlineData("PATCH")]
-        public async Task ActionNameAttribute_ActionGetsExposedViaActionName_UnreachableByConvention(string verb)
+        public void ActionNameAttribute_ActionGetsExposedViaActionName_UnreachableByConvention(string verb)
         {
             // Arrange
             var routeContext = new RouteContext(GetHttpContext(verb));
@@ -474,7 +473,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             routeContext.RouteData.Values.Add("action", "RPCMethodWithHttpGet");
 
             // Act
-            var result = await InvokeActionSelector(routeContext);
+            var result = InvokeActionSelector(routeContext);
 
             // Assert
             Assert.Null(result);
@@ -496,7 +495,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
         [InlineData("POST", "CustomActionName_RpcMethod")]
         [InlineData("DELETE", "CustomActionName_RpcMethod")]
         [InlineData("PATCH", "CustomActionName_RpcMethod")]
-        public async Task ActionNameAttribute_DifferentActionName_UsesActionNameFromActionNameAttribute(string verb, string actionName)
+        public void ActionNameAttribute_DifferentActionName_UsesActionNameFromActionNameAttribute(string verb, string actionName)
         {
             // Arrange
             var routeContext = new RouteContext(GetHttpContext(verb));
@@ -504,13 +503,13 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             routeContext.RouteData.Values.Add("action", actionName);
 
             // Act
-            var result = await InvokeActionSelector(routeContext);
+            var result = InvokeActionSelector(routeContext);
 
             // Assert
             Assert.Equal(actionName, result.Name);
         }
 
-        private async Task<ActionDescriptor> InvokeActionSelector(RouteContext context)
+        private ActionDescriptor InvokeActionSelector(RouteContext context)
         {
             var actionDescriptorProvider = GetActionDescriptorProvider();
 
@@ -536,7 +535,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
                 actionConstraintProviders,
                 NullLoggerFactory.Instance);
 
-            return await defaultActionSelector.SelectAsync(context);
+            return defaultActionSelector.SelectAsync(context);
         }
 
         private ControllerActionDescriptorProvider GetActionDescriptorProvider()

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Infrastructure/DefaultActionSelectorTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Infrastructure/DefaultActionSelectorTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
     public class DefaultActionSelectorTests
     {
         [Fact]
-        public void SelectAsync_AmbiguousActions_LogIsCorrect()
+        public void Select_AmbiguousActions_LogIsCorrect()
         {
             // Arrange
             var sink = new TestSink();
@@ -45,7 +45,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             // Act
             Assert.Throws<AmbiguousActionException>(() =>
             {
-                selector.SelectAsync(routeContext);
+                selector.Select(routeContext);
             });
 
             // Assert
@@ -55,7 +55,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
         }
 
         [Fact]
-        public void SelectAsync_PrefersActionWithConstraints()
+        public void Select_PrefersActionWithConstraints()
         {
             // Arrange
             var actionWithConstraints = new ActionDescriptor()
@@ -78,14 +78,14 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             var context = CreateRouteContext("POST");
 
             // Act
-            var action = selector.SelectAsync(context);
+            var action = selector.Select(context);
 
             // Assert
             Assert.Same(action, actionWithConstraints);
         }
 
         [Fact]
-        public void SelectAsync_ConstraintsRejectAll()
+        public void Select_ConstraintsRejectAll()
         {
             // Arrange
             var action1 = new ActionDescriptor()
@@ -110,14 +110,14 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             var context = CreateRouteContext("POST");
 
             // Act
-            var action = selector.SelectAsync(context);
+            var action = selector.Select(context);
 
             // Assert
             Assert.Null(action);
         }
 
         [Fact]
-        public void SelectAsync_ConstraintsRejectAll_DifferentStages()
+        public void Select_ConstraintsRejectAll_DifferentStages()
         {
             // Arrange
             var action1 = new ActionDescriptor()
@@ -144,14 +144,14 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             var context = CreateRouteContext("POST");
 
             // Act
-            var action = selector.SelectAsync(context);
+            var action = selector.Select(context);
 
             // Assert
             Assert.Null(action);
         }
 
         [Fact]
-        public void SelectAsync_ActionConstraintFactory()
+        public void Select_ActionConstraintFactory()
         {
             // Arrange
             var actionWithConstraints = new ActionDescriptor()
@@ -176,14 +176,14 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             var context = CreateRouteContext("POST");
 
             // Act
-            var action = selector.SelectAsync(context);
+            var action = selector.Select(context);
 
             // Assert
             Assert.Same(action, actionWithConstraints);
         }
 
         [Fact]
-        public void SelectAsync_ActionConstraintFactory_ReturnsNull()
+        public void Select_ActionConstraintFactory_ReturnsNull()
         {
             // Arrange
             var nullConstraint = new ActionDescriptor()
@@ -202,7 +202,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             var context = CreateRouteContext("POST");
 
             // Act
-            var action = selector.SelectAsync(context);
+            var action = selector.Select(context);
 
             // Assert
             Assert.Same(action, nullConstraint);
@@ -210,7 +210,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
 
         // There's a custom constraint provider registered that only understands BooleanConstraintMarker
         [Fact]
-        public void SelectAsync_CustomProvider()
+        public void Select_CustomProvider()
         {
             // Arrange
             var actionWithConstraints = new ActionDescriptor()
@@ -232,7 +232,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             var context = CreateRouteContext("POST");
 
             // Act
-            var action = selector.SelectAsync(context);
+            var action = selector.Select(context);
 
             // Assert
             Assert.Same(action, actionWithConstraints);
@@ -240,7 +240,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
 
         // Due to ordering of stages, the first action will be better.
         [Fact]
-        public void SelectAsync_ConstraintsInOrder()
+        public void Select_ConstraintsInOrder()
         {
             // Arrange
             var best = new ActionDescriptor()
@@ -265,7 +265,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             var context = CreateRouteContext("POST");
 
             // Act
-            var action = selector.SelectAsync(context);
+            var action = selector.Select(context);
 
             // Assert
             Assert.Same(action, best);
@@ -273,7 +273,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
 
         // Due to ordering of stages, the first action will be better.
         [Fact]
-        public void SelectAsync_ConstraintsInOrder_MultipleStages()
+        public void Select_ConstraintsInOrder_MultipleStages()
         {
             // Arrange
             var best = new ActionDescriptor()
@@ -302,14 +302,14 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             var context = CreateRouteContext("POST");
 
             // Act
-            var action = selector.SelectAsync(context);
+            var action = selector.Select(context);
 
             // Assert
             Assert.Same(action, best);
         }
 
         [Fact]
-        public void SelectAsync_Fallback_ToActionWithoutConstraints()
+        public void Select_Fallback_ToActionWithoutConstraints()
         {
             // Arrange
             var nomatch1 = new ActionDescriptor()
@@ -340,14 +340,14 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             var context = CreateRouteContext("POST");
 
             // Act
-            var action = selector.SelectAsync(context);
+            var action = selector.Select(context);
 
             // Assert
             Assert.Same(action, best);
         }
 
         [Fact]
-        public void SelectAsync_Ambiguous()
+        public void Select_Ambiguous()
         {
             // Arrange
             var expectedMessage =
@@ -376,7 +376,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             // Act
             var ex = Assert.Throws<AmbiguousActionException>(() =>
             {
-                selector.SelectAsync(context);
+                selector.Select(context);
             });
 
             // Assert
@@ -535,7 +535,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
                 actionConstraintProviders,
                 NullLoggerFactory.Instance);
 
-            return defaultActionSelector.SelectAsync(context);
+            return defaultActionSelector.Select(context);
         }
 
         private ControllerActionDescriptorProvider GetActionDescriptorProvider()

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Infrastructure/MvcRouteHandlerTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Infrastructure/MvcRouteHandlerTests.cs
@@ -58,8 +58,9 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             var loggerFactory = new TestLoggerFactory(sink, enabled: true);
 
             var mockActionSelector = new Mock<IActionSelector>();
-            mockActionSelector.Setup(a => a.SelectAsync(It.IsAny<RouteContext>()))
-                .Returns(Task.FromResult<ActionDescriptor>(null));
+            mockActionSelector
+                .Setup(a => a.SelectAsync(It.IsAny<RouteContext>()))
+                .Returns<ActionDescriptor>(null);
 
             var context = CreateRouteContext(
                 actionSelector: mockActionSelector.Object,
@@ -173,7 +174,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             {
                 var mockActionSelector = new Mock<IActionSelector>();
                 mockActionSelector.Setup(a => a.SelectAsync(It.IsAny<RouteContext>()))
-                    .Returns(Task.FromResult(actionDescriptor));
+                    .Returns(actionDescriptor);
 
                 actionSelector = mockActionSelector.Object;
             }

--- a/test/Microsoft.AspNet.Mvc.Core.Test/Infrastructure/MvcRouteHandlerTests.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/Infrastructure/MvcRouteHandlerTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
 
             var mockActionSelector = new Mock<IActionSelector>();
             mockActionSelector
-                .Setup(a => a.SelectAsync(It.IsAny<RouteContext>()))
+                .Setup(a => a.Select(It.IsAny<RouteContext>()))
                 .Returns<ActionDescriptor>(null);
 
             var context = CreateRouteContext(
@@ -173,7 +173,7 @@ namespace Microsoft.AspNet.Mvc.Infrastructure
             if (actionSelector == null)
             {
                 var mockActionSelector = new Mock<IActionSelector>();
-                mockActionSelector.Setup(a => a.SelectAsync(It.IsAny<RouteContext>()))
+                mockActionSelector.Setup(a => a.Select(It.IsAny<RouteContext>()))
                     .Returns(actionDescriptor);
 
                 actionSelector = mockActionSelector.Object;


### PR DESCRIPTION
- Check MVC services once at startup
- Make action selector sync

We've never really had a scenario for the action selector being async, it
just ended up that way. None of our extensibility here lets you do
anything async without replacing it wholesale, which we don't
recommend.