### PR TITLE
Refactoring CacheTagHelper

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/Cache/DistributedCacheTagHelperFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/Cache/DistributedCacheTagHelperFormatter.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace Microsoft.AspNetCore.Mvc.TagHelpers.Cache
+{
+    /// <summary>
+    /// Implements <see cref="IDistributedCacheTagHelperFormatter"/> by serializing the content
+    /// in UTF8.
+    /// </summary>
+    public class DistributedCacheTagHelperFormatter : IDistributedCacheTagHelperFormatter
+    {
+        
+        /// <inheritdoc />
+        public Task<byte[]> SerializeAsync(DistributedCacheTagHelperFormattingContext context)
+        {
+            if (context == null) 
+            {
+                throw new ArgumentNullException(nameof(context));    
+            }
+            
+            if (context.Html == null) 
+            {
+                throw new ArgumentNullException(nameof(context.Html));    
+            }
+
+            var serialized = Encoding.UTF8.GetBytes(context.Html.ToString());
+            return Task.FromResult(serialized);
+        }
+
+        /// <inheritdoc />
+        public Task<HtmlString> DeserializeAsync(byte[] value)
+        {
+            if (value == null) 
+            {
+                throw new ArgumentNullException(nameof(value));    
+            }
+            
+            var content = Encoding.UTF8.GetString(value);
+            return Task.FromResult(new HtmlString(content));
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/Cache/DistributedCacheTagHelperFormattingContext.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/Cache/DistributedCacheTagHelperFormattingContext.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace Microsoft.AspNetCore.Mvc.TagHelpers.Cache
+{
+    /// <summary>
+    /// Represents an object containing the information to serialize with <see cref="IDistributedCacheTagHelperFormatter" />.
+    /// </summary>
+    public class DistributedCacheTagHelperFormattingContext
+    {
+        /// <summary>
+        /// Gets the <see cref="HtmlString"/> instance.
+        /// </summary>
+        public HtmlString Html { get; set; }  
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/Cache/DistributedCacheTagHelperService.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/Cache/DistributedCacheTagHelperService.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using System.IO;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace Microsoft.AspNetCore.Mvc.TagHelpers.Cache
+{
+    /// <summary>
+    /// Implements <see cref="IDistributedCacheTagHelperService"/> and ensure
+    /// multiple concurrent requests are gated.
+    /// </summary>
+    public class DistributedCacheTagHelperService : IDistributedCacheTagHelperService
+    {
+        private readonly IDistributedCacheTagHelperStorage _storage;
+        private readonly IDistributedCacheTagHelperFormatter _formatter;
+        private readonly HtmlEncoder _htmlEncoder;
+        private readonly ConcurrentDictionary<string, Task<IHtmlContent>> _workers;
+
+        public DistributedCacheTagHelperService(
+            IDistributedCacheTagHelperStorage storage,
+            IDistributedCacheTagHelperFormatter formatter,
+            HtmlEncoder HtmlEncoder 
+        )
+        {
+            _formatter = formatter;
+            _storage = storage;
+            _htmlEncoder = HtmlEncoder;
+
+            _workers = new ConcurrentDictionary<string, Task<IHtmlContent>>();
+        }
+
+        /// <inheritdoc />
+        public async Task<IHtmlContent> ProcessContentAsync(TagHelperOutput output, string key, DistributedCacheEntryOptions options)
+        {
+            IHtmlContent content = null;
+
+            while (content == null)
+            {
+                Task<IHtmlContent> result = null;
+
+                // Is there any request already processing the value?
+                if (!_workers.TryGetValue(key, out result))
+                {
+                    var tcs = new TaskCompletionSource<IHtmlContent>();
+
+                    _workers.TryAdd(key, tcs.Task);
+
+                    try
+                    {
+                        var value = await _storage.GetAsync(key);
+
+                        if (value == null)
+                        {
+                            var processedContent = await output.GetChildContentAsync();
+
+                            var stringBuilder = new StringBuilder();
+                            using (var writer = new StringWriter(stringBuilder))
+                            {
+                                processedContent.WriteTo(writer, _htmlEncoder);
+                            }
+
+                            var formattingContext = new DistributedCacheTagHelperFormattingContext
+                            {
+                                Html = new HtmlString(stringBuilder.ToString())
+                            };
+
+                            value = await _formatter.SerializeAsync(formattingContext);
+
+                            await _storage.SetAsync(key, value, options);
+
+                            content = formattingContext.Html;
+                        }
+                        else
+                        {
+                            content = await _formatter.DeserializeAsync(value);
+
+                            // If the deserialization fails, it can return null, for instance when the 
+                            // value is not in the expected format.
+                            if (content == null)
+                            {
+                                content = await output.GetChildContentAsync();
+                            }
+                        }
+
+                        tcs.TrySetResult(content);
+                    }
+                    catch
+                    {
+                        tcs.TrySetResult(null);
+                        throw;
+                    }
+                    finally
+                    {
+                        // Remove the worker task from the in-memory cache
+                        Task<IHtmlContent> worker;
+                        _workers.TryRemove(key, out worker);
+                    }
+                }
+                else
+                {
+                    content = await result;
+                }
+            }
+
+            return content;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/Cache/DistributedCacheTagHelperStorage.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/Cache/DistributedCacheTagHelperStorage.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace Microsoft.AspNetCore.Mvc.TagHelpers.Cache
+{
+    /// <summary>
+    /// Implements <see cref="IDistributedCacheTagHelperStorage"/> by storing the content
+    /// in using <see cref="IDistributedCache"/> as the store.
+    /// </summary>
+    public class DistributedCacheTagHelperStorage : IDistributedCacheTagHelperStorage
+    {
+        private readonly IDistributedCache _distributedCache;
+
+        /// <summary>
+        /// Creates a new <see cref="DistributedCacheTagHelperStorage"/>.
+        /// </summary>
+        /// <param name="distributedCache">The <see cref="IDistributedCache"/> to use.</param>
+        public DistributedCacheTagHelperStorage(IDistributedCache distributedCache)
+        {
+            _distributedCache = distributedCache;
+        }
+
+        /// <inheritdoc />
+        public Task<byte[]> GetAsync(string key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+            
+            return _distributedCache.GetAsync(key);
+        }
+
+        /// <inheritdoc />
+        public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            return _distributedCache.SetAsync(key, value, options);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/Cache/IDistributedCacheTagHelperFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/Cache/IDistributedCacheTagHelperFormatter.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace Microsoft.AspNetCore.Mvc.TagHelpers.Cache
+{
+    /// <summary>
+    /// An implementation of this interface provides a service to 
+    /// serialize html fragments for being store by <see cref="IDistributedCacheTagHelperStorage" />
+    /// </summary>
+    public interface IDistributedCacheTagHelperFormatter 
+    {
+        /// <summary>
+        /// Serializes some html content.
+        /// </summary>
+        /// <param name="context">The <see cref="DistributedCacheTagHelperFormattingContext" /> to serialize.</param>
+        /// <returns>The serialized result.</returns>
+        Task<byte[]> SerializeAsync(DistributedCacheTagHelperFormattingContext context);
+
+        /// <summary>
+        /// Deserialize some html content.
+        /// </summary>
+        /// <param name="value">The value to deserialize.</param>
+        /// <returns>The deserialized content, <value>null</value> otherwise.</returns>
+        Task<HtmlString> DeserializeAsync(byte[] value);
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/Cache/IDistributedCacheTagHelperService.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/Cache/IDistributedCacheTagHelperService.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace Microsoft.AspNetCore.Mvc.TagHelpers.Cache
+{
+    /// <summary>
+    /// An implementation of this interface provides a service to process
+    /// the content or fetches it from cache for distributed cache tag helpers.
+    /// </summary>
+    public interface IDistributedCacheTagHelperService
+    {
+        /// <summary>
+        /// Processes the html content of a distributed cache tag helper.
+        /// </summary>
+        /// <param name="output">The <see cref="TagHelperOutput" />.</param>
+        /// <param name="key">The key in the storage.</param>
+        /// <param name="options">The <see cref="DistributedCacheEntryOptions"/>.</param>
+        /// <returns>A cached or new content for the cache tag helper.</returns>
+        Task<IHtmlContent> ProcessContentAsync(TagHelperOutput output, string key, DistributedCacheEntryOptions options);
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/Cache/IDistributedCacheTagHelperStorage.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/Cache/IDistributedCacheTagHelperStorage.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace Microsoft.AspNetCore.Mvc.TagHelpers.Cache
+{
+    /// <summary>
+    /// An implementation of this interface provides a service to 
+    /// cache distributed html fragments from the &lt;distributed-cache&gt;
+    /// tag helper.
+    /// </summary>
+    public interface IDistributedCacheTagHelperStorage
+    {
+        /// <summary>
+        /// Gets the content from the cache and deserializes it.
+        /// </summary>
+        /// <param name="key">The unique key to use in the cache.</param>
+        /// <returns>The stored value if it exists, <value>null</value> otherwise.</returns>
+        Task<byte[]> GetAsync(string key);
+
+        /// <summary>
+        /// Sets the content in the cache and serialized it.
+        /// </summary>
+        /// <param name="key">The unique key to use in the cache.</param>
+        /// <param name="value">The value to cache.</param>
+        /// <param name="options">The cache entry options.</param>
+        Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options);
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/CacheTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/CacheTagHelper.cs
@@ -2,15 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Security.Cryptography;
 using System.Text;
 using System.Text.Encodings.Web;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
-using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Primitives;
@@ -20,44 +17,22 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
     /// <summary>
     /// <see cref="TagHelper"/> implementation targeting &lt;cache&gt; elements.
     /// </summary>
-    public class CacheTagHelper : TagHelper
+    public class CacheTagHelper : CacheTagHelperBase
     {
         /// <summary>
         /// Prefix used by <see cref="CacheTagHelper"/> instances when creating entries in <see cref="MemoryCache"/>.
         /// </summary>
         public static readonly string CacheKeyPrefix = nameof(CacheTagHelper);
-        private const string VaryByAttributeName = "vary-by";
-        private const string VaryByHeaderAttributeName = "vary-by-header";
-        private const string VaryByQueryAttributeName = "vary-by-query";
-        private const string VaryByRouteAttributeName = "vary-by-route";
-        private const string VaryByCookieAttributeName = "vary-by-cookie";
-        private const string VaryByUserAttributeName = "vary-by-user";
-        private const string ExpiresOnAttributeName = "expires-on";
-        private const string ExpiresAfterAttributeName = "expires-after";
-        private const string ExpiresSlidingAttributeName = "expires-sliding";
         private const string CachePriorityAttributeName = "priority";
-        private const string CacheKeyTokenSeparator = "||";
-        private const string EnabledAttributeName = "enabled";
-        private static readonly char[] AttributeSeparator = new[] { ',' };
 
         /// <summary>
         /// Creates a new <see cref="CacheTagHelper"/>.
         /// </summary>
         /// <param name="memoryCache">The <see cref="IMemoryCache"/>.</param>
         /// <param name="htmlEncoder">The <see cref="HtmlEncoder"/> to use.</param>
-        public CacheTagHelper(IMemoryCache memoryCache, HtmlEncoder htmlEncoder)
+        public CacheTagHelper(IMemoryCache memoryCache, HtmlEncoder htmlEncoder) : base(htmlEncoder)
         {
             MemoryCache = memoryCache;
-            HtmlEncoder = htmlEncoder;
-        }
-
-        /// <inheritdoc />
-        public override int Order
-        {
-            get
-            {
-                return -1000;
-            }
         }
 
         /// <summary>
@@ -66,83 +41,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         protected IMemoryCache MemoryCache { get; }
 
         /// <summary>
-        /// Gets the <see cref="System.Text.Encodings.Web.HtmlEncoder"/> which encodes the content to be cached.
-        /// </summary>
-        protected HtmlEncoder HtmlEncoder { get; }
-
-        /// <summary>
-        /// Gets or sets the <see cref="ViewContext"/> for the current executing View.
-        /// </summary>
-        [HtmlAttributeNotBound]
-        [ViewContext]
-        public ViewContext ViewContext { get; set; }
-
-        /// <summary>
-        /// Gets or sets a <see cref="string" /> to vary the cached result by.
-        /// </summary>
-        [HtmlAttributeName(VaryByAttributeName)]
-        public string VaryBy { get; set; }
-
-        /// <summary>
-        /// Gets or sets the name of a HTTP request header to vary the cached result by.
-        /// </summary>
-        [HtmlAttributeName(VaryByHeaderAttributeName)]
-        public string VaryByHeader { get; set; }
-
-        /// <summary>
-        /// Gets or sets a comma-delimited set of query parameters to vary the cached result by.
-        /// </summary>
-        [HtmlAttributeName(VaryByQueryAttributeName)]
-        public string VaryByQuery { get; set; }
-
-        /// <summary>
-        /// Gets or sets a comma-delimited set of route data parameters to vary the cached result by.
-        /// </summary>
-        [HtmlAttributeName(VaryByRouteAttributeName)]
-        public string VaryByRoute { get; set; }
-
-        /// <summary>
-        /// Gets or sets a comma-delimited set of cookie names to vary the cached result by.
-        /// </summary>
-        [HtmlAttributeName(VaryByCookieAttributeName)]
-        public string VaryByCookie { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value that determines if the cached result is to be varied by the Identity for the logged in
-        /// <see cref="Http.HttpContext.User"/>.
-        /// </summary>
-        [HtmlAttributeName(VaryByUserAttributeName)]
-        public bool VaryByUser { get; set; }
-
-        /// <summary>
-        /// Gets or sets the exact <see cref="DateTimeOffset"/> the cache entry should be evicted.
-        /// </summary>
-        [HtmlAttributeName(ExpiresOnAttributeName)]
-        public DateTimeOffset? ExpiresOn { get; set; }
-
-        /// <summary>
-        /// Gets or sets the duration, from the time the cache entry was added, when it should be evicted.
-        /// </summary>
-        [HtmlAttributeName(ExpiresAfterAttributeName)]
-        public TimeSpan? ExpiresAfter { get; set; }
-
-        /// <summary>
-        /// Gets or sets the duration from last access that the cache entry should be evicted.
-        /// </summary>
-        [HtmlAttributeName(ExpiresSlidingAttributeName)]
-        public TimeSpan? ExpiresSliding { get; set; }
-
-        /// <summary>
         /// Gets or sets the <see cref="CacheItemPriority"/> policy for the cache entry.
         /// </summary>
         [HtmlAttributeName(CachePriorityAttributeName)]
         public CacheItemPriority? Priority { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value which determines if the tag helper is enabled or not.
-        /// </summary>
-        [HtmlAttributeName(EnabledAttributeName)]
-        public bool Enabled { get; set; } = true;
 
         /// <inheritdoc />
         public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
@@ -156,87 +58,84 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             {
                 throw new ArgumentNullException(nameof(output));
             }
+            
+            IHtmlContent content = null;
 
-            IHtmlContent result = null;
             if (Enabled)
             {
                 var key = GenerateKey(context);
-                if (!MemoryCache.TryGetValue(key, out result))
+                MemoryCacheEntryOptions options;
+    
+                while (content == null)
                 {
-                    // Create an entry link scope and flow it so that any tokens related to the cache entries
-                    // created within this scope get copied to this scope.
-                    using (var link = MemoryCache.CreateLinkingScope())
+                    Task<IHtmlContent> result = null;
+                    
+                    if (!MemoryCache.TryGetValue(key, out result))
                     {
-                        var content = await output.GetChildContentAsync();
+                        var tokenSource = new CancellationTokenSource();
 
-                        var stringBuilder = new StringBuilder();
-                        using (var writer = new StringWriter(stringBuilder))
+                        // Create an entry link scope and flow it so that any tokens related to the cache entries
+                        // created within this scope get copied to this scope.
+
+                        options = GetMemoryCacheEntryOptions();
+                        options.AddExpirationToken(new CancellationChangeToken(tokenSource.Token));
+
+                        var tcs = new TaskCompletionSource<IHtmlContent>();
+                         
+                        MemoryCache.Set(key, tcs.Task, options);
+                        
+                        try 
                         {
-                            content.WriteTo(writer, HtmlEncoder);
+                            using (var link = MemoryCache.CreateLinkingScope())
+                            {
+                                result = ProcessContentAsync(output);
+                                content = await result;
+                                options.AddEntryLink(link);
+                            }
+                            
+                            // The entry is set instead of assigning a value to the 
+                            // task so that the expiration options are are not impacted 
+                            // by the time it took to compute it.
+                            
+                            MemoryCache.Set(key, result, options);
                         }
+                        catch
+                        {
+                            // Remove the worker task from the cache in case it can't complete.
+                            tokenSource.Cancel();
+                            throw;
+                        }
+                        finally
+                        {
+                            // If an exception occurs, ensure the other awaiters 
+                            // render the output by themselves.
+                            tcs.SetResult(null);
+                        }
+                    }
+                    else
+                    {
+                        // There is either some value already cached (as a Task)
+                        // or a worker processing the output. In the case of a worker,
+                        // the result will be null, and the request will try to acquire
+                        // the result from memory another time.
 
-                        result = new StringBuilderHtmlContent(stringBuilder);
-                        MemoryCache.Set(key, result, GetMemoryCacheEntryOptions(link));
+                        content = await result;
                     }
                 }
+            }
+            else
+            {
+                content = await output.GetChildContentAsync();
             }
 
             // Clear the contents of the "cache" element since we don't want to render it.
             output.SuppressOutput();
-            if (Enabled)
-            {
-                output.Content.SetContent(result);
-            }
-            else
-            {
-                result = await output.GetChildContentAsync();
-                output.Content.SetContent(result);
-            }
+
+            output.Content.SetContent(content);
         }
 
         // Internal for unit testing
-        internal string GenerateKey(TagHelperContext context)
-        {
-            var builder = new StringBuilder(CacheKeyPrefix);
-            builder.Append(CacheKeyTokenSeparator)
-                   .Append(context.UniqueId);
-
-            var request = ViewContext.HttpContext.Request;
-
-            if (!string.IsNullOrEmpty(VaryBy))
-            {
-                builder.Append(CacheKeyTokenSeparator)
-                       .Append(nameof(VaryBy))
-                       .Append(CacheKeyTokenSeparator)
-                       .Append(VaryBy);
-            }
-
-            AddStringCollectionKey(builder, nameof(VaryByCookie), VaryByCookie, request.Cookies, (c, key) => c[key]);
-            AddStringCollectionKey(builder, nameof(VaryByHeader), VaryByHeader, request.Headers, (c, key) => c[key]);
-            AddStringCollectionKey(builder, nameof(VaryByQuery), VaryByQuery, request.Query, (c, key) => c[key]);
-            AddVaryByRouteKey(builder);
-
-            if (VaryByUser)
-            {
-                builder.Append(CacheKeyTokenSeparator)
-                       .Append(nameof(VaryByUser))
-                       .Append(CacheKeyTokenSeparator)
-                       .Append(ViewContext.HttpContext.User?.Identity?.Name);
-            }
-
-            // The key is typically too long to be useful, so we use a cryptographic hash
-            // as the actual key (better randomization and key distribution, so small vary
-            // values will generate dramatically different keys).
-            using (var sha = SHA256.Create())
-            {
-                var contentBytes = Encoding.UTF8.GetBytes(builder.ToString());
-                var hashedBytes = sha.ComputeHash(contentBytes);
-                return Convert.ToBase64String(hashedBytes);
-            }
-        }
-
-        // Internal for unit testing
-        internal MemoryCacheEntryOptions GetMemoryCacheEntryOptions(IEntryLink entryLink)
+        internal MemoryCacheEntryOptions GetMemoryCacheEntryOptions()
         {
             var options = new MemoryCacheEntryOptions();
             if (ExpiresOn != null)
@@ -259,134 +158,30 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 options.SetPriority(Priority.Value);
             }
 
-            options.AddEntryLink(entryLink);
             return options;
         }
 
-        private static void AddStringCollectionKey(
-            StringBuilder builder,
-            string keyName,
-            string value,
-            IDictionary<string, StringValues> sourceCollection)
+        protected override string GetUniqueId(TagHelperContext context)
         {
-            if (!string.IsNullOrEmpty(value))
-            {
-                // keyName(param1=value1|param2=value2)
-                builder.Append(CacheKeyTokenSeparator)
-                       .Append(keyName)
-                       .Append("(");
-
-                var values = Tokenize(value);
-
-                // Perf: Avoid allocating enumerator
-                for (var i = 0; i < values.Count; i++)
-                {
-                    var item = values[i];
-                    builder.Append(item)
-                           .Append(CacheKeyTokenSeparator)
-                           .Append(sourceCollection[item])
-                           .Append(CacheKeyTokenSeparator);
-                }
-
-                if (values.Count > 0)
-                {
-                    // Remove the trailing separator
-                    builder.Length -= CacheKeyTokenSeparator.Length;
-                }
-
-                builder.Append(")");
-            }
+            return context.UniqueId;
         }
 
-        private static void AddStringCollectionKey<TSourceCollection>(
-            StringBuilder builder,
-            string keyName,
-            string value,
-            TSourceCollection sourceCollection,
-            Func<TSourceCollection, string, StringValues> accessor)
+        protected override string GetKeyPrefix(TagHelperContext context)
         {
-            if (!string.IsNullOrEmpty(value))
-            {
-                // keyName(param1=value1|param2=value2)
-                builder.Append(CacheKeyTokenSeparator)
-                       .Append(keyName)
-                       .Append("(");
-
-                var values = Tokenize(value);
-
-                // Perf: Avoid allocating enumerator
-                for (var i = 0; i < values.Count; i++)
-                {
-                    var item = values[i];
-
-                    builder.Append(item)
-                           .Append(CacheKeyTokenSeparator)
-                           .Append(accessor(sourceCollection, item))
-                           .Append(CacheKeyTokenSeparator);
-                }
-
-                if (values.Count > 0)
-                {
-                    // Remove the trailing separator
-                    builder.Length -= CacheKeyTokenSeparator.Length;
-                }
-
-                builder.Append(")");
-            }
+            return CacheKeyPrefix;
         }
 
-        private void AddVaryByRouteKey(StringBuilder builder)
+        private async Task<IHtmlContent> ProcessContentAsync(TagHelperOutput output)
         {
-            var tokenFound = false;
+            var content = await output.GetChildContentAsync();
 
-            if (!string.IsNullOrEmpty(VaryByRoute))
+            var stringBuilder = new StringBuilder();
+            using (var writer = new StringWriter(stringBuilder))
             {
-                builder.Append(CacheKeyTokenSeparator)
-                       .Append(nameof(VaryByRoute))
-                       .Append("(");
-
-                var varyByRoutes = Tokenize(VaryByRoute);
-                for (var i = 0; i < varyByRoutes.Count; i++)
-                {
-                    var route = varyByRoutes[i];
-                    tokenFound = true;
-
-                    builder.Append(route)
-                           .Append(CacheKeyTokenSeparator)
-                           .Append(ViewContext.RouteData.Values[route])
-                           .Append(CacheKeyTokenSeparator);
-                }
-
-                if (tokenFound)
-                {
-                    builder.Length -= CacheKeyTokenSeparator.Length;
-                }
-
-                builder.Append(")");
-            }
-        }
-
-        private static IList<string> Tokenize(string value)
-        {
-            var values = value.Split(AttributeSeparator, StringSplitOptions.RemoveEmptyEntries);
-            if (values.Length == 0)
-            {
-                return values;
+                content.WriteTo(writer, HtmlEncoder);
             }
 
-            var trimmedValues = new List<string>();
-
-            for (var i = 0; i < values.Length; i++)
-            {
-                var trimmedValue = values[i].Trim();
-
-                if (trimmedValue.Length > 0)
-                {
-                    trimmedValues.Add(trimmedValue);
-                }
-            }
-
-            return trimmedValues;
+            return new StringBuilderHtmlContent(stringBuilder);
         }
 
         private class StringBuilderHtmlContent : IHtmlContent

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/CacheTagHelperBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/CacheTagHelperBase.cs
@@ -1,0 +1,312 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.AspNetCore.Mvc.TagHelpers
+{
+    /// <summary>
+    /// <see cref="TagHelper"/> base implementation for caching elements.
+    /// </summary>
+    public abstract class CacheTagHelperBase : TagHelper
+    {
+        private const string VaryByAttributeName = "vary-by";
+        private const string VaryByHeaderAttributeName = "vary-by-header";
+        private const string VaryByQueryAttributeName = "vary-by-query";
+        private const string VaryByRouteAttributeName = "vary-by-route";
+        private const string VaryByCookieAttributeName = "vary-by-cookie";
+        private const string VaryByUserAttributeName = "vary-by-user";
+        private const string ExpiresOnAttributeName = "expires-on";
+        private const string ExpiresAfterAttributeName = "expires-after";
+        private const string ExpiresSlidingAttributeName = "expires-sliding";
+        private const string CacheKeyTokenSeparator = "||";
+        private const string EnabledAttributeName = "enabled";
+        private static readonly char[] AttributeSeparator = new[] { ',' };
+
+        /// <summary>
+        /// Creates a new <see cref="CacheTagHelperBase"/>.
+        /// </summary>
+        /// <param name="htmlEncoder">The <see cref="HtmlEncoder"/> to use.</param>
+        public CacheTagHelperBase(HtmlEncoder htmlEncoder)
+        {
+            HtmlEncoder = htmlEncoder;
+        }
+
+        /// <inheritdoc />
+        public override int Order
+        {
+            get
+            {
+                return -1000;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="System.Text.Encodings.Web.HtmlEncoder"/> which encodes the content to be cached.
+        /// </summary>
+        protected HtmlEncoder HtmlEncoder { get; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ViewContext"/> for the current executing View.
+        /// </summary>
+        [HtmlAttributeNotBound]
+        [ViewContext]
+        public ViewContext ViewContext { get; set; }
+
+        /// <summary>
+        /// Gets or sets a <see cref="string" /> to vary the cached result by.
+        /// </summary>
+        [HtmlAttributeName(VaryByAttributeName)]
+        public string VaryBy { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of a HTTP request header to vary the cached result by.
+        /// </summary>
+        [HtmlAttributeName(VaryByHeaderAttributeName)]
+        public string VaryByHeader { get; set; }
+
+        /// <summary>
+        /// Gets or sets a comma-delimited set of query parameters to vary the cached result by.
+        /// </summary>
+        [HtmlAttributeName(VaryByQueryAttributeName)]
+        public string VaryByQuery { get; set; }
+
+        /// <summary>
+        /// Gets or sets a comma-delimited set of route data parameters to vary the cached result by.
+        /// </summary>
+        [HtmlAttributeName(VaryByRouteAttributeName)]
+        public string VaryByRoute { get; set; }
+
+        /// <summary>
+        /// Gets or sets a comma-delimited set of cookie names to vary the cached result by.
+        /// </summary>
+        [HtmlAttributeName(VaryByCookieAttributeName)]
+        public string VaryByCookie { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that determines if the cached result is to be varied by the Identity for the logged in
+        /// <see cref="Http.HttpContext.User"/>.
+        /// </summary>
+        [HtmlAttributeName(VaryByUserAttributeName)]
+        public bool VaryByUser { get; set; }
+
+        /// <summary>
+        /// Gets or sets the exact <see cref="DateTimeOffset"/> the cache entry should be evicted.
+        /// </summary>
+        [HtmlAttributeName(ExpiresOnAttributeName)]
+        public DateTimeOffset? ExpiresOn { get; set; }
+
+        /// <summary>
+        /// Gets or sets the duration, from the time the cache entry was added, when it should be evicted.
+        /// </summary>
+        [HtmlAttributeName(ExpiresAfterAttributeName)]
+        public TimeSpan? ExpiresAfter { get; set; }
+
+        /// <summary>
+        /// Gets or sets the duration from last access that the cache entry should be evicted.
+        /// </summary>
+        [HtmlAttributeName(ExpiresSlidingAttributeName)]
+        public TimeSpan? ExpiresSliding { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value which determines if the tag helper is enabled or not.
+        /// </summary>
+        [HtmlAttributeName(EnabledAttributeName)]
+        public bool Enabled { get; set; } = true;
+
+        // Internal for unit testing
+        protected internal string GenerateKey(TagHelperContext context)
+        {
+            var builder = new StringBuilder(GetKeyPrefix(context));
+            builder
+                .Append(CacheKeyTokenSeparator)
+                .Append(GetUniqueId(context));
+
+            var request = ViewContext.HttpContext.Request;
+
+            if (!string.IsNullOrEmpty(VaryBy))
+            {
+                builder
+                    .Append(CacheKeyTokenSeparator)
+                    .Append(nameof(VaryBy))
+                    .Append(CacheKeyTokenSeparator)
+                    .Append(VaryBy);
+            }
+
+            AddStringCollectionKey(builder, nameof(VaryByCookie), VaryByCookie, request.Cookies, (c, key) => c[key]);
+            AddStringCollectionKey(builder, nameof(VaryByHeader), VaryByHeader, request.Headers, (c, key) => c[key]);
+            AddStringCollectionKey(builder, nameof(VaryByQuery), VaryByQuery, request.Query, (c, key) => c[key]);
+            AddVaryByRouteKey(builder);
+
+            if (VaryByUser)
+            {
+                builder
+                    .Append(CacheKeyTokenSeparator)
+                    .Append(nameof(VaryByUser))
+                    .Append(CacheKeyTokenSeparator)
+                    .Append(ViewContext.HttpContext.User?.Identity?.Name);
+            }
+
+            // The key is typically too long to be useful, so we use a cryptographic hash
+            // as the actual key (better randomization and key distribution, so small vary
+            // values will generate dramatically different keys).
+            using (var sha = SHA256.Create())
+            {
+                var contentBytes = Encoding.UTF8.GetBytes(builder.ToString());
+                var hashedBytes = sha.ComputeHash(contentBytes);
+                return Convert.ToBase64String(hashedBytes);
+            }
+        }
+
+        protected abstract string GetUniqueId(TagHelperContext context);
+
+        protected abstract string GetKeyPrefix(TagHelperContext context);
+
+        protected static void AddStringCollectionKey(
+            StringBuilder builder,
+            string keyName,
+            string value,
+            IDictionary<string, StringValues> sourceCollection)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return;
+            }
+            
+            // keyName(param1=value1|param2=value2)
+            builder
+                .Append(CacheKeyTokenSeparator)
+                .Append(keyName)
+                .Append("(");
+
+            var values = Tokenize(value);
+
+            // Perf: Avoid allocating enumerator
+            for (var i = 0; i < values.Count; i++)
+            {
+                var item = values[i];
+                builder
+                    .Append(item)
+                    .Append(CacheKeyTokenSeparator)
+                    .Append(sourceCollection[item])
+                    .Append(CacheKeyTokenSeparator);
+            }
+
+            if (values.Count > 0)
+            {
+                // Remove the trailing separator
+                builder.Length -= CacheKeyTokenSeparator.Length;
+            }
+
+            builder.Append(")");
+        }
+
+        protected static void AddStringCollectionKey<TSourceCollection>(
+            StringBuilder builder,
+            string keyName,
+            string value,
+            TSourceCollection sourceCollection,
+            Func<TSourceCollection, string, StringValues> accessor)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return;
+            }
+
+            // keyName(param1=value1|param2=value2)
+            builder
+                .Append(CacheKeyTokenSeparator)
+                .Append(keyName)
+                .Append("(");
+
+            var values = Tokenize(value);
+
+            // Perf: Avoid allocating enumerator
+            for (var i = 0; i < values.Count; i++)
+            {
+                var item = values[i];
+
+                builder
+                    .Append(item)
+                    .Append(CacheKeyTokenSeparator)
+                    .Append(accessor(sourceCollection, item))
+                    .Append(CacheKeyTokenSeparator);
+            }
+
+            if (values.Count > 0)
+            {
+                // Remove the trailing separator
+                builder.Length -= CacheKeyTokenSeparator.Length;
+            }
+
+            builder.Append(")");
+        }
+
+        protected static IList<string> Tokenize(string value)
+        {
+            var values = value.Split(AttributeSeparator, StringSplitOptions.RemoveEmptyEntries);
+            if (values.Length == 0)
+            {
+                return values;
+            }
+
+            var trimmedValues = new List<string>();
+
+            for (var i = 0; i < values.Length; i++)
+            {
+                var trimmedValue = values[i].Trim();
+
+                if (trimmedValue.Length > 0)
+                {
+                    trimmedValues.Add(trimmedValue);
+                }
+            }
+
+            return trimmedValues;
+        }
+        
+        protected void AddVaryByRouteKey(StringBuilder builder)
+        {
+            var tokenFound = false;
+
+            if (string.IsNullOrEmpty(VaryByRoute))
+            {
+                return;
+            }
+            
+            builder
+                .Append(CacheKeyTokenSeparator)
+                .Append(nameof(VaryByRoute))
+                .Append("(");
+
+            var varyByRoutes = Tokenize(VaryByRoute);
+            for (var i = 0; i < varyByRoutes.Count; i++)
+            {
+                var route = varyByRoutes[i];
+                tokenFound = true;
+
+                builder
+                    .Append(route)
+                    .Append(CacheKeyTokenSeparator)
+                    .Append(ViewContext.RouteData.Values[route])
+                    .Append(CacheKeyTokenSeparator);
+            }
+
+            if (tokenFound)
+            {
+                builder.Length -= CacheKeyTokenSeparator.Length;
+            }
+
+            builder.Append(")");
+        }
+
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/DependencyInjection/TagHelperExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/DependencyInjection/TagHelperExtensions.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Mvc.TagHelpers.Cache;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Microsoft.Extensions.DependencyInjection
+{   
+    /// <summary>
+    /// Extension methods for configuring Razor cache tag helpers.
+    /// </summary>
+    public static class TagHelperServicesExtensions
+    {
+        /// <summary>
+        ///  Adds MVC cache tag helper services to the application.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcCoreBuilder"/>.</param>
+        /// <returns>The <see cref="IMvcCoreBuilder"/>.</returns>
+        public static IMvcCoreBuilder AddCacheTagHelper(this IMvcCoreBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.Services.TryAddTransient<IDistributedCacheTagHelperStorage, DistributedCacheTagHelperStorage>();
+            builder.Services.TryAddTransient<IDistributedCacheTagHelperFormatter, DistributedCacheTagHelperFormatter>();
+            builder.Services.TryAddSingleton<IDistributedCacheTagHelperService, DistributedCacheTagHelperService>();
+
+            // Required default services for cache tag helpers
+            builder.Services.TryAddSingleton<IDistributedCache, MemoryDistributedCache>();
+            builder.Services.TryAddSingleton<IMemoryCache, MemoryCache>();
+
+            return builder;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/DistributedCacheTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/DistributedCacheTagHelper.cs
@@ -1,0 +1,123 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text.Encodings.Web;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.TagHelpers.Cache;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Microsoft.AspNetCore.Mvc.TagHelpers
+{
+    /// <summary>
+    /// <see cref="TagHelper"/> implementation targeting &lt;distributed-cache&gt; elements.
+    /// </summary>
+    [HtmlTargetElement("distributed-cache", Attributes = NameAttributeName)]
+    public class DistributedCacheTagHelper : CacheTagHelperBase
+    {
+        private readonly IDistributedCacheTagHelperService _distributedCacheService;
+
+        /// <summary>
+        /// Prefix used by <see cref="DistributedCacheTagHelper"/> instances when creating entries in <see cref="IDistributedCacheTagHelperStorage"/>.
+        /// </summary>
+        public static readonly string CacheKeyPrefix = nameof(DistributedCacheTagHelper);
+
+        private const string NameAttributeName = "name";
+
+        /// <summary>
+        /// Creates a new <see cref="CacheTagHelper"/>.
+        /// </summary>
+        /// <param name="distributedCacheService">The <see cref="IDistributedCacheTagHelperService"/>.</param>
+        /// <param name="htmlEncoder">The <see cref="HtmlEncoder"/>.</param>
+        public DistributedCacheTagHelper(
+            IDistributedCacheTagHelperService distributedCacheService,
+            HtmlEncoder htmlEncoder) 
+            : base(htmlEncoder)
+        {
+            _distributedCacheService = distributedCacheService;
+        }
+        
+        /// <summary>
+        /// Gets the <see cref="IMemoryCache"/> instance used to cache workers.
+        /// </summary>
+        protected IMemoryCache MemoryCache { get; }
+
+        /// <summary>
+        /// Gets or sets a unique name to discriminate cached entries.
+        /// </summary>
+        [HtmlAttributeName(NameAttributeName)]
+        public string Name { get; set; }
+        
+        /// <inheritdoc />
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (output == null)
+            {
+                throw new ArgumentNullException(nameof(output));
+            }
+
+            IHtmlContent content = null;
+
+            // Create a cancellation token that will be used 
+            // to release the task from the memory cache.
+            var tokenSource = new CancellationTokenSource();
+
+            if (Enabled)
+            {
+                var key = GenerateKey(context);
+
+                content = await _distributedCacheService.ProcessContentAsync(output, key, GetDistributedCacheEntryOptions());
+            }
+            else
+            {
+                content = await output.GetChildContentAsync();
+            }
+
+            // Clear the contents of the "cache" element since we don't want to render it.
+            output.SuppressOutput();
+
+            output.Content.SetContent(content);
+        }
+        
+        // Internal for unit testing
+        internal DistributedCacheEntryOptions GetDistributedCacheEntryOptions()
+        {
+            var options = new DistributedCacheEntryOptions();
+            if (ExpiresOn != null)
+            {
+                options.SetAbsoluteExpiration(ExpiresOn.Value);
+            }
+
+            if (ExpiresAfter != null)
+            {
+                options.SetAbsoluteExpiration(ExpiresAfter.Value);
+            }
+
+            if (ExpiresSliding != null)
+            {
+                options.SetSlidingExpiration(ExpiresSliding.Value);
+            }
+
+            return options;
+        }
+
+        protected override string GetUniqueId(TagHelperContext context)
+        {
+            return Name;
+        }
+
+        protected override string GetKeyPrefix(TagHelperContext context)
+        {
+            return CacheKeyPrefix;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc/MvcServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc/MvcServiceCollectionExtensions.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.AddFormatterMappings();
             builder.AddViews();
             builder.AddRazorViewEngine();
+            builder.AddCacheTagHelper();
 
             // +1 order
             builder.AddDataAnnotations(); // +1 order

--- a/src/Microsoft.AspNetCore.Mvc/project.json
+++ b/src/Microsoft.AspNetCore.Mvc/project.json
@@ -20,6 +20,7 @@
     "Microsoft.AspNetCore.Mvc.Formatters.Json": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.Localization": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.Razor": "1.0.0-*",
+    "Microsoft.AspNetCore.Mvc.TagHelpers": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.ViewFeatures": "1.0.0-*",
     "Microsoft.Extensions.Caching.Memory": "1.0.0-*",
     "Microsoft.Extensions.DependencyInjection": "1.0.0-*",


### PR DESCRIPTION
- Introducing a new distributed cache tag helper
- Sharing base implementation for both cache tag helper
- Preventing concurrent execution of cache tag helpers

Fixes #4147 , Fixes #3867