### PR TITLE
Be smarter about StringBuilders

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/JQueryFormValueProviderFactory.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/JQueryFormValueProviderFactory.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             {
                 throw new ArgumentNullException(nameof(context));
             }
-            
+
             var request = context.HttpContext.Request;
             if (request.HasFormContentType)
             {
@@ -47,10 +47,16 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         {
             var formCollection = await request.ReadFormAsync();
 
-            var dictionary = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
+            var builder = new StringBuilder();
+            var dictionary = new Dictionary<string, StringValues>(
+                formCollection.Count,
+                StringComparer.OrdinalIgnoreCase);
             foreach (var entry in formCollection)
             {
-                var key = NormalizeJQueryToMvc(entry.Key);
+                NormalizeJQueryToMvc(builder, entry.Key);
+
+                var key = builder.ToString();
+                builder.Clear();
                 dictionary[key] = entry.Value;
             }
 
@@ -63,7 +69,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         // [] --> ""
         // x[12] --> x[12]
         // x[field]  --> x.field, where field is not a number
-        private static string NormalizeJQueryToMvc(string key)
+        private static string NormalizeJQueryToMvc(StringBuilder builder, string key)
         {
             if (string.IsNullOrEmpty(key))
             {
@@ -79,7 +85,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 return key;
             }
 
-            var builder = new StringBuilder();
             var position = 0;
             while (position < key.Length)
             {


### PR DESCRIPTION
/cc @Eilon 

This saves about 40mb of allocations by moving a declaration out of the loop.

*Before*:
![image](https://cloud.githubusercontent.com/assets/1430011/12690722/67ef3a80-c69a-11e5-9f67-dce938fe1cbd.png)

*After*:
![image](https://cloud.githubusercontent.com/assets/1430011/12690710/4a06dbea-c69a-11e5-9a39-eed29efadc58.png)

