### PR TITLE
Reduce allocations in FormContext

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/RenderAtEndOfFormTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/RenderAtEndOfFormTagHelper.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             }
 
             // Reset the FormContext
-            ViewContext.FormContext = null;
+            ViewContext.FormContext = new FormContext();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/MvcForm.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/MvcForm.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Mvc.Rendering
@@ -56,7 +57,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             RenderEndOfFormContent();
             _viewContext.Writer.Write("</form>");
-            _viewContext.FormContext = null;
+            _viewContext.FormContext = new FormContext();
         }
 
         private void RenderEndOfFormContent()

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/ViewContext.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/ViewContext.cs
@@ -15,9 +15,6 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
     /// </summary>
     public class ViewContext : ActionContext
     {
-        // We need a default FormContext if the user uses HTML <form> instead of an MvcForm
-        private readonly FormContext _defaultFormContext = new FormContext();
-
         private FormContext _formContext;
         private DynamicViewData _viewBag;
 
@@ -84,7 +81,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             TempData = tempData;
             Writer = writer;
 
-            _formContext = _defaultFormContext;
+            FormContext = new FormContext();
+            
             ClientValidationEnabled = htmlHelperOptions.ClientValidationEnabled;
             Html5DateRenderingMode = htmlHelperOptions.Html5DateRenderingMode;
             ValidationSummaryMessageElement = htmlHelperOptions.ValidationSummaryMessageElement;
@@ -125,7 +123,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            _formContext = viewContext.FormContext;
+            FormContext = viewContext.FormContext;
+
             ClientValidationEnabled = viewContext.ClientValidationEnabled;
             Html5DateRenderingMode = viewContext.Html5DateRenderingMode;
             ValidationSummaryMessageElement = viewContext.ValidationSummaryMessageElement;
@@ -144,14 +143,16 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </summary>
         public virtual FormContext FormContext
         {
-            get
-            {
-                return _formContext;
-            }
+            get { return _formContext; }
+
             set
             {
-                // Never return a null form context, this is important for validation purposes.
-                _formContext = value ?? _defaultFormContext;
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                _formContext = value;
             }
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/DefaultHtmlGenerator.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/DefaultHtmlGenerator.cs
@@ -801,8 +801,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 throw new ArgumentNullException(nameof(viewContext));
             }
 
-            var formContext = viewContext.ClientValidationEnabled ? viewContext.FormContext : null;
-            if (viewContext.ViewData.ModelState.IsValid && (formContext == null || excludePropertyErrors))
+            if (viewContext.ViewData.ModelState.IsValid && (!viewContext.ClientValidationEnabled || excludePropertyErrors))
             {
                 // No client side validation/updates
                 return null;
@@ -869,7 +868,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             tagBuilder.InnerHtml.AppendHtml(wrappedMessage);
             tagBuilder.InnerHtml.AppendHtml(htmlSummary);
 
-            if (formContext != null && !excludePropertyErrors)
+            if (viewContext.ClientValidationEnabled && !excludePropertyErrors)
             {
                 // Inform the client where to replace the list of property errors after validation.
                 tagBuilder.MergeAttribute("data-valmsg-summary", "true");

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/FormContext.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/FormContext.cs
@@ -9,8 +9,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 {
     public class FormContext
     {
-        private readonly Dictionary<string, bool> _renderedFields =
-            new Dictionary<string, bool>(StringComparer.Ordinal);
+        private Dictionary<string, bool> _renderedFields;
         private Dictionary<string, object> _formData;
         private IList<IHtmlContent> _endOfFormContent;
 
@@ -52,6 +51,19 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 
         public bool CanRenderAtEndOfForm { get; set; }
 
+        private Dictionary<string, bool> RenderedFields
+        {
+            get
+            {
+                if (_renderedFields == null)
+                {
+                    _renderedFields = new Dictionary<string, bool>(StringComparer.Ordinal);
+                }
+
+                return _renderedFields;
+            }
+        }
+
         public bool RenderedField(string fieldName)
         {
             if (fieldName == null)
@@ -60,7 +72,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             }
 
             bool result;
-            _renderedFields.TryGetValue(fieldName, out result);
+            RenderedFields.TryGetValue(fieldName, out result);
 
             return result;
         }
@@ -72,7 +84,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 throw new ArgumentNullException(nameof(fieldName));
             }
 
-            _renderedFields[fieldName] = value;
+            RenderedFields[fieldName] = value;
         }
     }
 }


### PR DESCRIPTION
This change reduces the allocations of `FormContext` instances and also of the resulting dictionary.

**Before** `(dictionary<string, bool> allocations)`
![image](https://cloud.githubusercontent.com/assets/1430011/12733528/2c4a92ec-c8f0-11e5-9533-dd7df48f1c7f.png)

**After** `(dictionary<string, bool> allocations)`
![image](https://cloud.githubusercontent.com/assets/1430011/12733547/42120542-c8f0-11e5-9ffb-0bb99f8875ab.png)

The reduction in `FormContext` instances is worth about 400kb also.