### PR TITLE
Simplify `IsAssignableFrom()` use

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelMetadata.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelMetadata.cs
@@ -406,7 +406,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 var enumerableType = ClosedGenericMatcher.ExtractGenericInterface(ModelType, typeof(IEnumerable<>));
                 ElementType = enumerableType?.GenericTypeArguments[0];
 
-                if (ElementType == null && typeof(IEnumerable).IsAssignableFrom(ModelType))
+                if (ElementType == null)
                 {
                     // ModelType implements IEnumerable but not IEnumerable<T>.
                     ElementType = typeof(object);

--- a/src/Microsoft.AspNetCore.Mvc.ApiExplorer/DefaultApiDescriptionProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ApiExplorer/DefaultApiDescriptionProvider.cs
@@ -4,10 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+#if DOTNET5_4
 using System.Reflection;
+#endif
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Abstractions;
-using Microsoft.AspNetCore.Mvc.ActionConstraints;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.Internal;
@@ -135,9 +136,9 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                     apiDescription.SupportedResponseFormats.Add(format);
                 }
             }
-            
+
             // It would be possible here to configure an action with multiple body parameters, in which case you
-            // could end up with duplicate data. 
+            // could end up with duplicate data.
             foreach (var parameter in apiDescription.ParameterDescriptions.Where(p => p.Source == BindingSource.Body))
             {
                 var formats = GetRequestFormats(action, requestMetadataAttributes, parameter.Type);
@@ -427,7 +428,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
 
             // If the method is declared to return IActionResult or a derived class, that information
             // isn't valuable to the formatter.
-            if (typeof(IActionResult).GetTypeInfo().IsAssignableFrom(unwrappedType.GetTypeInfo()))
+            if (typeof(IActionResult).IsAssignableFrom(unwrappedType))
             {
                 return null;
             }
@@ -577,7 +578,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
 
             public ParameterDescriptor Parameter { get; }
 
-            // Avoid infinite recursion by tracking properties. 
+            // Avoid infinite recursion by tracking properties.
             private HashSet<PropertyKey> Visited { get; }
 
             public void WalkParameter(ApiParameterDescriptionContext context)

--- a/src/Microsoft.AspNetCore.Mvc.Core/BindAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/BindAttribute.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+#if DOTNET5_4
 using System.Reflection;
+#endif
 using Microsoft.AspNetCore.Mvc.Core;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.DependencyInjection;
@@ -52,8 +54,7 @@ namespace Microsoft.AspNetCore.Mvc
                 throw new ArgumentNullException(nameof(predicateProviderType));
             }
 
-            if (!typeof(IPropertyBindingPredicateProvider).GetTypeInfo()
-                    .IsAssignableFrom(predicateProviderType.GetTypeInfo()))
+            if (!typeof(IPropertyBindingPredicateProvider).IsAssignableFrom(predicateProviderType))
             {
                 var message = Resources.FormatPropertyBindingPredicateProvider_WrongType(
                     predicateProviderType.FullName,

--- a/src/Microsoft.AspNetCore.Mvc.Core/Filters/FilterCollection.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Filters/FilterCollection.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.ObjectModel;
+#if DOTNET5_4
 using System.Reflection;
+#endif
 using Microsoft.AspNetCore.Mvc.Core;
 
 namespace Microsoft.AspNetCore.Mvc.Filters
@@ -99,7 +101,7 @@ namespace Microsoft.AspNetCore.Mvc.Filters
                 throw new ArgumentNullException(nameof(filterType));
             }
 
-            if (!typeof(IFilterMetadata).GetTypeInfo().IsAssignableFrom(filterType.GetTypeInfo()))
+            if (!typeof(IFilterMetadata).IsAssignableFrom(filterType))
             {
                 var message = Resources.FormatTypeMustDeriveFromType(
                     filterType.FullName,

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionInvoker.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionInvoker.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+#if DOTNET5_4
 using System.Reflection;
+#endif
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Core;
@@ -143,7 +145,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             // Unwrap potential Task<T> types.
             var actualReturnType = GetTaskInnerTypeOrNull(declaredReturnType) ?? declaredReturnType;
             if (actionReturnValue == null &&
-                typeof(IActionResult).GetTypeInfo().IsAssignableFrom(actualReturnType.GetTypeInfo()))
+                typeof(IActionResult).IsAssignableFrom(actualReturnType))
             {
                 throw new InvalidOperationException(
                     Resources.FormatActionResult_ActionReturnValueCannotBeNull(actualReturnType));

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/KeyValuePairModelBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/KeyValuePairModelBinder.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Core;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding
 {
@@ -17,9 +17,13 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 throw new ArgumentNullException(nameof(bindingContext));
             }
 
-            ModelBindingHelper.ValidateBindingContext(bindingContext,
-                                                      typeof(KeyValuePair<TKey, TValue>),
-                                                      allowNullModel: true);
+            if (bindingContext.ModelType != typeof(KeyValuePair<TKey, TValue>))
+            {
+                var message = Resources.FormatModelBinderUtil_ModelTypeIsWrong(
+                    bindingContext.ModelType,
+                    typeof(KeyValuePair<TKey, TValue>));
+                throw new ArgumentException(message, nameof(bindingContext));
+            }
 
             var keyResult = await TryBindStrongModel<TKey>(bindingContext, "Key");
             var valueResult = await TryBindStrongModel<TValue>(bindingContext, "Value");

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/ModelBindingHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/ModelBindingHelper.cs
@@ -13,7 +13,6 @@ using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Core;
 using Microsoft.AspNetCore.Mvc.Formatters;
-using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding
@@ -741,35 +740,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             if (bindingContext.ModelMetadata == null)
             {
                 throw new ArgumentException(Resources.ModelBinderUtil_ModelMetadataCannotBeNull, nameof(bindingContext));
-            }
-        }
-
-        internal static void ValidateBindingContext(
-            ModelBindingContext bindingContext,
-            Type requiredType,
-            bool allowNullModel)
-        {
-            ValidateBindingContext(bindingContext);
-
-            if (bindingContext.ModelType != requiredType)
-            {
-                var message = Resources.FormatModelBinderUtil_ModelTypeIsWrong(bindingContext.ModelType, requiredType);
-                throw new ArgumentException(message, nameof(bindingContext));
-            }
-
-            if (!allowNullModel && bindingContext.Model == null)
-            {
-                var message = Resources.FormatModelBinderUtil_ModelCannotBeNull(requiredType);
-                throw new ArgumentException(message, nameof(bindingContext));
-            }
-
-            if (bindingContext.Model != null &&
-                !bindingContext.ModelType.GetTypeInfo().IsAssignableFrom(requiredType.GetTypeInfo()))
-            {
-                var message = Resources.FormatModelBinderUtil_ModelInstanceIsWrong(
-                    bindingContext.Model.GetType(),
-                    requiredType);
-                throw new ArgumentException(message, nameof(bindingContext));
             }
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Validation/ValidationExcludeFilter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Validation/ValidationExcludeFilter.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
 
             if (Type != null)
             {
-                if (Type.GetTypeInfo().IsAssignableFrom(context.Key.ModelType.GetTypeInfo()))
+                if (Type.IsAssignableFrom(context.Key.ModelType))
                 {
                     context.ValidationMetadata.ValidateChildren = false;
                 }

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/SelectTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/SelectTagHelper.cs
@@ -5,7 +5,9 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+#if DOTNET5_6
 using System.Reflection;
+#endif
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.TagHelpers.Internal;
@@ -95,7 +97,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             // Metadata.IsEnumerableType is similar but does not take runtime type into account.
             var realModelType = For.ModelExplorer.ModelType;
             _allowMultiple = typeof(string) != realModelType &&
-                typeof(IEnumerable).GetTypeInfo().IsAssignableFrom(realModelType.GetTypeInfo());
+                typeof(IEnumerable).IsAssignableFrom(realModelType);
             _currentValues = Generator.GetCurrentValues(
                 ViewContext,
                 For.ModelExplorer,

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/DefaultViewComponentInvoker.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/DefaultViewComponentInvoker.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
                     nameof(ViewComponentDescriptor)));
             }
 
-            var isAsync = typeof(Task).GetTypeInfo().IsAssignableFrom(methodInfo.ReturnType.GetTypeInfo());
+            var isAsync = typeof(Task).IsAssignableFrom(methodInfo.ReturnType);
             IViewComponentResult result;
             if (isAsync)
             {

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/TemplateRenderer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/TemplateRenderer.cs
@@ -228,9 +228,9 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
                 }
             }
 
-            if (typeof(IEnumerable).GetTypeInfo().IsAssignableFrom(fieldTypeInfo))
+            if (typeof(IEnumerable).IsAssignableFrom(fieldType))
             {
-                if (typeof(IEnumerable<IFormFile>).GetTypeInfo().IsAssignableFrom(fieldTypeInfo))
+                if (typeof(IEnumerable<IFormFile>).IsAssignableFrom(fieldType))
                 {
                     yield return IEnumerableOfIFormFileName;
 
@@ -243,7 +243,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
 
                 yield return "Collection";
             }
-            else if (typeof(IFormFile) != fieldType && typeof(IFormFile).GetTypeInfo().IsAssignableFrom(fieldTypeInfo))
+            else if (typeof(IFormFile) != fieldType && typeof(IFormFile).IsAssignableFrom(fieldType))
             {
                 yield return nameof(IFormFile);
             }

--- a/src/Microsoft.AspNetCore.Mvc.WebApiCompatShim/ContentNegotiator/FormattingUtilities.cs
+++ b/src/Microsoft.AspNetCore.Mvc.WebApiCompatShim/ContentNegotiator/FormattingUtilities.cs
@@ -124,7 +124,7 @@ namespace System.Net.Http
         /// </returns>
         public static bool IsJTokenType(Type type)
         {
-            return typeof(JToken).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo());
+            return typeof(JToken).IsAssignableFrom(type);
         }
 
         /// <summary>


### PR DESCRIPTION
- standardize on the `Type` extension method; less verbiage
- `ModelMetadata` had a redundant `IsAssignableFrom()` call
- `ModelBindingHelper.ValidateBindingContext()` over-engineered and used just once
 - do useful bit inline in `KeyValuePairModelBinder`
- found while investigating #3482 but not part of a fix for that issue