### PR TITLE
RazorCompilationService should throw a meaningful error when a user p…

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/DefaultRoslynCompilationService.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/DefaultRoslynCompilationService.cs
@@ -85,7 +85,6 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 #if NETSTANDARD1_5
             _razorLoadContext = new RazorLoadContext();
 #endif
-
         }
 
         /// <inheritdoc />
@@ -144,6 +143,18 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
                     if (!result.Success)
                     {
+                        if (!compilation.References.Any() && !_applicationReferences.Value.Any())
+                        {
+                            // DependencyModel had no references specified and the user did not use the
+                            // CompilationCallback to add extra references. It is likely that the user did not specify
+                            // preserveCompilationContext in the app's project.json.
+                            throw new InvalidOperationException(
+                                Resources.FormatCompilation_DependencyContextIsNotSpecified(
+                                    fileInfo.RelativePath,
+                                    "project.json",
+                                    "preserveCompilationContext"));
+                        }
+
                         return GetCompilationFailedResult(
                             fileInfo.RelativePath,
                             compilationContent,

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Properties/Resources.Designer.cs
@@ -462,6 +462,22 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             return string.Format(CultureInfo.CurrentCulture, GetString("LayoutHasCircularReference"), p0, p1);
         }
 
+        /// <summary>
+        /// The Razor page '{0}' failed to compile. Ensure that your application's {1} sets the '{2}' compilation property.
+        /// </summary>
+        internal static string Compilation_DependencyContextIsNotSpecified
+        {
+            get { return GetString("Compilation_DependencyContextIsNotSpecified"); }
+        }
+
+        /// <summary>
+        /// The Razor page '{0}' failed to compile. Ensure that your application's {1} sets the '{2}' compilation property.
+        /// </summary>
+        internal static string FormatCompilation_DependencyContextIsNotSpecified(object p0, object p1, object p2)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Compilation_DependencyContextIsNotSpecified"), p0, p1, p2);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Resources.resx
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Resources.resx
@@ -203,4 +203,7 @@
   <data name="LayoutHasCircularReference" xml:space="preserve">
     <value>A circular layout reference was detected when rendering '{0}'. The layout page '{1}' has already been rendered.</value>
   </data>
+  <data name="Compilation_DependencyContextIsNotSpecified" xml:space="preserve">
+    <value>The Razor page '{0}' failed to compile. Ensure that your application's {1} sets the '{2}' compilation property.</value>
+  </data>
 </root>


### PR DESCRIPTION
…roduces an application without `preserveCompilationContext`

Fixes #4202