### PR TITLE
[Perf] [Design] Optimize controller action invoke

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionInvoker.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionInvoker.cs
@@ -94,6 +94,9 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             }
 
             var actionMethodInfo = _descriptor.MethodInfo;
+
+            var methodExecutor = GetControllerActionMethodExecutor();
+
             var arguments = ControllerActionExecutor.PrepareArguments(
                 actionExecutingContext.ActionArguments,
                 actionMethodInfo.GetParameters());
@@ -101,7 +104,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             Logger.ActionMethodExecuting(actionExecutingContext, arguments);
 
             var actionReturnValue = await ControllerActionExecutor.ExecuteAsync(
-                actionMethodInfo,
+                methodExecutor,
                 actionExecutingContext.Controller,
                 arguments);
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/FilterActionInvoker.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/FilterActionInvoker.cs
@@ -182,6 +182,11 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             return _filterCache.GetFilters(Context);
         }
 
+        protected ObjectMethodExecutor GetControllerActionMethodExecutor()
+        {
+            return _filterCache.GetControllerActionMethodExecutor(Context);
+        }
+
         private Task InvokeAllAuthorizationFiltersAsync()
         {
             _cursor.Reset();

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ObjectMethodExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ObjectMethodExecutor.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Microsoft.AspNetCore.Mvc.Internal
+{
+    /// <summary>
+    /// This class represents a general purpose executor for a method(static/instance) on an object using MethodInfo.
+    /// This executor is an alternative approach for MethodInfo.Invoke(). 
+    /// Given the MethodInfo and the type of the target object, it creates a delegate and calls the method using it.
+    /// The delegate is created dynamically using the Linq expressions. 
+    /// The executor should be cached to get the maximum performance benefit or else compiling Linq expression adds overhead.
+    /// </summary>
+    public class ObjectMethodExecutor
+    {
+        private ActionExecutor _executor;
+
+        public ObjectMethodExecutor(MethodInfo methodInfo, TypeInfo targetTypeInfo)
+        {            
+            if (methodInfo == null)
+            {
+                throw new ArgumentNullException(nameof(methodInfo));
+            }
+
+            if (targetTypeInfo == null)
+            {
+                throw new ArgumentNullException(nameof(targetTypeInfo));
+            }
+
+            _executor = GetExecutor(methodInfo, targetTypeInfo);
+            MethodInfo = methodInfo;
+        }
+
+        private delegate object ActionExecutor(object target, object[] parameters);
+
+        private delegate void VoidActionExecutor(object target, object[] parameters);
+
+        public MethodInfo MethodInfo { get; private set; }
+
+        /// <inheritdoc />
+        public object Execute(object target, object[] parameters)
+        {
+            return _executor(target, parameters);
+        }
+
+        private static ActionExecutor GetExecutor(MethodInfo methodInfo, TypeInfo targetTypeInfo)
+        {
+            // Parameters to executor
+            ParameterExpression targetParameter = Expression.Parameter(typeof(object), "target");
+            ParameterExpression parametersParameter = Expression.Parameter(typeof(object[]), "parameters");
+
+            // Build parameter list
+            List<Expression> parameters = new List<Expression>();
+            ParameterInfo[] paramInfos = methodInfo.GetParameters();
+            for (int i = 0; i < paramInfos.Length; i++)
+            {
+                ParameterInfo paramInfo = paramInfos[i];
+                BinaryExpression valueObj = Expression.ArrayIndex(parametersParameter, Expression.Constant(i));
+                UnaryExpression valueCast = Expression.Convert(valueObj, paramInfo.ParameterType);
+
+                // valueCast is "(Ti) parameters[i]"
+                parameters.Add(valueCast);
+            }
+
+            // Call method
+            UnaryExpression instanceCast = (!methodInfo.IsStatic) ? Expression.Convert(targetParameter, targetTypeInfo.AsType()) : null;
+            MethodCallExpression methodCall = methodCall = Expression.Call(instanceCast, methodInfo, parameters);
+
+            // methodCall is "((Ttarget) target) method((T0) parameters[0], (T1) parameters[1], ...)"
+            // Create function
+            if (methodCall.Type == typeof(void))
+            {
+                Expression<VoidActionExecutor> lambda = Expression.Lambda<VoidActionExecutor>(methodCall, targetParameter, parametersParameter);
+                VoidActionExecutor voidExecutor = lambda.Compile();
+                return WrapVoidAction(voidExecutor);
+            }
+            else
+            {
+                // must coerce methodCall to match ActionExecutor signature
+                UnaryExpression castMethodCall = Expression.Convert(methodCall, typeof(object));
+                Expression<ActionExecutor> lambda = Expression.Lambda<ActionExecutor>(castMethodCall, targetParameter, parametersParameter);
+                return lambda.Compile();
+            }
+        }
+
+        private static ActionExecutor WrapVoidAction(VoidActionExecutor executor)
+        {
+            return delegate (object target, object[] parameters)
+            {
+                executor(target, parameters);
+                return null;
+            };
+        }
+
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerActionInvokerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerActionInvokerTest.cs
@@ -1977,6 +1977,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             {
                 actionDescriptor.MethodInfo = typeof(ControllerActionInvokerTest).GetMethod("ActionMethod");
             }
+            actionDescriptor.ControllerTypeInfo = typeof(ControllerActionInvokerTest).GetTypeInfo();
 
             var httpContext = new Mock<HttpContext>(MockBehavior.Loose);
 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ObjectMethodExecutorTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ObjectMethodExecutorTests.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.AspNetCore.Testing;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.Core.Test.Internal
+{
+    public class ObjectMethodExecutorTests
+    {
+        private TestObject _targetObject = new TestObject();
+        private TypeInfo targetTypeInfo = typeof(TestObject).GetTypeInfo();
+
+        [Fact]
+        public void ExecuteStaticVoidMethod()
+        {
+            var executor = GetExecutorForMethod("StaticVoidMethod");
+            var result = executor.Execute(null, null);
+            Assert.Same(null, result);
+        }
+
+        [Fact]
+        public void ExecuteStaticValueMethod()
+        {
+            var executor = GetExecutorForMethod("StaticValueMethod");
+            var result = executor.Execute(null, new object[] { 10 });
+            Assert.Equal(10, (int)result);
+        }
+
+        [Fact]
+        public void ExecuteStaticMethodThrowsException()
+        {
+            var executor = GetExecutorForMethod("StaticMethodThrowsException");
+            Assert.Throws<NotImplementedException>(
+                        () => executor.Execute(null, new object[] { 10 }));
+            
+        }
+
+        [Fact]
+        public void ExecuteValueMethod()
+        {
+            var executor = GetExecutorForMethod("ValueMethod");
+            var result = executor.Execute(_targetObject, new object[] { 10 , 20 });
+            Assert.Equal(30, (int)result);
+        }
+
+        [Fact]
+        public void ExecuteVoidValueMethod()
+        {
+            var executor = GetExecutorForMethod("VoidValueMethod");
+            var result = executor.Execute(_targetObject, new object[] { 10 });
+            Assert.Same(null, result);
+        }
+
+        [Fact]
+        public void ExecuteValueMethodWithReturnType()
+        {
+            var executor = GetExecutorForMethod("ValueMethodWithReturnType");
+            var result = executor.Execute(_targetObject, new object[] { 10 });
+            Assert.True(result is TestObject);
+            TestObject resultObject = (TestObject)result;
+            Assert.Equal("Hello", resultObject.value);
+        }
+
+        [Fact]
+        public void ExecuteValueMethodUpdateValue()
+        {
+            var executor = GetExecutorForMethod("ValueMethodUpdateValue");
+            TestObject parameter = new TestObject();
+            var result = executor.Execute(_targetObject, new object[] { parameter });
+            Assert.True(result is TestObject);
+            TestObject resultObject = (TestObject)result;
+            Assert.Equal("HelloWorld", resultObject.value);
+        }
+
+        [Fact]
+        public void ExecuteValueMethodWithReturnTypeThrowsException()
+        {
+            var executor = GetExecutorForMethod("ValueMethodWithReturnTypeThrowsException");
+            TestObject parameter = new TestObject();
+            Assert.Throws<NotImplementedException>(
+                        () => executor.Execute(_targetObject, new object[] { parameter }));
+        }
+
+        private ObjectMethodExecutor GetExecutorForMethod(string methodName)
+        {
+            var method = typeof(TestObject).GetMethod(methodName);
+            var executor = new ObjectMethodExecutor(method, targetTypeInfo);
+            return executor;
+        }
+
+        public class TestObject
+        {            
+            public string value;
+            public static void StaticVoidMethod()
+            {
+
+            }
+            public static int StaticValueMethod(int i)
+            {
+                return i;
+            }
+
+            public static int StaticMethodThrowsException(int i)
+            {
+                throw new NotImplementedException("Not Implemented Exception");
+            }
+
+            public int ValueMethod(int i, int j)
+            {
+                return i+j;
+            }
+
+            public void VoidValueMethod(int i)
+            {
+                
+            }
+            public TestObject ValueMethodWithReturnType(int i)
+            {
+                return new TestObject() { value = "Hello" }; ;
+            }
+
+            public TestObject ValueMethodWithReturnTypeThrowsException(TestObject i)
+            {
+                throw new NotImplementedException("Not Implemented Exception");
+            }
+
+            public TestObject ValueMethodUpdateValue(TestObject parameter)
+            {
+                parameter.value = "HelloWorld";
+                return parameter;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/aspnet/Mvc/issues/3903 
1. Added a general purpose method executor that provides an alternative to MethodInfo.Invoke()
2. This executor creates a delegate for the method which can be cached for performance benefit.
3. The delegate is created dynamically using the Linq expressions.
2. Controller action methods are invoked using the cached executor.


