### PR TITLE
Remove ServiceProvider

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
@@ -31,17 +31,6 @@ namespace Microsoft.AspNetCore.Mvc
         private IUrlHelper _url;
 
         /// <summary>
-        /// Gets the request-specific <see cref="IServiceProvider"/>.
-        /// </summary>
-        public IServiceProvider Resolver
-        {
-            get
-            {
-                return HttpContext?.RequestServices;
-            }
-        }
-
-        /// <summary>
         /// Gets the <see cref="Http.HttpContext"/> for the executing action.
         /// </summary>
         public HttpContext HttpContext
@@ -136,7 +125,7 @@ namespace Microsoft.AspNetCore.Mvc
             {
                 if (_metadataProvider == null)
                 {
-                    _metadataProvider = Resolver?.GetRequiredService<IModelMetadataProvider>();
+                    _metadataProvider = HttpContext?.RequestServices?.GetRequiredService<IModelMetadataProvider>();
                 }
 
                 return _metadataProvider;
@@ -161,7 +150,7 @@ namespace Microsoft.AspNetCore.Mvc
             {
                 if (_url == null)
                 {
-                    var factory = Resolver?.GetRequiredService<IUrlHelperFactory>();
+                    var factory = HttpContext?.RequestServices?.GetRequiredService<IUrlHelperFactory>();
                     _url = factory?.GetUrlHelper(ControllerContext);
                 }
 
@@ -187,7 +176,7 @@ namespace Microsoft.AspNetCore.Mvc
             {
                 if (_objectValidator == null)
                 {
-                    _objectValidator = Resolver?.GetRequiredService<IObjectModelValidator>();
+                    _objectValidator = HttpContext?.RequestServices?.GetRequiredService<IObjectModelValidator>();
                 }
 
                 return _objectValidator;
@@ -1429,7 +1418,7 @@ namespace Microsoft.AspNetCore.Mvc
             {
                 throw new ArgumentNullException(nameof(model));
             }
-            
+
             ObjectValidator.Validate(
                 ControllerContext,
                 new CompositeModelValidatorProvider(ControllerContext.ValidatorProviders),

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Controller.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Controller.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.Mvc
             {
                 if (_tempData == null)
                 {
-                    var factory = Resolver?.GetRequiredService<ITempDataDictionaryFactory>();
+                    var factory = HttpContext?.RequestServices?.GetRequiredService<ITempDataDictionaryFactory>();
                     _tempData = factory?.GetTempData(HttpContext);
                 }
 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ControllerBaseTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ControllerBaseTest.cs
@@ -1409,7 +1409,7 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
             controller.ControllerContext.HttpContext = httpContext.Object;
 
             // Act
-            var innerServiceProvider = controller.Resolver;
+            var innerServiceProvider = controller.HttpContext?.RequestServices;
 
             // Assert
             Assert.Same(serviceProvider, innerServiceProvider);

--- a/test/WebSites/BasicWebSite/Controllers/OrderController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/OrderController.cs
@@ -16,7 +16,7 @@ namespace BasicWebSite
 
             var queryType = typeof(IEnumerable<>).MakeGenericType(elementType);
 
-            var services = (IEnumerable<object>)Resolver.GetService(queryType);
+            var services = (IEnumerable<object>)HttpContext?.RequestServices.GetService(queryType);
             foreach (var service in services)
             {
                 if (actualType != null && service.GetType().AssemblyQualifiedName == actualType)


### PR DESCRIPTION
Remove the ServiceProvider from ControllerBase. People should use `HttpContext?.RequestServices` instead.

Fixes #4097