### PR TITLE
Fix behavior of StartsWithPrefix

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelStateDictionary.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelStateDictionary.cs
@@ -683,49 +683,30 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 
             if (prefix.Length == 0)
             {
-                // Everything is prefixed by the empty string
+                // Everything is prefixed by the empty string.
                 return true;
             }
 
-            if (key.Length < prefix.Length)
+            if (prefix.Length > key.Length)
+            {
+                return false; // Not long enough.
+            }
+
+            if (!key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }
-
-            var subKeyIndex = 0;
-            if (!key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            
+            if (key.Length == prefix.Length)
             {
-                if (key[0] == '[')
-                {
-                    subKeyIndex = key.IndexOf('.') + 1;
-
-                    if (string.Compare(key, subKeyIndex, prefix, 0, prefix.Length, StringComparison.OrdinalIgnoreCase) != 0)
-                    {
-                        return false;
-                    }
-                    else if (prefix.Length == (key.Length - subKeyIndex))
-                    {
-                        // prefix == subKey
-                        return true;
-                    }
-                }
-                else
-                {
-                    return false;
-                }
-            }
-            else if (key.Length == prefix.Length)
-            {
-                // key == prefix
+                // Exact match
                 return true;
             }
 
-            var charAfterPrefix = key[subKeyIndex + prefix.Length];
-            switch (charAfterPrefix)
+            var charAfterPrefix = key[prefix.Length];
+            if (charAfterPrefix == '.' || charAfterPrefix == '[')
             {
-                case '[':
-                case '.':
-                    return true;
+                return true;
             }
 
             return false;

--- a/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
@@ -1429,21 +1429,12 @@ namespace Microsoft.AspNetCore.Mvc
             {
                 throw new ArgumentNullException(nameof(model));
             }
-
-            var modelName = prefix ?? string.Empty;
-
-            // Clear ModelStateDictionary entries for the model so that it will be re-validated.
-            ModelBindingHelper.ClearValidationStateForModel(
-                model.GetType(),
-                ModelState,
-                MetadataProvider,
-                modelName);
-
+            
             ObjectValidator.Validate(
                 ControllerContext,
                 new CompositeModelValidatorProvider(ControllerContext.ValidatorProviders),
                 validationState: null,
-                prefix: prefix,
+                prefix: prefix ?? string.Empty,
                 model: model);
             return ModelState.IsValid;
         }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ElementalValueProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ElementalValueProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
         public bool ContainsPrefix(string prefix)
         {
-            return PrefixContainer.IsPrefixMatch(prefix, Key);
+            return ModelStateDictionary.StartsWithPrefix(prefix, Key);
         }
 
         public ValueProviderResult GetValue(string key)

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/PrefixContainer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/PrefixContainer.cs
@@ -173,45 +173,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             }
         }
 
-        public static bool IsPrefixMatch(string prefix, string testString)
-        {
-            if (testString == null)
-            {
-                return false;
-            }
-
-            if (prefix.Length == 0)
-            {
-                return true; // shortcut - non-null testString matches empty prefix
-            }
-
-            if (prefix.Length > testString.Length)
-            {
-                return false; // not long enough
-            }
-
-            if (!testString.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-            {
-                return false; // prefix doesn't match
-            }
-
-            if (testString.Length == prefix.Length)
-            {
-                return true; // exact match
-            }
-
-            // invariant: testString.Length > prefix.Length
-            switch (testString[prefix.Length])
-            {
-                case '.':
-                case '[':
-                    return true; // known delimiters
-
-                default:
-                    return false; // not known delimiter
-            }
-        }
-
+        // This is tightly coupled to the definition at ModelStateDictionary.StartsWithPrefix
         private int BinarySearch(string prefix)
         {
             var start = 0;

--- a/test/Microsoft.AspNetCore.Mvc.Abstractions.Test/ModelBinding/ModelStateDictionaryTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Abstractions.Test/ModelBinding/ModelStateDictionaryTest.cs
@@ -245,8 +245,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         [Theory]
         [InlineData("foo")]
         [InlineData("foo.bar")]
-        [InlineData("[0].foo.bar")]
-        [InlineData("[0].foo.bar[0]")]
+        [InlineData("foo[bar]")]
         public void GetFieldValidationState_ReturnsInvalidIfKeyChildContainsErrors(string key)
         {
             // Arrange
@@ -263,8 +262,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         [Theory]
         [InlineData("foo")]
         [InlineData("foo.bar")]
-        [InlineData("[0].foo.bar")]
-        [InlineData("[0].foo.bar[0]")]
+        [InlineData("foo[bar]")]
         public void GetFieldValidationState_ReturnsValidIfModelStateDoesNotContainErrors(string key)
         {
             // Arrange
@@ -505,9 +503,9 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         }
 
         [Theory]
+        [InlineData("")]
         [InlineData("user")]
         [InlineData("user.Age")]
-        [InlineData("product")]
         public void GetFieldValidity_ReturnsInvalid_IfAllKeysAreValidatedAndAnyEntryIsInvalid(string key)
         {
             // Arrange
@@ -515,9 +513,26 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             dictionary["user.Address"] = new ModelStateEntry { ValidationState = ModelValidationState.Valid };
             dictionary["user.Name"] = new ModelStateEntry { ValidationState = ModelValidationState.Valid };
             dictionary.AddModelError("user.Age", "Age is not a valid int");
+
+            // Act
+            var validationState = dictionary.GetFieldValidationState(key);
+
+            // Assert
+            Assert.Equal(ModelValidationState.Invalid, validationState);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("[0]")]
+        [InlineData("[0].product")]
+        public void GetFieldValidity_ReturnsInvalid_IfAllKeysAreValidatedAndAnyEntryIsInvalid_Collection(string key)
+        {
+            // Arrange
+            var dictionary = new ModelStateDictionary();
+
             dictionary["[0].product.Name"] = new ModelStateEntry { ValidationState = ModelValidationState.Valid };
             dictionary["[0].product.Age[0]"] = new ModelStateEntry { ValidationState = ModelValidationState.Valid };
-            dictionary.AddModelError("[1].product.Name", "Name is invalid");
+            dictionary.AddModelError("[0].product.Name", "Name is invalid");
 
             // Act
             var validationState = dictionary.GetFieldValidationState(key);

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/SimpleValueProvider.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/SimpleValueProvider.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using Microsoft.AspNetCore.Mvc.Internal;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding.Test
 {
@@ -27,7 +26,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Test
         {
             foreach (string key in Keys)
             {
-                if (PrefixContainer.IsPrefixMatch(prefix, key))
+                if (ModelStateDictionary.StartsWithPrefix(prefix, key))
                 {
                     return true;
                 }


### PR DESCRIPTION
This undoes a behavior change introduced in
7b18d1d3f1f04ba8952b13fd2b0f903e684bf78d.

The intent was to have ClearValidationState do the right thing for a case
where a collection was bound to the empty prefix, and then used again with
TryUpdateModel.

This change was implemented by saying that a key like "[0].Foo" is a match
for the prefix of "Foo". This isn't really right, and it's only
interesting for the ClearValidationState case.

The problem is that we don't know what the keys look like for a
collection. We can assume that they start with [0] but that's not really a
guarantee, it's a guess.

This change fixes the behavior of StartsWithModel, and move the
responsibility for this case back into ClearValidationState.