### PR TITLE
Removing redundant null logger after hosting fix

### DIFF
--- a/test/Microsoft.AspNet.Mvc.FunctionalTests/MvcTestFixture.cs
+++ b/test/Microsoft.AspNet.Mvc.FunctionalTests/MvcTestFixture.cs
@@ -70,7 +70,6 @@ namespace Microsoft.AspNet.Mvc.FunctionalTests
             var assemblyProvider = new StaticAssemblyProvider();
             assemblyProvider.CandidateAssemblies.Add(startupAssembly);
             services.AddSingleton<IAssemblyProvider>(assemblyProvider);
-            services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
         }
     }
 }


### PR DESCRIPTION
I have resolved https://github.com/aspnet/Hosting/issues/532. I think this is the only place where you added a null logger in https://github.com/aspnet/Mvc/pull/3796 right? @pranavkm 