### PR TITLE
Correct `Type.IsAssignableFrom()` polarity

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/DictionaryModelBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/DictionaryModelBinder.cs
@@ -113,10 +113,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 return collection.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
             }
 
-            var newCollection = CreateInstance(targetType);
-            CopyToModel(newCollection, collection);
-
-            return newCollection;
+            return base.ConvertToCollectionType(targetType, collection);
         }
 
         /// <inheritdoc />
@@ -128,7 +125,18 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 return new Dictionary<TKey, TValue>();
             }
 
-            return CreateInstance(targetType);
+            return base.CreateEmptyCollection(targetType);
+        }
+
+        public override bool CanCreateInstance(Type targetType)
+        {
+            if (targetType.IsAssignableFrom(typeof(Dictionary<TKey, TValue>)))
+            {
+                // Simple case such as IDictionary<TKey, TValue>.
+                return true;
+            }
+
+            return base.CanCreateInstance(targetType);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/FormFileModelBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/FormFileModelBinder.cs
@@ -30,8 +30,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             }
 
             // This method is optimized to use cached tasks when possible and avoid allocating
-            // using Task.FromResult. If you need to make changes of this nature, profile
-            // allocations afterwards and look for Task<ModelBindingResult>.
+            // using Task.FromResult or async state machines.
 
             var modelType = bindingContext.ModelType;
             if (modelType != typeof(IFormFile) && !typeof(IEnumerable<IFormFile>).IsAssignableFrom(modelType))
@@ -57,7 +56,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             }
             else
             {
-                postedFiles = ModelBindingHelper.GetCompatibleCollection<IFormFile>(bindingContext, capacity: null);
+                postedFiles = ModelBindingHelper.GetCompatibleCollection<IFormFile>(bindingContext);
                 if (postedFiles == null)
                 {
                     // Silently fail and stop other model binders running if unable to activate an instance.

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/HeaderModelBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/HeaderModelBinder.cs
@@ -26,8 +26,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             }
 
             // This method is optimized to use cached tasks when possible and avoid allocating
-            // using Task.FromResult. If you need to make changes of this nature, profile
-            // allocations afterwards and look for Task<ModelBindingResult>.
+            // using Task.FromResult or async state machines.
 
             var allowedBindingSource = bindingContext.BindingSource;
             if (allowedBindingSource == null ||
@@ -48,8 +47,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             {
                 if (bindingContext.ModelType == typeof(string))
                 {
-                    string value = request.Headers[headerName];
-                    model = value;
+                    var value = request.Headers[headerName];
+                    model = (string)value;
                 }
                 else
                 {

--- a/src/Microsoft.AspNetCore.Mvc.Razor/RazorPageActivator.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/RazorPageActivator.cs
@@ -110,10 +110,16 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             Func<ViewContext, object> valueAccessor;
             if (typeof(ViewDataDictionary).IsAssignableFrom(property.PropertyType))
             {
+                // Logic looks reversed in condition above but is OK. Support only properties of base
+                // ViewDataDictionary type and activationInfo.ViewDataDictionaryType. VDD<AnotherType> will fail when
+                // assigning to the property (InvalidCastException) and that's fine.
                 valueAccessor = context => context.ViewData;
             }
-            else if (typeof(IUrlHelper).IsAssignableFrom(property.PropertyType))
+            else if (property.PropertyType == typeof(IUrlHelper))
             {
+                // W.r.t. specificity of above condition: Users are much more likely to inject their own
+                // IUrlHelperFactory than to create a class implementing IUrlHelper (or a sub-interface) and inject
+                // that. But the second scenario is supported. (Note the class must implement ICanHasViewContext.)
                 valueAccessor = context =>
                 {
                     var serviceProvider = context.HttpContext.RequestServices;

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/DefaultViewComponentDescriptorProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/DefaultViewComponentDescriptorProvider.cs
@@ -115,13 +115,14 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
             }
             else
             {
+                // Will invoke synchronously. Method must not return void, Task or Task<T>.
                 if (selectedMethod.ReturnType == typeof(void))
                 {
                     throw new InvalidOperationException(Resources.FormatViewComponent_SyncMethod_ShouldReturnValue(
                         SyncMethodName,
                         componentName));
                 }
-                else if (selectedMethod.ReturnType.IsAssignableFrom(typeof(Task)))
+                else if (typeof(Task).IsAssignableFrom(selectedMethod.ReturnType))
                 {
                     throw new InvalidOperationException(Resources.FormatViewComponent_SyncMethod_CannotReturnTask(
                         SyncMethodName,

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/CollectionModelBinderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/CollectionModelBinderTest.cs
@@ -317,8 +317,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                     { typeof(List<int>), true },
                     { typeof(LinkedList<int>), true },
                     { typeof(ISet<int>), false },
-                    { typeof(ListWithInternalConstructor<int>), false },
-                    { typeof(ListWithThrowingConstructor<int>), false },
                 };
             }
         }
@@ -445,23 +443,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             public int Id { get; set; }
 
             public string Name { get; set; }
-        }
-
-        private class ListWithInternalConstructor<T> : List<T>
-        {
-            internal ListWithInternalConstructor()
-                : base()
-            {
-            }
-        }
-
-        private class ListWithThrowingConstructor<T> : List<T>
-        {
-            public ListWithThrowingConstructor()
-                : base()
-            {
-                throw new RankException("No, don't do this.");
-            }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/DictionaryModelBinderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/DictionaryModelBinderTest.cs
@@ -388,9 +388,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Test
                     { typeof(IDictionary<int, int>), true },
                     { typeof(Dictionary<int, int>), true },
                     { typeof(SortedDictionary<int, int>), true },
-                    { typeof(IList<KeyValuePair<int, int>>), false },
-                    { typeof(DictionaryWithInternalConstructor<int, int>), false },
-                    { typeof(DictionaryWithThrowingConstructor<int, int>), false },
+                    { typeof(IList<KeyValuePair<int, int>>), true },
+                    { typeof(ISet<KeyValuePair<int, int>>), false },
                 };
             }
         }
@@ -552,23 +551,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Test
             public override string ToString()
             {
                 return $"{{{ Id }, '{ Name }'}}";
-            }
-        }
-
-        private class DictionaryWithInternalConstructor<TKey, TValue> : Dictionary<TKey, TValue>
-        {
-            internal DictionaryWithInternalConstructor()
-                : base()
-            {
-            }
-        }
-
-        private class DictionaryWithThrowingConstructor<TKey, TValue> : Dictionary<TKey, TValue>
-        {
-            public DictionaryWithThrowingConstructor()
-                : base()
-            {
-                throw new RankException("No, don't do this.");
             }
         }
     }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/FormFileModelBinderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/FormFileModelBinderTest.cs
@@ -248,17 +248,14 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             Assert.Null(result.Model);
         }
 
-        [Theory]
-        [InlineData(typeof(ISet<IFormFile>))]
-        [InlineData(typeof(ListWithInternalConstructor<IFormFile>))]
-        [InlineData(typeof(ListWithThrowingConstructor<IFormFile>))]
-        public async Task FormFileModelBinder_ReturnsFailedResult_ForCollectionsItCannotCreate(Type destinationType)
+        [Fact]
+        public async Task FormFileModelBinder_ReturnsFailedResult_ForCollectionsItCannotCreate()
         {
             // Arrange
             var binder = new FormFileModelBinder();
             var formFiles = GetTwoFiles();
             var httpContext = GetMockHttpContext(GetMockFormCollection(formFiles));
-            var bindingContext = GetBindingContext(destinationType, httpContext);
+            var bindingContext = GetBindingContext(typeof(ISet<IFormFile>), httpContext);
 
             // Act
             var result = await binder.BindModelResultAsync(bindingContext);
@@ -358,23 +355,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 
         private class FileList : List<IFormFile>
         {
-        }
-
-        private class ListWithInternalConstructor<T> : List<T>
-        {
-            internal ListWithInternalConstructor()
-                : base()
-            {
-            }
-        }
-
-        private class ListWithThrowingConstructor<T> : List<T>
-        {
-            public ListWithThrowingConstructor()
-                : base()
-            {
-                throw new RankException("No, don't do this.");
-            }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/FormFileModelBinderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/FormFileModelBinderTest.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
-using Microsoft.Net.Http.Headers;
 using Moq;
 using Xunit;
 
@@ -43,9 +42,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         public async Task FormFileModelBinder_ExpectMultipleFiles_BindSuccessful()
         {
             // Arrange
-            var formFiles = new FormFileCollection();
-            formFiles.Add(GetMockFormFile("file", "file1.txt"));
-            formFiles.Add(GetMockFormFile("file", "file2.txt"));
+            var formFiles = GetTwoFiles();
             var httpContext = GetMockHttpContext(GetMockFormCollection(formFiles));
             var bindingContext = GetBindingContext(typeof(IEnumerable<IFormFile>), httpContext);
             var binder = new FormFileModelBinder();
@@ -66,13 +63,38 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             Assert.Equal(2, files.Count);
         }
 
+        [Theory]
+        [InlineData(typeof(IFormFile[]))]
+        [InlineData(typeof(ICollection<IFormFile>))]
+        [InlineData(typeof(IList<IFormFile>))]
+        [InlineData(typeof(IFormFileCollection))]
+        [InlineData(typeof(List<IFormFile>))]
+        [InlineData(typeof(LinkedList<IFormFile>))]
+        [InlineData(typeof(FileList))]
+        [InlineData(typeof(FormFileCollection))]
+        public async Task FormFileModelBinder_BindsFiles_ForCollectionsItCanCreate(Type destinationType)
+        {
+            // Arrange
+            var binder = new FormFileModelBinder();
+            var formFiles = GetTwoFiles();
+            var httpContext = GetMockHttpContext(GetMockFormCollection(formFiles));
+            var bindingContext = GetBindingContext(destinationType, httpContext);
+
+            // Act
+            var result = await binder.BindModelResultAsync(bindingContext);
+
+            // Assert
+            Assert.NotEqual(default(ModelBindingResult), result);
+            Assert.True(result.IsModelSet);
+            Assert.IsAssignableFrom(destinationType, result.Model);
+            Assert.Equal(formFiles, result.Model as IEnumerable<IFormFile>);
+        }
+
         [Fact]
         public async Task FormFileModelBinder_ExpectSingleFile_BindFirstFile()
         {
             // Arrange
-            var formFiles = new FormFileCollection();
-            formFiles.Add(GetMockFormFile("file", "file1.txt"));
-            formFiles.Add(GetMockFormFile("file", "file2.txt"));
+            var formFiles = GetTwoFiles();
             var httpContext = GetMockHttpContext(GetMockFormCollection(formFiles));
             var bindingContext = GetBindingContext(typeof(IFormFile), httpContext);
             var binder = new FormFileModelBinder();
@@ -86,8 +108,26 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             Assert.Equal("file1.txt", file.FileName);
         }
 
+        [Theory]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(IEnumerable<string>))]
+        public async Task FormFileModelBinder_ReturnsNothing_ForUnsupportedDestinationTypes(Type destinationType)
+        {
+            // Arrange
+            var formFiles = GetTwoFiles();
+            var httpContext = GetMockHttpContext(GetMockFormCollection(formFiles));
+            var bindingContext = GetBindingContext(destinationType, httpContext);
+            var binder = new FormFileModelBinder();
+
+            // Act
+            var result = await binder.BindModelResultAsync(bindingContext);
+
+            // Assert
+            Assert.Equal(default(ModelBindingResult), result);
+        }
+
         [Fact]
-        public async Task FormFileModelBinder_ReturnsNothing_WhenNoFilePosted()
+        public async Task FormFileModelBinder_ReturnsFailedResult_WhenNoFilePosted()
         {
             // Arrange
             var formFiles = new FormFileCollection();
@@ -100,11 +140,12 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 
             // Assert
             Assert.NotEqual(default(ModelBindingResult), result);
+            Assert.False(result.IsModelSet);
             Assert.Null(result.Model);
         }
 
         [Fact]
-        public async Task FormFileModelBinder_ReturnsNothing_WhenNamesDontMatch()
+        public async Task FormFileModelBinder_ReturnsFailedResult_WhenNamesDoNotMatch()
         {
             // Arrange
             var formFiles = new FormFileCollection();
@@ -118,6 +159,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 
             // Assert
             Assert.NotEqual(default(ModelBindingResult), result);
+            Assert.False(result.IsModelSet);
             Assert.Null(result.Model);
         }
 
@@ -151,7 +193,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         }
 
         [Fact]
-        public async Task FormFileModelBinder_ReturnsNothing_WithEmptyContentDisposition()
+        public async Task FormFileModelBinder_ReturnsFailedResult_WithEmptyContentDisposition()
         {
             // Arrange
             var formFiles = new FormFileCollection();
@@ -165,11 +207,12 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 
             // Assert
             Assert.NotEqual(default(ModelBindingResult), result);
+            Assert.False(result.IsModelSet);
             Assert.Null(result.Model);
         }
 
         [Fact]
-        public async Task FormFileModelBinder_ReturnsNothing_WithNoFileNameAndZeroLength()
+        public async Task FormFileModelBinder_ReturnsFailedResult_WithNoFileNameAndZeroLength()
         {
             // Arrange
             var formFiles = new FormFileCollection();
@@ -183,15 +226,78 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 
             // Assert
             Assert.NotEqual(default(ModelBindingResult), result);
+            Assert.False(result.IsModelSet);
             Assert.Null(result.Model);
+        }
+
+        [Fact]
+        public async Task FormFileModelBinder_ReturnsFailedResult_ForReadOnlyDestination()
+        {
+            // Arrange
+            var binder = new FormFileModelBinder();
+            var formFiles = GetTwoFiles();
+            var httpContext = GetMockHttpContext(GetMockFormCollection(formFiles));
+            var bindingContext = GetBindingContextForReadOnlyArray(httpContext);
+
+            // Act
+            var result = await binder.BindModelResultAsync(bindingContext);
+
+            // Assert
+            Assert.NotEqual(default(ModelBindingResult), result);
+            Assert.False(result.IsModelSet);
+            Assert.Null(result.Model);
+        }
+
+        [Theory]
+        [InlineData(typeof(ISet<IFormFile>))]
+        [InlineData(typeof(ListWithInternalConstructor<IFormFile>))]
+        [InlineData(typeof(ListWithThrowingConstructor<IFormFile>))]
+        public async Task FormFileModelBinder_ReturnsFailedResult_ForCollectionsItCannotCreate(Type destinationType)
+        {
+            // Arrange
+            var binder = new FormFileModelBinder();
+            var formFiles = GetTwoFiles();
+            var httpContext = GetMockHttpContext(GetMockFormCollection(formFiles));
+            var bindingContext = GetBindingContext(destinationType, httpContext);
+
+            // Act
+            var result = await binder.BindModelResultAsync(bindingContext);
+
+            // Assert
+            Assert.NotEqual(default(ModelBindingResult), result);
+            Assert.False(result.IsModelSet);
+            Assert.Null(result.Model);
+        }
+
+        private static DefaultModelBindingContext GetBindingContextForReadOnlyArray(HttpContext httpContext)
+        {
+            var metadataProvider = new TestModelMetadataProvider();
+            metadataProvider
+                .ForProperty<ModelWithReadOnlyArray>(nameof(ModelWithReadOnlyArray.ArrayProperty))
+                .BindingDetails(bd => bd.BindingSource = BindingSource.Header);
+            var modelMetadata = metadataProvider.GetMetadataForProperty(
+                typeof(ModelWithReadOnlyArray),
+                nameof(ModelWithReadOnlyArray.ArrayProperty));
+
+            return GetBindingContext(metadataProvider, modelMetadata, httpContext);
         }
 
         private static DefaultModelBindingContext GetBindingContext(Type modelType, HttpContext httpContext)
         {
             var metadataProvider = new EmptyModelMetadataProvider();
+            var metadata = metadataProvider.GetMetadataForType(modelType);
+
+            return GetBindingContext(metadataProvider, metadata, httpContext);
+        }
+
+        private static DefaultModelBindingContext GetBindingContext(
+            IModelMetadataProvider metadataProvider,
+            ModelMetadata metadata,
+            HttpContext httpContext)
+        {
             var bindingContext = new DefaultModelBindingContext
             {
-                ModelMetadata = metadataProvider.GetMetadataForType(modelType),
+                ModelMetadata = metadata,
                 ModelName = "file",
                 ModelState = new ModelStateDictionary(),
                 OperationBindingContext = new OperationBindingContext
@@ -218,6 +324,17 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             return httpContext.Object;
         }
 
+        private static FormFileCollection GetTwoFiles()
+        {
+            var formFiles = new FormFileCollection
+            {
+                GetMockFormFile("file", "file1.txt"),
+                GetMockFormFile("file", "file2.txt"),
+            };
+
+            return formFiles;
+        }
+
         private static IFormCollection GetMockFormCollection(FormFileCollection formFiles)
         {
             var formCollection = new Mock<IFormCollection>();
@@ -232,6 +349,32 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             formFile.Setup(f => f.FileName).Returns(filename);
 
             return formFile.Object;
+        }
+
+        private class ModelWithReadOnlyArray
+        {
+            public IFormFile[] ArrayProperty { get; }
+        }
+
+        private class FileList : List<IFormFile>
+        {
+        }
+
+        private class ListWithInternalConstructor<T> : List<T>
+        {
+            internal ListWithInternalConstructor()
+                : base()
+            {
+            }
+        }
+
+        private class ListWithThrowingConstructor<T> : List<T>
+        {
+            public ListWithThrowingConstructor()
+                : base()
+            {
+                throw new RankException("No, don't do this.");
+            }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/HeaderModelBinderTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/HeaderModelBinderTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http.Internal;
 using Xunit;
@@ -72,6 +73,34 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Test
             Assert.Equal(headerValue, result.Model);
         }
 
+        [Theory]
+        [InlineData(typeof(IEnumerable<string>))]
+        [InlineData(typeof(ICollection<string>))]
+        [InlineData(typeof(IList<string>))]
+        [InlineData(typeof(List<string>))]
+        [InlineData(typeof(LinkedList<string>))]
+        [InlineData(typeof(StringList))]
+        public async Task HeaderBinder_BindsHeaders_ForCollectionsItCanCreate(Type destinationType)
+        {
+            // Arrange
+            var header = "Accept";
+            var headerValue = "application/json,text/json";
+            var binder = new HeaderModelBinder();
+            var modelBindingContext = GetBindingContext(destinationType);
+
+            modelBindingContext.FieldName = header;
+            modelBindingContext.OperationBindingContext.HttpContext.Request.Headers.Add(header, new[] { headerValue });
+
+            // Act
+            var result = await binder.BindModelResultAsync(modelBindingContext);
+
+            // Assert
+            Assert.NotEqual(default(ModelBindingResult), result);
+            Assert.True(result.IsModelSet);
+            Assert.IsAssignableFrom(destinationType, result.Model);
+            Assert.Equal(headerValue.Split(','), result.Model as IEnumerable<string>);
+        }
+
         [Fact]
         public async Task HeaderBinder_ReturnsNothing_ForNullBindingSource()
         {
@@ -116,11 +145,79 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Test
             Assert.Equal(default(ModelBindingResult), result);
         }
 
+        [Fact]
+        public async Task HeaderBinder_ReturnsFailedResult_ForReadOnlyDestination()
+        {
+            // Arrange
+            var header = "Accept";
+            var headerValue = "application/json,text/json";
+            var binder = new HeaderModelBinder();
+            var modelBindingContext = GetBindingContextForReadOnlyArray();
+
+            modelBindingContext.FieldName = header;
+            modelBindingContext.OperationBindingContext.HttpContext.Request.Headers.Add(header, new[] { headerValue });
+
+            // Act
+            var result = await binder.BindModelResultAsync(modelBindingContext);
+
+            // Assert
+            Assert.NotEqual(default(ModelBindingResult), result);
+            Assert.False(result.IsModelSet);
+            Assert.Equal("modelName", result.Key);
+            Assert.Null(result.Model);
+        }
+
+        [Theory]
+        [InlineData(typeof(ISet<string>))]
+        [InlineData(typeof(ListWithInternalConstructor<string>))]
+        [InlineData(typeof(ListWithThrowingConstructor<string>))]
+        public async Task HeaderBinder_ReturnsFailedResult_ForCollectionsItCannotCreate(Type destinationType)
+        {
+            // Arrange
+            var header = "Accept";
+            var headerValue = "application/json,text/json";
+            var binder = new HeaderModelBinder();
+            var modelBindingContext = GetBindingContext(destinationType);
+
+            modelBindingContext.FieldName = header;
+            modelBindingContext.OperationBindingContext.HttpContext.Request.Headers.Add(header, new[] { headerValue });
+
+            // Act
+            var result = await binder.BindModelResultAsync(modelBindingContext);
+
+            // Assert
+            Assert.NotEqual(default(ModelBindingResult), result);
+            Assert.False(result.IsModelSet);
+            Assert.Equal("modelName", result.Key);
+            Assert.Null(result.Model);
+        }
+
         private static DefaultModelBindingContext GetBindingContext(Type modelType)
         {
             var metadataProvider = new TestModelMetadataProvider();
             metadataProvider.ForType(modelType).BindingDetails(d => d.BindingSource = BindingSource.Header);
             var modelMetadata = metadataProvider.GetMetadataForType(modelType);
+
+            return GetBindingContext(metadataProvider, modelMetadata);
+        }
+
+        private static DefaultModelBindingContext GetBindingContextForReadOnlyArray()
+        {
+            var metadataProvider = new TestModelMetadataProvider();
+            metadataProvider
+                .ForProperty<ModelWithReadOnlyArray>(nameof(ModelWithReadOnlyArray.ArrayProperty))
+                .BindingDetails(bd => bd.BindingSource = BindingSource.Header);
+            var modelMetadata = metadataProvider.GetMetadataForProperty(
+                typeof(ModelWithReadOnlyArray),
+                nameof(ModelWithReadOnlyArray.ArrayProperty));
+
+            return GetBindingContext(metadataProvider, modelMetadata);
+        }
+
+        private static DefaultModelBindingContext GetBindingContext(
+            IModelMetadataProvider metadataProvider,
+            ModelMetadata modelMetadata)
+        {
             var bindingContext = new DefaultModelBindingContext
             {
                 ModelMetadata = modelMetadata,
@@ -141,6 +238,32 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Test
             };
 
             return bindingContext;
+        }
+
+        private class ModelWithReadOnlyArray
+        {
+            public string[] ArrayProperty { get; }
+        }
+
+        private class StringList : List<string>
+        {
+        }
+
+        private class ListWithInternalConstructor<T> : List<T>
+        {
+            internal ListWithInternalConstructor()
+                : base()
+            {
+            }
+        }
+
+        private class ListWithThrowingConstructor<T> : List<T>
+        {
+            public ListWithThrowingConstructor()
+                : base()
+            {
+                throw new RankException("No, don't do this.");
+            }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/HeaderModelBinderTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/HeaderModelBinderTests.cs
@@ -167,17 +167,14 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Test
             Assert.Null(result.Model);
         }
 
-        [Theory]
-        [InlineData(typeof(ISet<string>))]
-        [InlineData(typeof(ListWithInternalConstructor<string>))]
-        [InlineData(typeof(ListWithThrowingConstructor<string>))]
-        public async Task HeaderBinder_ReturnsFailedResult_ForCollectionsItCannotCreate(Type destinationType)
+        [Fact]
+        public async Task HeaderBinder_ReturnsFailedResult_ForCollectionsItCannotCreate()
         {
             // Arrange
             var header = "Accept";
             var headerValue = "application/json,text/json";
             var binder = new HeaderModelBinder();
-            var modelBindingContext = GetBindingContext(destinationType);
+            var modelBindingContext = GetBindingContext(typeof(ISet<string>));
 
             modelBindingContext.FieldName = header;
             modelBindingContext.OperationBindingContext.HttpContext.Request.Headers.Add(header, new[] { headerValue });
@@ -247,23 +244,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Test
 
         private class StringList : List<string>
         {
-        }
-
-        private class ListWithInternalConstructor<T> : List<T>
-        {
-            internal ListWithInternalConstructor()
-                : base()
-            {
-            }
-        }
-
-        private class ListWithThrowingConstructor<T> : List<T>
-        {
-            public ListWithThrowingConstructor()
-                : base()
-            {
-                throw new RankException("No, don't do this.");
-            }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ModelBindingHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ModelBindingHelperTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Linq.Expressions;
@@ -12,10 +13,8 @@ using Microsoft.AspNetCore.Mvc.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.DataAnnotations.Internal;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.Internal;
-using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Test;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
-using Microsoft.AspNetCore.Routing;
 using Moq;
 using Xunit;
 
@@ -1018,7 +1017,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         }
 
         [Fact]
-        public void ConvertToReturnsNullIfTrimmedValueIsEmptyString()
+        public void ConvertToReturnsNull_IfConvertingNullToArrayType()
         {
             // Arrange
 
@@ -1245,21 +1244,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         }
 
         [Fact]
-        public void ConvertToThrowsIfNoConverterExists()
-        {
-            // Arrange
-            var destinationType = typeof(MyClassWithoutConverter);
-
-            // Act & Assert
-            var ex = Assert.Throws<InvalidOperationException>(
-                () => ModelBindingHelper.ConvertTo("x", destinationType));
-            Assert.Equal("The parameter conversion from type 'System.String' to type " +
-                        $"'{typeof(MyClassWithoutConverter).FullName}' " +
-                        "failed because no type converter can convert between these types.",
-                         ex.Message);
-        }
-
-        [Fact]
         public void ConvertToUsesProvidedCulture()
         {
             // Arrange
@@ -1308,43 +1292,80 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             }
         }
 
+        // None of the types here have converters from MyClassWithoutConverter.
         [Theory]
         [InlineData(typeof(TimeSpan))]
         [InlineData(typeof(DateTime))]
         [InlineData(typeof(DateTimeOffset))]
         [InlineData(typeof(Guid))]
         [InlineData(typeof(IntEnum))]
-        public void ConvertTo_Throws_IfValueIsNotStringData(Type destinationType)
+        public void ConvertTo_Throws_IfValueIsNotConvertible(Type destinationType)
         {
             // Arrange
+            var expectedMessage = $"The parameter conversion from type '{typeof(MyClassWithoutConverter)}' to type " +
+                $"'{destinationType}' failed because no type converter can convert between these types.";
 
-            // Act
+            // Act & Assert
             var ex = Assert.Throws<InvalidOperationException>(
                 () => ModelBindingHelper.ConvertTo(new MyClassWithoutConverter(), destinationType));
-
-            // Assert
-            var expectedMessage = string.Format("The parameter conversion from type '{0}' to type '{1}' " +
-                                                "failed because no type converter can convert between these types.",
-                                                typeof(MyClassWithoutConverter), destinationType);
             Assert.Equal(expectedMessage, ex.Message);
         }
 
+        // String does not have a converter to MyClassWithoutConverter.
         [Fact]
         public void ConvertTo_Throws_IfDestinationTypeIsNotConvertible()
         {
             // Arrange
             var value = "Hello world";
             var destinationType = typeof(MyClassWithoutConverter);
+            var expectedMessage = $"The parameter conversion from type '{value.GetType()}' to type " +
+                $"'{typeof(MyClassWithoutConverter)}' failed because no type converter can convert between these types.";
 
-            // Act
+            // Act & Assert
             var ex = Assert.Throws<InvalidOperationException>(
                 () => ModelBindingHelper.ConvertTo(value, destinationType));
+            Assert.Equal(expectedMessage, ex.Message);
+        }
+
+        // Happens very rarely in practice since conversion is almost-always from strings or string arrays.
+        [Theory]
+        [InlineData(typeof(MyClassWithoutConverter))]
+        [InlineData(typeof(MySubClassWithoutConverter))]
+        public void ConvertTo_ReturnsValue_IfCompatible(Type destinationType)
+        {
+            // Arrange
+            var value = new MySubClassWithoutConverter();
+
+            // Act
+            var result = ModelBindingHelper.ConvertTo(value, destinationType);
 
             // Assert
-            var expectedMessage = string.Format("The parameter conversion from type '{0}' to type '{1}' " +
-                                                "failed because no type converter can convert between these types.",
-                                                value.GetType(), typeof(MyClassWithoutConverter));
-            Assert.Equal(expectedMessage, ex.Message);
+            Assert.Same(value, result);
+        }
+
+        [Theory]
+        [InlineData(typeof(MyClassWithoutConverter[]))]
+        [InlineData(typeof(MySubClassWithoutConverter[]))]
+        public void ConvertTo_ReusesArrayElements_IfCompatible(Type destinationType)
+        {
+            // Arrange
+            var value = new MyClassWithoutConverter[]
+            {
+                new MySubClassWithoutConverter(),
+                new MySubClassWithoutConverter(),
+                new MySubClassWithoutConverter(),
+            };
+
+            // Act
+            var result = ModelBindingHelper.ConvertTo(value, destinationType);
+
+            // Assert
+            Assert.IsType(destinationType, result);
+            Assert.Collection(
+                result as IEnumerable<MyClassWithoutConverter>,
+                element => { Assert.Same(value[0], element); },
+                element => { Assert.Same(value[1], element); },
+                element => { Assert.Same(value[2], element); });
         }
 
         [Theory]
@@ -1367,8 +1388,105 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             Assert.Equal(expected, outValue);
         }
 
+        [Theory]
+        [InlineData(typeof(IEnumerable<int>))]
+        [InlineData(typeof(IReadOnlyCollection<int>))]
+        [InlineData(typeof(IReadOnlyList<int>))]
+        [InlineData(typeof(ICollection<int>))]
+        [InlineData(typeof(IList<int>))]
+        [InlineData(typeof(List<int>))]
+        public void CreateCompatibleCollection_ReturnsList(Type destinationType)
+        {
+            // Arrange & Act
+            var result = ModelBindingHelper.CreateCompatibleCollection<int>(destinationType, capacity: null);
+
+            // Assert
+            Assert.IsType<List<int>>(result);
+        }
+
+        [Fact]
+        public void CreateCompatibleCollection_SetsCapacity()
+        {
+            // Arrange & Act
+            var result = ModelBindingHelper.CreateCompatibleCollection<int>(typeof(IList<int>), capacity: 23);
+
+            // Assert
+            var list = Assert.IsType<List<int>>(result);
+            Assert.Equal(23, list.Capacity);
+        }
+
+        [Theory]
+        [InlineData(typeof(Collection<int>))]
+        [InlineData(typeof(IntList))]
+        [InlineData(typeof(LinkedList<int>))]
+        public void CreateCompatibleCollection_ActivatesCollection(Type destinationType)
+        {
+            // Arrange & Act
+            var result = ModelBindingHelper.CreateCompatibleCollection<int>(destinationType, capacity: null);
+
+            // Assert
+            Assert.IsType(destinationType, result);
+        }
+
+        [Theory]
+        [InlineData(typeof(Collection<string>))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(List<long>))]
+        [InlineData(typeof(MyModel))]
+        public void CreateCompatibleCollection_ReturnsNull_IfDestinationTypeIsNotCompatible(Type destinationType)
+        {
+            // Arrange & Act
+            var result = ModelBindingHelper.CreateCompatibleCollection<int>(destinationType, capacity: null);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData(typeof(AbstractIntList))]
+        [InlineData(typeof(ISet<int>))]
+        [InlineData(typeof(ListWithInternalConstructor<int>))]
+        [InlineData(typeof(ListWithThrowingConstructor<int>))]
+        public void CreateCompatibleCollection_ReturnsNull_IfDestinationTypeCannotBeActivated(Type destinationType)
+        {
+            // Arrange & Act
+            var result = ModelBindingHelper.CreateCompatibleCollection<int>(destinationType, capacity: null);
+
+            // Assert (also, above statement does not throw)
+            Assert.Null(result);
+        }
+
         private class MyClassWithoutConverter
         {
+        }
+
+        private class MySubClassWithoutConverter : MyClassWithoutConverter
+        {
+        }
+
+        private abstract class AbstractIntList : List<int>
+        {
+        }
+
+        private class IntList : List<int>
+        {
+        }
+
+        private class ListWithInternalConstructor<T> : List<T>
+        {
+            internal ListWithInternalConstructor()
+                : base()
+            {
+            }
+        }
+
+        private class ListWithThrowingConstructor<T> : List<T>
+        {
+            public ListWithThrowingConstructor()
+                : base()
+            {
+                throw new RankException("No, don't do this.");
+            }
         }
 
         private enum IntEnum

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ModelBindingHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ModelBindingHelperTest.cs
@@ -1425,7 +1425,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             var bindingContext = GetBindingContext(destinationType);
 
             // Act
-            var result = ModelBindingHelper.GetCompatibleCollection<int>(bindingContext, capacity: null);
+            var result = ModelBindingHelper.GetCompatibleCollection<int>(bindingContext);
 
             // Assert
             Assert.IsType<List<int>>(result);
@@ -1441,7 +1441,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             var bindingContext = GetBindingContext(destinationType);
 
             // Act
-            var result = ModelBindingHelper.GetCompatibleCollection<int>(bindingContext, capacity: null);
+            var result = ModelBindingHelper.GetCompatibleCollection<int>(bindingContext);
 
             // Assert
             Assert.IsType(destinationType, result);
@@ -1506,7 +1506,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             var bindingContext = GetBindingContextForProperty(propertyName);
 
             // Act
-            var result = ModelBindingHelper.GetCompatibleCollection<int>(bindingContext, capacity: null);
+            var result = ModelBindingHelper.GetCompatibleCollection<int>(bindingContext);
 
             // Assert
             Assert.Same(bindingContext.Model, result);
@@ -1522,7 +1522,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 nameof(ModelWithReadOnlyAndSpecialCaseProperties.EnumerablePropertyWithArrayValueAndSetter));
 
             // Act
-            var result = ModelBindingHelper.GetCompatibleCollection<int>(bindingContext, capacity: null);
+            var result = ModelBindingHelper.GetCompatibleCollection<int>(bindingContext);
 
             // Assert
             Assert.NotSame(bindingContext.Model, result);
@@ -1546,39 +1546,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 
             // Assert
             Assert.False(result);
-        }
-
-        [Theory]
-        [InlineData(typeof(Collection<string>))]
-        [InlineData(typeof(List<long>))]
-        [InlineData(typeof(MyModel))]
-        public void GetCompatibleCollection_ReturnsNull_IfDestinationTypeIsNotCompatible(Type destinationType)
-        {
-            // Arrange
-            var bindingContext = GetBindingContext(destinationType);
-
-            // Act
-            var result = ModelBindingHelper.GetCompatibleCollection<int>(bindingContext, capacity: null);
-
-            // Assert
-            Assert.Null(result);
-        }
-
-        [Theory]
-        [InlineData(typeof(AbstractIntList))]
-        [InlineData(typeof(ISet<int>))]
-        [InlineData(typeof(ListWithInternalConstructor<int>))]
-        [InlineData(typeof(ListWithThrowingConstructor<int>))]
-        public void GetCompatibleCollection_ReturnsNull_IfDestinationTypeCannotBeActivated(Type destinationType)
-        {
-            // Arrange
-            var bindingContext = GetBindingContext(destinationType);
-
-            // Act
-            var result = ModelBindingHelper.GetCompatibleCollection<int>(bindingContext, capacity: null);
-
-            // Assert (also, above statement does not throw)
-            Assert.Null(result);
         }
 
         private static DefaultModelBindingContext GetBindingContextForProperty(string propertyName)
@@ -1657,23 +1624,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 
         private class IntList : List<int>
         {
-        }
-
-        private class ListWithInternalConstructor<T> : List<T>
-        {
-            internal ListWithInternalConstructor()
-                : base()
-            {
-            }
-        }
-
-        private class ListWithThrowingConstructor<T> : List<T>
-        {
-            public ListWithThrowingConstructor()
-                : base()
-            {
-                throw new RankException("No, don't do this.");
-            }
         }
 
         private enum IntEnum

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/MutableObjectModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/MutableObjectModelBinderIntegrationTest.cs
@@ -517,17 +517,14 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             var model = Assert.IsType<Order4>(modelBindingResult.Model);
             Assert.NotNull(model.Customer);
             Assert.Equal("bill", model.Customer.Name);
-            Assert.Empty(model.Customer.Documents);
+            Assert.Null(model.Customer.Documents);
 
-            Assert.Equal(2, modelState.Count);
             Assert.Equal(0, modelState.ErrorCount);
             Assert.True(modelState.IsValid);
 
-            var entry = Assert.Single(modelState, e => e.Key == "parameter.Customer.Documents").Value;
-            Assert.Null(entry.AttemptedValue); // FormFile entries don't include the model.
-            Assert.Null(entry.RawValue);
-
-            entry = Assert.Single(modelState, e => e.Key == "parameter.Customer.Name").Value;
+            var kvp = Assert.Single(modelState);
+            Assert.Equal("parameter.Customer.Name", kvp.Key);
+            var entry = kvp.Value;
             Assert.Equal("bill", entry.AttemptedValue);
             Assert.Equal("bill", entry.RawValue);
         }

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponents/DefaultViewComponentDescriptorProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponents/DefaultViewComponentDescriptorProviderTest.cs
@@ -93,11 +93,12 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
             Assert.Equal(expected, ex.Message);
         }
 
-        [Fact]
-        public void GetViewComponents_ThrowsIfInvokeReturnsATask()
+        [Theory]
+        [InlineData(typeof(TaskReturningInvokeViewComponent))]
+        [InlineData(typeof(GenericTaskReturningInvokeViewComponent))]
+        public void GetViewComponents_ThrowsIfInvokeReturnsATask(Type type)
         {
             // Arrange
-            var type = typeof(TaskReturningInvokeViewComponent);
             var expected = $"Method 'Invoke' of view component '{type}' cannot return a Task.";
             var provider = CreateProvider(type);
 
@@ -187,6 +188,11 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
         public class TaskReturningInvokeViewComponent
         {
             public Task Invoke() => Task.FromResult(0);
+        }
+
+        public class GenericTaskReturningInvokeViewComponent
+        {
+            public Task<int> Invoke() => Task.FromResult(0);
         }
 
         public class VoidReturningInvokeViewComponent


### PR DESCRIPTION
- #3482
- see new tests; many failed without fixes in the product code
 - `ModelBindingHelper.ConvertValuesToCollectionType<T>()` -> `CreateCompatibleCollection<T>()`
- make `FormFileModelBinder` / `HeaderModelBinder` collection handling consistent w/ `GenericModelBinder`++
 - add checks around creating collections and leaving non-top-level collections `null` (not empty)
 - add checks around binding collections to read-only properties
- add support for binding `IFormFileCollection` properties

nit: Correct a few existing test names since nothing is not the same as `ModelBindingResult.Failed()`