### PR TITLE
Update `TagHelperSampleTest` to avoid failures due to statefulness of the service

### DIFF
--- a/samples/TagHelperSample.Web/Controllers/HomeController.cs
+++ b/samples/TagHelperSample.Web/Controllers/HomeController.cs
@@ -17,11 +17,11 @@ namespace TagHelperSample.Web.Controllers
 
         public HomeController()
         {
-            // Unable to set ViewBag (or ViewData) entries from constructor due to an InvalidOperationException thrown
+            // Unable to set ViewBag or ViewData entries from constructor due to an InvalidOperationException thrown
             // from the DynamicViewData.ViewData getter. In MVC 5.2, no properties in the Controller class except
             // ControllerContext, Url, and anything ControllerContext-derived (e.g. HttpContext and User) return null
             // even if invoked from the constructor i.e. prior to the Initialize() call.
-            ////ViewBag.Items = _items;
+            ////ViewData["Items"] = _items;
         }
 
         // GET: /<controller>/
@@ -33,7 +33,7 @@ namespace TagHelperSample.Web.Controllers
         // GET: /Home/Create
         public IActionResult Create()
         {
-            ViewBag.Items = _items;
+            ViewData["Items"] = _items;
             return View();
         }
 
@@ -49,7 +49,7 @@ namespace TagHelperSample.Web.Controllers
                 return RedirectToAction("Index");
             }
 
-            ViewBag.Items = _items;
+            ViewData["Items"] = _items;
             return View();
         }
 
@@ -59,7 +59,7 @@ namespace TagHelperSample.Web.Controllers
             User user;
             _users.TryGetValue(id, out user);
 
-            ViewBag.Items = _items;
+            ViewData["Items"] = _items;
             return View(user);
         }
 
@@ -73,8 +73,18 @@ namespace TagHelperSample.Web.Controllers
                 return RedirectToAction("Index");
             }
 
-            ViewBag.Items = _items;
+            ViewData["Items"] = _items;
             return View();
+        }
+
+        // POST: Home/Reset
+        [HttpPost]
+        public IActionResult Reset()
+        {
+            _users.Clear();
+            _next = 0;
+
+            return RedirectToAction("Index");
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/TagHelperSample.Web.Home.Index-Reset.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/TagHelperSample.Web.Home.Index-Reset.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link href="/css/sub/blank.css" rel="stylesheet" data-test="value" />
+    <link href="site.min.css" rel="stylesheet" data-test="value" />
+<meta name="x-stylesheet-fallback-test" content="" class="fallback-test" /><script>!function(a,b,c){var d,e=document,f=e.getElementsByTagName("SCRIPT"),g=f[f.length-1].previousElementSibling,h=e.defaultView&&e.defaultView.getComputedStyle?e.defaultView.getComputedStyle(g):g.currentStyle;if(h&&h[a]!==b)for(d=0;d<c.length;d++)e.write('<link rel="stylesheet" href="'+c[d]+'"/>')}("visibility","hidden",["\/site.css"]);</script>
+    
+</head>
+<body>
+    
+
+
+<script src="/originalXX.js">
+    // 1. By removing the src attribute, the script below will execute and prevent fallback from running
+    // 2. Alternatively fix the type in the value of the src attribute
+    function foo() {
+        return 1;
+    }
+
+    function bar() {
+        document.write("<p>foo is from page</p>");
+    }
+</script>
+<script>(window.foo||document.write("<script src=\"\/fallback.js\"><\/script>"));</script>
+
+<script>bar();</script>
+
+<h2>Index</h2>
+<p>
+    <a href="/Home/Create">Create New</a>
+</p>
+
+</body>
+</html>

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/TagHelperSample.Web.Home.Index.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/TagHelperSample.Web.Home.Index.html
@@ -33,7 +33,7 @@
             </div>
             <div class="form-group">
                 <label for="z0__DateOfBirth">DateOfBirth</label>
-                <input type="date" disabled="disabled" readonly="readonly" data-val="true" data-val-required="The DateOfBirth field is required." id="z0__DateOfBirth" name="[0].DateOfBirth" value="2000-11-30" />
+                <input type="date" disabled="disabled" readonly="readonly" data-val="true" data-val-required="The DateOfBirth field is required." id="z0__DateOfBirth" name="[0].DateOfBirth" value="2000-11-28" />
             </div>
             <div class="form-group">
                 <label for="z0__YearsEmployeed">YearsEmployeed</label>
@@ -49,20 +49,20 @@ hello</textarea>
             </p>
             <div class="form-group">
                 <label for="z1__Name">Name</label>
-                <input type="text" disabled="disabled" readonly="readonly" id="z1__Name" name="[1].Name" value="Billy" />
+                <input type="text" disabled="disabled" readonly="readonly" id="z1__Name" name="[1].Name" value="Bobby" />
             </div>
             <div class="form-group">
                 <label for="z1__DateOfBirth">DateOfBirth</label>
-                <input type="date" disabled="disabled" readonly="readonly" data-val="true" data-val-required="The DateOfBirth field is required." id="z1__DateOfBirth" name="[1].DateOfBirth" value="2000-11-30" />
+                <input type="date" disabled="disabled" readonly="readonly" data-val="true" data-val-required="The DateOfBirth field is required." id="z1__DateOfBirth" name="[1].DateOfBirth" value="1999-10-27" />
             </div>
             <div class="form-group">
                 <label for="z1__YearsEmployeed">YearsEmployeed</label>
-                <input type="number" disabled="disabled" readonly="readonly" data-val="true" data-val-required="The YearsEmployeed field is required." id="z1__YearsEmployeed" name="[1].YearsEmployeed" value="0" />
+                <input type="number" disabled="disabled" readonly="readonly" data-val="true" data-val-required="The YearsEmployeed field is required." id="z1__YearsEmployeed" name="[1].YearsEmployeed" value="1" />
             </div>
             <div class="form-group">
                 <label for="z1__Blurb">Blurb</label>
                 <textarea rows="4" disabled="disabled" readonly="readonly" id="z1__Blurb" name="[1].Blurb">
-hello</textarea>
+howdy</textarea>
             </div>
             <p>
                 <a href="/Home/Edit/1">Edit</a>


### PR DESCRIPTION
- have one test muted at the moment in our CI
- add `Reset()` action to the service, enabling `// Arrange` to bring `Index()` content to a known state
  - add a couple more tests to `TagHelperSampleTest` covering the new action and empty `Index()` list

nits:
- use `ViewData`, not `ViewBag`