### PR TITLE
[Perf] Optimize controller action invoke

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             // These are stateless
             services.TryAddSingleton<IControllerActionArgumentBinder, ControllerArgumentBinder>();
-            services.TryAddSingleton<FilterCache>();
+            services.TryAddSingleton<ControllerActionInvokerCache>();
             services.TryAddEnumerable(
                 ServiceDescriptor.Singleton<IFilterProvider, DefaultFilterProvider>());
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionInvoker.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionInvoker.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
         public ControllerActionInvoker(
             ActionContext actionContext,
-            FilterCache filterCache,
+            ControllerActionInvokerCache controllerActionInvokerCache,
             IControllerFactory controllerFactory,
             ControllerActionDescriptor descriptor,
             IReadOnlyList<IInputFormatter> inputFormatters,
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             int maxModelValidationErrors)
             : base(
                   actionContext,
-                  filterCache,
+                  controllerActionInvokerCache,
                   inputFormatters,
                   modelBinders,
                   modelValidatorProviders,
@@ -96,6 +96,9 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             }
 
             var actionMethodInfo = _descriptor.MethodInfo;
+
+            var methodExecutor = GetControllerActionMethodExecutor();
+
             var arguments = ControllerActionExecutor.PrepareArguments(
                 actionExecutingContext.ActionArguments,
                 actionMethodInfo.GetParameters());
@@ -103,7 +106,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             Logger.ActionMethodExecuting(actionExecutingContext, arguments);
 
             var actionReturnValue = await ControllerActionExecutor.ExecuteAsync(
-                actionMethodInfo,
+                methodExecutor,
                 actionExecutingContext.Controller,
                 arguments);
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionInvokerProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionInvokerProvider.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
     {
         private readonly IControllerActionArgumentBinder _argumentBinder;
         private readonly IControllerFactory _controllerFactory;
-        private readonly FilterCache _filterCache;
+        private readonly ControllerActionInvokerCache _controllerActionInvokerCache;
         private readonly IReadOnlyList<IInputFormatter> _inputFormatters;
         private readonly IReadOnlyList<IModelBinder> _modelBinders;
         private readonly IReadOnlyList<IModelValidatorProvider> _modelValidatorProviders;
@@ -30,14 +30,14 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
         public ControllerActionInvokerProvider(
             IControllerFactory controllerFactory,
-            FilterCache filterCache,
+            ControllerActionInvokerCache controllerActionInvokerCache,
             IControllerActionArgumentBinder argumentBinder,
             IOptions<MvcOptions> optionsAccessor,
             ILoggerFactory loggerFactory,
             DiagnosticSource diagnosticSource)
         {
             _controllerFactory = controllerFactory;
-            _filterCache = filterCache;
+            _controllerActionInvokerCache = controllerActionInvokerCache;
             _argumentBinder = argumentBinder;
             _inputFormatters = optionsAccessor.Value.InputFormatters.ToArray();
             _modelBinders = optionsAccessor.Value.ModelBinders.ToArray();
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             {
                 context.Result = new ControllerActionInvoker(
                     context.ActionContext,
-                    _filterCache,
+                    _controllerActionInvokerCache,
                     _controllerFactory,
                     actionDescriptor,
                     _inputFormatters,

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ObjectMethodExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ObjectMethodExecutor.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Microsoft.AspNetCore.Mvc.Internal
+{
+    public class ObjectMethodExecutor
+    {
+        private ActionExecutor _executor;
+
+        private ObjectMethodExecutor(MethodInfo methodInfo)
+        {            
+            if (methodInfo == null)
+            {
+                throw new ArgumentNullException(nameof(methodInfo));
+            }
+            MethodInfo = methodInfo;
+        }
+
+        private delegate object ActionExecutor(object target, object[] parameters);
+
+        private delegate void VoidActionExecutor(object target, object[] parameters);
+
+        public MethodInfo MethodInfo { get; }
+
+        public static ObjectMethodExecutor Create(MethodInfo methodInfo, TypeInfo targetTypeInfo)
+        {
+            var executor = new ObjectMethodExecutor(methodInfo);
+            executor._executor = GetExecutor(methodInfo, targetTypeInfo);
+            return executor;
+        }
+
+        public object Execute(object target, object[] parameters)
+        {
+            return _executor(target, parameters);
+        }
+
+        private static ActionExecutor GetExecutor(MethodInfo methodInfo, TypeInfo targetTypeInfo)
+        {
+            // Parameters to executor
+            var targetParameter = Expression.Parameter(typeof(object), "target");
+            var parametersParameter = Expression.Parameter(typeof(object[]), "parameters");
+
+            // Build parameter list
+            var parameters = new List<Expression>();
+            var paramInfos = methodInfo.GetParameters();
+            for (int i = 0; i < paramInfos.Length; i++)
+            {
+                var paramInfo = paramInfos[i];
+                var valueObj = Expression.ArrayIndex(parametersParameter, Expression.Constant(i));
+                var valueCast = Expression.Convert(valueObj, paramInfo.ParameterType);
+
+                // valueCast is "(Ti) parameters[i]"
+                parameters.Add(valueCast);
+            }
+
+            // Call method
+            var instanceCast = Expression.Convert(targetParameter, targetTypeInfo.AsType());
+            var methodCall = Expression.Call(instanceCast, methodInfo, parameters);
+
+            // methodCall is "((Ttarget) target) method((T0) parameters[0], (T1) parameters[1], ...)"
+            // Create function
+            if (methodCall.Type == typeof(void))
+            {
+                var lambda = Expression.Lambda<VoidActionExecutor>(methodCall, targetParameter, parametersParameter);
+                var voidExecutor = lambda.Compile();
+                return WrapVoidAction(voidExecutor);
+            }
+            else
+            {
+                // must coerce methodCall to match ActionExecutor signature
+                var castMethodCall = Expression.Convert(methodCall, typeof(object));
+                var lambda = Expression.Lambda<ActionExecutor>(castMethodCall, targetParameter, parametersParameter);
+                return lambda.Compile();
+            }
+        }
+
+        private static ActionExecutor WrapVoidAction(VoidActionExecutor executor)
+        {
+            return delegate (object target, object[] parameters)
+            {
+                executor(target, parameters);
+                return null;
+            };
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/DependencyInjection/MvcViewFeaturesMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/DependencyInjection/MvcViewFeaturesMvcCoreBuilderExtensions.cs
@@ -127,6 +127,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 IViewComponentDescriptorCollectionProvider,
                 DefaultViewComponentDescriptorCollectionProvider>();
 
+            services.TryAddSingleton<ViewComponentInvokerCache>();
             services.TryAddTransient<IViewComponentDescriptorProvider, DefaultViewComponentDescriptorProvider>();
             services.TryAddSingleton<IViewComponentInvokerFactory, DefaultViewComponentInvokerFactory>();
             services.TryAddTransient<IViewComponentHelper, DefaultViewComponentHelper>();

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/DefaultViewComponentInvokerFactory.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/DefaultViewComponentInvokerFactory.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Diagnostics;
-using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.AspNetCore.Mvc.ViewFeatures.Internal;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Mvc.ViewComponents
@@ -11,17 +11,24 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
     public class DefaultViewComponentInvokerFactory : IViewComponentInvokerFactory
     {
         private readonly IViewComponentFactory _viewComponentFactory;
+        private readonly ViewComponentInvokerCache _viewComponentInvokerCache;
         private readonly ILogger _logger;
         private readonly DiagnosticSource _diagnosticSource;
 
         public DefaultViewComponentInvokerFactory(
             IViewComponentFactory viewComponentFactory,
+            ViewComponentInvokerCache viewComponentInvokerCache,
             DiagnosticSource diagnosticSource,
             ILoggerFactory loggerFactory)
         {
             if (viewComponentFactory == null)
             {
                 throw new ArgumentNullException(nameof(viewComponentFactory));
+            }
+
+            if (viewComponentInvokerCache == null)
+            {
+                throw new ArgumentNullException(nameof(viewComponentInvokerCache));
             }
 
             if (diagnosticSource == null)
@@ -36,6 +43,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
 
             _viewComponentFactory = viewComponentFactory;
             _diagnosticSource = diagnosticSource;
+            _viewComponentInvokerCache = viewComponentInvokerCache;
 
             _logger = loggerFactory.CreateLogger<DefaultViewComponentInvoker>();
         }
@@ -53,6 +61,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
 
             return new DefaultViewComponentInvoker(
                 _viewComponentFactory,
+                _viewComponentInvokerCache,
                 _diagnosticSource,
                 _logger);
         }

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/ViewComponentInvokerCache.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/ViewComponentInvokerCache.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.AspNetCore.Mvc.ViewComponents;
+
+namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
+{
+    public class ViewComponentInvokerCache
+    {
+        private readonly IViewComponentDescriptorCollectionProvider _collectionProvider;
+
+        private volatile InnerCache _currentCache;
+
+        public ViewComponentInvokerCache(IViewComponentDescriptorCollectionProvider collectionProvider)
+        {
+            _collectionProvider = collectionProvider;
+        }
+
+        private InnerCache CurrentCache
+        {
+            get
+            {
+                var current = _currentCache;
+                var actionDescriptors = _collectionProvider.ViewComponents;
+
+                if (current == null || current.Version != actionDescriptors.Version)
+                {
+                    current = new InnerCache(actionDescriptors.Version);
+                    _currentCache = current;
+                }
+
+                return current;
+            }
+        }
+
+        public ObjectMethodExecutor GetViewComponentMethodExecutor(ViewComponentContext viewComponentContext)
+        {
+            var cache = CurrentCache;
+            var viewComponentDescriptor = viewComponentContext.ViewComponentDescriptor;
+
+            ObjectMethodExecutor executor;
+            if (cache.Entries.TryGetValue(viewComponentDescriptor, out executor))
+            {
+                return executor;
+            }
+
+            executor = ObjectMethodExecutor.Create(viewComponentDescriptor.MethodInfo, viewComponentDescriptor.TypeInfo);
+
+            cache.Entries.TryAdd(viewComponentDescriptor, executor);
+            return executor;
+        }
+
+        private class InnerCache
+        {
+            public InnerCache(int version)
+            {
+                Version = version;
+            }
+
+            public ConcurrentDictionary<ViewComponentDescriptor, ObjectMethodExecutor> Entries { get; } =
+                new ConcurrentDictionary<ViewComponentDescriptor, ObjectMethodExecutor>();
+
+            public int Version { get; }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerActionExecutorTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerActionExecutorTests.cs
@@ -33,22 +33,6 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         private delegate dynamic ReturnTaskAsDynamicValue(int i, string s);
 
         [Fact]
-        public async Task AsyncAction_WithVoidReturnType()
-        {
-            // Arrange
-            var methodWithVoidReturnType = new MethodWithVoidReturnType(TestController.VoidAction);
-
-            // Act
-            var result = await ControllerActionExecutor.ExecuteAsync(
-                                                        methodWithVoidReturnType.GetMethodInfo(),
-                                                        null,
-                                                        (IDictionary<string, object>)null);
-
-            // Assert
-            Assert.Same(null, result);
-        }
-
-        [Fact]
         public async Task AsyncAction_TaskReturnType()
         {
             // Arrange
@@ -57,12 +41,10 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             var actionParameters = new Dictionary<string, object> { { "i", inputParam1 }, { "s", inputParam2 } };
 
             var methodWithTaskReturnType = new MethodWithTaskReturnType(_controller.TaskAction);
-
-            // Act
-            var result = await ControllerActionExecutor.ExecuteAsync(
-                                                            methodWithTaskReturnType.GetMethodInfo(),
-                                                            _controller,
-                                                            actionParameters);
+            var result = await ExecuteAction(
+                methodWithTaskReturnType,
+                _controller,
+                actionParameters);
 
             // Assert
             Assert.Same(null, result);
@@ -79,11 +61,10 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             var methodWithTaskOfIntReturnType = new MethodWithTaskOfIntReturnType(_controller.TaskValueTypeAction);
 
             // Act
-            var result = await ControllerActionExecutor.ExecuteAsync(
-                                                        methodWithTaskOfIntReturnType.GetMethodInfo(),
-                                                        _controller,
-                                                        actionParameters);
-
+            var result = await ExecuteAction(
+                methodWithTaskOfIntReturnType,
+                _controller,
+                actionParameters);
             // Assert
             Assert.Equal(inputParam1, result);
         }
@@ -99,10 +80,10 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             var methodWithTaskOfTaskOfIntReturnType = new MethodWithTaskOfTaskOfIntReturnType(_controller.TaskOfTaskAction);
 
             // Act
-            var result = await (Task<int>)(await ControllerActionExecutor.ExecuteAsync(
-                                                                        methodWithTaskOfTaskOfIntReturnType.GetMethodInfo(),
-                                                                        _controller,
-                                                                        actionParameters));
+            var result = await (Task<int>)( await ExecuteAction(
+                methodWithTaskOfTaskOfIntReturnType,
+                _controller,
+                actionParameters));
 
             // Assert
             Assert.Equal(inputParam1, result);
@@ -120,9 +101,10 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
             // Act and Assert
             await Assert.ThrowsAsync<NotImplementedException>(
-                    () => ControllerActionExecutor.ExecuteAsync(methodWithTaskOfIntReturnType.GetMethodInfo(),
-                                                               _controller,
-                                                               actionParameters));
+                    () => ExecuteAction(
+                        methodWithTaskOfIntReturnType,
+                        _controller,
+                        actionParameters));
         }
 
         [Fact]
@@ -137,9 +119,10 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
             // Act & Assert
             await Assert.ThrowsAsync<NotImplementedException>(
-                        () => ControllerActionExecutor.ExecuteAsync(methodWithTaskOfIntReturnType.GetMethodInfo(),
-                                                                   _controller,
-                                                                   actionParameters));
+                        () => ExecuteAction(
+                            methodWithTaskOfIntReturnType,
+                            _controller,
+                            actionParameters));
         }
 
         [Fact]
@@ -155,8 +138,8 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
             // Act & Assert
             var ex = await Assert.ThrowsAsync<ArgumentException>(
-                () => ControllerActionExecutor.ExecuteAsync(
-                    methodWithTaskOfIntReturnType.GetMethodInfo(),
+                () => ExecuteAction(
+                    methodWithTaskOfIntReturnType,
                     _controller,
                     actionParameters));
             Assert.Equal(expectedException, ex.Message);
@@ -170,11 +153,10 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             var syncMethod = new SyncMethod(_controller.Echo);
 
             // Act
-            var result = await ControllerActionExecutor.ExecuteAsync(
-                                                syncMethod.GetMethodInfo(),
-                                                _controller,
-                                                new Dictionary<string, object>() { { "input", inputString } });
-
+            var result = await ExecuteAction(
+                syncMethod,
+                _controller,
+                new Dictionary<string, object>() { { "input", inputString } });
             // Assert
             Assert.Equal(inputString, result);
         }
@@ -188,10 +170,10 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
             // Act & Assert
             await Assert.ThrowsAsync<NotImplementedException>(
-                        () => ControllerActionExecutor.ExecuteAsync(
-                                                syncMethod.GetMethodInfo(),
-                                                _controller,
-                                                new Dictionary<string, object>() { { "input", inputString } }));
+                        () => ExecuteAction(
+                            syncMethod,
+                            _controller,
+                            new Dictionary<string, object>() { { "input", inputString } }));
         }
 
         [Fact]
@@ -201,8 +183,8 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             var syncMethod = new SyncMethod(_controller.EchoWithDefaultValue);
 
             // Act
-            var result = await ControllerActionExecutor.ExecuteAsync(
-                syncMethod.GetMethodInfo(),
+            var result = await ExecuteAction(
+                syncMethod,
                 _controller,
                 new Dictionary<string, object>());
 
@@ -217,8 +199,8 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             var syncMethod = new SyncMethod(_controller.EchoWithDefaultValue);
 
             // Act
-            var result = await ControllerActionExecutor.ExecuteAsync(
-                syncMethod.GetMethodInfo(),
+            var result = await ExecuteAction(
+                syncMethod,
                 _controller,
                 new object[] { null, });
 
@@ -233,8 +215,8 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             var syncMethod = new SyncMethod(_controller.EchoWithDefaultValueAndAttribute);
 
             // Act
-            var result = await ControllerActionExecutor.ExecuteAsync(
-                syncMethod.GetMethodInfo(),
+            var result = await ExecuteAction(
+                syncMethod,
                 _controller,
                 new Dictionary<string, object>());
 
@@ -249,8 +231,8 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             var syncMethod = new SyncMethod(_controller.EchoWithDefaultValueAndAttribute);
 
             // Act
-            var result = await ControllerActionExecutor.ExecuteAsync(
-                syncMethod.GetMethodInfo(),
+            var result = await ExecuteAction(
+                syncMethod,
                 _controller,
                 new Dictionary<string, object>() { { "input", null } });
 
@@ -276,8 +258,8 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
             // Act & Assert
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-                () => ControllerActionExecutor.ExecuteAsync(
-                    methodWithCutomTaskReturnType.GetMethodInfo(),
+                () => ExecuteAction(
+                    methodWithCutomTaskReturnType,
                     _controller,
                     actionParameters));
             Assert.Equal(expectedException, ex.Message);
@@ -299,8 +281,8 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
             // Act & Assert
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-                () => ControllerActionExecutor.ExecuteAsync(
-                    methodWithCutomTaskOfTReturnType.GetMethodInfo(),
+                () => ExecuteAction(
+                    methodWithCutomTaskOfTReturnType,
                     _controller,
                     actionParameters));
             Assert.Equal(expectedException, ex.Message);
@@ -325,8 +307,8 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
             // Act & Assert
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-                () => ControllerActionExecutor.ExecuteAsync(
-                    methodWithUnwrappedTask.GetMethodInfo(),
+                () => ExecuteAction(
+                    methodWithUnwrappedTask,
                     _controller,
                     actionParameters));
             Assert.Equal(expectedException, ex.Message);
@@ -348,10 +330,10 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
             // Act & Assert
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-               () => ControllerActionExecutor.ExecuteAsync(
-                    dynamicTaskMethod.GetMethodInfo(),
-                    _controller,
-                    actionParameters));
+               () => ExecuteAction(
+                   dynamicTaskMethod,
+                   _controller,
+                   actionParameters));
             Assert.Equal(expectedException, ex.Message);
         }
 
@@ -367,10 +349,10 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             var methodWithTaskOfIntReturnType = new MethodWithTaskOfIntReturnType(_controller.TaskValueTypeAction);
 
             // Act
-            var result = await ControllerActionExecutor.ExecuteAsync(
-                                                        methodWithTaskOfIntReturnType.GetMethodInfo(),
-                                                        _controller,
-                                                        actionParameters);
+            var result = await ExecuteAction(
+                methodWithTaskOfIntReturnType,
+                _controller,
+                actionParameters);
 
             // Assert
             Assert.Equal(inputParam1, result);
@@ -383,32 +365,48 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             var inputParam2 = "Second Parameter";
 
             var actionParameters = new Dictionary<string, object> { { "i", "Some Invalid Value" }, { "s", inputParam2 } };
-            var methodWithTaskOfIntReturnType = new MethodWithTaskOfIntReturnType(_controller.TaskValueTypeAction);
-            var message = TestPlatformHelper.IsMono ? "Object type {0} cannot be converted to target type: {1}" :
-                                                      "Object of type '{0}' cannot be converted to type '{1}'.";
-            var expectedException = string.Format(
-                CultureInfo.CurrentCulture,
-                message,
-                typeof(string),
-                typeof(int));
+            var methodWithTaskOfIntReturnType = new MethodWithTaskOfIntReturnType(_controller.TaskValueTypeAction);            
 
             // Act & Assert
             // If it is an unrecognized derived type we throw an InvalidOperationException.
-            var ex = await Assert.ThrowsAsync<ArgumentException>(
-                () => ControllerActionExecutor.ExecuteAsync(
-                        methodWithTaskOfIntReturnType.GetMethodInfo(),
-                        _controller,
-                        actionParameters));
+            var ex = await Assert.ThrowsAsync<InvalidCastException>(
+                () => ExecuteAction(
+                    methodWithTaskOfIntReturnType,
+                    _controller,
+                    actionParameters));
+        }
 
-            Assert.Equal(expectedException, ex.Message);
+        private async Task<object> ExecuteAction(
+            Delegate methodDelegate,
+            TestController controller,
+            IDictionary<string, object> actionParameters)
+        {
+            var executor = ObjectMethodExecutor.Create(methodDelegate.GetMethodInfo(), _controller.GetType().GetTypeInfo());
+
+            var result = await ControllerActionExecutor.ExecuteAsync(
+                executor,
+                controller,
+                actionParameters);
+
+            return result;
+        }
+
+        private async Task<object> ExecuteAction(
+            Delegate methodDelegate,
+            TestController controller,
+            object[] actionParameters)
+        {
+            var executor = ObjectMethodExecutor.Create(methodDelegate.GetMethodInfo(), _controller.GetType().GetTypeInfo());
+
+            var result = await ControllerActionExecutor.ExecuteAsync(
+                executor,
+                controller,
+                actionParameters);
+            return result;
         }
 
         public class TestController
         {
-            public static void VoidAction()
-            {
-            }
-
 #pragma warning disable 1998
             public async Task TaskAction(int i, string s)
             {

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerActionInvokerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerActionInvokerTest.cs
@@ -1977,6 +1977,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             {
                 actionDescriptor.MethodInfo = typeof(ControllerActionInvokerTest).GetMethod("ActionMethod");
             }
+            actionDescriptor.ControllerTypeInfo = typeof(ControllerActionInvokerTest).GetTypeInfo();
 
             var httpContext = new Mock<HttpContext>(MockBehavior.Loose);
 
@@ -2224,11 +2225,11 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             }
         }
 
-        private static FilterCache CreateFilterCache(IFilterProvider[] filterProviders = null)
+        private static ControllerActionInvokerCache CreateFilterCache(IFilterProvider[] filterProviders = null)
         {
             var services = new ServiceCollection().BuildServiceProvider();
             var descriptorProvider = new ActionDescriptorCollectionProvider(services);
-            return new FilterCache(descriptorProvider, filterProviders.AsEnumerable() ?? new List<IFilterProvider>());
+            return new ControllerActionInvokerCache(descriptorProvider, filterProviders.AsEnumerable() ?? new List<IFilterProvider>());
         }
 
         private class TestControllerActionInvoker : ControllerActionInvoker

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ObjectMethodExecutorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ObjectMethodExecutorTest.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.AspNetCore.Testing;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.Internal
+{
+    public class ObjectMethodExecutorTest
+    {
+        private TestObject _targetObject = new TestObject();
+        private TypeInfo targetTypeInfo = typeof(TestObject).GetTypeInfo();
+
+        [Fact]
+        public void ExecuteValueMethod()
+        {
+            var executor = GetExecutorForMethod("ValueMethod");
+            var result = executor.Execute(
+                _targetObject,
+                new object[] { 10 , 20 });
+            Assert.Equal(30, (int)result);
+        }
+
+        [Fact]
+        public void ExecuteVoidValueMethod()
+        {
+            var executor = GetExecutorForMethod("VoidValueMethod");
+            var result = executor.Execute(
+                _targetObject,
+                new object[] { 10 });
+            Assert.Same(null, result);
+        }
+
+        [Fact]
+        public void ExecuteValueMethodWithReturnType()
+        {
+            var executor = GetExecutorForMethod("ValueMethodWithReturnType");
+            var result = executor.Execute(
+                _targetObject,
+                new object[] { 10 });
+            var resultObject = Assert.IsType<TestObject>(result);
+            Assert.Equal("Hello", resultObject.value);
+        }
+
+        [Fact]
+        public void ExecuteValueMethodUpdateValue()
+        {
+            var executor = GetExecutorForMethod("ValueMethodUpdateValue");
+            var parameter = new TestObject();
+            var result = executor.Execute(
+                _targetObject,
+                new object[] { parameter });
+            var resultObject = Assert.IsType<TestObject>(result);
+            Assert.Equal("HelloWorld", resultObject.value);
+        }
+
+        [Fact]
+        public void ExecuteValueMethodWithReturnTypeThrowsException()
+        {
+            var executor = GetExecutorForMethod("ValueMethodWithReturnTypeThrowsException");
+            var parameter = new TestObject();
+            Assert.Throws<NotImplementedException>(
+                        () => executor.Execute(
+                            _targetObject,
+                            new object[] { parameter }));
+        }
+
+        private ObjectMethodExecutor GetExecutorForMethod(string methodName)
+        {
+            var method = typeof(TestObject).GetMethod(methodName);
+            var executor = ObjectMethodExecutor.Create(method, targetTypeInfo);
+            return executor;
+        }
+
+        public class TestObject
+        {            
+            public string value;
+            public int ValueMethod(int i, int j)
+            {
+                return i+j;
+            }
+
+            public void VoidValueMethod(int i)
+            {
+                
+            }
+            public TestObject ValueMethodWithReturnType(int i)
+            {
+                return new TestObject() { value = "Hello" }; ;
+            }
+
+            public TestObject ValueMethodWithReturnTypeThrowsException(TestObject i)
+            {
+                throw new NotImplementedException("Not Implemented Exception");
+            }
+
+            public TestObject ValueMethodUpdateValue(TestObject parameter)
+            {
+                parameter.value = "HelloWorld";
+                return parameter;
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponentResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponentResultTest.cs
@@ -518,6 +518,7 @@ namespace Microsoft.AspNetCore.Mvc
 
             var services = new ServiceCollection();
             services.AddSingleton<DiagnosticSource>(diagnosticSource);
+            services.AddSingleton<ViewComponentInvokerCache>();
             services.AddSingleton<IOptions<MvcViewOptions>, TestOptionsManager<MvcViewOptions>>();
             services.AddTransient<IViewComponentHelper, DefaultViewComponentHelper>();
             services.AddSingleton<IViewComponentSelector, DefaultViewComponentSelector>();


### PR DESCRIPTION
Fixes #3903 
 1. Added a general purpose method executor that provides an alternative to MethodInfo.Invoke()
 2. This executor creates a delegate for the method which can be cached for performance benefit.
 3. The delegate is created dynamically using the Linq expressions.
 4. Controller action methods are invoked using the cached executor.
The same concept is applied to ViewComponentInvoker where the ViewComponentDescriptor method is invoked using the cached delegate
