### PR TITLE
ModelStateDictionary StartsWithPrefix efficiencies

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelStateDictionary.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelStateDictionary.cs
@@ -681,6 +681,12 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 throw new ArgumentNullException(nameof(key));
             }
 
+            if (prefix.Length == 0)
+            {
+                // Everything is prefixed by the empty string
+                return true;
+            }
+
             if (key.Length < prefix.Length)
             {
                 return false;
@@ -688,7 +694,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 
             if (!key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
             {
-                if (key.StartsWith("[", StringComparison.OrdinalIgnoreCase))
+                if (key[0] == '[')
                 {
                     var subKey = key.Substring(key.IndexOf('.') + 1);
 
@@ -696,9 +702,9 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                     {
                         return false;
                     }
-
-                    if (string.Equals(prefix, subKey, StringComparison.OrdinalIgnoreCase))
+                    else if (prefix.Length == subKey.Length)
                     {
+                        // prefix == subKey
                         return true;
                     }
 
@@ -711,23 +717,16 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             }
             else if (key.Length == prefix.Length)
             {
+                // key == prefix
                 return true;
             }
 
-            // Everything is prefixed by the empty string
-            if (prefix.Length == 0)
+            var charAfterPrefix = key[prefix.Length];
+            switch (charAfterPrefix)
             {
-                return true;
-            }
-            else
-            {
-                var charAfterPrefix = key[prefix.Length];
-                switch (charAfterPrefix)
-                {
-                    case '[':
-                    case '.':
-                        return true;
-                }
+                case '[':
+                case '.':
+                    return true;
             }
 
             return false;

--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelStateDictionary.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelStateDictionary.cs
@@ -681,12 +681,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 throw new ArgumentNullException(nameof(key));
             }
 
-            if (StringComparer.OrdinalIgnoreCase.Equals(key, prefix))
-            {
-                return true;
-            }
-
-            if (key.Length <= prefix.Length)
+            if (key.Length < prefix.Length)
             {
                 return false;
             }
@@ -713,6 +708,10 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 {
                     return false;
                 }
+            }
+            else if (key.Length == prefix.Length)
+            {
+                return true;
             }
 
             // Everything is prefixed by the empty string

--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelStateDictionary.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelStateDictionary.cs
@@ -692,23 +692,22 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 return false;
             }
 
+            var subKeyIndex = 0;
             if (!key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
             {
                 if (key[0] == '[')
                 {
-                    var subKey = key.Substring(key.IndexOf('.') + 1);
+                    subKeyIndex = key.IndexOf('.') + 1;
 
-                    if (!subKey.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    if (string.Compare(key, subKeyIndex, prefix, 0, prefix.Length, StringComparison.OrdinalIgnoreCase) != 0)
                     {
                         return false;
                     }
-                    else if (prefix.Length == subKey.Length)
+                    else if (prefix.Length == (key.Length - subKeyIndex))
                     {
                         // prefix == subKey
                         return true;
                     }
-
-                    key = subKey;
                 }
                 else
                 {
@@ -721,7 +720,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 return true;
             }
 
-            var charAfterPrefix = key[prefix.Length];
+            var charAfterPrefix = key[subKeyIndex + prefix.Length];
             switch (charAfterPrefix)
             {
                 case '[':


### PR DESCRIPTION
Looking at your hot functions in #4066 top one is StartsWithPrefix

Currently it first does a string equals OrdinalIgnoreCase; then if not found does a StartsWith test.

String equals will only match one entry; so doing it for every entry then doing StartsWith is unnecessary.

/cc @rynowak 