### PR TITLE
Update TagBuilder to support valueless attributes.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/TagBuilder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/TagBuilder.cs
@@ -204,9 +204,12 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
 
                     writer.Write(" ");
                     writer.Write(key);
-                    writer.Write("=\"");
-                    encoder.Encode(writer, attribute.Value);
-                    writer.Write("\"");
+                    if (attribute.Value != null)
+                    {
+                        writer.Write("=\"");
+                        encoder.Encode(writer, attribute.Value);
+                        writer.Write("\"");
+                    }
                 }
             }
         }


### PR DESCRIPTION
Ref. #4078 

This change makes it possible to add valueless attributes. For instance, the async attribute: <script src="..." async>

Attributes can now be rendered in the three ways, specified by w3c: http://www.w3.org/TR/html5/infrastructure.html#boolean-attribute
