### PR TITLE
Ignore body/section now returns HtmlString.Empty

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor/RazorPage.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/RazorPage.cs
@@ -672,9 +672,12 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         /// <summary>
         /// In a Razor layout page, ignores rendering the portion of a content page that is not within a named section.
         /// </summary>
-        public void IgnoreBody()
+        /// <returns><see cref="HtmlString.Empty"/>.</returns>
+        public HtmlString IgnoreBody()
         {
             _ignoreBody = true;
+
+            return HtmlString.Empty;
         }
 
         /// <summary>
@@ -841,7 +844,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         /// In layout pages, ignores rendering the content of the section named <paramref name="sectionName"/>.
         /// </summary>
         /// <param name="sectionName">The section to ignore.</param>
-        public void IgnoreSection(string sectionName)
+        /// <returns><see cref="HtmlString.Empty"/>.</returns>
+        public HtmlString IgnoreSection(string sectionName)
         {
             if (sectionName == null)
             {
@@ -863,6 +867,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             }
 
             _ignoredSections.Add(sectionName);
+
+            return HtmlString.Empty;
         }
 
         /// <summary>

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorPageTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorPageTest.cs
@@ -676,22 +676,25 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         public async Task EnsureRenderedBodyOrSections_SucceedsIfDefinedSectionsAreNotRendered_AndIgnored()
         {
             // Arrange
-            var path = "page-path";
-            var sectionName = "sectionA";
+            var sectionA = "sectionA";
+            var sectionB = "sectionB";
             var page = CreatePage(v =>
             {
+                v.Write(v.RenderSection(sectionA));
             });
-            page.Path = path;
-            page.BodyContent = new HtmlString("some content");
             page.PreviousSectionWriters = new Dictionary<string, RenderAsyncDelegate>
             {
-                { sectionName, _nullRenderAsyncDelegate }
+                { sectionA, writer => writer.WriteAsync(sectionA) },
+                { sectionB, writer => writer.WriteAsync(sectionB) }
             };
-            page.IgnoreSection(sectionName);
+            page.IgnoreSection(sectionB);
 
-            // Act & Assert (does not throw)
+            // Act
             await page.ExecuteAsync();
+
+            // Assert
             page.EnsureRenderedBodyOrSections();
+            Assert.Equal(sectionA, page.RenderedContent);
         }
 
         [Fact]


### PR DESCRIPTION
This is in fact a followup for the discussion here
https://github.com/aspnet/Mvc/pull/4024
I was late to fix some of @pranavkm points, and the PR merged before I address them

The missing parts

> Could you verify that content written by the page - inside the delegate for CreatePage - gets written out (and not ignored?)

based on this 
https://github.com/aspnet/Mvc/issues/3293#issuecomment-146991821
`IgnoreSection` only suppresses errors right now, and wont stop sections from rendering in other words:
If u call `RenderSection("section1")` and also `IgnoreSection("section1")` the section would be rendered
should I change this behavior?

> One more test that verifies that IgnoreSection does not affect EnsureRenderedBodyOrSections for sections that aren't ignored?

Done

Also I changed the return types so it would be easier to use