### PR TITLE
[Fixes #3752] Cleanup Controller invocation pipeline

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Controllers/IControllerActivator.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Controllers/IControllerActivator.cs
@@ -13,7 +13,13 @@ namespace Microsoft.AspNetCore.Mvc.Controllers
         /// <summary>
         /// Creates a controller.
         /// </summary>
-        /// <param name="context">The <see cref="ActionContext"/> for the executing action.</param>
-        object Create(ActionContext context, Type controllerType);
+        /// <param name="context">The <see cref="ControllerContext"/> for the executing action.</param>
+        object Create(ControllerContext context);
+
+        /// <summary>
+        /// Releases a controller.
+        /// </summary>
+        /// <param name="controller">The controller to release.</param>
+        void Release(ControllerContext context, object controller);
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Controllers/IControllerFactory.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Controllers/IControllerFactory.cs
@@ -19,6 +19,6 @@ namespace Microsoft.AspNetCore.Mvc.Controllers
         /// Releases a controller instance.
         /// </summary>
         /// <param name="controller">The controller.</param>
-        void ReleaseController(object controller);
+        void ReleaseController(ControllerContext context, object controller);
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Controllers/ServiceBasedControllerActivator.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Controllers/ServiceBasedControllerActivator.cs
@@ -13,19 +13,21 @@ namespace Microsoft.AspNetCore.Mvc.Controllers
     public class ServiceBasedControllerActivator : IControllerActivator
     {
         /// <inheritdoc />
-        public object Create(ActionContext actionContext, Type controllerType)
+        public object Create(ControllerContext actionContext)
         {
             if (actionContext == null)
             {
                 throw new ArgumentNullException(nameof(actionContext));
             }
 
-            if (controllerType == null)
-            {
-                throw new ArgumentNullException(nameof(controllerType));
-            }
+            var controllerType = actionContext.ActionDescriptor.ControllerTypeInfo.AsType();
 
             return actionContext.HttpContext.RequestServices.GetRequiredService(controllerType);
+        }
+
+        /// <inheritdoc />
+        public virtual void Release(ControllerContext context, object controller)
+        {
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionInvoker.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionInvoker.cs
@@ -83,11 +83,16 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
         protected override void ReleaseInstance(object instance)
         {
-            _controllerFactory.ReleaseController(instance);
+            _controllerFactory.ReleaseController(Context, instance);
         }
 
         protected override async Task<IActionResult> InvokeActionAsync(ActionExecutingContext actionExecutingContext)
         {
+            if (actionExecutingContext == null)
+            {
+                throw new ArgumentNullException(nameof(actionExecutingContext));
+            }
+
             var actionMethodInfo = _descriptor.MethodInfo;
             var arguments = ControllerActionExecutor.PrepareArguments(
                 actionExecutingContext.ActionArguments,

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerActionInvokerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerActionInvokerTest.cs
@@ -2208,7 +2208,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 return _controller;
             }
 
-            public void ReleaseController(object controller)
+            public void ReleaseController(ControllerContext context, object controller)
             {
                 Assert.NotNull(controller);
                 Assert.Same(_controller, controller);


### PR DESCRIPTION
* Added a Release method to IControllerActivator
* Changed Create in IControllerActivator to take in a ControllerActionContext
* Move the check to determine if a controller can be instantiated into the controller activator.
* Move logic for disposing controllers into the controller activator and make release on the
  controller factory delegate into the activator.
* Changed release methods to take in a controller context.