### PR TITLE
Invert TimestampToTicks division

### DIFF
--- a/src/Microsoft.AspNet.Mvc.Core/Logging/MvcRouteHandlerLoggerExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.Core/Logging/MvcRouteHandlerLoggerExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNet.Mvc.Logging
 {
     internal static class MvcRouteHandlerLoggerExtensions
     {
-        private static readonly double TimestampToTicks = Stopwatch.Frequency / 10000000.0;
+        private static readonly double TimestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
 
         private static readonly Action<ILogger, string, Exception> _actionExecuting;
         private static readonly Action<ILogger, string, double, Exception> _actionExecuted;

--- a/src/Microsoft.AspNet.Mvc.ViewFeatures/Logging/DefaultViewComponentInvokerLoggerExtensions.cs
+++ b/src/Microsoft.AspNet.Mvc.ViewFeatures/Logging/DefaultViewComponentInvokerLoggerExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNet.Mvc.ViewFeatures.Logging
 {
     public static class DefaultViewComponentInvokerLoggerExtensions
     {
-        private static readonly double TimestampToTicks = Stopwatch.Frequency / 10000000.0;
+        private static readonly double TimestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
         private static readonly string[] EmptyArguments =
 #if NET451
             new string[0];


### PR DESCRIPTION
Division to do the conversion was backwards. Also use const [`TimeSpan.TicksPerSecond`](https://msdn.microsoft.com/en-us/library/system.timespan.tickspersecond(v=vs.110).aspx) rather than numeric 10,000,000.0

Resolves #3849