### PR TITLE
[Fixes #4112 #4093] Adding support for custom SSL port

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs
@@ -127,5 +127,11 @@ namespace Microsoft.AspNetCore.Mvc
         /// Gets a list of <see cref="IValueProviderFactory"/> used by this application.
         /// </summary>
         public IList<IValueProviderFactory> ValueProviderFactories { get; }
+
+        /// <summary>
+        /// Gets or sets the SSL port that is used by this application when <see cref="RequireHttpsAttribute"/>
+        /// is used. If not set the port won't be specified in the secured URL e.g. https://localhost/path.
+        /// </summary>
+        public int? SslPort { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/RequireHttpsAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RequireHttpsAttribute.cs
@@ -4,6 +4,8 @@
 using System;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Mvc
 {
@@ -35,10 +37,25 @@ namespace Microsoft.AspNetCore.Mvc
             }
             else
             {
+                var optionsAccessor = filterContext.HttpContext.RequestServices.GetRequiredService<IOptions<MvcOptions>>();
+
                 var request = filterContext.HttpContext.Request;
+
+                var host = request.Host;
+                if (optionsAccessor.Value.SslPort.HasValue && optionsAccessor.Value.SslPort > 0)
+                {
+                    // a specific SSL port is specified
+                    host = new HostString(host.Host, optionsAccessor.Value.SslPort.Value);
+                }
+                else
+                {
+                    // clear the port
+                    host = new HostString(host.Host);
+                }
+                
                 var newUrl = string.Concat(
                     "https://",
-                    request.Host.ToUriComponent(),
+                    host.ToUriComponent(),
                     request.PathBase.ToUriComponent(),
                     request.Path.ToUriComponent(),
                     request.QueryString.ToUriComponent());


### PR DESCRIPTION
New optional MvcOptions.SslPort. If not defined the redirection uses an empty port (default),
otherwise the custom port is used.