### PR TITLE
Remove OSx+Mono skips related to aspnet/External#50

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/RequireHttpsAttributeTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/RequireHttpsAttributeTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Mvc.Abstractions;
@@ -30,30 +29,30 @@ namespace Microsoft.AspNetCore.Mvc
             Assert.Null(authContext.Result);
         }
 
-        public static IEnumerable<object[]> RedirectToHttpEndpointTestData
+        public static TheoryData<string, string, string, string, string> RedirectToHttpEndpointTestData
         {
             get
             {
                 // host, pathbase, path, query, expectedRedirectUrl
-                var data = new TheoryData<string, string, string, string, string>();
+                return new TheoryData<string, string, string, string, string>
+                {
+                    { "localhost", null, null, null, "https://localhost" },
+                    { "localhost:5000", null, null, null, "https://localhost:5000" },
+                    { "localhost", "/pathbase", null, null, "https://localhost/pathbase" },
+                    { "localhost", "/pathbase", "/path", null, "https://localhost/pathbase/path" },
+                    { "localhost", "/pathbase", "/path", "?foo=bar", "https://localhost/pathbase/path?foo=bar" },
 
-                data.Add("localhost", null, null, null, "https://localhost");
-                data.Add("localhost:5000", null, null, null, "https://localhost:5000");
-                data.Add("localhost", "/pathbase", null, null, "https://localhost/pathbase");
-                data.Add("localhost", "/pathbase", "/path", null, "https://localhost/pathbase/path");
-                data.Add("localhost", "/pathbase", "/path", "?foo=bar", "https://localhost/pathbase/path?foo=bar");
+                    // Encode some special characters on the URL.
+                    { "localhost", "/path?base", null, null, "https://localhost/path%3Fbase" },
+                    { "localhost", null, "/pa?th", null, "https://localhost/pa%3Fth" },
 
-                // Encode some special characters on the url.
-                data.Add("localhost", "/path?base", null, null, "https://localhost/path%3Fbase");
-                data.Add("localhost", null, "/pa?th", null, "https://localhost/pa%3Fth");
+                    { "localhost", "/", null, "?foo=bar%2Fbaz", "https://localhost/?foo=bar%2Fbaz" },
 
-                data.Add("localhost", "/", null, "?foo=bar%2Fbaz", "https://localhost/?foo=bar%2Fbaz");
-
-                // Urls with punycode
-                // 本地主機 is "localhost" in chinese traditional, "xn--tiq21tzznx7c" is the
-                // punycode representation.
-                data.Add("本地主機", "/", null, null, "https://xn--tiq21tzznx7c/");
-                return data;
+                    // URLs with punycode
+                    // 本地主機 is "localhost" in chinese traditional, "xn--tiq21tzznx7c" is the
+                    // punycode representation.
+                    { "本地主機", "/", null, null, "https://xn--tiq21tzznx7c/" },
+                };
             }
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/RequireHttpsAttributeTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/RequireHttpsAttributeTests.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.AspNetCore.Testing;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc
@@ -45,12 +44,8 @@ namespace Microsoft.AspNetCore.Mvc
                 data.Add("localhost", "/pathbase", "/path", "?foo=bar", "https://localhost/pathbase/path?foo=bar");
 
                 // Encode some special characters on the url.
-                // Two paths hit aspnet/External#50 with Mono on Mac.
-                if (!TestPlatformHelper.IsMac || !TestPlatformHelper.IsMono)
-                {
-                    data.Add("localhost", "/path?base", null, null, "https://localhost/path%3Fbase");
-                    data.Add("localhost", null, "/pa?th", null, "https://localhost/pa%3Fth");
-                }
+                data.Add("localhost", "/path?base", null, null, "https://localhost/path%3Fbase");
+                data.Add("localhost", null, "/pa?th", null, "https://localhost/pa%3Fth");
 
                 data.Add("localhost", "/", null, "?foo=bar%2Fbaz", "https://localhost/?foo=bar%2Fbaz");
 

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/HtmlGenerationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/HtmlGenerationTest.cs
@@ -9,7 +9,6 @@ using System.Net.Http.Headers;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Testing;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests
@@ -64,14 +63,9 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                     { "OrderUsingHtmlHelpers", "/HtmlGeneration_Order/Submit" },
                     // Testing InputTagHelpers invoked in the partial views
                     { "ProductList", "/HtmlGeneration_Product" },
-                };
-
-                // One path hits aspnet/External#50 with Mono on Mac.
-                if (!TestPlatformHelper.IsMac || !TestPlatformHelper.IsMono)
-                {
                     // Testing the ScriptTagHelper
-                    data.Add("Script", null);
-                }
+                    { "Script", null },
+                };
 
                 return data;
             }

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/TagHelperSampleTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/TagHelperSampleTest.cs
@@ -9,7 +9,6 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests
@@ -23,8 +22,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
         public HttpClient Client { get; }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task HomeController_Index_ReturnsExpectedContent()
         {
             // Arrange
@@ -61,7 +59,10 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(resourceAssembly, outputFile, expectedContent, responseContent);
 #else
-            Assert.Equal(expectedContent, responseContent, ignoreLineEndingDifferences: true);
+            Assert.Equal(
+                PlatformNormalizer.NormalizeContent(expectedContent),
+                responseContent,
+                ignoreLineEndingDifferences: true);
 #endif
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/ActionParametersIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/ActionParametersIntegrationTest.cs
@@ -8,9 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-#if !DNXCORE50
-using Microsoft.AspNetCore.Testing.xunit;
-#endif
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.IntegrationTests
@@ -32,12 +29,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             public List<Address> Address { get; }
         }
 
-#if DNXCORE50
         [Fact]
-#else
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         public async Task ActionParameter_NonSettableCollectionModel_EmptyPrefix_GetsBound()
         {
             // Arrange
@@ -84,12 +76,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             public CustomReadOnlyCollection<Address> Address { get; set; }
         }
 
-#if DNXCORE50
         [Fact]
-#else
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         public async Task ActionParameter_ReadOnlyCollectionModel_EmptyPrefix_DoesNotGetBound()
         {
             // Arrange
@@ -136,12 +123,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             public Address[] Address { get; set; }
         }
 
-#if DNXCORE50
         [Fact]
-#else
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         public async Task ActionParameter_SettableArrayModel_EmptyPrefix_GetsBound()
         {
             // Arrange
@@ -188,12 +170,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             public Address[] Address { get; } = new Address[] { };
         }
 
-#if DNXCORE50
         [Fact]
-#else
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         public async Task ActionParameter_NonSettableArrayModel_EmptyPrefix_DoesNotGetBound()
         {
             // Arrange
@@ -229,12 +206,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.Empty(modelState.Keys);
         }
 
-#if DNXCORE50
         [Fact]
-#else
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         public async Task ActionParameter_NonSettableCollectionModel_WithPrefix_GetsBound()
         {
             // Arrange
@@ -279,12 +251,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.Equal(ModelValidationState.Valid, modelState[key].ValidationState);
         }
 
-#if DNXCORE50
         [Fact]
-#else
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         public async Task ActionParameter_ReadOnlyCollectionModel_WithPrefix_DoesNotGetBound()
         {
             // Arrange
@@ -330,12 +297,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.Equal("SomeStreet", state.RawValue);
         }
 
-#if DNXCORE50
         [Fact]
-#else
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         public async Task ActionParameter_SettableArrayModel_WithPrefix_GetsBound()
         {
             // Arrange
@@ -380,12 +342,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.Equal(ModelValidationState.Valid, modelState[key].ValidationState);
         }
 
-#if DNXCORE50
         [Fact]
-#else
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         public async Task ActionParameter_NonSettableArrayModel_WithPrefix_DoesNotGetBound()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/ByteArrayModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/ByteArrayModelBinderIntegrationTest.cs
@@ -6,9 +6,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-#if !DNXCORE50
-using Microsoft.AspNetCore.Testing.xunit;
-#endif
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.IntegrationTests
@@ -20,12 +17,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             public byte[] Token { get; set; }
         }
 
-#if DNXCORE50
         [Theory]
-#else
-        [ConditionalTheory]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         [InlineData(true)]
         [InlineData(false)]
         public async Task BindProperty_WithData_GetsBound(bool fallBackScenario)

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/SimpleTypeModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/SimpleTypeModelBinderIntegrationTest.cs
@@ -10,9 +10,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-#if !DNXCORE50
-using Microsoft.AspNetCore.Testing.xunit;
-#endif
 using Microsoft.Extensions.Primitives;
 using Xunit;
 
@@ -307,12 +304,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.Equal($"Hmm, 'abcd' is not a valid value for 'Int32'.", error.ErrorMessage);
         }
 
-#if DNXCORE50
         [Theory]
-#else
-        [ConditionalTheory]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         [InlineData(typeof(int))]
         [InlineData(typeof(bool))]
         public async Task BindParameter_WithEmptyData_DoesNotBind(Type parameterType)

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/TryUpdateModelIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/TryUpdateModelIntegrationTest.cs
@@ -6,9 +6,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-#if !DNXCORE50
-using Microsoft.AspNetCore.Testing.xunit;
-#endif
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.IntegrationTests
@@ -103,12 +100,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             public Address Address { get; set; }
         }
 
-#if DNXCORE50
         [Fact]
-#else
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         public async Task TryUpdateModel_TopLevelCollection_EmptyPrefix_BindsAfterClearing()
         {
             // Arrange
@@ -216,12 +208,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             public List<Address> Address { get; set; }
         }
 
-#if DNXCORE50
         [Fact]
-#else
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         public async Task TryUpdateModel_SettableCollectionModel_EmptyPrefix_CreatesCollection()
         {
             // Arrange
@@ -257,12 +244,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.Equal(ModelValidationState.Valid, state.ValidationState);
         }
 
-#if DNXCORE50
         [Fact]
-#else
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         public async Task TryUpdateModel_SettableCollectionModel_EmptyPrefix_MaintainsCollectionIfNonNull()
         {
             // Arrange
@@ -313,12 +295,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             public List<Address> Address { get; }
         }
 
-#if DNXCORE50
         [Fact]
-#else
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         public async Task TryUpdateModel_NonSettableCollectionModel_EmptyPrefix_GetsBound()
         {
             // Arrange
@@ -412,12 +389,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             public Address[] Address { get; set; }
         }
 
-#if DNXCORE50
         [Fact]
-#else
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         public async Task TryUpdateModel_SettableArrayModel_EmptyPrefix_CreatesArray()
         {
             // Arrange
@@ -453,12 +425,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.Equal(ModelValidationState.Valid, state.ValidationState);
         }
 
-#if DNXCORE50
         [Fact]
-#else
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         public async Task TryUpdateModel_SettableArrayModel_EmptyPrefix_OverwritesArray()
         {
             // Arrange
@@ -511,12 +478,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             public Address[] Address { get; } = new Address[] { };
         }
 
-#if DNXCORE50
         [Fact]
-#else
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         public async Task TryUpdateModel_NonSettableArrayModel_EmptyPrefix_GetsBound()
         {
             // Arrange
@@ -620,12 +582,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.Equal(ModelValidationState.Valid, state.ValidationState);
         }
 
-#if DNXCORE50
         [Fact]
-#else
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         public async Task TryUpdateModel_TopLevelCollection_WithPrefix_BindsAfterClearing()
         {
             // Arrange
@@ -728,12 +685,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.Equal(ModelValidationState.Valid, state.ValidationState);
         }
 
-#if DNXCORE50
         [Fact]
-#else
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         public async Task TryUpdateModel_SettableCollectionModel_WithPrefix_CreatesCollection()
         {
             // Arrange
@@ -769,12 +721,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.Equal(ModelValidationState.Valid, state.ValidationState);
         }
 
-#if DNXCORE50
         [Fact]
-#else
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         public async Task TryUpdateModel_SettableCollectionModel_WithPrefix_MaintainsCollectionIfNonNull()
         {
             // Arrange
@@ -815,12 +762,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.Equal(ModelValidationState.Valid, state.ValidationState);
         }
 
-#if DNXCORE50
         [Fact]
-#else
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         public async Task TryUpdateModel_NonSettableCollectionModel_WithPrefix_GetsBound()
         {
             // Arrange
@@ -904,12 +846,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.Equal("SomeStreet", state.RawValue);
         }
 
-#if DNXCORE50
         [Fact]
-#else
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         public async Task TryUpdateModel_SettableArrayModel_WithPrefix_CreatesArray()
         {
             // Arrange
@@ -945,12 +882,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.Equal(ModelValidationState.Valid, state.ValidationState);
         }
 
-#if DNXCORE50
         [Fact]
-#else
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         public async Task TryUpdateModel_SettableArrayModel_WithPrefix_OverwritesArray()
         {
             // Arrange
@@ -998,12 +930,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.Equal(ModelValidationState.Valid, state.ValidationState);
         }
 
-#if DNXCORE50
         [Fact]
-#else
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         public async Task TryUpdateModel_NonSettableArrayModel_WithPrefix_GetsBound()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponentTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponentTests.cs
@@ -5,9 +5,6 @@ using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewComponents;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
-#if !DNXCORE50
-using Microsoft.AspNetCore.Testing.xunit;
-#endif
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc
@@ -46,12 +43,7 @@ namespace Microsoft.AspNetCore.Mvc
             Assert.Equal("Bob", viewComponent.ViewBag.B);
         }
 
-#if DNXCORE50
         [Fact]
-#else
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/External#50")]
-#endif
         public void ViewComponent_Content_SetsResultContentAndEncodedContent()
         {
             // Arrange


### PR DESCRIPTION
- CoreFx worked around the underlying issue
- add `PlatformNormalizer.NormalizeContent()` call in previously-disabled test