### PR TITLE
Always clear buffers returned to the memory pool

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/MemoryPoolViewBufferScope.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/MemoryPoolViewBufferScope.cs
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
 
                 for (var i = 0; i < _leased.Count; i++)
                 {
-                    _viewBufferPool.Return(_leased[i]);
+                    _viewBufferPool.Return(_leased[i], clearArray: true);
                 }
 
                 _leased.Clear();


### PR DESCRIPTION
Just a safety measure in case anything evades our 'flattening'. I don't
have any evidence that we're failing to clear something, but we want this
here as a safeguard.