### PR TITLE
Use grunt-newer to make TagHelpers incrementally build.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/gruntfile.js
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/gruntfile.js
@@ -20,6 +20,7 @@ module.exports = function (grunt) {
 
     grunt.loadNpmTasks("grunt-contrib-jshint");
     grunt.loadNpmTasks("grunt-contrib-uglify");
+    grunt.loadNpmTasks('grunt-newer');
 
-    grunt.registerTask("default", [ "jshint", "uglify" ]);
+    grunt.registerTask("default", [ "newer:jshint", "newer:uglify" ]);
 };

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/package.json
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/package.json
@@ -5,6 +5,7 @@
     "devDependencies": {
         "grunt": "~0.4.5",
         "grunt-contrib-jshint": "~0.11.0",
-        "grunt-contrib-uglify": "~0.7.0"
+        "grunt-contrib-uglify": "~0.7.0",
+        "grunt-newer": "1.1.2"
     }
 }


### PR DESCRIPTION
The newer task prevents grunt from doing work in the event the file hasn't changed. This would allow us to run `build` locally without Microsoft.AspNetCore.Mvc.TagHelpers from recompiling every time