### PR TITLE
Make GetSupportedContentTypes on InputFormatter virtual

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Formatters/InputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Formatters/InputFormatter.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         public abstract Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context);
 
         /// <inheritdoc />
-        public IReadOnlyList<string> GetSupportedContentTypes(string contentType, Type objectType)
+        public virtual IReadOnlyList<string> GetSupportedContentTypes(string contentType, Type objectType)
         {
             if (!CanReadType(objectType))
             {


### PR DESCRIPTION
Spoke with @rynowak this was just an oversight during the previous implementation