### PR TITLE
Support overrides for client-side validation messages

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/Metadata/IModelBindingMessageProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/Metadata/IModelBindingMessageProvider.cs
@@ -51,5 +51,12 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
         /// </summary>
         /// <value>Default <see cref="string"/> is "The value '{0}' is invalid.".</value>
         Func<string, string> ValueIsInvalidAccessor { get; }
+
+        /// <summary>
+        /// Error message HTML and tag helpers add for client-side validation of numeric formats. Visible in the
+        /// browser if the field for a <c>float</c> property (for example) does not have a correctly-formatted value.
+        /// </summary>
+        /// <value>Default <see cref="string"/> is "The field {0} must be a number.".</value>
+        Func<string, string> ValueMustBeANumberAccessor { get; }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcCoreMvcOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcCoreMvcOptionsSetup.cs
@@ -34,6 +34,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             messageProvider.AttemptedValueIsInvalidAccessor = Resources.FormatModelState_AttemptedValueIsInvalid;
             messageProvider.UnknownValueIsInvalidAccessor = Resources.FormatModelState_UnknownValueIsInvalid;
             messageProvider.ValueIsInvalidAccessor = Resources.FormatHtmlGeneration_ValueIsInvalid;
+            messageProvider.ValueMustBeANumberAccessor = Resources.FormatHtmlGeneration_ValueMustBeNumber;
 
             // Set up ModelBinding
             options.ModelBinders.Add(new BinderTypeBasedModelBinder());

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/EmptyModelMetadataProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/EmptyModelMetadataProvider.cs
@@ -44,6 +44,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                     AttemptedValueIsInvalidAccessor = Resources.FormatModelState_AttemptedValueIsInvalid,
                     UnknownValueIsInvalidAccessor = Resources.FormatModelState_UnknownValueIsInvalid,
                     ValueIsInvalidAccessor = Resources.FormatHtmlGeneration_ValueIsInvalid,
+                    ValueMustBeANumberAccessor = Resources.FormatHtmlGeneration_ValueMustBeNumber,
                 };
             }
         }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Metadata/ModelBindingMessageProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Metadata/ModelBindingMessageProvider.cs
@@ -16,6 +16,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
         private Func<string, string, string> _attemptedValueIsInvalidAccessor;
         private Func<string, string> _unknownValueIsInvalidAccessor;
         private Func<string, string> _valueIsInvalidAccessor;
+        private Func<string, string> _valueMustBeANumberAccessor;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelBindingMessageProvider"/> class.
@@ -42,6 +43,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
             AttemptedValueIsInvalidAccessor = originalProvider.AttemptedValueIsInvalidAccessor;
             UnknownValueIsInvalidAccessor = originalProvider.UnknownValueIsInvalidAccessor;
             ValueIsInvalidAccessor = originalProvider.ValueIsInvalidAccessor;
+            ValueMustBeANumberAccessor = originalProvider.ValueMustBeANumberAccessor;
         }
 
         /// <inheritdoc/>
@@ -149,6 +151,24 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
                 }
 
                 _valueIsInvalidAccessor = value;
+            }
+        }
+
+        /// <inheritdoc/>
+        public Func<string, string> ValueMustBeANumberAccessor
+        {
+            get
+            {
+                return _valueMustBeANumberAccessor;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                _valueMustBeANumberAccessor = value;
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Properties/Resources.Designer.cs
@@ -1003,38 +1003,6 @@ namespace Microsoft.AspNetCore.Mvc.Core
         }
 
         /// <summary>
-        /// The stream must support reading.
-        /// </summary>
-        internal static string HttpRequestStreamReader_StreamNotReadable
-        {
-            get { return GetString("HttpRequestStreamReader_StreamNotReadable"); }
-        }
-
-        /// <summary>
-        /// The stream must support reading.
-        /// </summary>
-        internal static string FormatHttpRequestStreamReader_StreamNotReadable()
-        {
-            return GetString("HttpRequestStreamReader_StreamNotReadable");
-        }
-
-        /// <summary>
-        /// The stream must support writing.
-        /// </summary>
-        internal static string HttpResponseStreamWriter_StreamNotWritable
-        {
-            get { return GetString("HttpResponseStreamWriter_StreamNotWritable"); }
-        }
-
-        /// <summary>
-        /// The stream must support writing.
-        /// </summary>
-        internal static string FormatHttpResponseStreamWriter_StreamNotWritable()
-        {
-            return GetString("HttpResponseStreamWriter_StreamNotWritable");
-        }
-
-        /// <summary>
         /// The argument '{0}' is invalid. Empty or null formats are not supported.
         /// </summary>
         internal static string FormatFormatterMappings_GetMediaTypeMappingForFormat_InvalidFormat
@@ -1112,6 +1080,22 @@ namespace Microsoft.AspNetCore.Mvc.Core
         internal static string FormatHtmlGeneration_ValueIsInvalid(object p0)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("HtmlGeneration_ValueIsInvalid"), p0);
+        }
+
+        /// <summary>
+        /// The field {0} must be a number.
+        /// </summary>
+        internal static string HtmlGeneration_ValueMustBeNumber
+        {
+            get { return GetString("HtmlGeneration_ValueMustBeNumber"); }
+        }
+
+        /// <summary>
+        /// The field {0} must be a number.
+        /// </summary>
+        internal static string FormatHtmlGeneration_ValueMustBeNumber(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("HtmlGeneration_ValueMustBeNumber"), p0);
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/Microsoft.AspNetCore.Mvc.Core/Resources.resx
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Resources.resx
@@ -328,4 +328,7 @@
   <data name="HtmlGeneration_ValueIsInvalid" xml:space="preserve">
     <value>The value '{0}' is invalid.</value>
   </data>
+  <data name="HtmlGeneration_ValueMustBeNumber" xml:space="preserve">
+    <value>The field {0} must be a number.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNetCore.Mvc.DataAnnotations/Internal/NumericClientModelValidator.cs
+++ b/src/Microsoft.AspNetCore.Mvc.DataAnnotations/Internal/NumericClientModelValidator.cs
@@ -44,7 +44,8 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
                 throw new ArgumentNullException(nameof(modelMetadata));
             }
 
-            return Resources.FormatNumericClientModelValidator_FieldMustBeNumber(modelMetadata.GetDisplayName());
+            return modelMetadata.ModelBindingMessageProvider.ValueMustBeANumberAccessor(
+                modelMetadata.GetDisplayName());
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.DataAnnotations/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.DataAnnotations/Properties/Resources.Designer.cs
@@ -43,22 +43,6 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations
         }
 
         /// <summary>
-        /// The field {0} must be a number.
-        /// </summary>
-        internal static string NumericClientModelValidator_FieldMustBeNumber
-        {
-            get { return GetString("NumericClientModelValidator_FieldMustBeNumber"); }
-        }
-
-        /// <summary>
-        /// The field {0} must be a number.
-        /// </summary>
-        internal static string FormatNumericClientModelValidator_FieldMustBeNumber(object p0)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("NumericClientModelValidator_FieldMustBeNumber"), p0);
-        }
-
-        /// <summary>
         /// The '{0}' property of '{1}' must not be null.
         /// </summary>
         internal static string PropertyOfTypeCannotBeNull

--- a/src/Microsoft.AspNetCore.Mvc.DataAnnotations/Resources.resx
+++ b/src/Microsoft.AspNetCore.Mvc.DataAnnotations/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -122,9 +122,6 @@
   </data>
   <data name="ArgumentCannotBeNullOrEmpty" xml:space="preserve">
     <value>Value cannot be null or empty.</value>
-  </data>
-  <data name="NumericClientModelValidator_FieldMustBeNumber" xml:space="preserve">
-    <value>The field {0} must be a number.</value>
   </data>
   <data name="PropertyOfTypeCannotBeNull" xml:space="preserve">
     <value>The '{0}' property of '{1}' must not be null.</value>

--- a/test/Microsoft.AspNetCore.Mvc.Abstractions.Test/ModelBinding/ModelStateDictionaryTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Abstractions.Test/ModelBinding/ModelStateDictionaryTest.cs
@@ -754,6 +754,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                     (value, name) => "Unexpected InvalidValueWithKnownAttemptedValueAccessor use",
                 UnknownValueIsInvalidAccessor = name => $"Hmm, the supplied value is not valid for { name }.",
                 ValueIsInvalidAccessor = value => "Unexpected InvalidValueWithUnknownModelErrorAccessor use",
+                ValueMustBeANumberAccessor = name => "Unexpected ValueMustBeANumberAccessor use",
             };
             var bindingMetadataProvider = new DefaultBindingMetadataProvider(messageProvider);
             var compositeProvider = new DefaultCompositeMetadataDetailsProvider(new[] { bindingMetadataProvider });
@@ -805,6 +806,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                     (value, name) => $"Hmm, the value '{ value }' is not valid for { name }.",
                 UnknownValueIsInvalidAccessor = name => "Unexpected InvalidValueWithUnknownAttemptedValueAccessor use",
                 ValueIsInvalidAccessor = value => "Unexpected InvalidValueWithUnknownModelErrorAccessor use",
+                ValueMustBeANumberAccessor = name => "Unexpected ValueMustBeANumberAccessor use",
             };
             var bindingMetadataProvider = new DefaultBindingMetadataProvider(messageProvider);
             var compositeProvider = new DefaultCompositeMetadataDetailsProvider(new[] { bindingMetadataProvider });

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/DefaultBindingMetadataProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/DefaultBindingMetadataProviderTest.cs
@@ -527,6 +527,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 AttemptedValueIsInvalidAccessor = Resources.FormatModelState_AttemptedValueIsInvalid,
                 UnknownValueIsInvalidAccessor = Resources.FormatModelState_UnknownValueIsInvalid,
                 ValueIsInvalidAccessor = Resources.FormatHtmlGeneration_ValueIsInvalid,
+                ValueMustBeANumberAccessor = Resources.FormatHtmlGeneration_ValueMustBeNumber,
             };
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/ModelMetadataProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/ModelMetadataProviderTest.cs
@@ -1067,6 +1067,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
                         (value, name) => $"The value '{ value }' is not valid for { name }.",
                     UnknownValueIsInvalidAccessor = name => $"The supplied value is invalid for { name }.",
                     ValueIsInvalidAccessor = value => $"The value '{ value }' is invalid.",
+                    ValueMustBeANumberAccessor = name => $"The field { name } must be a number.",
                 };
             }
 

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/NumericClientModelValidatorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/NumericClientModelValidatorTest.cs
@@ -38,6 +38,35 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
         }
 
         [Fact]
+        public void AddValidation_CorrectValidationTypeAndOverriddenErrorMessage()
+        {
+            // Arrange
+            var expectedMessage = "Error message about 'DisplayId' from override.";
+            var provider = new TestModelMetadataProvider();
+            provider
+                .ForProperty(typeof(TypeWithNumericProperty), nameof(TypeWithNumericProperty.Id))
+                .BindingDetails(d => d.ModelBindingMessageProvider.ValueMustBeANumberAccessor =
+                    name => $"Error message about '{ name }' from override.");
+            var metadata = provider.GetMetadataForProperty(
+                typeof(TypeWithNumericProperty),
+                nameof(TypeWithNumericProperty.Id));
+
+            var adapter = new NumericClientModelValidator();
+
+            var actionContext = new ActionContext();
+            var context = new ClientModelValidationContext(actionContext, metadata, provider, new AttributeDictionary());
+
+            // Act
+            adapter.AddValidation(context);
+
+            // Assert
+            Assert.Collection(
+                context.Attributes,
+                kvp => { Assert.Equal("data-val", kvp.Key); Assert.Equal("true", kvp.Value); },
+                kvp => { Assert.Equal("data-val-number", kvp.Key); Assert.Equal(expectedMessage, kvp.Value); });
+        }
+
+        [Fact]
         [ReplaceCulture]
         public void AddValidation_DoesNotTrounceExistingAttributes()
         {

--- a/test/Microsoft.AspNetCore.Mvc.TestCommon/TestModelMetadataProvider.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TestCommon/TestModelMetadataProvider.cs
@@ -116,6 +116,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 AttemptedValueIsInvalidAccessor = (value, name) => $"The value '{ value }' is not valid for { name }.",
                 UnknownValueIsInvalidAccessor = name => $"The supplied value is invalid for { name }.",
                 ValueIsInvalidAccessor = value => $"The value '{ value }' is invalid.",
+                ValueMustBeANumberAccessor = name => $"The field { name } must be a number.",
             };
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Properties/Resources.Designer.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Properties/Resources.Designer.cs
@@ -58,6 +58,22 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Test
             return GetString("DisplayAttribute_Name");
         }
 
+        /// <summary>
+        /// Error about '{0}' from resources.
+        /// </summary>
+        internal static string RemoteAttribute_Error
+        {
+            get { return GetString("RemoteAttribute_Error"); }
+        }
+
+        /// <summary>
+        /// Error about '{0}' from resources.
+        /// </summary>
+        internal static string FormatRemoteAttribute_Error(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("RemoteAttribute_Error"), p0);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Resources.resx
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -125,5 +125,8 @@
   </data>
   <data name="DisplayAttribute_Name" xml:space="preserve">
     <value>name from resources</value>
+  </data>
+  <data name="RemoteAttribute_Error" xml:space="preserve">
+    <value>Error about '{0}' from resources.</value>
   </data>
 </root>


### PR DESCRIPTION
- #2969
- `RemoteAttribute` did not support `IStringLocalizer` overrides
 - use same `MvcDataAnnotationsLocalizationOptions` property as for other `ValidationAttribute`s
- error message `NumericClientModelValidator` added could not be overridden
 - not related to `IStringLocalizer` because users have no way to set the resource lookup key
 - extend `IModelBindingMessageProvider` to add the necessary `Func<,>`
- also correct problem using resources with `RemoteAttribute` and add lots of tests