### PR TITLE
Add convenience overloads for AddControllersAsServices

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/DependencyInjection/MvcCoreMvcBuilderExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/DependencyInjection/MvcCoreMvcBuilderExtensions.cs
@@ -74,11 +74,6 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            if (controllerTypes == null)
-            {
-                throw new ArgumentNullException(nameof(controllerTypes));
-            }
-
             ControllersAsServices.AddControllersAsServices(builder.Services, controllerTypes);
             return builder;
         }
@@ -97,11 +92,6 @@ namespace Microsoft.Extensions.DependencyInjection
             if (builder == null)
             {
                 throw new ArgumentNullException(nameof(builder));
-            }
-
-            if (controllerAssemblies == null)
-            {
-                throw new ArgumentNullException(nameof(controllerAssemblies));
             }
 
             ControllersAsServices.AddControllersAsServices(builder.Services, controllerAssemblies);

--- a/src/Microsoft.AspNet.Mvc.Core/DependencyInjection/MvcCoreMvcBuilderExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/DependencyInjection/MvcCoreMvcBuilderExtensions.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using Microsoft.AspNet.Mvc;
 using Microsoft.AspNet.Mvc.Formatters;
 using Microsoft.AspNet.Mvc.Internal;
+using System.Linq;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -66,6 +67,20 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IMvcBuilder"/>.</returns>
         public static IMvcBuilder AddControllersAsServices(
            this IMvcBuilder builder,
+           params Type[] controllerTypes)
+        {
+            return builder.AddControllersAsServices(controllerTypes.AsEnumerable());
+        }
+
+        /// <summary>
+        /// Register the specified <paramref name="controllerTypes"/> as services and as a source for controller
+        /// discovery.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
+        /// <param name="controllerTypes">A sequence of controller <see cref="Type"/>s to register.</param>
+        /// <returns>The <see cref="IMvcBuilder"/>.</returns>
+        public static IMvcBuilder AddControllersAsServices(
+           this IMvcBuilder builder,
            IEnumerable<Type> controllerTypes)
         {
             if (builder == null)
@@ -75,6 +90,20 @@ namespace Microsoft.Extensions.DependencyInjection
 
             ControllersAsServices.AddControllersAsServices(builder.Services, controllerTypes);
             return builder;
+        }
+
+        /// <summary>
+        /// Registers controller types from the specified <paramref name="controllerAssemblies"/> as services and as a source
+        /// for controller discovery.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
+        /// <param name="controllerAssemblies">Assemblies to scan.</param>
+        /// <returns>The <see cref="IMvcBuilder"/>.</returns>
+        public static IMvcBuilder AddControllersAsServices(
+            this IMvcBuilder builder,
+            params Assembly[] controllerAssemblies)
+        {
+            return builder.AddControllersAsServices(controllerAssemblies.AsEnumerable());
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Mvc.Core/DependencyInjection/MvcCoreMvcBuilderExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/DependencyInjection/MvcCoreMvcBuilderExtensions.cs
@@ -62,8 +62,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// discovery.
         /// </summary>
         /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
-        /// <param name="controllerTypes">A sequence of controller <see cref="Type"/>s to register in the
-        /// <paramref name="services"/> and used for controller discovery.</param>
+        /// <param name="controllerTypes">A sequence of controller <see cref="Type"/>s to register.</param>
         /// <returns>The <see cref="IMvcBuilder"/>.</returns>
         public static IMvcBuilder AddControllersAsServices(
            this IMvcBuilder builder,
@@ -79,7 +78,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Registers controller types from the specified <paramref name="assemblies"/> as services and as a source
+        /// Registers controller types from the specified <paramref name="controllerAssemblies"/> as services and as a source
         /// for controller discovery.
         /// </summary>
         /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>

--- a/src/Microsoft.AspNet.Mvc.Core/DependencyInjection/MvcCoreMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/DependencyInjection/MvcCoreMvcCoreBuilderExtensions.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNet.Mvc.ApplicationModels;
 using Microsoft.AspNet.Mvc.Formatters;
 using Microsoft.AspNet.Mvc.Internal;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using System.Linq;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -99,8 +100,21 @@ namespace Microsoft.Extensions.DependencyInjection
         /// discovery.
         /// </summary>
         /// <param name="builder">The <see cref="IMvcCoreBuilder"/>.</param>
-        /// <param name="controllerTypes">A sequence of controller <see cref="Type"/>s to register in the
-        /// <paramref name="services"/> and used for controller discovery.</param>
+        /// <param name="controllerTypes">A sequence of controller <see cref="Type"/>s to register.</param>
+        /// <returns>The <see cref="IMvcCoreBuilder"/>.</returns>
+        public static IMvcCoreBuilder AddControllersAsServices(
+           this IMvcCoreBuilder builder,
+           params Type[] controllerTypes)
+        {
+            return builder.AddControllersAsServices(controllerTypes.AsEnumerable());
+        }
+
+        /// <summary>
+        /// Register the specified <paramref name="controllerTypes"/> as services and as a source for controller
+        /// discovery.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcCoreBuilder"/>.</param>
+        /// <param name="controllerTypes">A sequence of controller <see cref="Type"/>s to register.</param>
         /// <returns>The <see cref="IMvcCoreBuilder"/>.</returns>
         public static IMvcCoreBuilder AddControllersAsServices(
            this IMvcCoreBuilder builder,
@@ -111,17 +125,26 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            if (controllerTypes == null)
-            {
-                throw new ArgumentNullException(nameof(controllerTypes));
-            }
-
             ControllersAsServices.AddControllersAsServices(builder.Services, controllerTypes);
             return builder;
         }
 
         /// <summary>
-        /// Registers controller types from the specified <paramref name="assemblies"/> as services and as a source
+        /// Registers controller types from the specified <paramref name="controllerAssemblies"/> as services and as a source
+        /// for controller discovery.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcCoreBuilder"/>.</param>
+        /// <param name="controllerAssemblies">Assemblies to scan.</param>
+        /// <returns>The <see cref="IMvcCoreBuilder"/>.</returns>
+        public static IMvcCoreBuilder AddControllersAsServices(
+            this IMvcCoreBuilder builder,
+            params Assembly[] controllerAssemblies)
+        {
+            return builder.AddControllersAsServices(controllerAssemblies.AsEnumerable());
+        }
+
+        /// <summary>
+        /// Registers controller types from the specified <paramref name="controllerAssemblies"/> as services and as a source
         /// for controller discovery.
         /// </summary>
         /// <param name="builder">The <see cref="IMvcCoreBuilder"/>.</param>
@@ -134,11 +157,6 @@ namespace Microsoft.Extensions.DependencyInjection
             if (builder == null)
             {
                 throw new ArgumentNullException(nameof(builder));
-            }
-
-            if (controllerAssemblies == null)
-            {
-                throw new ArgumentNullException(nameof(controllerAssemblies));
             }
 
             ControllersAsServices.AddControllersAsServices(builder.Services, controllerAssemblies);

--- a/src/Microsoft.AspNet.Mvc.Core/Internal/ControllersAsServices.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Internal/ControllersAsServices.cs
@@ -16,7 +16,18 @@ namespace Microsoft.AspNet.Mvc.Internal
     {
         public static void AddControllersAsServices(IServiceCollection services, IEnumerable<Type> types)
         {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (types == null)
+            {
+                throw new ArgumentNullException(nameof(types));
+            }
+
             var controllerTypeProvider = new StaticControllerTypeProvider();
+
             foreach (var type in types)
             {
                 services.TryAddTransient(type, type);
@@ -29,7 +40,18 @@ namespace Microsoft.AspNet.Mvc.Internal
 
         public static void AddControllersAsServices(IServiceCollection services, IEnumerable<Assembly> assemblies)
         {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (assemblies == null)
+            {
+                throw new ArgumentNullException(nameof(assemblies));
+            }
+
             var assemblyProvider = new StaticAssemblyProvider();
+
             foreach (var assembly in assemblies)
             {
                 assemblyProvider.CandidateAssemblies.Add(assembly);


### PR DESCRIPTION
What the title says :dancers: 

This adds one overload for adding assemblies, taking a `TAssembly`, which will add a single assembly based on the type argument.

It also adds a `params` overload for both assemblies and types :sparkles:

![Is that something you'd be interested in?](http://cdn.styleforum.net/a/a3/350x700px-LL-a3ffbd1a_Bob-Ryan.jpeg)