### PR TITLE
Simplify BindAttribute - rename PredicateProvider

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/BindingInfo.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/BindingInfo.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             BindingSource = other.BindingSource;
             BinderModelName = other.BinderModelName;
             BinderType = other.BinderType;
-            PropertyBindingPredicateProvider = other.PropertyBindingPredicateProvider;
+            PropertyFilterProvider = other.PropertyFilterProvider;
         }
 
         /// <summary>
@@ -52,9 +52,9 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         public Type BinderType { get; set; }
 
         /// <summary>
-        /// Gets or sets the <see cref="ModelBinding.IPropertyBindingPredicateProvider"/>.
+        /// Gets or sets the <see cref="ModelBinding.IPropertyFilterProvider"/>.
         /// </summary>
-        public IPropertyBindingPredicateProvider PropertyBindingPredicateProvider { get; set; }
+        public IPropertyFilterProvider PropertyFilterProvider { get; set; }
 
         /// <summary>
         /// Constructs a new instance of <see cref="BindingInfo"/> from the given <paramref name="attributes"/>.
@@ -100,46 +100,45 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 }
             }
 
-            // PropertyBindingPredicateProvider
-            var predicateProviders = attributes.OfType<IPropertyBindingPredicateProvider>().ToArray();
-            if (predicateProviders.Length > 0)
+            // PropertyFilterProvider
+            var propertyFilterProviders = attributes.OfType<IPropertyFilterProvider>().ToArray();
+            if (propertyFilterProviders.Length > 0)
             {
                 isBindingInfoPresent = true;
-                bindingInfo.PropertyBindingPredicateProvider = new CompositePredicateProvider(
-                    predicateProviders);
+                bindingInfo.PropertyFilterProvider = new CompositePropertyFilterProvider(propertyFilterProviders);
             }
 
             return isBindingInfoPresent ? bindingInfo : null;
         }
 
-        private class CompositePredicateProvider : IPropertyBindingPredicateProvider
+        private class CompositePropertyFilterProvider : IPropertyFilterProvider
         {
-            private readonly IEnumerable<IPropertyBindingPredicateProvider> _providers;
+            private readonly IEnumerable<IPropertyFilterProvider> _providers;
 
-            public CompositePredicateProvider(IEnumerable<IPropertyBindingPredicateProvider> providers)
+            public CompositePropertyFilterProvider(IEnumerable<IPropertyFilterProvider> providers)
             {
                 _providers = providers;
             }
 
-            public Func<ModelBindingContext, string, bool> PropertyFilter
+            public Func<ModelMetadata, bool> PropertyFilter
             {
                 get
                 {
-                    return CreatePredicate();
+                    return CreatePropertyFilter();
                 }
             }
 
-            private Func<ModelBindingContext, string, bool> CreatePredicate()
+            private Func<ModelMetadata, bool> CreatePropertyFilter()
             {
-                var predicates = _providers
+                var propertyFilters = _providers
                     .Select(p => p.PropertyFilter)
                     .Where(p => p != null);
 
-                return (context, propertyName) =>
+                return (m) =>
                 {
-                    foreach (var predicate in predicates)
+                    foreach (var propertyFilter in propertyFilters)
                     {
-                        if (!predicate(context, propertyName))
+                        if (!propertyFilter(m))
                         {
                             return false;
                         }

--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/IPropertyFilterProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/IPropertyFilterProvider.cs
@@ -8,11 +8,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
     /// <summary>
     /// Provides a predicate which can determines which model properties should be bound by model binding.
     /// </summary>
-    public interface IPropertyBindingPredicateProvider
+    public interface IPropertyFilterProvider
     {
         /// <summary>
         /// Gets a predicate which can determines which model properties should be bound by model binding.
         /// </summary>
-        Func<ModelBindingContext, string, bool> PropertyFilter { get; }
+        Func<ModelMetadata, bool> PropertyFilter { get; }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelBindingContext.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelBindingContext.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         /// Gets or sets a predicate which will be evaluated for each property to determine if the property
         /// is eligible for model binding.
         /// </summary>
-        public abstract Func<ModelBindingContext, string, bool> PropertyFilter { get; set; }
+        public abstract Func<ModelMetadata, bool> PropertyFilter { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="ValidationStateDictionary"/>. Used for tracking validation state to

--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelMetadata.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelMetadata.cs
@@ -269,10 +269,10 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         public abstract string NullDisplayText { get; }
 
         /// <summary>
-        /// Gets the <see cref="IPropertyBindingPredicateProvider"/>, which can determine which properties
+        /// Gets the <see cref="IPropertyFilterProvider"/>, which can determine which properties
         /// should be model bound.
         /// </summary>
-        public abstract IPropertyBindingPredicateProvider PropertyBindingPredicateProvider { get; }
+        public abstract IPropertyFilterProvider PropertyFilterProvider { get; }
 
         /// <summary>
         /// Gets a value that indicates whether the property should be displayed in read-only views.

--- a/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
@@ -1221,13 +1221,13 @@ namespace Microsoft.AspNetCore.Mvc
         /// <param name="model">The model instance to update.</param>
         /// <param name="prefix">The prefix to use when looking up values in the current <see cref="IValueProvider"/>.
         /// </param>
-        /// <param name="predicate">A predicate which can be used to filter properties at runtime.</param>
+        /// <param name="propertyFilter">A predicate which can be used to filter properties at runtime.</param>
         /// <returns>A <see cref="Task"/> that on completion returns <c>true</c> if the update is successful.</returns>
         [NonAction]
         public Task<bool> TryUpdateModelAsync<TModel>(
             TModel model,
             string prefix,
-            Func<ModelBindingContext, string, bool> predicate)
+            Func<ModelMetadata, bool> propertyFilter)
             where TModel : class
         {
             if (model == null)
@@ -1235,9 +1235,9 @@ namespace Microsoft.AspNetCore.Mvc
                 throw new ArgumentNullException(nameof(model));
             }
 
-            if (predicate == null)
+            if (propertyFilter == null)
             {
-                throw new ArgumentNullException(nameof(predicate));
+                throw new ArgumentNullException(nameof(propertyFilter));
             }
 
             return ModelBindingHelper.TryUpdateModelAsync(
@@ -1250,7 +1250,7 @@ namespace Microsoft.AspNetCore.Mvc
                 ControllerContext.InputFormatters,
                 ObjectValidator,
                 new CompositeModelValidatorProvider(ControllerContext.ValidatorProviders),
-                predicate);
+                propertyFilter);
         }
 
         /// <summary>
@@ -1310,14 +1310,14 @@ namespace Microsoft.AspNetCore.Mvc
         /// <param name="prefix">The prefix to use when looking up values in the <paramref name="valueProvider"/>.
         /// </param>
         /// <param name="valueProvider">The <see cref="IValueProvider"/> used for looking up values.</param>
-        /// <param name="predicate">A predicate which can be used to filter properties at runtime.</param>
+        /// <param name="propertyFilter">A predicate which can be used to filter properties at runtime.</param>
         /// <returns>A <see cref="Task"/> that on completion returns <c>true</c> if the update is successful.</returns>
         [NonAction]
         public Task<bool> TryUpdateModelAsync<TModel>(
             TModel model,
             string prefix,
             IValueProvider valueProvider,
-            Func<ModelBindingContext, string, bool> predicate)
+            Func<ModelMetadata, bool> propertyFilter)
             where TModel : class
         {
             if (model == null)
@@ -1330,9 +1330,9 @@ namespace Microsoft.AspNetCore.Mvc
                 throw new ArgumentNullException(nameof(valueProvider));
             }
 
-            if (predicate == null)
+            if (propertyFilter == null)
             {
-                throw new ArgumentNullException(nameof(predicate));
+                throw new ArgumentNullException(nameof(propertyFilter));
             }
 
             return ModelBindingHelper.TryUpdateModelAsync(
@@ -1345,7 +1345,7 @@ namespace Microsoft.AspNetCore.Mvc
                 ControllerContext.InputFormatters,
                 ObjectValidator,
                 new CompositeModelValidatorProvider(ControllerContext.ValidatorProviders),
-                predicate);
+                propertyFilter);
         }
 
         /// <summary>
@@ -1395,7 +1395,7 @@ namespace Microsoft.AspNetCore.Mvc
         /// <param name="prefix">The prefix to use when looking up values in the <paramref name="valueProvider"/>.
         /// </param>
         /// <param name="valueProvider">The <see cref="IValueProvider"/> used for looking up values.</param>
-        /// <param name="predicate">A predicate which can be used to filter properties at runtime.</param>
+        /// <param name="propertyFilter">A predicate which can be used to filter properties at runtime.</param>
         /// <returns>A <see cref="Task"/> that on completion returns <c>true</c> if the update is successful.</returns>
         [NonAction]
         public Task<bool> TryUpdateModelAsync(
@@ -1403,7 +1403,7 @@ namespace Microsoft.AspNetCore.Mvc
             Type modelType,
             string prefix,
             IValueProvider valueProvider,
-            Func<ModelBindingContext, string, bool> predicate)
+            Func<ModelMetadata, bool> propertyFilter)
         {
             if (model == null)
             {
@@ -1420,9 +1420,9 @@ namespace Microsoft.AspNetCore.Mvc
                 throw new ArgumentNullException(nameof(valueProvider));
             }
 
-            if (predicate == null)
+            if (propertyFilter == null)
             {
-                throw new ArgumentNullException(nameof(predicate));
+                throw new ArgumentNullException(nameof(propertyFilter));
             }
 
             return ModelBindingHelper.TryUpdateModelAsync(
@@ -1436,7 +1436,7 @@ namespace Microsoft.AspNetCore.Mvc
                 ControllerContext.InputFormatters,
                 ObjectValidator,
                 new CompositeModelValidatorProvider(ControllerContext.ValidatorProviders),
-                predicate);
+                propertyFilter);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/DefaultModelBindingContext.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/DefaultModelBindingContext.cs
@@ -56,8 +56,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             }
 
             var binderModelName = bindingInfo?.BinderModelName ?? metadata.BinderModelName;
-            var propertyPredicateProvider =
-                bindingInfo?.PropertyBindingPredicateProvider ?? metadata.PropertyBindingPredicateProvider;
+            var propertyFilterProvider = bindingInfo?.PropertyFilterProvider ?? metadata.PropertyFilterProvider;
 
             var valueProvider = operationBindingContext.ValueProvider;
             var bindingSource = bindingInfo?.BindingSource ?? metadata.BindingSource;
@@ -70,7 +69,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             {
                 BinderModelName = binderModelName,
                 BindingSource = bindingSource,
-                PropertyFilter = propertyPredicateProvider?.PropertyFilter,
+                PropertyFilter = propertyFilterProvider?.PropertyFilter,
 
                 // Because this is the top-level context, FieldName and ModelName should be the same.
                 FieldName = binderModelName ?? modelName,
@@ -123,7 +122,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             FieldName = fieldName;
             BinderModelName = modelMetadata.BinderModelName;
             BindingSource = modelMetadata.BindingSource;
-            PropertyFilter = modelMetadata.PropertyBindingPredicateProvider?.PropertyFilter;
+            PropertyFilter = modelMetadata.PropertyFilterProvider?.PropertyFilter;
 
             IsTopLevelObject = false;
 
@@ -262,7 +261,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         }
 
         /// <inheritdoc />
-        public override Func<ModelBindingContext, string, bool> PropertyFilter
+        public override Func<ModelMetadata, bool> PropertyFilter
         {
             get { return _state.PropertyFilter; }
             set { _state.PropertyFilter = value; }
@@ -317,7 +316,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             public string ModelName;
 
             public IValueProvider ValueProvider;
-            public Func<ModelBindingContext, string, bool> PropertyFilter;
+            public Func<ModelMetadata, bool> PropertyFilter;
             public ValidationStateDictionary ValidationState;
             public ModelStateDictionary ModelState;
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/ComplexTypeModelBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/ComplexTypeModelBinder.cs
@@ -114,13 +114,13 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         /// <returns><c>true</c> if the model property can be bound, otherwise <c>false</c>.</returns>
         protected virtual bool CanBindProperty(ModelBindingContext bindingContext, ModelMetadata propertyMetadata)
         {
-            var modelMetadataPredicate = bindingContext.ModelMetadata.PropertyBindingPredicateProvider?.PropertyFilter;
-            if (modelMetadataPredicate?.Invoke(bindingContext, propertyMetadata.PropertyName) == false)
+            var metadataProviderFilter = bindingContext.ModelMetadata.PropertyFilterProvider?.PropertyFilter;
+            if (metadataProviderFilter?.Invoke(propertyMetadata) == false)
             {
                 return false;
             }
 
-            if (bindingContext.PropertyFilter?.Invoke(bindingContext, propertyMetadata.PropertyName) == false)
+            if (bindingContext.PropertyFilter?.Invoke(propertyMetadata) == false)
             {
                 return false;
             }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/DefaultPropertyBindingPredicateProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/DefaultPropertyBindingPredicateProvider.cs
@@ -5,20 +5,18 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding
 {
     /// <summary>
-    /// Default implementation for <see cref="IPropertyBindingPredicateProvider"/>.
+    /// Default implementation for <see cref="IPropertyFilterProvider"/>.
     /// Provides a expression based way to provide include properties.
     /// </summary>
     /// <typeparam name="TModel">The target model Type.</typeparam>
-    public class DefaultPropertyBindingPredicateProvider<TModel> : IPropertyBindingPredicateProvider
+    public class DefaultPropertyFilterProvider<TModel> : IPropertyFilterProvider
         where TModel : class
     {
-        private static readonly Func<ModelBindingContext, string, bool> _defaultFilter =
-            (context, propertyName) => true;
+        private static readonly Func<ModelMetadata, bool> _default = (m) => true;
 
         /// <summary>
         /// The prefix which is used while generating the property filter.
@@ -44,24 +42,24 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         }
 
         /// <inheritdoc />
-        public virtual Func<ModelBindingContext, string, bool> PropertyFilter
+        public virtual Func<ModelMetadata, bool> PropertyFilter
         {
             get
             {
                 if (PropertyIncludeExpressions == null)
                 {
-                    return _defaultFilter;
+                    return _default;
                 }
 
                 // We do not cache by default.
-                return GetPredicateFromExpression(PropertyIncludeExpressions);
+                return GetPropertyFilterFromExpression(PropertyIncludeExpressions);
             }
         }
 
-        private Func<ModelBindingContext, string, bool> GetPredicateFromExpression(
+        private Func<ModelMetadata, bool> GetPropertyFilterFromExpression(
             IEnumerable<Expression<Func<TModel, object>>> includeExpressions)
         {
-            var expression = ModelBindingHelper.GetIncludePredicateExpression(Prefix, includeExpressions.ToArray());
+            var expression = ModelBindingHelper.GetPropertyFilterExpression(includeExpressions.ToArray());
             return expression.Compile();
         }
     }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Metadata/BindingMetadata.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Metadata/BindingMetadata.cs
@@ -74,9 +74,9 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="ModelBinding.IPropertyBindingPredicateProvider"/>.
-        /// See <see cref="ModelMetadata.PropertyBindingPredicateProvider"/>.
+        /// Gets or sets the <see cref="ModelBinding.IPropertyFilterProvider"/>.
+        /// See <see cref="ModelMetadata.PropertyFilterProvider"/>.
         /// </summary>
-        public IPropertyBindingPredicateProvider PropertyBindingPredicateProvider { get; set; }
+        public IPropertyFilterProvider PropertyFilterProvider { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Metadata/DefaultModelMetadata.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Metadata/DefaultModelMetadata.cs
@@ -456,11 +456,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
         }
 
         /// <inheritdoc />
-        public override IPropertyBindingPredicateProvider PropertyBindingPredicateProvider
+        public override IPropertyFilterProvider PropertyFilterProvider
         {
             get
             {
-                return BindingMetadata.PropertyBindingPredicateProvider;
+                return BindingMetadata.PropertyFilterProvider;
             }
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/ModelBinderFactory.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/ModelBinderFactory.cs
@@ -168,7 +168,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                     BinderModelName = metadata.BinderModelName,
                     BinderType = metadata.BinderType,
                     BindingSource = metadata.BindingSource,
-                    PropertyBindingPredicateProvider = metadata.PropertyBindingPredicateProvider,
+                    PropertyFilterProvider = metadata.PropertyFilterProvider,
                 };
             }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Properties/Resources.Designer.cs
@@ -923,22 +923,6 @@ namespace Microsoft.AspNetCore.Mvc.Core
         }
 
         /// <summary>
-        /// The type '{0}' does not implement the interface '{1}'.
-        /// </summary>
-        internal static string PropertyBindingPredicateProvider_WrongType
-        {
-            get { return GetString("PropertyBindingPredicateProvider_WrongType"); }
-        }
-
-        /// <summary>
-        /// The type '{0}' does not implement the interface '{1}'.
-        /// </summary>
-        internal static string FormatPropertyBindingPredicateProvider_WrongType(object p0, object p1)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("PropertyBindingPredicateProvider_WrongType"), p0, p1);
-        }
-
-        /// <summary>
         /// The parameter conversion from type '{0}' to type '{1}' failed because no type converter can convert between these types.
         /// </summary>
         internal static string ValueProviderResult_NoConverterExists
@@ -1159,7 +1143,7 @@ namespace Microsoft.AspNetCore.Mvc.Core
         /// </summary>
         internal static string FormatMustSpecifyAtLeastOneAuthenticationScheme()
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("MustSpecifyAtLeastOneAuthenticationScheme"));
+            return GetString("MustSpecifyAtLeastOneAuthenticationScheme");
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Mvc.Core/Resources.resx
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Resources.resx
@@ -297,9 +297,6 @@
   <data name="ModelBinding_MissingBindRequiredMember" xml:space="preserve">
     <value>A value for the '{0}' property was not provided.</value>
   </data>
-  <data name="PropertyBindingPredicateProvider_WrongType" xml:space="preserve">
-    <value>The type '{0}' does not implement the interface '{1}'.</value>
-  </data>
   <data name="ValueProviderResult_NoConverterExists" xml:space="preserve">
     <value>The parameter conversion from type '{0}' to type '{1}' failed because no type converter can convert between these types.</value>
   </data>

--- a/test/Microsoft.AspNetCore.Mvc.Abstractions.Test/ModelBinding/ModelMetadataTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Abstractions.Test/ModelBinding/ModelMetadataTest.cs
@@ -536,7 +536,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 }
             }
 
-            public override IPropertyBindingPredicateProvider PropertyBindingPredicateProvider
+            public override IPropertyFilterProvider PropertyFilterProvider
             {
                 get
                 {

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/BindAttributeTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/BindAttributeTest.cs
@@ -1,8 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using Microsoft.AspNetCore.Http.Internal;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Moq;
 using Xunit;
 
@@ -10,34 +9,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 {
     public class BindAttributeTest
     {
-        [Fact]
-        public void Constructor_Throws_IfTypeDoesNotImplement_IPropertyBindingPredicateProvider()
-        {
-            // Arrange
-            var expected =
-                "The type 'Microsoft.AspNetCore.Mvc.ModelBinding.BindAttributeTest+UnrelatedType' " +
-                "does not implement the interface " +
-                "'Microsoft.AspNetCore.Mvc.ModelBinding.IPropertyBindingPredicateProvider'." +
-                Environment.NewLine +
-                "Parameter name: predicateProviderType";
-
-            // Act & Assert
-            var exception = Assert.Throws<ArgumentException>(() => new BindAttribute(typeof(UnrelatedType)));
-            Assert.Equal(expected, exception.Message);
-        }
-
-        [Theory]
-        [InlineData(typeof(DerivedProvider))]
-        [InlineData(typeof(BaseProvider))]
-        public void Constructor_SetsThe_PropertyFilterProviderType_ForValidTypes(Type type)
-        {
-            // Arrange
-            var attribute = new BindAttribute(type);
-
-            // Act & Assert
-            Assert.Equal(type, attribute.PredicateProviderType);
-        }
-
         [Theory]
         [InlineData("UserName", true)]
         [InlineData("Username", false)]
@@ -54,98 +25,14 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 
             var context = new DefaultModelBindingContext();
 
-            // Act
-            var predicate = bind.PropertyFilter;
-
-            // Assert
-            Assert.Equal(isIncluded, predicate(context, property));
-        }
-
-        [Theory]
-        [InlineData("UserName", true)]
-        [InlineData("Username", false)]
-        [InlineData("Password", false)]
-        public void BindAttribute_ProviderType(string property, bool isIncluded)
-        {
-            // Arrange
-            var bind = new BindAttribute(typeof(TestProvider));
-
-            var context = new DefaultModelBindingContext();
-            context.OperationBindingContext = new OperationBindingContext()
-            {
-                ActionContext = new ActionContext()
-                {
-                    HttpContext = new DefaultHttpContext(),
-                },
-            };
-            var services = new Mock<IServiceProvider>();
-
-            context.OperationBindingContext.HttpContext.RequestServices = services.Object;
+            var identity = ModelMetadataIdentity.ForProperty(typeof(int), property, typeof(string));
+            context.ModelMetadata = new Mock<ModelMetadata>(identity).Object;
 
             // Act
-            var predicate = bind.PropertyFilter;
+            var propertyFilter = bind.PropertyFilter;
 
             // Assert
-            Assert.Equal(isIncluded, predicate(context, property));
-        }
-
-        // Each time .PropertyFilter is called, a since instance of the provider should
-        // be created and cached.
-        [Fact]
-        public void BindAttribute_ProviderType_Cached()
-        {
-            // Arrange
-            var bind = new BindAttribute(typeof(TestProvider));
-
-            var context = new DefaultModelBindingContext();
-            context.OperationBindingContext = new OperationBindingContext()
-            {
-                ActionContext = new ActionContext()
-                {
-                    HttpContext = new DefaultHttpContext(),
-                },
-            };
-
-            var services = new Mock<IServiceProvider>(MockBehavior.Strict);
-
-            context.OperationBindingContext.HttpContext.RequestServices = services.Object;
-
-            // Act
-            var predicate = bind.PropertyFilter;
-
-            // Assert
-            Assert.True(predicate(context, "UserName"));
-            Assert.True(predicate(context, "UserName"));
-        }
-
-        private class TestProvider : IPropertyBindingPredicateProvider
-        {
-            public Func<ModelBindingContext, string, bool> PropertyFilter
-            {
-                get
-                {
-                    return (context, property) => string.Equals(property, "UserName", StringComparison.Ordinal);
-                }
-            }
-        }
-
-        private class BaseProvider : IPropertyBindingPredicateProvider
-        {
-            public Func<ModelBindingContext, string, bool> PropertyFilter
-            {
-                get
-                {
-                    throw new NotImplementedException();
-                }
-            }
-        }
-
-        private class DerivedProvider : BaseProvider
-        {
-        }
-
-        private class UnrelatedType
-        {
+            Assert.Equal(isIncluded, propertyFilter(context.ModelMetadata));
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ControllerBaseTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ControllerBaseTest.cs
@@ -1152,8 +1152,8 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
 
                 // Include and exclude should be null, resulting in property
                 // being included.
-                Assert.True(context.PropertyFilter(context, "Property1"));
-                Assert.True(context.PropertyFilter(context, "Property2"));
+                Assert.True(context.PropertyFilter(context.ModelMetadata.Properties["Property1"]));
+                Assert.True(context.PropertyFilter(context.ModelMetadata.Properties["Property2"]));
             });
 
             var controller = GetController(binder, valueProvider);
@@ -1180,8 +1180,8 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
 
                 // Include and exclude should be null, resulting in property
                 // being included.
-                Assert.True(context.PropertyFilter(context, "Property1"));
-                Assert.True(context.PropertyFilter(context, "Property2"));
+                Assert.True(context.PropertyFilter(context.ModelMetadata.Properties["Property1"]));
+                Assert.True(context.PropertyFilter(context.ModelMetadata.Properties["Property2"]));
             });
 
             var controller = GetController(binder, valueProvider);
@@ -1207,8 +1207,8 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
 
                       // Include and exclude should be null, resulting in property
                       // being included.
-                      Assert.True(context.PropertyFilter(context, "Property1"));
-                      Assert.True(context.PropertyFilter(context, "Property2"));
+                      Assert.True(context.PropertyFilter(context.ModelMetadata.Properties["Property1"]));
+                      Assert.True(context.PropertyFilter(context.ModelMetadata.Properties["Property2"]));
                   });
 
             var controller = GetController(binder, valueProvider: null);
@@ -1222,64 +1222,65 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
         }
 
         [Fact]
-        public async Task TryUpdateModel_PredicateOverload_UsesPassedArguments()
+        public async Task TryUpdateModel_PropertyFilterOverload_UsesPassedArguments()
         {
             // Arrange
             var modelName = "mymodel";
 
-            Func<ModelBindingContext, string, bool> includePredicate = (context, propertyName) =>
-                string.Equals(propertyName, "include1", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(propertyName, "include2", StringComparison.OrdinalIgnoreCase);
+            Func<ModelMetadata, bool> propertyFilter = (m) =>
+                string.Equals(m.PropertyName, "Include1", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(m.PropertyName, "Include2", StringComparison.OrdinalIgnoreCase);
 
             var valueProvider = Mock.Of<IValueProvider>();
             var binder = new StubModelBinder(context =>
             {
                 Assert.Same(valueProvider, Assert.IsType<CompositeValueProvider>(context.ValueProvider)[0]);
 
-                Assert.True(context.PropertyFilter(context, "include1"));
-                Assert.True(context.PropertyFilter(context, "include2"));
+                Assert.True(context.PropertyFilter(context.ModelMetadata.Properties["Include1"]));
+                Assert.True(context.PropertyFilter(context.ModelMetadata.Properties["Include2"]));
 
-                Assert.False(context.PropertyFilter(context, "exclude1"));
-                Assert.False(context.PropertyFilter(context, "exclude2"));
+                Assert.False(context.PropertyFilter(context.ModelMetadata.Properties["Exclude1"]));
+                Assert.False(context.PropertyFilter(context.ModelMetadata.Properties["Exclude2"]));
+
             });
 
             var controller = GetController(binder, valueProvider);
             var model = new MyModel();
 
             // Act
-            await controller.TryUpdateModelAsync(model, modelName, includePredicate);
+            await controller.TryUpdateModelAsync(model, modelName, propertyFilter);
 
             // Assert
             Assert.NotEqual(0, binder.BindModelCount);
         }
 
         [Fact]
-        public async Task TryUpdateModel_PredicateWithValueProviderOverload_UsesPassedArguments()
+        public async Task TryUpdateModel_PropertyFilterWithValueProviderOverload_UsesPassedArguments()
         {
             // Arrange
             var modelName = "mymodel";
 
-            Func<ModelBindingContext, string, bool> includePredicate =
-               (context, propertyName) => string.Equals(propertyName, "include1", StringComparison.OrdinalIgnoreCase) ||
-                                          string.Equals(propertyName, "include2", StringComparison.OrdinalIgnoreCase);
+            Func<ModelMetadata, bool> propertyFilter = (m) => 
+                string.Equals(m.PropertyName, "Include1", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(m.PropertyName, "Include2", StringComparison.OrdinalIgnoreCase);
 
             var valueProvider = Mock.Of<IValueProvider>();
             var binder = new StubModelBinder(context =>
             {
                 Assert.Same(valueProvider, context.ValueProvider);
 
-                Assert.True(context.PropertyFilter(context, "include1"));
-                Assert.True(context.PropertyFilter(context, "include2"));
+                Assert.True(context.PropertyFilter(context.ModelMetadata.Properties["Include1"]));
+                Assert.True(context.PropertyFilter(context.ModelMetadata.Properties["Include2"]));
 
-                Assert.False(context.PropertyFilter(context, "exclude1"));
-                Assert.False(context.PropertyFilter(context, "exclude2"));
+                Assert.False(context.PropertyFilter(context.ModelMetadata.Properties["Exclude1"]));
+                Assert.False(context.PropertyFilter(context.ModelMetadata.Properties["Exclude2"]));
             });
             var controller = GetController(binder, valueProvider: null);
 
             var model = new MyModel();
 
             // Act
-            await controller.TryUpdateModelAsync(model, modelName, valueProvider, includePredicate);
+            await controller.TryUpdateModelAsync(model, modelName, valueProvider, propertyFilter);
 
             // Assert
             Assert.NotEqual(0, binder.BindModelCount);
@@ -1299,14 +1300,14 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
             var binder = new StubModelBinder(context =>
             {
                 Assert.Same(
-                          valueProvider.Object,
-                          Assert.IsType<CompositeValueProvider>(context.ValueProvider)[0]);
+                    valueProvider.Object,
+                    Assert.IsType<CompositeValueProvider>(context.ValueProvider)[0]);
 
-                Assert.True(context.PropertyFilter(context, "Property1"));
-                Assert.True(context.PropertyFilter(context, "Property2"));
+                Assert.True(context.PropertyFilter(context.ModelMetadata.Properties["Property1"]));
+                Assert.True(context.PropertyFilter(context.ModelMetadata.Properties["Property2"]));
 
-                Assert.False(context.PropertyFilter(context, "exclude1"));
-                Assert.False(context.PropertyFilter(context, "exclude2"));
+                Assert.False(context.PropertyFilter(context.ModelMetadata.Properties["Exclude1"]));
+                Assert.False(context.PropertyFilter(context.ModelMetadata.Properties["Exclude2"]));
             });
 
 
@@ -1336,11 +1337,11 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
             {
                 Assert.Same(valueProvider.Object, context.ValueProvider);
 
-                Assert.True(context.PropertyFilter(context, "Property1"));
-                Assert.True(context.PropertyFilter(context, "Property2"));
+                Assert.True(context.PropertyFilter(context.ModelMetadata.Properties["Property1"]));
+                Assert.True(context.PropertyFilter(context.ModelMetadata.Properties["Property2"]));
 
-                Assert.False(context.PropertyFilter(context, "exclude1"));
-                Assert.False(context.PropertyFilter(context, "exclude2"));
+                Assert.False(context.PropertyFilter(context.ModelMetadata.Properties["Exclude1"]));
+                Assert.False(context.PropertyFilter(context.ModelMetadata.Properties["Exclude2"]));
             });
 
             var controller = GetController(binder, valueProvider: null);
@@ -1354,14 +1355,14 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
         }
 
         [Fact]
-        public async Task TryUpdateModelNonGeneric_PredicateWithValueProviderOverload_UsesPassedArguments()
+        public async Task TryUpdateModelNonGeneric_PropertyFilterWithValueProviderOverload_UsesPassedArguments()
         {
             // Arrange
             var modelName = "mymodel";
 
-            Func<ModelBindingContext, string, bool> includePredicate =
-               (context, propertyName) => string.Equals(propertyName, "include1", StringComparison.OrdinalIgnoreCase) ||
-                                          string.Equals(propertyName, "include2", StringComparison.OrdinalIgnoreCase);
+            Func<ModelMetadata, bool> propertyFilter = (m) => 
+                string.Equals(m.PropertyName, "Include1", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(m.PropertyName, "Include2", StringComparison.OrdinalIgnoreCase);
 
             var valueProvider = Mock.Of<IValueProvider>();
 
@@ -1369,11 +1370,11 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
             {
                 Assert.Same(valueProvider, context.ValueProvider);
 
-                Assert.True(context.PropertyFilter(context, "include1"));
-                Assert.True(context.PropertyFilter(context, "include2"));
+                Assert.True(context.PropertyFilter(context.ModelMetadata.Properties["Include1"]));
+                Assert.True(context.PropertyFilter(context.ModelMetadata.Properties["Include2"]));
 
-                Assert.False(context.PropertyFilter(context, "exclude1"));
-                Assert.False(context.PropertyFilter(context, "exclude2"));
+                Assert.False(context.PropertyFilter(context.ModelMetadata.Properties["Exclude1"]));
+                Assert.False(context.PropertyFilter(context.ModelMetadata.Properties["Exclude2"]));
             });
 
             var controller = GetController(binder, valueProvider: null);
@@ -1381,7 +1382,7 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
             var model = new MyModel();
 
             // Act
-            await controller.TryUpdateModelAsync(model, model.GetType(), modelName, valueProvider, includePredicate);
+            await controller.TryUpdateModelAsync(model, model.GetType(), modelName, valueProvider, propertyFilter);
 
             // Assert
             Assert.NotEqual(0, binder.BindModelCount);
@@ -1401,8 +1402,8 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
 
                 // Include and exclude should be null, resulting in property
                 // being included.
-                Assert.True(context.PropertyFilter(context, "Property1"));
-                Assert.True(context.PropertyFilter(context, "Property2"));
+                Assert.True(context.PropertyFilter(context.ModelMetadata.Properties["Property1"]));
+                Assert.True(context.PropertyFilter(context.ModelMetadata.Properties["Property2"]));
             });
 
             var controller = GetController(binder, valueProvider);
@@ -1429,8 +1430,8 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
 
                 // Include and exclude should be null, resulting in property
                 // being included.
-                Assert.True(context.PropertyFilter(context, "Property1"));
-                Assert.True(context.PropertyFilter(context, "Property2"));
+                Assert.True(context.PropertyFilter(context.ModelMetadata.Properties["Property1"]));
+                Assert.True(context.PropertyFilter(context.ModelMetadata.Properties["Property2"]));
             });
 
             var controller = GetController(binder, valueProvider);
@@ -1668,6 +1669,12 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
         {
             public string Property1 { get; set; }
             public string Property2 { get; set; }
+
+            public string Include1 { get; set; }
+            public string Include2 { get; set; }
+
+            public string Exclude1 { get; set; }
+            public string Exclude2 { get; set; }
         }
 
         private class MyDerivedModel : MyModel

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/ComplexTypeModelBinderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/ComplexTypeModelBinderTest.cs
@@ -489,39 +489,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         }
 
         [Theory]
-        [InlineData(nameof(TypeWithExcludedPropertiesUsingBindAttribute.IncludedByDefault1), true)]
-        [InlineData(nameof(TypeWithExcludedPropertiesUsingBindAttribute.IncludedByDefault2), true)]
-        [InlineData(nameof(TypeWithExcludedPropertiesUsingBindAttribute.Excluded1), false)]
-        [InlineData(nameof(TypeWithExcludedPropertiesUsingBindAttribute.Excluded2), false)]
-        public void CanBindProperty_WithPredicate(string property, bool expected)
-        {
-            // Arrange
-            var metadata = GetMetadataForProperty(typeof(TypeWithExcludedPropertiesUsingBindAttribute), property);
-            var bindingContext = new DefaultModelBindingContext()
-            {
-                ModelMetadata = GetMetadataForType(typeof(TypeWithExcludedPropertiesUsingBindAttribute)),
-                OperationBindingContext = new OperationBindingContext()
-                {
-                    ActionContext = new ActionContext()
-                    {
-                        HttpContext = new DefaultHttpContext()
-                        {
-                            RequestServices = new ServiceCollection().BuildServiceProvider(),
-                        },
-                    },
-                },
-            };
-
-            var binder = CreateBinder(bindingContext.ModelMetadata);
-
-            // Act
-            var result = binder.CanBindPropertyPublic(bindingContext, metadata);
-
-            // Assert
-            Assert.Equal(expected, result);
-        }
-
-        [Theory]
         [InlineData(nameof(TypeWithIncludedPropertiesUsingBindAttribute.IncludedExplicitly1), true)]
         [InlineData(nameof(TypeWithIncludedPropertiesUsingBindAttribute.IncludedExplicitly2), true)]
         [InlineData(nameof(TypeWithIncludedPropertiesUsingBindAttribute.ExcludedByDefault1), false)]
@@ -1083,7 +1050,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                     BinderModelName = metadata.BinderModelName,
                     BinderType = metadata.BinderType,
                     BindingSource = metadata.BindingSource,
-                    PropertyBindingPredicateProvider = metadata.PropertyBindingPredicateProvider,
+                    PropertyFilterProvider = metadata.PropertyFilterProvider,
                 },
             });
         }
@@ -1283,17 +1250,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             public int IncludedExplicitly2 { get; set; }
         }
 
-        [Bind(typeof(ExcludedProvider))]
-        private class TypeWithExcludedPropertiesUsingBindAttribute
-        {
-            public int Excluded1 { get; set; }
-
-            public int Excluded2 { get; set; }
-
-            public int IncludedByDefault1 { get; set; }
-            public int IncludedByDefault2 { get; set; }
-        }
-
         private class Document
         {
             [NonValueBinderMetadata]
@@ -1316,15 +1272,15 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             public BindingSource BindingSource { get { return BindingSource.Query; } }
         }
 
-        private class ExcludedProvider : IPropertyBindingPredicateProvider
+        private class ExcludedProvider : IPropertyFilterProvider
         {
-            public Func<ModelBindingContext, string, bool> PropertyFilter
+            public Func<ModelMetadata, bool> PropertyFilter
             {
                 get
                 {
-                    return (context, propertyName) =>
-                       !string.Equals("Excluded1", propertyName, StringComparison.OrdinalIgnoreCase) &&
-                       !string.Equals("Excluded2", propertyName, StringComparison.OrdinalIgnoreCase);
+                    return (m) =>
+                       !string.Equals("Excluded1", m.PropertyName, StringComparison.OrdinalIgnoreCase) &&
+                       !string.Equals("Excluded2", m.PropertyName, StringComparison.OrdinalIgnoreCase);
                 }
             }
         }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Metadata/DefaultModelMetadataTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Metadata/DefaultModelMetadataTest.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
             Assert.Null(metadata.BinderModelName);
             Assert.Null(metadata.BinderType);
             Assert.Null(metadata.BindingSource);
-            Assert.Null(metadata.PropertyBindingPredicateProvider);
+            Assert.Null(metadata.PropertyFilterProvider);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ModelBindingHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ModelBindingHelperTest.cs
@@ -150,14 +150,14 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 
         [Theory]
         [MemberData(nameof(UnsuccessfulModelBindingData))]
-        public async Task TryUpdateModel_UsingIncludePredicateOverload_ReturnsFalse_IfBinderIsUnsuccessful(
+        public async Task TryUpdateModel_UsingPropertyFilterOverload_ReturnsFalse_IfBinderIsUnsuccessful(
             ModelBindingResult? binderResult)
         {
             // Arrange
             var metadataProvider = new EmptyModelMetadataProvider();
             var binder = new StubModelBinder(binderResult);
             var model = new MyModel();
-            Func<ModelBindingContext, string, bool> includePredicate = (context, propertyName) => true;
+            Func<ModelMetadata, bool> propertyFilter = (m) => true;
 
             // Act
             var result = await ModelBindingHelper.TryUpdateModelAsync(
@@ -170,7 +170,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 new List<IInputFormatter>(),
                 new Mock<IObjectModelValidator>(MockBehavior.Strict).Object,
                 Mock.Of<IModelValidatorProvider>(),
-                includePredicate);
+                propertyFilter);
 
             // Assert
             Assert.False(result);
@@ -180,7 +180,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         }
 
         [Fact]
-        public async Task TryUpdateModel_UsingIncludePredicateOverload_ReturnsTrue_ModelBindsAndValidatesSuccessfully()
+        public async Task TryUpdateModel_UsingPropertyFilterOverload_ReturnsTrue_ModelBindsAndValidatesSuccessfully()
         {
             // Arrange
             var binderProviders = new IModelBinderProvider[]
@@ -208,9 +208,9 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 { "ExcludedProperty", "ExcludedPropertyValue" }
             };
 
-            Func<ModelBindingContext, string, bool> includePredicate = (context, propertyName) =>
-                string.Equals(propertyName, "IncludedProperty", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(propertyName, "MyProperty", StringComparison.OrdinalIgnoreCase);
+            Func<ModelMetadata, bool> propertyFilter = (m) =>
+                string.Equals(m.PropertyName, "IncludedProperty", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(m.PropertyName, "MyProperty", StringComparison.OrdinalIgnoreCase);
 
             var valueProvider = new TestValueProvider(values);
             var metadataProvider = TestModelMetadataProvider.CreateDefaultProvider();
@@ -226,7 +226,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 new List<IInputFormatter>(),
                 new DefaultObjectValidator(metadataProvider, new ValidatorCache()),
                 validator,
-                includePredicate);
+                propertyFilter);
 
             // Assert
             Assert.True(result);
@@ -491,14 +491,14 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 
         [Theory]
         [MemberData(nameof(UnsuccessfulModelBindingData))]
-        public async Task TryUpdateModelNonGeneric_PredicateOverload_ReturnsFalse_IfBinderIsUnsuccessful(
+        public async Task TryUpdateModelNonGeneric_PropertyFilterOverload_ReturnsFalse_IfBinderIsUnsuccessful(
             ModelBindingResult? binderResult)
         {
             // Arrange
             var metadataProvider = new EmptyModelMetadataProvider();
             var binder = new StubModelBinder(binderResult);
             var model = new MyModel();
-            Func<ModelBindingContext, string, bool> includePredicate = (context, propertyName) => true;
+            Func<ModelMetadata, bool> propertyFilter = (m) => true;
 
             // Act
             var result = await ModelBindingHelper.TryUpdateModelAsync(
@@ -512,7 +512,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 inputFormatters: new List<IInputFormatter>(),
                 objectModelValidator: new Mock<IObjectModelValidator>(MockBehavior.Strict).Object,
                 validatorProvider: Mock.Of<IModelValidatorProvider>(),
-                predicate: includePredicate);
+                propertyFilter: propertyFilter);
 
             // Assert
             Assert.False(result);
@@ -522,7 +522,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         }
 
         [Fact]
-        public async Task TryUpdateModelNonGeneric_PredicateOverload_ReturnsTrue_ModelBindsAndValidatesSuccessfully()
+        public async Task TryUpdateModelNonGeneric_PropertyFilterOverload_ReturnsTrue_ModelBindsAndValidatesSuccessfully()
         {
             // Arrange
             var binderProviders = new IModelBinderProvider[]
@@ -550,9 +550,9 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 { "ExcludedProperty", "ExcludedPropertyValue" }
             };
 
-            Func<ModelBindingContext, string, bool> includePredicate = (context, propertyName) =>
-                string.Equals(propertyName, "IncludedProperty", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(propertyName, "MyProperty", StringComparison.OrdinalIgnoreCase);
+            Func<ModelMetadata, bool> propertyFilter = (m) =>
+                string.Equals(m.PropertyName, "IncludedProperty", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(m.PropertyName, "MyProperty", StringComparison.OrdinalIgnoreCase);
 
             var valueProvider = new TestValueProvider(values);
             var metadataProvider = TestModelMetadataProvider.CreateDefaultProvider();
@@ -569,7 +569,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 new List<IInputFormatter>(),
                 new DefaultObjectValidator(metadataProvider, new ValidatorCache()),
                 validator,
-                includePredicate);
+                propertyFilter);
 
             // Assert
             Assert.True(result);
@@ -657,7 +657,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 
             var binder = new StubModelBinder();
             var model = new MyModel();
-            Func<ModelBindingContext, string, bool> includePredicate = (context, propertyName) => true;
+            Func<ModelMetadata, bool> propertyFilter = (m) => true;
 
             // Act & Assert
             var exception = await Assert.ThrowsAsync<ArgumentException>(
@@ -672,7 +672,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                     new List<IInputFormatter>(),
                     new DefaultObjectValidator(metadataProvider, new ValidatorCache()),
                     Mock.Of<IModelValidatorProvider>(),
-                    includePredicate));
+                    propertyFilter));
 
             var expectedMessage = string.Format("The model's runtime type '{0}' is not assignable to the type '{1}'." +
                 Environment.NewLine +

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/TestModelBinderProviderContext.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/TestModelBinderProviderContext.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 BinderModelName = Metadata.BinderModelName,
                 BinderType = Metadata.BinderType,
                 BindingSource = Metadata.BindingSource,
-                PropertyBindingPredicateProvider = Metadata.PropertyBindingPredicateProvider,
+                PropertyFilterProvider = Metadata.PropertyFilterProvider,
             };
 
         }

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/ModelMetadataProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/ModelMetadataProviderTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
     public class ModelMetadataProviderTest
     {
         [Fact]
-        public void ModelMetadataProvider_UsesPredicateOnType()
+        public void ModelMetadataProvider_UsesPropertyFilterProviderOnType()
         {
             // Arrange
             var type = typeof(User);
@@ -32,12 +32,12 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
             var metadata = provider.GetMetadataForType(type);
 
             // Assert
-            var predicate = metadata.PropertyBindingPredicateProvider.PropertyFilter;
+            var propertyFilter = metadata.PropertyFilterProvider.PropertyFilter;
 
             var matched = new HashSet<string>();
             foreach (var property in metadata.Properties)
             {
-                if (predicate(context, property.PropertyName))
+                if (propertyFilter(property))
                 {
                     matched.Add(property.PropertyName);
                 }


### PR DESCRIPTION
This change renames IPropertyBindingPredicateProvider to
IPropertyFilterProvider. The changes here are mostly renames of
parameters/variables from predicate -> propertyFilter. I did a
find+replace and left the term 'predicate' in some of the docs because it
refers to a predicate in the abstract sense.

This change also simplifies BindAttribute and removes support for type
activation.