### PR TITLE
Updated `Controller`s `ViewComponent` method to handle arguments.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Controller.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Controller.cs
@@ -216,12 +216,16 @@ namespace Microsoft.AspNetCore.Mvc
         /// The view component name. Can be a view component
         /// <see cref="ViewComponents.ViewComponentDescriptor.ShortName"/> or
         /// <see cref="ViewComponents.ViewComponentDescriptor.FullName"/>.</param>
-        /// <param name="arguments">The arguments to pass to the view component.</param>
+        /// <param name="arguments">
+        /// An anonymous <see cref="object"/> containing arguments to be passed to the invoked view component method.
+        /// Alternatively, an <see cref="System.Collections.Generic.IDictionary{string, object}"/> instance containing
+        /// the invocation arguments.
+        /// </param>
         /// <returns>The created <see cref="ViewComponentResult"/> object for the response.</returns>
         [NonAction]
-        public virtual ViewComponentResult ViewComponent(string componentName, params object[] arguments)
+        public virtual ViewComponentResult ViewComponent(string componentName, object arguments)
         {
-            return new ViewComponentResult()
+            return new ViewComponentResult
             {
                 ViewComponentName = componentName,
                 Arguments = arguments,
@@ -235,12 +239,16 @@ namespace Microsoft.AspNetCore.Mvc
         /// render.
         /// </summary>
         /// <param name="componentType">The view component <see cref="Type"/>.</param>
-        /// <param name="arguments">The arguments to pass to the view component.</param>
+        /// <param name="arguments">
+        /// An anonymous <see cref="object"/> containing arguments to be passed to the invoked view component method.
+        /// Alternatively, an <see cref="System.Collections.Generic.IDictionary{string, object}"/> instance containing
+        /// the invocation arguments.
+        /// </param>
         /// <returns>The created <see cref="ViewComponentResult"/> object for the response.</returns>
         [NonAction]
-        public virtual ViewComponentResult ViewComponent(Type componentType, params object[] arguments)
+        public virtual ViewComponentResult ViewComponent(Type componentType, object arguments)
         {
-            return new ViewComponentResult()
+            return new ViewComponentResult
             {
                 ViewComponentType = componentType,
                 Arguments = arguments,

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/IViewComponentHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/IViewComponentHelper.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Mvc
         /// </summary>
         /// <param name="name">The name of the view component.</param>
         /// <param name="arguments">
-        /// An <see cref="object"/> containing arguments to be passed to the invoked view component method.
+        /// An anonymous <see cref="object"/> containing arguments to be passed to the invoked view component method.
         /// Alternatively, an <see cref="System.Collections.Generic.IDictionary{string, object}"/> instance containing
         /// the invocation arguments.
         /// </param>
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Mvc
         /// </summary>
         /// <param name="componentType">The view component <see cref="Type"/>.</param>
         /// <param name="arguments">
-        /// An <see cref="object"/> containing arguments to be passed to the invoked view component method.
+        /// An anonymous <see cref="object"/> containing arguments to be passed to the invoked view component method.
         /// Alternatively, an <see cref="System.Collections.Generic.IDictionary{string, object}"/> instance containing
         /// the invocation arguments.
         /// </param>

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/BasicTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/BasicTests.cs
@@ -30,6 +30,30 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
         public HttpClient Client { get; }
 
+        [Fact]
+        public async Task CanRender_ViewComponentWithArgumentsFromController()
+        {
+            // Arrange
+            var expectedMediaType = MediaTypeHeaderValue.Parse("text/html; charset=utf-8");
+            var outputFile = "compiler/resources/BasicWebSite.PassThrough.Index.html";
+            var expectedContent =
+                await ResourceFile.ReadResourceAsync(_resourcesAssembly, outputFile, sourceFile: false);
+
+            // Act
+            var response = await Client.GetAsync("PassThrough/Index?value=123");
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(expectedMediaType, response.Content.Headers.ContentType);
+
+#if GENERATE_BASELINES
+            ResourceFile.UpdateFile(_resourcesAssembly, outputFile, expectedContent, responseContent);
+#else
+            Assert.Equal(expectedContent, responseContent, ignoreLineEndingDifferences: true);
+#endif
+        }
+
         [Theory]
         [InlineData("")]
         [InlineData("Home")]

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/BasicWebSite.PassThrough.Index.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/BasicWebSite.PassThrough.Index.html
@@ -1,0 +1,1 @@
+<p>The passed through value was: 123</p>

--- a/test/WebSites/BasicWebSite/Components/PassThroughViewComponent.cs
+++ b/test/WebSites/BasicWebSite/Components/PassThroughViewComponent.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace HtmlGenerationWebSite.Components
+{
+    public class PassThroughViewComponent : ViewComponent
+    {
+        public IViewComponentResult Invoke(long value)
+        {
+            return View(value);
+        }
+    }
+}

--- a/test/WebSites/BasicWebSite/Controllers/PassThroughController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/PassThroughController.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using HtmlGenerationWebSite.Components;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BasicWebSite.Controllers
+{
+    public class PassThroughController : Controller
+    {
+        public IActionResult Index(long value)
+        {
+            return ViewComponent(typeof(PassThroughViewComponent), new { value });
+        }
+    }
+}

--- a/test/WebSites/BasicWebSite/Views/Shared/Components/PassThrough/Default.cshtml
+++ b/test/WebSites/BasicWebSite/Views/Shared/Components/PassThrough/Default.cshtml
@@ -1,0 +1,3 @@
+﻿@model long
+
+<p>The passed through value was: @Model</p>


### PR DESCRIPTION
- This bit was missed when changing the `ViewComponent` invocation pattern resulting in the inability to invoke `ViewComponent`s with arguments in a `Controller`.

#4004