### PR TITLE
Test fix: Change `CollectionModelBinderTest` to update `ModelMetadata.IsReadOnly`

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/CollectionModelBinderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/CollectionModelBinderTest.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Test;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
-using Moq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding
@@ -367,11 +366,16 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             bool isReadOnly = false)
         {
             var metadataProvider = new TestModelMetadataProvider();
-            metadataProvider.ForType<IList<int>>().BindingDetails(bd => bd.IsReadOnly = isReadOnly);
+            metadataProvider
+                .ForProperty<ModelWithIListProperty>(nameof(ModelWithIListProperty.ListProperty))
+                .BindingDetails(bd => bd.IsReadOnly = isReadOnly);
+            var metadata = metadataProvider.GetMetadataForProperty(
+                typeof(ModelWithIListProperty),
+                nameof(ModelWithIListProperty.ListProperty));
 
             var bindingContext = new DefaultModelBindingContext
             {
-                ModelMetadata = metadataProvider.GetMetadataForType(typeof(IList<int>)),
+                ModelMetadata = metadata,
                 ModelName = "someName",
                 ModelState = new ModelStateDictionary(),
                 ValueProvider = valueProvider,
@@ -429,6 +433,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         private class ModelWithListProperty
         {
             public List<string> ListProperty { get; set; }
+        }
+
+        private class ModelWithIListProperty
+        {
+            public IList<int> ListProperty { get; set; }
         }
 
         private class ModelWithSimpleProperties

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/DictionaryModelBinderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/DictionaryModelBinderTest.cs
@@ -472,7 +472,12 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Test
             IDictionary<string, KeyValuePair<int, string>> values)
         {
             var metadataProvider = new TestModelMetadataProvider();
-            metadataProvider.ForType<IDictionary<int, string>>().BindingDetails(bd => bd.IsReadOnly = isReadOnly);
+            metadataProvider
+                .ForProperty<ModelWithIDictionaryProperty>(nameof(ModelWithIDictionaryProperty.DictionaryProperty))
+                .BindingDetails(bd => bd.IsReadOnly = isReadOnly);
+            var metadata = metadataProvider.GetMetadataForProperty(
+                typeof(ModelWithIDictionaryProperty),
+                nameof(ModelWithIDictionaryProperty.DictionaryProperty));
 
             var binder = new StubModelBinder(mbc =>
             {
@@ -491,7 +496,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Test
 
             var bindingContext = new DefaultModelBindingContext
             {
-                ModelMetadata = metadataProvider.GetMetadataForType(typeof(IDictionary<int, string>)),
+                ModelMetadata = metadata,
                 ModelName = "someName",
                 ModelState = new ModelStateDictionary(),
                 OperationBindingContext = new OperationBindingContext
@@ -505,6 +510,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Test
             };
 
             return bindingContext;
+        }
+
+        private class ModelWithIDictionaryProperty
+        {
+            public IDictionary<int, string> DictionaryProperty { get; set; }
         }
 
         private class ModelWithDictionaryProperties


### PR DESCRIPTION
- unrelated to #3482 except that I discovered the issue while investigating that issue
- tests previously set `BindingDetails.IsReadOnly` for a `Type` and that was ignored
 - same for `DictionaryModelBinderTest`