### PR TITLE
[Perf] Optimize CoerceResultToTaskAsync to remove MethodInfo.Invoke

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionExecutor.cs
@@ -4,27 +4,13 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Reflection;
-using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc.Core;
-using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Mvc.Internal
 {
     public static class ControllerActionExecutor
     {
-        private static readonly MethodInfo _convertOfTMethod =
-            typeof(ControllerActionExecutor).GetRuntimeMethods().Single(methodInfo => methodInfo.Name == "Convert");
-
-        // Method called via reflection.
-        private static Task<object> Convert<T>(object taskAsObject)
-        {
-            var task = (Task<T>)taskAsObject;
-            return CastToObject<T>(task);
-        }
-
         public static Task<object> ExecuteAsync(
             ObjectMethodExecutor actionMethodExecutor,
             object instance,
@@ -39,57 +25,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             object instance,
             object[] orderedActionArguments)
         {
-            object invocationResult = actionMethodExecutor.Execute(instance, orderedActionArguments);
-            return CoerceResultToTaskAsync(
-                invocationResult,
-                actionMethodExecutor.MethodInfo.ReturnType,
-                actionMethodExecutor.MethodInfo.Name,
-                actionMethodExecutor.MethodInfo.DeclaringType);
-        }
-
-        // We need to CoerceResult as the object value returned from methodInfo.Invoke has to be cast to a Task<T>.
-        // This is necessary to enable calling await on the returned task.
-        // i.e we need to write the following var result = await (Task<ActualType>)mInfo.Invoke.
-        // Returning Task<object> enables us to await on the result.
-        // This method is intentionally not using async pattern to keep jit time (on cold start) to a minimum.
-        private static Task<object> CoerceResultToTaskAsync(
-            object result,
-            Type returnType,
-            string methodName,
-            Type declaringType)
-        {
-            // If it is either a Task or Task<T>
-            // must coerce the return value to Task<object>
-            var resultAsTask = result as Task;
-            if (resultAsTask != null)
-            {
-                if (returnType == typeof(Task))
-                {
-                    ThrowIfWrappedTaskInstance(resultAsTask.GetType(), methodName, declaringType);
-                    return CastToObject(resultAsTask);
-                }
-
-                var taskValueType = GetTaskInnerTypeOrNull(returnType);
-                if (taskValueType != null)
-                {
-                    // for: public Task<T> Action()
-                    // constructs: return (Task<object>)Convert<T>((Task<T>)result)
-                    var genericMethodInfo = _convertOfTMethod.MakeGenericMethod(taskValueType);
-                    var convertedResult = (Task<object>)genericMethodInfo.Invoke(null, new object[] { result });
-                    return convertedResult;
-                }
-
-                // This will be the case for:
-                // 1. Types which have derived from Task and Task<T>,
-                // 2. Action methods which use dynamic keyword but return a Task or Task<T>.
-                throw new InvalidOperationException(Resources.FormatActionExecutor_UnexpectedTaskInstance(
-                    methodName,
-                    declaringType));
-            }
-            else
-            {
-                return Task.FromResult(result);
-            }
+            return actionMethodExecutor.ExecuteAsync(instance, orderedActionArguments);
         }
 
         public static object[] PrepareArguments(
@@ -136,48 +72,6 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             }
 
             return arguments;
-        }
-
-        private static void ThrowIfWrappedTaskInstance(Type actualTypeReturned, string methodName, Type declaringType)
-        {
-            // Throw if a method declares a return type of Task and returns an instance of Task<Task> or Task<Task<T>>
-            // This most likely indicates that the developer forgot to call Unwrap() somewhere.
-            if (actualTypeReturned != typeof(Task))
-            {
-                var innerTaskType = GetTaskInnerTypeOrNull(actualTypeReturned);
-                if (innerTaskType != null && typeof(Task).IsAssignableFrom(innerTaskType))
-                {
-                    throw new InvalidOperationException(
-                        Resources.FormatActionExecutor_WrappedTaskInstance(
-                            methodName,
-                            declaringType,
-                            actualTypeReturned.FullName));
-                }
-            }
-        }
-
-        /// <summary>
-        /// Cast Task to Task of object
-        /// </summary>
-        private static async Task<object> CastToObject(Task task)
-        {
-            await task;
-            return null;
-        }
-
-        /// <summary>
-        /// Cast Task of T to Task of object
-        /// </summary>
-        private static async Task<object> CastToObject<T>(Task<T> task)
-        {
-            return (object)await task;
-        }
-
-        private static Type GetTaskInnerTypeOrNull(Type type)
-        {
-            var genericType = ClosedGenericMatcher.ExtractGenericInterface(type, typeof(Task<>));
-
-            return genericType?.GenericTypeArguments[0];
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ObjectMethodExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ObjectMethodExecutor.cs
@@ -3,14 +3,34 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Core;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Mvc.Internal
 {
     public class ObjectMethodExecutor
     {
+        private ActionExecutorAsync _executorAsync;
         private ActionExecutor _executor;
+
+        private static readonly MethodInfo _convertOfTMethod =
+            typeof(ObjectMethodExecutor).GetRuntimeMethods().Single(methodInfo => methodInfo.Name == nameof(ObjectMethodExecutor.Convert));
+
+        private static readonly Expression<Func<object, Task<object>>> _createTaskFromResultExpression =
+            ((result) => Task.FromResult(result));
+
+        private static readonly MethodInfo _createTaskFromResultMethod = 
+            ((MethodCallExpression)_createTaskFromResultExpression.Body).Method;
+
+        private static readonly Expression<Func<object, string, Type, Task<object>>> _coerceTaskExpression =
+            ((result, methodName, declaringType) => ObjectMethodExecutor.CoerceTaskType(result, methodName, declaringType));
+
+        private static readonly MethodInfo _coerceMethod = ((MethodCallExpression)_coerceTaskExpression.Body).Method;
+
 
         private ObjectMethodExecutor(MethodInfo methodInfo)
         {            
@@ -20,6 +40,8 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             }
             MethodInfo = methodInfo;
         }
+
+        private delegate Task<object> ActionExecutorAsync(object target, object[] parameters);
 
         private delegate object ActionExecutor(object target, object[] parameters);
 
@@ -31,7 +53,13 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         {
             var executor = new ObjectMethodExecutor(methodInfo);
             executor._executor = GetExecutor(methodInfo, targetTypeInfo);
+            executor._executorAsync = GetExecutorAsync(methodInfo, targetTypeInfo);
             return executor;
+        }
+
+        public Task<object> ExecuteAsync(object target, object[] parameters)
+        {
+            return _executorAsync(target, parameters);
         }
 
         public object Execute(object target, object[] parameters)
@@ -86,6 +114,129 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 executor(target, parameters);
                 return null;
             };
+        }
+
+        private static ActionExecutorAsync GetExecutorAsync(MethodInfo methodInfo, TypeInfo targetTypeInfo)
+        {
+            // Parameters to executor
+            var targetParameter = Expression.Parameter(typeof(object), "target");
+            var parametersParameter = Expression.Parameter(typeof(object[]), "parameters");
+
+            // Build parameter list
+            var parameters = new List<Expression>();
+            var paramInfos = methodInfo.GetParameters();
+            for (int i = 0; i < paramInfos.Length; i++)
+            {
+                var paramInfo = paramInfos[i];
+                var valueObj = Expression.ArrayIndex(parametersParameter, Expression.Constant(i));
+                var valueCast = Expression.Convert(valueObj, paramInfo.ParameterType);
+
+                // valueCast is "(Ti) parameters[i]"
+                parameters.Add(valueCast);
+            }
+
+            // Call method
+            var instanceCast = Expression.Convert(targetParameter, targetTypeInfo.AsType());
+            var methodCall = Expression.Call(instanceCast, methodInfo, parameters);
+
+            // methodCall is "((Ttarget) target) method((T0) parameters[0], (T1) parameters[1], ...)"
+            // Create function
+            if (methodCall.Type == typeof(void))
+            {
+                var lambda = Expression.Lambda<VoidActionExecutor>(methodCall, targetParameter, parametersParameter);
+                var voidExecutor = lambda.Compile();
+                return WrapVoidActionAsync(voidExecutor);
+            }
+            else
+            {
+                // must coerce methodCall to match ActionExecutorAsync signature
+                var coerceMethodCall = GetCoerceMethodCallExpression(methodCall, methodInfo);
+                var lambda = Expression.Lambda<ActionExecutorAsync>(coerceMethodCall, targetParameter, parametersParameter);
+                return lambda.Compile();
+            }
+        }
+
+        // We need to CoerceResult as the object value returned from methodInfo.Invoke has to be cast to a Task<T>.
+        // This is necessary to enable calling await on the returned task.
+        // i.e we need to write the following var result = await (Task<ActualType>)mInfo.Invoke.
+        // Returning Task<object> enables us to await on the result.
+        private static Expression GetCoerceMethodCallExpression(MethodCallExpression methodCall, MethodInfo methodInfo)
+        {
+            var castMethodCall = Expression.Convert(methodCall, typeof(object));
+            var returnType = methodCall.Type;
+
+            if (typeof(Task).IsAssignableFrom(returnType))
+            {
+                if (returnType == typeof(Task))
+                {
+                    var stringExpression = Expression.Constant(methodInfo.Name);
+                    var typeExpression = Expression.Constant(methodInfo.DeclaringType);
+                    return Expression.Call(null, _coerceMethod, castMethodCall, stringExpression, typeExpression);
+                }
+
+                var taskValueType = GetTaskInnerTypeOrNull(returnType);
+                if (taskValueType != null)
+                {
+                    // for: public Task<T> Action()
+                    // constructs: return (Task<object>)Convert<T>((Task<T>)result)
+                    var genericMethodInfo = _convertOfTMethod.MakeGenericMethod(taskValueType);
+                    var genericMethodCall = Expression.Call(null, genericMethodInfo, castMethodCall);
+                    var convertedResult = Expression.Convert(genericMethodCall, typeof(Task<object>));
+                    return convertedResult;
+                }
+
+                // This will be the case for types which have derived from Task and Task<T>
+                throw new InvalidOperationException(Resources.FormatActionExecutor_UnexpectedTaskInstance(
+                    methodInfo.Name,
+                    methodInfo.DeclaringType));
+            }
+
+            return Expression.Call(null, _createTaskFromResultMethod, castMethodCall);
+        }
+
+        private static ActionExecutorAsync WrapVoidActionAsync(VoidActionExecutor executor)
+        {
+            return delegate (object target, object[] parameters)
+            {
+                executor(target, parameters);
+                return Task.FromResult<object>(null);
+            };
+        }
+
+        private static Task<object> CoerceTaskType(object result, string methodName, Type declaringType)
+        {
+            var resultAsTask = (Task)result;
+            return CastToObject(resultAsTask);
+        }
+
+        /// <summary>
+        /// Cast Task to Task of object
+        /// </summary>
+        private static async Task<object> CastToObject(Task task)
+        {
+            await task;
+            return null;
+        }
+
+        /// <summary>
+        /// Cast Task of T to Task of object
+        /// </summary>
+        private static async Task<object> CastToObject<T>(Task<T> task)
+        {
+            return (object)await task;
+        }
+
+        private static Type GetTaskInnerTypeOrNull(Type type)
+        {
+            var genericType = ClosedGenericMatcher.ExtractGenericInterface(type, typeof(Task<>));
+
+            return genericType?.GenericTypeArguments[0];
+        }
+
+        private static Task<object> Convert<T>(object taskAsObject)
+        {
+            var task = (Task<T>)taskAsObject;
+            return CastToObject<T>(task);
         }
     }
 }


### PR DESCRIPTION
Fixes #4267 
The controller action return values are the coerced to Task<object> type. This involved using MethodInfo.Invoke when the return type is a generic Task type. Folding this coercing process in the cached action delegate to reduce the perf penalty from reflection