### PR TITLE
Fix #3501 - Issues with Flush

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Formatters.Json/JsonOutputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Formatters.Json/JsonOutputFormatter.cs
@@ -132,7 +132,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
             return _serializer;
         }
 
-        public override Task WriteResponseBodyAsync(OutputFormatterWriteContext context)
+        public override async Task WriteResponseBodyAsync(OutputFormatterWriteContext context)
         {
             if (context == null)
             {
@@ -145,9 +145,12 @@ namespace Microsoft.AspNet.Mvc.Formatters
             using (var writer = context.WriterFactory(response.Body, selectedEncoding))
             {
                 WriteObject(writer, context.Object);
-            }
 
-            return Task.FromResult(true);
+                // Perf: call FlushAsync to call WriteAsync on the stream with any content left in the TextWriter's
+                // buffers. This is better than just letting dispose handle it (which would result in a synchronous 
+                // write).
+                await writer.FlushAsync();
+            }
         }
     }
 }

--- a/src/Microsoft.AspNet.Mvc.Formatters.Xml/XmlDataContractSerializerOutputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Formatters.Xml/XmlDataContractSerializerOutputFormatter.cs
@@ -179,7 +179,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
         }
 
         /// <inheritdoc />
-        public override Task WriteResponseBodyAsync(OutputFormatterWriteContext context)
+        public override async Task WriteResponseBodyAsync(OutputFormatterWriteContext context)
         {
             if (context == null)
             {
@@ -209,9 +209,12 @@ namespace Microsoft.AspNet.Mvc.Formatters
                 {
                     dataContractSerializer.WriteObject(xmlWriter, value);
                 }
-            }
 
-            return TaskCache.CompletedTask;
+                // Perf: call FlushAsync to call WriteAsync on the stream with any content left in the TextWriter's
+                // buffers. This is better than just letting dispose handle it (which would result in a synchronous 
+                // write).
+                await textWriter.FlushAsync();
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Mvc.Formatters.Xml/XmlSerializerOutputFormatter.cs
+++ b/src/Microsoft.AspNet.Mvc.Formatters.Xml/XmlSerializerOutputFormatter.cs
@@ -154,7 +154,7 @@ namespace Microsoft.AspNet.Mvc.Formatters
         }
 
         /// <inheritdoc />
-        public override Task WriteResponseBodyAsync(OutputFormatterWriteContext context)
+        public override async Task WriteResponseBodyAsync(OutputFormatterWriteContext context)
         {
             if (context == null)
             {
@@ -186,9 +186,12 @@ namespace Microsoft.AspNet.Mvc.Formatters
                 {
                     xmlSerializer.Serialize(xmlWriter, value);
                 }
-            }
 
-            return TaskCache.CompletedTask;
+                // Perf: call FlushAsync to call WriteAsync on the stream with any content left in the TextWriter's
+                // buffers. This is better than just letting dispose handle it (which would result in a synchronous 
+                // write).
+                await textWriter.FlushAsync();
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
+++ b/src/Microsoft.AspNet.Mvc.Razor/RazorPage.cs
@@ -812,8 +812,8 @@ namespace Microsoft.AspNet.Mvc.Razor
         }
 
         /// <summary>
-        /// Invokes <see cref="TextWriter.FlushAsync"/> on <see cref="Output"/> writing out any buffered
-        /// content to the <see cref="HttpResponse.Body"/>.
+        /// Invokes <see cref="TextWriter.FlushAsync"/> on <see cref="Output"/> and <see cref="Stream.FlushAsync"/>
+        /// on the response stream, writing out any buffered content to the <see cref="HttpResponse.Body"/>.
         /// </summary>
         /// <returns>A <see cref="Task{HtmlString}"/> that represents the asynchronous flush operation and on
         /// completion returns <see cref="HtmlString.Empty"/>.</returns>
@@ -842,6 +842,7 @@ namespace Microsoft.AspNet.Mvc.Razor
             }
 
             await Output.FlushAsync();
+            await Context.Response.Body.FlushAsync();
             return HtmlString.Empty;
         }
 

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ViewFeatures/ViewExecutorTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ViewFeatures/ViewExecutorTest.cs
@@ -309,6 +309,8 @@ namespace Microsoft.AspNet.Mvc.ViewFeatures
                 await v.Writer.WriteAsync(text);
             });
 
+            var expectedWriteCallCount = Math.Ceiling((double)writeLength / HttpResponseStreamWriter.DefaultBufferSize);
+
             var context = new DefaultHttpContext();
             var stream = new Mock<Stream>();
             stream.SetupGet(s => s.CanWrite).Returns(true);
@@ -332,7 +334,10 @@ namespace Microsoft.AspNet.Mvc.ViewFeatures
                 statusCode: null);
 
             // Assert
-            stream.Verify(s => s.FlushAsync(It.IsAny<CancellationToken>()), Times.Once());
+            stream.Verify(s => s.FlushAsync(It.IsAny<CancellationToken>()), Times.Never());
+            stream.Verify(
+                s => s.WriteAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), 
+                Times.Exactly((int)expectedWriteCallCount));
             stream.Verify(s => s.Write(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never());
         }
 


### PR DESCRIPTION
Calling `Flush[Async]()` on the writer will NOT flush the stream.
Calling `Flush[Async]()` in Razor will flush both the writer and the stream.

Our normal flow will be to flush the writer, but not the stream. This
avoids chunking, but allows us to do a `WriteAsync` on the stream as part of
the call to `FlushAsync`. This is done to avoid a synchronous write due to
`Dispose` calling `Flush` on the writer, which needs to call `Write `on the
stream.

See issue for extensive background.