### PR TITLE
[Perf] One UrlHelper per context and pool StringBuilders used by it

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/LocalRedirectResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/LocalRedirectResultTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Routing;
@@ -120,6 +121,8 @@ namespace Microsoft.AspNetCore.Mvc
                        .Returns(response);
             httpContext.SetupGet(o => o.RequestServices)
                        .Returns(serviceProvider);
+            httpContext.SetupGet(o => o.Items)
+                       .Returns(new ItemsDictionary());
             httpContext.Setup(o => o.Request.PathBase)
                        .Returns(new PathString(appRoot));
 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/RedirectResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/RedirectResultTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Routing;
@@ -128,6 +129,8 @@ namespace Microsoft.AspNetCore.Mvc
                        .Returns(response);
             httpContext.SetupGet(o => o.RequestServices)
                        .Returns(serviceProvider);
+            httpContext.SetupGet(o => o.Items)
+                       .Returns(new ItemsDictionary());
             httpContext.Setup(o => o.Request.PathBase)
                        .Returns(new PathString(appRoot));
 


### PR DESCRIPTION
I modified https://github.com/aspnet/Performance/blob/dev/testapp/BasicViews/Views/TagHelpers/Index.cshtml 
 to contain 6 action Links with href generated by TagHelpers. 
 And the loadtest is executed with the following settings
 loadtest -k -n 3000 --rps 100 

The total objects(StringBuilder, char[] and UrlHelper)  saved is 2% and bytes saved is 1.5%