### PR TITLE
Remove use of `String.Split` in Environment taghelper

### DIFF
--- a/src/Microsoft.AspNet.Mvc.TagHelpers/project.json
+++ b/src/Microsoft.AspNet.Mvc.TagHelpers/project.json
@@ -17,6 +17,7 @@
       "version": "1.0.0-*",
       "type": "build"
     },
+    "Microsoft.Extensions.Primitives": "1.0.0-*",
     "Microsoft.Extensions.PropertyHelper.Sources": {
       "version": "1.0.0-*",
       "type": "build"


### PR DESCRIPTION
Fixes #3617