### PR TITLE
Stop using runtime type in `ViewDataDictionary` to determine `ModelMetadata`

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/ViewComponentContext.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/ViewComponentContext.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
             ViewContext = new ViewContext(
                 viewContext,
                 viewContext.View,
-                new ViewDataDictionary(viewContext.ViewData),
+                new ViewDataDictionary<object>(viewContext.ViewData),
                 writer);
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/HtmlHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/HtmlHelper.cs
@@ -589,7 +589,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 // Determine which ViewData we should use to construct a new ViewData
                 var baseViewData = viewData ?? ViewData;
 
-                var newViewData = new ViewDataDictionary(baseViewData, model);
+                var newViewData = new ViewDataDictionary<object>(baseViewData, model);
                 var viewContext = new ViewContext(ViewContext, view, newViewData, writer);
 
                 await viewEngineResult.View.RenderAsync(viewContext);

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/HtmlHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/HtmlHelper.cs
@@ -589,7 +589,15 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 // Determine which ViewData we should use to construct a new ViewData
                 var baseViewData = viewData ?? ViewData;
 
-                var newViewData = new ViewDataDictionary(baseViewData, model);
+                // Make an identical, defensive copy of the ViewDataDictionary to isolate changes.
+                ViewDataDictionary newViewData = new ViewDataDictionary(baseViewData);
+                if (!object.ReferenceEquals(model, baseViewData.Model))
+                {
+                    // Restart metadata from scratch since we know only the runtime type of the model. Of course an
+                    // @model directive in the partial view may give helpers in that view more information.
+                    newViewData.ModelExplorer = MetadataProvider.GetModelExplorerForType(typeof(object), model);
+                }
+
                 var viewContext = new ViewContext(ViewContext, view, newViewData, writer);
 
                 await viewEngineResult.View.RenderAsync(viewContext);

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/HtmlHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/HtmlHelper.cs
@@ -590,7 +590,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 var baseViewData = viewData ?? ViewData;
 
                 // Make an identical, defensive copy of the ViewDataDictionary to isolate changes.
-                ViewDataDictionary newViewData = new ViewDataDictionary(baseViewData);
+                var newViewData = new ViewDataDictionary(baseViewData);
                 if (!object.ReferenceEquals(model, baseViewData.Model))
                 {
                     // Restart metadata from scratch since we know only the runtime type of the model. Of course an

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/HtmlHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/HtmlHelper.cs
@@ -589,15 +589,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 // Determine which ViewData we should use to construct a new ViewData
                 var baseViewData = viewData ?? ViewData;
 
-                // Make an identical, defensive copy of the ViewDataDictionary to isolate changes.
-                var newViewData = new ViewDataDictionary(baseViewData);
-                if (!object.ReferenceEquals(model, baseViewData.Model))
-                {
-                    // Restart metadata from scratch since we know only the runtime type of the model. Of course an
-                    // @model directive in the partial view may give helpers in that view more information.
-                    newViewData.ModelExplorer = MetadataProvider.GetModelExplorerForType(typeof(object), model);
-                }
-
+                var newViewData = new ViewDataDictionary(baseViewData, model);
                 var viewContext = new ViewContext(ViewContext, view, newViewData, writer);
 
                 await viewEngineResult.View.RenderAsync(viewContext);

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/TemplateBuilder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/TemplateBuilder.cs
@@ -101,14 +101,11 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
                 return HtmlString.Empty;
             }
 
-            // We need to copy the ModelExplorer to copy the model metadata. Otherwise we might
-            // lose track of the model type/property. Passing null here explicitly, because
-            // this might be a typed VDD, and the model value might not be compatible.
-            // Create VDD of type object so it retains the correct metadata when the model type is not known.
-            var viewData = new ViewDataDictionary<object>(_viewData, model: null);
+            // Create VDD of type object so any model type is allowed.
+            var viewData = new ViewDataDictionary<object>(_viewData);
 
-            // We're setting ModelExplorer in order to preserve the model metadata of the original
-            // _viewData even though _model may be null.
+            // Create a new ModelExplorer in order to preserve the model metadata of the original _viewData even
+            // though _model may have been reset to null. Otherwise we might lose track of the model type /property.
             viewData.ModelExplorer = _modelExplorer.GetExplorerForModel(_model);
 
             viewData.TemplateInfo.FormattedModelValue = formattedModelValue;

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ViewDataDictionary.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ViewDataDictionary.cs
@@ -58,23 +58,6 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ViewDataDictionary"/> class based in part on an existing
-        /// instance. This constructor is careful to avoid exceptions <see cref="SetModel"/> may throw when
-        /// <paramref name="model"/> is <c>null</c>.
-        /// </summary>
-        /// <param name="source"><see cref="ViewDataDictionary"/> instance to copy initial values from.</param>
-        /// <param name="model">Value for the <see cref="Model"/> property.</param>
-        /// <remarks>
-        /// For use when the new instance's declared <see cref="Model"/> <see cref="Type"/> is unknown but its
-        /// <see cref="Model"/> is known. In this case, <see cref="object"/> is the best possible guess about the
-        /// declared type.
-        /// </remarks>
-        public ViewDataDictionary(ViewDataDictionary source, object model)
-            : this(source, model, declaredModelType: typeof(object))
-        {
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="ViewDataDictionary"/> class.
         /// </summary>
         /// <param name="metadataProvider">

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ViewDataDictionary.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ViewDataDictionary.cs
@@ -222,7 +222,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             var modelType = model?.GetType();
             var modelOrDeclaredType = modelType ?? declaredModelType;
             if (source.ModelMetadata.MetadataKind == ModelMetadataKind.Type &&
-                modelOrDeclaredType != source.ModelMetadata.ModelType &&
+                source.ModelMetadata.ModelType == typeof(object) &&
                 modelOrDeclaredType != typeof(object))
             {
                 // Base ModelMetadata on new type when there's no property information to preserve and type changes to
@@ -466,8 +466,8 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             // property information.
             var modelType = value?.GetType();
             if (ModelMetadata.MetadataKind == ModelMetadataKind.Type &&
+                ModelMetadata.ModelType == typeof(object) &&
                 modelType != null &&
-                modelType != ModelMetadata.ModelType &&
                 modelType != typeof(object))
             {
                 // Base ModelMetadata on new type when there's no property information to preserve and type changes to
@@ -477,8 +477,8 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             else if (modelType != null && !ModelMetadata.ModelType.IsAssignableFrom(modelType))
             {
                 // Base ModelMetadata on new type when new model is incompatible with the existing metadata. The most
-                // common case would be _declaredModelType==typeof(object), metadata was copied from another VDD, and
-                // user code sets the Model to a new type e.g. within a view component or a view that lacks an @model
+                // common case is _declaredModelType==typeof(object), metadata was copied from another VDD, and user
+                // code sets the Model to a new type e.g. within a view component or a view that lacks an @model
                 // directive.
                 ModelExplorer = _metadataProvider.GetModelExplorerForType(modelType, value);
             }

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ViewDataDictionary.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ViewDataDictionary.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Reflection;
 #endif
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Mvc.ViewFeatures
@@ -23,8 +24,8 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         /// Initializes a new instance of the <see cref="ViewDataDictionary"/> class.
         /// </summary>
         /// <param name="metadataProvider">
-        /// <see cref = "IModelMetadataProvider" /> instance used to calculate
-        /// <see cref="ViewDataDictionary.ModelMetadata"/> values.
+        /// <see cref="IModelMetadataProvider"/> instance used to create <see cref="ViewFeatures.ModelExplorer"/>
+        /// instances.
         /// </param>
         /// <param name="modelState"><see cref="ModelStateDictionary"/> instance for this scope.</param>
         /// <remarks>For use when creating a <see cref="ViewDataDictionary"/> for a new top-level scope.</remarks>
@@ -60,7 +61,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         /// <remarks>
         /// For use when the new instance's declared <see cref="Model"/> <see cref="Type"/> is unknown but its
         /// <see cref="Model"/> is known. In this case, <see cref="object"/> is the best possible guess about the
-        /// declared type when <paramref name="model"/> is <c>null</c>.
+        /// declared type.
         /// </remarks>
         public ViewDataDictionary(ViewDataDictionary source, object model)
             : this(source, model, declaredModelType: typeof(object))
@@ -71,8 +72,8 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         /// Initializes a new instance of the <see cref="ViewDataDictionary"/> class.
         /// </summary>
         /// <param name="metadataProvider">
-        /// <see cref="IModelMetadataProvider"/> instance used to calculate
-        /// <see cref="ViewDataDictionary.ModelMetadata"/> values.
+        /// <see cref="IModelMetadataProvider"/> instance used to create <see cref="ViewFeatures.ModelExplorer"/>
+        /// instances.
         /// </param>
         /// <remarks>Internal for testing.</remarks>
         internal ViewDataDictionary(IModelMetadataProvider metadataProvider)
@@ -84,12 +85,11 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         /// Initializes a new instance of the <see cref="ViewDataDictionary"/> class.
         /// </summary>
         /// <param name="metadataProvider">
-        /// <see cref = "IModelMetadataProvider" /> instance used to calculate
-        /// <see cref="ViewDataDictionary.ModelMetadata"/> values.
+        /// <see cref="IModelMetadataProvider"/> instance used to create <see cref="ViewFeatures.ModelExplorer"/>
+        /// instances.
         /// </param>
         /// <param name="declaredModelType">
-        /// <see cref="Type"/> of <see cref="Model"/> values expected. Used to set
-        /// <see cref="ViewDataDictionary.ModelMetadata"/> when <see cref="Model"/> is <c>null</c>.
+        /// <see cref="Type"/> of <see cref="Model"/> values expected. Used to set <see cref="ModelMetadata"/>.
         /// </param>
         /// <remarks>
         /// For use when creating a derived <see cref="ViewDataDictionary"/> for a new top-level scope.
@@ -105,17 +105,17 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         /// Initializes a new instance of the <see cref="ViewDataDictionary"/> class.
         /// </summary>
         /// <param name="metadataProvider">
-        /// <see cref = "IModelMetadataProvider" /> instance used to calculate
-        /// <see cref="ViewDataDictionary.ModelMetadata"/> values.
+        /// <see cref="IModelMetadataProvider"/> instance used to create <see cref="ViewFeatures.ModelExplorer"/>
+        /// instances.
         /// </param>
         /// <param name="modelState"><see cref="ModelStateDictionary"/> instance for this scope.</param>
         /// <param name="declaredModelType">
-        /// <see cref="Type"/> of <see cref="Model"/> values expected. Used to set
-        /// <see cref="ViewDataDictionary.ModelMetadata"/> when <see cref="Model"/> is <c>null</c>.
+        /// <see cref="Type"/> of <see cref="Model"/> values expected. Used to set <see cref="ModelMetadata"/>.
         /// </param>
         /// <remarks>
         /// For use when creating a derived <see cref="ViewDataDictionary"/> for a new top-level scope.
         /// </remarks>
+        // This is the core constructor called when Model is unknown.
         protected ViewDataDictionary(
             IModelMetadataProvider metadataProvider,
             ModelStateDictionary modelState,
@@ -141,7 +141,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 throw new ArgumentNullException(nameof(declaredModelType));
             }
 
-            // This is the core constructor called when Model is unknown. Base ModelMetadata on the declared type.
+            // Base ModelMetadata on the declared type.
             ModelExplorer = _metadataProvider.GetModelExplorerForType(declaredModelType, model: null);
         }
 
@@ -151,8 +151,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         /// </summary>
         /// <param name="source"><see cref="ViewDataDictionary"/> instance to copy initial values from.</param>
         /// <param name="declaredModelType">
-        /// <see cref="Type"/> of <see cref="Model"/> values expected. Used to set
-        /// <see cref="ViewDataDictionary.ModelMetadata"/> when <see cref="Model"/> is <c>null</c>.
+        /// <see cref="Type"/> of <see cref="Model"/> values expected. Used to set <see cref="ModelMetadata"/>.
         /// </param>
         /// <remarks>
         /// <para>
@@ -180,8 +179,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         /// <param name="source"><see cref="ViewDataDictionary"/> instance to copy initial values from.</param>
         /// <param name="model">Value for the <see cref="Model"/> property.</param>
         /// <param name="declaredModelType">
-        /// <see cref="Type"/> of <see cref="Model"/> values expected. Used to set
-        /// <see cref="ViewDataDictionary.ModelMetadata"/> when <see cref="Model"/> is <c>null</c>.
+        /// <see cref="Type"/> of <see cref="Model"/> values expected. Used to set <see cref="ModelMetadata"/>.
         /// </param>
         /// <remarks>
         /// <para>
@@ -193,6 +191,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         /// <paramref name="declaredModelType"/>.
         /// </para>
         /// </remarks>
+        // This is the core constructor called when Model is known.
         protected ViewDataDictionary(ViewDataDictionary source, object model, Type declaredModelType)
             : this(source._metadataProvider,
                    source.ModelState,
@@ -205,26 +204,51 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 throw new ArgumentNullException(nameof(source));
             }
 
-            // This is the core constructor called when Model is known.
-            var modelType = GetModelType(model);
-            var metadataModelType = source.ModelMetadata.UnderlyingOrModelType;
-            if (modelType == metadataModelType && model == source.ModelExplorer.Model)
+            // A non-null Model must always be assignable to both _declaredModelType and ModelMetadata.ModelType.
+            // ModelMetadata.ModelType should also be assignable to _declaredModelType. Though corner cases exist where
+            // a ViewDataDictionary instance might be expected to contain metadata for a _declaredModelType base class
+            // (e.g. a ViewDataDictionary<List<int>> holding information about an IEnumerable<int> property because an
+            // @model directive matched the runtime type though the view's name did not), we'll throw away the property
+            // metadata in those cases -- preserving invariant that ModelType can be assigned to _declaredModelType.
+            //
+            // More generally, since defensive copies to base VDD and VDD<object> abound, it's important to preserve
+            // metadata despite _declaredModelType changes.
+            if (source.ModelMetadata.MetadataKind == ModelMetadataKind.Type &&
+                source.ModelMetadata.ModelType != declaredModelType &&
+                declaredModelType != typeof(object))
             {
-                // Preserve any customizations made to source.ModelExplorer.ModelMetadata if the Type
-                // that will be calculated in SetModel() and source.Model match new instance's values.
+                // Base ModelMetadata on the declared type when there's no property information to preserve and the
+                // type changes to something besides typeof(object).
+                ModelExplorer = _metadataProvider.GetModelExplorerForType(declaredModelType, model);
+            }
+            else if (!declaredModelType.IsAssignableFrom(source.ModelMetadata.ModelType))
+            {
+                // Base ModelMetadata on the declared type when switching to an incompatible type.
+                ModelExplorer = _metadataProvider.GetModelExplorerForType(declaredModelType, model);
+            }
+            else if (object.ReferenceEquals(model, source.ModelExplorer.Model))
+            {
+                // Source's ModelExplorer is already exactly correct.
                 ModelExplorer = source.ModelExplorer;
             }
-            else if (model == null)
+            else
             {
-                // Ensure ModelMetadata is never null though SetModel() isn't called below.
-                ModelExplorer = _metadataProvider.GetModelExplorerForType(_declaredModelType, model: null);
+                ModelExplorer = new ModelExplorer(
+                    _metadataProvider,
+                    source.ModelExplorer.Container,
+                    source.ModelMetadata,
+                    model);
             }
 
-            // If we're constructing a ViewDataDictionary<TModel> where TModel is a non-Nullable value type,
-            // SetModel() will throw if we try to call it with null. We should not throw in that case.
+            // Ensure the given Model is compatible with _declaredModelType. Do not do this one of the following
+            // special cases:
+            // - Constructing a ViewDataDictionary<TModel> where TModel is a non-Nullable value type. This may for
+            // example occur when activating a RazorPage<int> and the container is null.
+            // - Constructing a ViewDataDictionary<object> immediately before overwriting ModelExplorer with correct
+            // information. See TemplateBuilder.Build().
             if (model != null)
             {
-                SetModel(model);
+                EnsureCompatible(model);
             }
         }
 
@@ -242,6 +266,9 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             TemplateInfo = templateInfo;
         }
 
+        /// <summary>
+        /// Gets or sets the current model.
+        /// </summary>
         public object Model
         {
             get
@@ -250,20 +277,22 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             }
             set
             {
-                // Reset ModelExplorer to ensure Model and ModelMetadata.Model remain equal.
+                // Reset ModelExplorer to ensure Model and ModelExplorer.Model remain equal.
                 SetModel(value);
             }
         }
 
+        /// <summary>
+        /// Gets the <see cref="ModelStateDictionary"/>.
+        /// </summary>
         public ModelStateDictionary ModelState { get; }
 
         /// <summary>
-        /// <see cref="ModelMetadata"/> for the current <see cref="Model"/> value or the declared <see cref="Type"/> if
-        /// <see cref="Model"/> is <c>null</c>.
+        /// Gets the <see cref="ModelBinding.ModelMetadata"/> for the declared <see cref="Type"/>.
         /// </summary>
         /// <remarks>
         /// Value is never <c>null</c> but may describe the <see cref="object"/> class in some cases. This may for
-        /// example occur in controllers if <see cref="Model"/> is <c>null</c>.
+        /// example occur in controllers.
         /// </remarks>
         public ModelMetadata ModelMetadata
         {
@@ -274,13 +303,17 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="ModelExplorer"/> for the <see cref="Model"/>.
+        /// Gets or sets the <see cref="ViewFeatures.ModelExplorer"/> for the <see cref="Model"/>.
         /// </summary>
         public ModelExplorer ModelExplorer { get; set; }
 
+        /// <summary>
+        /// Gets the <see cref="ViewFeatures.TemplateInfo"/>.
+        /// </summary>
         public TemplateInfo TemplateInfo { get; }
 
         #region IDictionary properties
+        /// <inheritdoc />
         // Do not just pass through to _data: Indexer should not throw a KeyNotFoundException.
         public object this[string index]
         {
@@ -296,21 +329,25 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             }
         }
 
+        /// <inheritdoc />
         public int Count
         {
             get { return _data.Count; }
         }
 
+        /// <inheritdoc />
         public bool IsReadOnly
         {
             get { return _data.IsReadOnly; }
         }
 
+        /// <inheritdoc />
         public ICollection<string> Keys
         {
             get { return _data.Keys; }
         }
 
+        /// <inheritdoc />
         public ICollection<object> Values
         {
             get { return _data.Values; }
@@ -360,6 +397,14 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             return FormatValue(value, format);
         }
 
+        /// <summary>
+        /// Formats the given <paramref name="value"/> using given <paramref name="format"/>.
+        /// </summary>
+        /// <param name="value">The value to format.</param>
+        /// <param name="format">
+        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx).
+        /// </param>
+        /// <returns>The formatted <see cref="string"/>.</returns>
         public static string FormatValue(object value, string format)
         {
             if (value == null)
@@ -395,31 +440,22 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             return ViewDataEvaluator.Eval(this, expression);
         }
 
-        // This method will execute before the derived type's instance constructor executes. Derived types must
-        // be aware of this and should plan accordingly. For example, the logic in SetModel() should be simple
-        // enough so as not to depend on the "this" pointer referencing a fully constructed object.
+        /// <summary>
+        /// Set <see cref="ModelExplorer"/> to ensure <see cref="Model"/> and <see cref="ModelExplorer.Model"/>
+        /// reflect the new <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">New <see cref="Model"/> value.</param>
         protected virtual void SetModel(object value)
         {
             EnsureCompatible(value);
 
-            // Reset or override ModelMetadata based on runtime value type. Fall back to declared type if value is
-            // null. When called from a constructor, current ModelExplorer may already be set to preserve
-            // customizations made in parent scope. But ModelExplorer is never null after instance is initialized.
-            var modelType = GetModelType(value);
-            Type metadataModelType = null;
-            if (ModelExplorer != null)
+            // Update ModelExplorer to reflect the new value. Preserve ModelMetadata to avoid losing property
+            // information or unexpectedly reflecting runtime information.
+            //
+            // Note EnsureCompatible() has already ensured ModelMetadata is correct.
+            if (object.ReferenceEquals(value, Model))
             {
-                metadataModelType = ModelMetadata.UnderlyingOrModelType;
-            }
-
-            if (metadataModelType != modelType)
-            {
-                ModelExplorer = _metadataProvider.GetModelExplorerForType(modelType, value);
-            }
-            else if (object.ReferenceEquals(value, Model))
-            {
-                // The metadata already matches, and the model is literally the same, nothing
-                // to do here. This will likely occur when using one of the copy constructors.
+                // The metadata matches and the model is literally the same; nothing to do here.
             }
             else
             {
@@ -450,11 +486,6 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             }
         }
 
-        private Type GetModelType(object value)
-        {
-            return (value == null) ? _declaredModelType : value.GetType();
-        }
-
         private bool IsCompatibleWithDeclaredType(object value)
         {
             if (value == null)
@@ -469,6 +500,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         }
 
         #region IDictionary methods
+        /// <inheritdoc />
         public void Add(string key, object value)
         {
             if (key == null)
@@ -479,6 +511,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             _data.Add(key, value);
         }
 
+        /// <inheritdoc />
         public bool ContainsKey(string key)
         {
             if (key == null)
@@ -489,6 +522,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             return _data.ContainsKey(key);
         }
 
+        /// <inheritdoc />
         public bool Remove(string key)
         {
             if (key == null)
@@ -499,6 +533,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             return _data.Remove(key);
         }
 
+        /// <inheritdoc />
         public bool TryGetValue(string key, out object value)
         {
             if (key == null)
@@ -509,21 +544,25 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             return _data.TryGetValue(key, out value);
         }
 
+        /// <inheritdoc />
         public void Add(KeyValuePair<string, object> item)
         {
             _data.Add(item);
         }
 
+        /// <inheritdoc />
         public void Clear()
         {
             _data.Clear();
         }
 
+        /// <inheritdoc />
         public bool Contains(KeyValuePair<string, object> item)
         {
             return _data.Contains(item);
         }
 
+        /// <inheritdoc />
         public void CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
         {
             if (array == null)
@@ -534,16 +573,19 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             _data.CopyTo(array, arrayIndex);
         }
 
+        /// <inheritdoc />
         public bool Remove(KeyValuePair<string, object> item)
         {
             return _data.Remove(item);
         }
 
+        /// <inheritdoc />
         IEnumerator<KeyValuePair<string, object>> IEnumerable<KeyValuePair<string, object>>.GetEnumerator()
         {
             return _data.GetEnumerator();
         }
 
+        /// <inheritdoc />
         IEnumerator IEnumerable.GetEnumerator()
         {
             return _data.GetEnumerator();

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ViewDataDictionaryOfT.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ViewDataDictionaryOfT.cs
@@ -79,6 +79,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         {
         }
 
+        /// <inheritdoc />
         public new TModel Model
         {
             get

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/HtmlGenerationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/HtmlGenerationTest.cs
@@ -189,6 +189,35 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             }
         }
 
+        // Testing how ModelMetadata is handled as ViewDataDictionary instances are created.
+        [Theory]
+        [InlineData("AtViewModel")]
+        [InlineData("NullViewModel")]
+        [InlineData("ViewModel")]
+        public async Task CheckViewData_GeneratesExpectedResults(string action)
+        {
+            // Arrange
+            var expectedMediaType = MediaTypeHeaderValue.Parse("text/html; charset=utf-8");
+            var outputFile = "compiler/resources/HtmlGenerationWebSite.CheckViewData." + action + ".html";
+            var expectedContent =
+                await ResourceFile.ReadResourceAsync(_resourcesAssembly, outputFile, sourceFile: false);
+
+            // Act
+            var response = await Client.GetAsync("http://localhost/CheckViewData/" + action);
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(expectedMediaType, response.Content.Headers.ContentType);
+
+            responseContent = responseContent.Trim();
+#if GENERATE_BASELINES
+            ResourceFile.UpdateFile(_resourcesAssembly, outputFile, expectedContent, responseContent);
+#else
+            Assert.Equal(expectedContent, responseContent, ignoreLineEndingDifferences: true);
+#endif
+        }
+
         [Fact]
         public async Task ValidationTagHelpers_GeneratesExpectedSpansAndDivs()
         {

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.CheckViewData.AtViewModel.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.CheckViewData.AtViewModel.html
@@ -1,0 +1,54 @@
+<div class="row">
+    <h4>At Model index</h4>
+    <div class="col-md-3">MetadataKind: 'Type'</div>
+    <div class="col-md-3">ModelType: 'ViewModel'</div>
+</div>
+
+<div class="row">
+    
+<h5>Template for ViewModel</h5>
+<div class="col-md-3">MetadataKind: 'Type'</div>
+<div class="col-md-3">ModelType: 'ViewModel'</div>
+
+</div>
+<div class="row">
+    
+<h5>Partial for ViewModel</h5>
+<div class="col-md-3">MetadataKind: 'Type'</div>
+<div class="col-md-3">ModelType: 'ViewModel'</div>
+
+</div>
+<div class="row">
+    <h5>Check View Data view component</h5>
+<div class="col-md-3">MetadataKind: 'Type'</div>
+<div class="col-md-3">ModelType: 'ViewModel'</div>
+
+<h5>Check View Data view component's view</h5>
+<div class="col-md-3">MetadataKind: 'Type'</div>
+<div class="col-md-3">ModelType: 'ViewModel'</div>
+
+</div>
+<div class="row">
+    
+<h5>Template for Int32</h5>
+<div class="col-md-3">MetadataKind: 'Property'</div>
+<div class="col-md-3">ModelType: 'Int32'</div>
+    <div class="col-md-3">PropertyName: 'Integer'</div>
+
+</div>
+<div class="row">
+    
+<h5>Template for Int64</h5>
+<div class="col-md-3">MetadataKind: 'Property'</div>
+<div class="col-md-3">ModelType: 'Nullable`1'</div>
+    <div class="col-md-3">PropertyName: 'NullableLong'</div>
+
+</div>
+<div class="row">
+    
+<h5>Template for TemplateModel</h5>
+<div class="col-md-3">MetadataKind: 'Property'</div>
+<div class="col-md-3">ModelType: 'TemplateModel'</div>
+    <div class="col-md-3">PropertyName: 'Template'</div>
+
+</div>

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.CheckViewData.AtViewModel.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.CheckViewData.AtViewModel.html
@@ -1,31 +1,31 @@
 <div class="row">
     <h4>At Model index</h4>
     <div class="col-md-3">MetadataKind: 'Type'</div>
-    <div class="col-md-3">ModelType: 'ViewModel'</div>
+    <div class="col-md-3">ModelType: 'SuperViewModel'</div>
 </div>
 
 <div class="row">
     
 <h5>Template for ViewModel</h5>
 <div class="col-md-3">MetadataKind: 'Type'</div>
-<div class="col-md-3">ModelType: 'ViewModel'</div>
+<div class="col-md-3">ModelType: 'SuperViewModel'</div>
 
 </div>
 <div class="row">
     
 <h5>Partial for ViewModel</h5>
 <div class="col-md-3">MetadataKind: 'Type'</div>
-<div class="col-md-3">ModelType: 'ViewModel'</div>
+<div class="col-md-3">ModelType: 'SuperViewModel'</div>
 
 </div>
 <div class="row">
     <h5>Check View Data view component</h5>
 <div class="col-md-3">MetadataKind: 'Type'</div>
-<div class="col-md-3">ModelType: 'ViewModel'</div>
+<div class="col-md-3">ModelType: 'SuperViewModel'</div>
 
 <h5>Check View Data view component's view</h5>
 <div class="col-md-3">MetadataKind: 'Type'</div>
-<div class="col-md-3">ModelType: 'ViewModel'</div>
+<div class="col-md-3">ModelType: 'SuperViewModel'</div>
 
 </div>
 <div class="row">

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.CheckViewData.NullViewModel.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.CheckViewData.NullViewModel.html
@@ -1,0 +1,54 @@
+<div class="row">
+    <h4>At Model index</h4>
+    <div class="col-md-3">MetadataKind: 'Type'</div>
+    <div class="col-md-3">ModelType: 'ViewModel'</div>
+</div>
+
+<div class="row">
+    
+<h5>Template for ViewModel</h5>
+<div class="col-md-3">MetadataKind: 'Type'</div>
+<div class="col-md-3">ModelType: 'ViewModel'</div>
+
+</div>
+<div class="row">
+    
+<h5>Partial for ViewModel</h5>
+<div class="col-md-3">MetadataKind: 'Type'</div>
+<div class="col-md-3">ModelType: 'ViewModel'</div>
+
+</div>
+<div class="row">
+    <h5>Check View Data view component</h5>
+<div class="col-md-3">MetadataKind: 'Type'</div>
+<div class="col-md-3">ModelType: 'ViewModel'</div>
+
+<h5>Check View Data view component's view</h5>
+<div class="col-md-3">MetadataKind: 'Type'</div>
+<div class="col-md-3">ModelType: 'ViewModel'</div>
+
+</div>
+<div class="row">
+    
+<h5>Template for Int32</h5>
+<div class="col-md-3">MetadataKind: 'Property'</div>
+<div class="col-md-3">ModelType: 'Int32'</div>
+    <div class="col-md-3">PropertyName: 'Integer'</div>
+
+</div>
+<div class="row">
+    
+<h5>Template for Int64</h5>
+<div class="col-md-3">MetadataKind: 'Property'</div>
+<div class="col-md-3">ModelType: 'Nullable`1'</div>
+    <div class="col-md-3">PropertyName: 'NullableLong'</div>
+
+</div>
+<div class="row">
+    
+<h5>Template for TemplateModel</h5>
+<div class="col-md-3">MetadataKind: 'Property'</div>
+<div class="col-md-3">ModelType: 'TemplateModel'</div>
+    <div class="col-md-3">PropertyName: 'Template'</div>
+
+</div>

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.CheckViewData.ViewModel.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.CheckViewData.ViewModel.html
@@ -1,7 +1,7 @@
 <div class="row">
     <h4>View Model index</h4>
     <div class="col-md-3">MetadataKind: 'Type'</div>
-    <div class="col-md-3">ModelType: 'ViewModel'</div>
+    <div class="col-md-3">ModelType: 'SuperViewModel'</div>
 </div>
 
 <div class="row">
@@ -9,7 +9,7 @@
 
 <h5>Template / partial for ... - LackModel</h5>
 <div class="col-md-3">MetadataKind: 'Type'</div>
-<div class="col-md-3">ModelType: 'ViewModel'</div>
+<div class="col-md-3">ModelType: 'SuperViewModel'</div>
 
 </div>
 <div class="row">
@@ -17,21 +17,21 @@
 
 <h5>Template / partial for ... - LackModel</h5>
 <div class="col-md-3">MetadataKind: 'Type'</div>
-<div class="col-md-3">ModelType: 'ViewModel'</div>
+<div class="col-md-3">ModelType: 'SuperViewModel'</div>
 
 </div>
 <div class="row">
     <h5>Check View Data - LackModel view component</h5>
 <div class="col-md-3">MetadataKind: 'Type'</div>
-<div class="col-md-3">ModelType: 'ViewModel'</div>
+<div class="col-md-3">ModelType: 'SuperViewModel'</div>
 <h5>Check View Data - LackModel view component after setting Model to 78.9</h5>
 <div class="col-md-3">MetadataKind: 'Type'</div>
-<div class="col-md-3">ModelType: 'Object'</div>
+<div class="col-md-3">ModelType: 'Double'</div>
 
 
 <h5>Check View Data - LackModel view component's view</h5>
 <div class="col-md-3">MetadataKind: 'Type'</div>
-<div class="col-md-3">ModelType: 'TemplateModel'</div>
+<div class="col-md-3">ModelType: 'SuperTemplateModel'</div>
 
 </div>
 <div class="row">
@@ -45,7 +45,7 @@
 
 <h5>Template for Int32 - LackModel after setting Model to 78.9</h5>
 <div class="col-md-3">MetadataKind: 'Type'</div>
-<div class="col-md-3">ModelType: 'Object'</div>
+<div class="col-md-3">ModelType: 'Double'</div>
 
 </div>
 <div class="row">
@@ -72,12 +72,12 @@
 <div class="col-md-3">PropertyName: 'NullableLong'</div>
 <h5>Check View Data - LackModel view component after setting Model to 78.9</h5>
 <div class="col-md-3">MetadataKind: 'Type'</div>
-<div class="col-md-3">ModelType: 'Object'</div>
+<div class="col-md-3">ModelType: 'Double'</div>
 
 
 <h5>Check View Data - LackModel view component's view</h5>
 <div class="col-md-3">MetadataKind: 'Type'</div>
-<div class="col-md-3">ModelType: 'TemplateModel'</div>
+<div class="col-md-3">ModelType: 'SuperTemplateModel'</div>
 
 </div>
 

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.CheckViewData.ViewModel.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.CheckViewData.ViewModel.html
@@ -1,0 +1,93 @@
+<div class="row">
+    <h4>View Model index</h4>
+    <div class="col-md-3">MetadataKind: 'Type'</div>
+    <div class="col-md-3">ModelType: 'ViewModel'</div>
+</div>
+
+<div class="row">
+    
+
+<h5>Template / partial for ... - LackModel</h5>
+<div class="col-md-3">MetadataKind: 'Type'</div>
+<div class="col-md-3">ModelType: 'ViewModel'</div>
+
+</div>
+<div class="row">
+    
+
+<h5>Template / partial for ... - LackModel</h5>
+<div class="col-md-3">MetadataKind: 'Type'</div>
+<div class="col-md-3">ModelType: 'ViewModel'</div>
+
+</div>
+<div class="row">
+    <h5>Check View Data - LackModel view component</h5>
+<div class="col-md-3">MetadataKind: 'Type'</div>
+<div class="col-md-3">ModelType: 'ViewModel'</div>
+<h5>Check View Data - LackModel view component after setting Model to 78.9</h5>
+<div class="col-md-3">MetadataKind: 'Type'</div>
+<div class="col-md-3">ModelType: 'Object'</div>
+
+
+<h5>Check View Data - LackModel view component's view</h5>
+<div class="col-md-3">MetadataKind: 'Type'</div>
+<div class="col-md-3">ModelType: 'TemplateModel'</div>
+
+</div>
+<div class="row">
+    
+
+<h5>Template for Int32 - LackModel</h5>
+<div class="col-md-3">MetadataKind: 'Property'</div>
+<div class="col-md-3">ModelType: 'Int32'</div>
+    <div class="col-md-3">PropertyName: 'Integer'</div>
+
+
+<h5>Template for Int32 - LackModel after setting Model to 78.9</h5>
+<div class="col-md-3">MetadataKind: 'Type'</div>
+<div class="col-md-3">ModelType: 'Object'</div>
+
+</div>
+<div class="row">
+    
+
+<h5>Template for Int64</h5>
+<div class="col-md-3">MetadataKind: 'Property'</div>
+<div class="col-md-3">ModelType: 'Nullable`1'</div>
+    <div class="col-md-3">PropertyName: 'NullableLong'</div>
+
+<div class="row">
+    
+
+<h5>Template / partial for ... - LackModel</h5>
+<div class="col-md-3">MetadataKind: 'Property'</div>
+<div class="col-md-3">ModelType: 'Nullable`1'</div>
+    <div class="col-md-3">PropertyName: 'NullableLong'</div>
+
+</div>
+<div class="row">
+    <h5>Check View Data - LackModel view component</h5>
+<div class="col-md-3">MetadataKind: 'Property'</div>
+<div class="col-md-3">ModelType: 'Nullable`1'</div>
+<div class="col-md-3">PropertyName: 'NullableLong'</div>
+<h5>Check View Data - LackModel view component after setting Model to 78.9</h5>
+<div class="col-md-3">MetadataKind: 'Type'</div>
+<div class="col-md-3">ModelType: 'Object'</div>
+
+
+<h5>Check View Data - LackModel view component's view</h5>
+<div class="col-md-3">MetadataKind: 'Type'</div>
+<div class="col-md-3">ModelType: 'TemplateModel'</div>
+
+</div>
+
+</div>
+<div class="row">
+    
+
+<h5>Template / partial for ... - LackModel</h5>
+<div class="col-md-3">MetadataKind: 'Property'</div>
+<div class="col-md-3">ModelType: 'TemplateModel'</div>
+    <div class="col-md-3">PropertyName: 'Template'</div>
+
+</div>

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ControllerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ControllerTest.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.DataAnnotations.Internal;
@@ -277,26 +276,26 @@ namespace Microsoft.AspNetCore.Mvc.Test
             Assert.Equal(input, result);
         }
 
-        public static TheoryData<object> IncompatibleModelData
+        public static TheoryData<object, Type> IncompatibleModelData
         {
             get
             {
-                // Small grab bag of types with no common base except typeof(object).
-                return new TheoryData<object>
+                // Small grab bag of instances and expected types with no common base except typeof(object).
+                return new TheoryData<object, Type>
                 {
-                    null,
-                    true,
-                    43.78,
-                    "test string",
-                    new List<int>(),
-                    new List<string>(),
+                    { null, typeof(object) },
+                    { true, typeof(bool) },
+                    { 43.78, typeof(double) },
+                    { "test string", typeof(string) },
+                    { new List<int>(), typeof(List<int>) },
+                    { new List<string>(), typeof(List<string>) },
                 };
             }
         }
 
         [Theory]
         [MemberData(nameof(IncompatibleModelData))]
-        public void ViewDataModelSetter_DoesNotThrow(object model)
+        public void ViewDataModelSetter_DoesNotThrow(object model, Type expectedType)
         {
             // Arrange
             var activator = new ViewDataDictionaryControllerPropertyActivator(new EmptyModelMetadataProvider());
@@ -316,7 +315,7 @@ namespace Microsoft.AspNetCore.Mvc.Test
 
             // Assert
             Assert.NotNull(controller.ViewData.ModelMetadata);
-            Assert.Equal(typeof(object), controller.ViewData.ModelMetadata.ModelType);
+            Assert.Equal(expectedType, controller.ViewData.ModelMetadata.ModelType);
         }
 
         private static Controller GetController(IModelBinder binder, IValueProvider valueProvider)

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ControllerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ControllerTest.cs
@@ -7,12 +7,15 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.DataAnnotations.Internal;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Routing;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
@@ -272,6 +275,48 @@ namespace Microsoft.AspNetCore.Mvc.Test
 
             // Assert
             Assert.Equal(input, result);
+        }
+
+        public static TheoryData<object> IncompatibleModelData
+        {
+            get
+            {
+                // Small grab bag of types with no common base except typeof(object).
+                return new TheoryData<object>
+                {
+                    null,
+                    true,
+                    43.78,
+                    "test string",
+                    new List<int>(),
+                    new List<string>(),
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(IncompatibleModelData))]
+        public void ViewDataModelSetter_DoesNotThrow(object model)
+        {
+            // Arrange
+            var activator = new ViewDataDictionaryControllerPropertyActivator(new EmptyModelMetadataProvider());
+            var actionContext = new ActionContext(
+                new DefaultHttpContext(),
+                new RouteData(),
+                new ControllerActionDescriptor());
+            var controllerContext = new ControllerContext(actionContext);
+            var controller = new TestableController();
+            activator.Activate(controllerContext, controller);
+
+            // Guard
+            Assert.NotNull(controller.ViewData);
+
+            // Act (does not throw)
+            controller.ViewData.Model = model;
+
+            // Assert
+            Assert.NotNull(controller.ViewData.ModelMetadata);
+            Assert.Equal(typeof(object), controller.ViewData.ModelMetadata.ModelType);
         }
 
         private static Controller GetController(IModelBinder binder, IValueProvider valueProvider)

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/DefaultTemplatesUtilities.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/DefaultTemplatesUtilities.cs
@@ -304,12 +304,6 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             return htmlHelper;
         }
 
-        public static string FormatOutput(IHtmlHelper helper, object model)
-        {
-            var modelExplorer = helper.MetadataProvider.GetModelExplorerForType(model.GetType(), model);
-            return FormatOutput(modelExplorer);
-        }
-
         private static ICompositeViewEngine CreateViewEngine()
         {
             var view = new Mock<IView>();
@@ -333,6 +327,17 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
                 .Verifiable();
 
             return viewEngine.Object;
+        }
+
+        public static string FormatOutput(IHtmlHelper helper, object model)
+        {
+            return FormatOutput(helper, model.GetType(), model);
+        }
+
+        public static string FormatOutput(IHtmlHelper helper, Type type, object model)
+        {
+            var modelExplorer = helper.MetadataProvider.GetModelExplorerForType(type, model);
+            return FormatOutput(modelExplorer);
         }
 
         private static string FormatOutput(ModelExplorer modelExplorer)

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/DefaultTemplatesUtilities.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/DefaultTemplatesUtilities.cs
@@ -331,12 +331,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
 
         public static string FormatOutput(IHtmlHelper helper, object model)
         {
-            return FormatOutput(helper, model.GetType(), model);
-        }
-
-        public static string FormatOutput(IHtmlHelper helper, Type type, object model)
-        {
-            var modelExplorer = helper.MetadataProvider.GetModelExplorerForType(type, model);
+            var modelExplorer = helper.MetadataProvider.GetModelExplorerForType(model.GetType(), model);
             return FormatOutput(modelExplorer);
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperPartialExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperPartialExtensionsTest.cs
@@ -372,7 +372,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             // Arrange
             var model = new TestModel();
             var helper = DefaultTemplatesUtilities.GetHtmlHelper();
-            var expected = DefaultTemplatesUtilities.FormatOutput(helper, model);
+            var expected = DefaultTemplatesUtilities.FormatOutput(helper, typeof(object), model);
 
             // Act
             var actual = helper.Partial("some-partial", model);
@@ -388,7 +388,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             var model = new TestModel();
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
             var viewData = new ViewDataDictionary(helper.MetadataProvider);
-            var expected = DefaultTemplatesUtilities.FormatOutput(helper, model);
+            var expected = DefaultTemplatesUtilities.FormatOutput(helper, typeof(object), model);
 
             // Act
             var actual = helper.Partial("some-partial", viewData);

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperPartialExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperPartialExtensionsTest.cs
@@ -372,7 +372,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             // Arrange
             var model = new TestModel();
             var helper = DefaultTemplatesUtilities.GetHtmlHelper();
-            var expected = DefaultTemplatesUtilities.FormatOutput(helper, typeof(object), model);
+            var expected = DefaultTemplatesUtilities.FormatOutput(helper, model);
 
             // Act
             var actual = helper.Partial("some-partial", model);
@@ -388,7 +388,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             var model = new TestModel();
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
             var viewData = new ViewDataDictionary(helper.MetadataProvider);
-            var expected = DefaultTemplatesUtilities.FormatOutput(helper, typeof(object), model);
+            var expected = DefaultTemplatesUtilities.FormatOutput(helper, model);
 
             // Act
             var actual = helper.Partial("some-partial", viewData);

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponents/ViewComponentContextTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponents/ViewComponentContextTest.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Mvc.ViewFeatures.Internal;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.WebEncoders.Testing;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.ViewComponents
+{
+    public class ViewComponentContextTest
+    {
+        [Fact]
+        public void Constructor_PerformsDefensiveCopies()
+        {
+            // Arrange
+            var httpContext = new DefaultHttpContext();
+            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+            var viewData = new ViewDataDictionary(new EmptyModelMetadataProvider());
+            var viewContext = new ViewContext(
+                actionContext,
+                NullView.Instance,
+                viewData,
+                new TempDataDictionary(httpContext, new SessionStateTempDataProvider()),
+                TextWriter.Null,
+                new HtmlHelperOptions());
+
+            var viewComponentDescriptor = new ViewComponentDescriptor();
+
+            // Act
+            var viewComponentContext = new ViewComponentContext(
+                viewComponentDescriptor,
+                new Dictionary<string, object>(),
+                new HtmlTestEncoder(),
+                viewContext,
+                TextWriter.Null);
+
+            // Assert
+            // New ViewContext but initial View and TextWriter copied over.
+            Assert.NotSame(viewContext, viewComponentContext.ViewContext);
+            Assert.Same(viewContext.View, viewComponentContext.ViewContext.View);
+            Assert.Same(viewContext.Writer, viewComponentContext.ViewContext.Writer);
+
+            // Double-check the convenience properties.
+            Assert.Same(viewComponentContext.ViewContext.ViewData, viewComponentContext.ViewData);
+            Assert.Same(viewComponentContext.ViewContext.Writer, viewComponentContext.Writer);
+
+            // New VDD instance but initial ModelMetadata copied over.
+            Assert.NotSame(viewData, viewComponentContext.ViewData);
+            Assert.Same(viewData.ModelMetadata, viewComponentContext.ViewData.ModelMetadata);
+        }
+
+        public static TheoryData<object> IncompatibleModelData
+        {
+            get
+            {
+                // Small "anything but int" grab bag.
+                return new TheoryData<object>
+                {
+                    null,
+                    true,
+                    43.78,
+                    "test string",
+                    new List<int>(),
+                    new List<string>(),
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(IncompatibleModelData))]
+        public void ViewDataModelSetter_DoesNotThrow_IfValueIncompatibleWithSourceDeclaredType(object model)
+        {
+            // Arrange
+            var httpContext = new DefaultHttpContext();
+            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+            var viewData = new ViewDataDictionary<int>(new EmptyModelMetadataProvider());
+            var viewContext = new ViewContext(
+                actionContext,
+                NullView.Instance,
+                viewData,
+                new TempDataDictionary(httpContext, new SessionStateTempDataProvider()),
+                TextWriter.Null,
+                new HtmlHelperOptions());
+
+            var viewComponentDescriptor = new ViewComponentDescriptor();
+            var viewComponentContext = new ViewComponentContext(
+                viewComponentDescriptor,
+                new Dictionary<string, object>(),
+                new HtmlTestEncoder(),
+                viewContext,
+                TextWriter.Null);
+
+            // Act (does not throw)
+            // Non-ints can be assigned despite type restrictions in the source ViewDataDictionary.
+            viewComponentContext.ViewData.Model = model;
+
+            // Assert
+            Assert.Equal(typeof(object), viewComponentContext.ViewData.ModelMetadata.ModelType);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponents/ViewComponentContextTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponents/ViewComponentContextTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.AspNetCore.Http;
@@ -57,26 +58,28 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
             Assert.Same(viewData.ModelMetadata, viewComponentContext.ViewData.ModelMetadata);
         }
 
-        public static TheoryData<object> IncompatibleModelData
+        public static TheoryData<object, Type> IncompatibleModelData
         {
             get
             {
-                // Small "anything but int" grab bag.
-                return new TheoryData<object>
+                // Small "anything but int" grab bag of instances and expected types.
+                return new TheoryData<object, Type>
                 {
-                    null,
-                    true,
-                    43.78,
-                    "test string",
-                    new List<int>(),
-                    new List<string>(),
+                    { null, typeof(object) },
+                    { true, typeof(bool) },
+                    { 43.78, typeof(double) },
+                    { "test string", typeof(string) },
+                    { new List<int>(), typeof(List<int>) },
+                    { new List<string>(), typeof(List<string>) },
                 };
             }
         }
 
         [Theory]
         [MemberData(nameof(IncompatibleModelData))]
-        public void ViewDataModelSetter_DoesNotThrow_IfValueIncompatibleWithSourceDeclaredType(object model)
+        public void ViewDataModelSetter_DoesNotThrow_IfValueIncompatibleWithSourceDeclaredType(
+            object model,
+            Type expectedType)
         {
             // Arrange
             var httpContext = new DefaultHttpContext();
@@ -103,7 +106,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
             viewComponentContext.ViewData.Model = model;
 
             // Assert
-            Assert.Equal(typeof(object), viewComponentContext.ViewData.ModelMetadata.ModelType);
+            Assert.Equal(expectedType, viewComponentContext.ViewData.ModelMetadata.ModelType);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/ViewDataDictionaryOfTModelTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/ViewDataDictionaryOfTModelTest.cs
@@ -207,7 +207,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         }
 
         [Fact]
-        public void CopyConstructors_ThrowInvalidOperation_IfModelIncompatible()
+        public void CopyConstructors_ThrowInvalidOperation_IfModelIncompatibleWithDeclaredType()
         {
             // Arrange
             var expectedMessage = "The model item passed into the ViewDataDictionary is of type 'System.Int32', " +
@@ -229,7 +229,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         [Theory]
         [InlineData(null)]
         [InlineData(23)]
-        public void CopyConstructor_DoesNotChangeMetadata_WhenValueCompatible(int? model)
+        public void CopyConstructor_DoesNotChangeMetadata_WhenValueCompatibleWithSourceMetadata(int? model)
         {
             // Arrange
             var metadataProvider = new EmptyModelMetadataProvider();
@@ -251,7 +251,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         }
 
         [Fact]
-        public void CopyConstructor_UpdatesMetadata_WhenSwitchingToIncompatibleType()
+        public void CopyConstructor_UpdatesMetadata_IfDeclaredTypeChangesIncompatibly()
         {
             // Arrange
             var metadataProvider = new EmptyModelMetadataProvider();
@@ -315,7 +315,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         }
 
         [Fact]
-        public void ModelSetters_ThrowInvalidOperation_IfModelIncompatible()
+        public void ModelSetters_ThrowInvalidOperation_IfModelIncompatibleWithDeclaredType()
         {
             // Arrange
             var expectedMessage = "The model item passed into the ViewDataDictionary is of type 'System.Int32', " +

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/ViewDataDictionaryOfTModelTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/ViewDataDictionaryOfTModelTest.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             Assert.NotSame(source.TemplateInfo, viewData1.TemplateInfo);
             Assert.Same(model, viewData1.Model);
             Assert.NotNull(viewData1.ModelMetadata);
-            Assert.Equal(typeof(object), viewData1.ModelMetadata.ModelType);
+            Assert.Equal(typeof(TestModel), viewData1.ModelMetadata.ModelType);
             Assert.Same(source.ModelMetadata, viewData1.ModelMetadata);
             Assert.Equal(source.Count, viewData1.Count);
             Assert.Equal("bar", viewData1["foo"]);
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             Assert.NotSame(source.TemplateInfo, viewData2.TemplateInfo);
             Assert.Same(model, viewData2.Model);
             Assert.NotNull(viewData2.ModelMetadata);
-            Assert.Equal(typeof(object), viewData2.ModelMetadata.ModelType);
+            Assert.Equal(typeof(TestModel), viewData2.ModelMetadata.ModelType);
             Assert.Same(source.ModelMetadata, viewData2.ModelMetadata);
             Assert.Equal(source.Count, viewData2.Count);
             Assert.Equal("bar", viewData2["foo"]);
@@ -129,7 +129,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             // Assert
             Assert.Same(model, viewData.Model);
             Assert.NotNull(viewData.ModelMetadata);
-            Assert.Equal(typeof(object), viewData.ModelMetadata.ModelType);
+            Assert.Equal(typeof(SupremeTestModel), viewData.ModelMetadata.ModelType);
             Assert.Same(source.ModelMetadata, viewData.ModelMetadata);
         }
 
@@ -152,8 +152,8 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             // Assert
             Assert.Same(model, viewData.Model);
             Assert.NotNull(viewData.ModelMetadata);
-            Assert.Equal(typeof(TestModel), viewData.ModelMetadata.ModelType);
-            Assert.NotSame(source.ModelMetadata, viewData.ModelMetadata);
+            Assert.Equal(typeof(SupremeTestModel), viewData.ModelMetadata.ModelType);
+            Assert.Same(source.ModelMetadata, viewData.ModelMetadata);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/ViewDataDictionaryOfTModelTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/ViewDataDictionaryOfTModelTest.cs
@@ -127,17 +127,10 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             var viewData = new ViewDataDictionary(source);
 
             // Assert
-            Assert.NotNull(viewData.ModelState);
-            Assert.NotNull(viewData.TemplateInfo);
-            Assert.Equal("prefix", viewData.TemplateInfo.HtmlFieldPrefix);
-            Assert.NotSame(source.TemplateInfo, viewData.TemplateInfo);
             Assert.Same(model, viewData.Model);
             Assert.NotNull(viewData.ModelMetadata);
             Assert.Equal(typeof(object), viewData.ModelMetadata.ModelType);
             Assert.Same(source.ModelMetadata, viewData.ModelMetadata);
-            Assert.Equal(source.Count, viewData.Count);
-            Assert.Equal("bar", viewData["foo"]);
-            Assert.IsType<CopyOnWriteDictionary<string, object>>(viewData.Data);
         }
 
         [Fact]
@@ -157,17 +150,10 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             var viewData = new ViewDataDictionary<TestModel>(source);
 
             // Assert
-            Assert.NotNull(viewData.ModelState);
-            Assert.NotNull(viewData.TemplateInfo);
-            Assert.Equal("prefix", viewData.TemplateInfo.HtmlFieldPrefix);
-            Assert.NotSame(source.TemplateInfo, viewData.TemplateInfo);
             Assert.Same(model, viewData.Model);
             Assert.NotNull(viewData.ModelMetadata);
             Assert.Equal(typeof(TestModel), viewData.ModelMetadata.ModelType);
             Assert.NotSame(source.ModelMetadata, viewData.ModelMetadata);
-            Assert.Equal(source.Count, viewData.Count);
-            Assert.Equal("bar", viewData["foo"]);
-            Assert.IsType<CopyOnWriteDictionary<string, object>>(viewData.Data);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/ViewDataDictionaryTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/ViewDataDictionaryTest.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         }
 
         [Fact]
-        public void SetModel_DoesNotUsePassedInModelMetadataProvider()
+        public void SetModel_DoesNotUseModelMetadataProvider()
         {
             // Arrange
             var metadataProvider = new Mock<IModelMetadataProvider>(MockBehavior.Strict);
@@ -85,8 +85,6 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 
             // Assert
             Assert.NotNull(viewData.ModelMetadata);
-
-            // Count is the same as in Constructor_UsesModelMetadataProvider().
             metadataProvider.Verify(m => m.GetMetadataForType(typeof(object)), Times.Once());
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/ViewDataDictionaryTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/ViewDataDictionaryTest.cs
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             var modelState = new ModelStateDictionary();
 
             // Act
-            var viewData = new TestViewDataDictionary(metadataProvider.Object, modelState);
+            var viewData = new ViewDataDictionary(metadataProvider.Object, modelState);
 
             // Assert
             Assert.NotNull(viewData.ModelMetadata);

--- a/test/WebSites/HtmlGenerationWebSite/Components/CheckViewData - LackModel.cs
+++ b/test/WebSites/HtmlGenerationWebSite/Components/CheckViewData - LackModel.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using HtmlGenerationWebSite.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+
+namespace HtmlGenerationWebSite.Components
+{
+    public class CheckViewData___LackModel : ViewComponent
+    {
+        public IViewComponentResult Invoke()
+        {
+            var metadata = ViewData.ModelMetadata;
+            var writer = ViewContext.Writer;
+            writer.WriteLine("<h5>Check View Data - LackModel view component</h5>");
+            writer.WriteLine($"<div class=\"col-md-3\">MetadataKind: '{ metadata.MetadataKind }'</div>");
+            writer.WriteLine($"<div class=\"col-md-3\">ModelType: '{ metadata.ModelType.Name }'</div>");
+            if (metadata.MetadataKind == ModelMetadataKind.Property)
+            {
+                writer.WriteLine($"<div class=\"col-md-3\">PropertyName: '{ metadata.PropertyName }'</div>");
+            }
+
+            // Confirm view component is able to set the model to anything.
+            ViewData.Model = 78.9;
+
+            // Expected metadata is for typeof(object).
+            metadata = ViewData.ModelMetadata;
+            writer.WriteLine("<h5>Check View Data - LackModel view component after setting Model to 78.9</h5>");
+            writer.WriteLine($"<div class=\"col-md-3\">MetadataKind: '{ metadata.MetadataKind }'</div>");
+            writer.WriteLine($"<div class=\"col-md-3\">ModelType: '{ metadata.ModelType.Name }'</div>");
+            if (metadata.MetadataKind == ModelMetadataKind.Property)
+            {
+                writer.WriteLine($"<div class=\"col-md-3\">PropertyName: '{ metadata.PropertyName }'</div>");
+            }
+
+            TemplateModel templateModel = new SuperTemplateModel();
+
+            return View(templateModel);
+        }
+    }
+}

--- a/test/WebSites/HtmlGenerationWebSite/Components/CheckViewData.cs
+++ b/test/WebSites/HtmlGenerationWebSite/Components/CheckViewData.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+
+namespace HtmlGenerationWebSite.Components
+{
+    public class CheckViewData : ViewComponent
+    {
+        public IViewComponentResult Invoke()
+        {
+            var metadata = ViewData.ModelMetadata;
+            var writer = ViewContext.Writer;
+            writer.WriteLine("<h5>Check View Data view component</h5>");
+            writer.WriteLine($"<div class=\"col-md-3\">MetadataKind: '{ metadata.MetadataKind }'</div>");
+            writer.WriteLine($"<div class=\"col-md-3\">ModelType: '{ metadata.ModelType.Name }'</div>");
+            if (metadata.MetadataKind == ModelMetadataKind.Property)
+            {
+                writer.WriteLine($"<div class=\"col-md-3\">PropertyName: '{ metadata.PropertyName }'</div>");
+            }
+
+            return View();
+        }
+    }
+}

--- a/test/WebSites/HtmlGenerationWebSite/Controllers/CheckViewData.cs
+++ b/test/WebSites/HtmlGenerationWebSite/Controllers/CheckViewData.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using HtmlGenerationWebSite.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HtmlGenerationWebSite.Controllers
+{
+    public class CheckViewData : Controller
+    {
+        public IActionResult AtViewModel()
+        {
+            return View(new SuperViewModel());
+        }
+
+        public IActionResult NullViewModel()
+        {
+            return View("AtViewModel");
+        }
+
+        public IActionResult ViewModel()
+        {
+            return View(new SuperViewModel());
+        }
+    }
+}

--- a/test/WebSites/HtmlGenerationWebSite/Models/PartialModel.cs
+++ b/test/WebSites/HtmlGenerationWebSite/Models/PartialModel.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace HtmlGenerationWebSite.Models
+{
+    public class PartialModel
+    {
+    }
+}

--- a/test/WebSites/HtmlGenerationWebSite/Models/SuperTemplateModel.cs
+++ b/test/WebSites/HtmlGenerationWebSite/Models/SuperTemplateModel.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace HtmlGenerationWebSite.Models
+{
+    public class SuperTemplateModel : TemplateModel
+    {
+    }
+}

--- a/test/WebSites/HtmlGenerationWebSite/Models/SuperViewModel.cs
+++ b/test/WebSites/HtmlGenerationWebSite/Models/SuperViewModel.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace HtmlGenerationWebSite.Models
+{
+    public class SuperViewModel : ViewModel
+    {
+    }
+}

--- a/test/WebSites/HtmlGenerationWebSite/Models/TemplateModel.cs
+++ b/test/WebSites/HtmlGenerationWebSite/Models/TemplateModel.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace HtmlGenerationWebSite.Models
+{
+    public class TemplateModel
+    {
+    }
+}

--- a/test/WebSites/HtmlGenerationWebSite/Models/ViewModel.cs
+++ b/test/WebSites/HtmlGenerationWebSite/Models/ViewModel.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace HtmlGenerationWebSite.Models
+{
+    public class ViewModel
+    {
+        public int Integer { get; set; } = 23;
+
+        public long? NullableLong { get; set; } = 24L;
+
+        public TemplateModel Template { get; set; } = new SuperTemplateModel();
+    }
+}

--- a/test/WebSites/HtmlGenerationWebSite/Startup.cs
+++ b/test/WebSites/HtmlGenerationWebSite/Startup.cs
@@ -47,6 +47,7 @@ namespace HtmlGenerationWebSite
             var host = new WebHostBuilder()
                 .UseDefaultHostingConfiguration(args)
                 .UseStartup<Startup>()
+                .UseIISPlatformHandlerUrl()
                 .UseKestrel()
                 .Build();
 

--- a/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/AtViewModel.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/AtViewModel.cshtml
@@ -1,0 +1,37 @@
+﻿@using HtmlGenerationWebSite.Components
+@using HtmlGenerationWebSite.Models
+@using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
+@model ViewModel
+
+@{
+    var metadata = ViewData.ModelMetadata;
+}
+
+<div class="row">
+    <h4>At Model index</h4>
+    <div class="col-md-3">MetadataKind: '@metadata.MetadataKind'</div>
+    <div class="col-md-3">ModelType: '@metadata.ModelType.Name'</div>
+    @if (metadata.MetadataKind == ModelMetadataKind.Property)
+    {
+        <div class="col-md-3">PropertyName: '@metadata.PropertyName'</div>
+    }
+</div>
+
+<div class="row">
+    @Html.DisplayFor(m => m)
+</div>
+<div class="row">
+    @Html.Partial("PartialForViewModel")
+</div>
+<div class="row">
+    @(await Component.InvokeAsync<CheckViewData>())
+</div>
+<div class="row">
+    @Html.DisplayFor(m => m.Integer)
+</div>
+<div class="row">
+    @Html.DisplayFor(m => m.NullableLong)
+</div>
+<div class="row">
+    @Html.DisplayFor(m => m.Template)
+</div>

--- a/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/Components/CheckViewData/Default.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/Components/CheckViewData/Default.cshtml
@@ -1,0 +1,15 @@
+﻿@using HtmlGenerationWebSite.Models
+@using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
+@model ViewModel
+
+@{
+    var metadata = ViewData.ModelMetadata;
+}
+
+<h5>Check View Data view component's view</h5>
+<div class="col-md-3">MetadataKind: '@metadata.MetadataKind'</div>
+<div class="col-md-3">ModelType: '@metadata.ModelType.Name'</div>
+@if (metadata.MetadataKind == ModelMetadataKind.Property)
+{
+    <div class="col-md-3">PropertyName: '@metadata.PropertyName'</div>
+}

--- a/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/Components/CheckViewData___LackModel/Default.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/Components/CheckViewData___LackModel/Default.cshtml
@@ -1,0 +1,14 @@
+﻿@using HtmlGenerationWebSite.Models
+@using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
+
+@{
+    var metadata = ViewData.ModelMetadata;
+}
+
+<h5>Check View Data - LackModel view component's view</h5>
+<div class="col-md-3">MetadataKind: '@metadata.MetadataKind'</div>
+<div class="col-md-3">ModelType: '@metadata.ModelType.Name'</div>
+@if (metadata.MetadataKind == ModelMetadataKind.Property)
+{
+    <div class="col-md-3">PropertyName: '@metadata.PropertyName'</div>
+}

--- a/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/DisplayTemplates/Int32 - LackModel.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/DisplayTemplates/Int32 - LackModel.cshtml
@@ -1,0 +1,27 @@
+﻿@using HtmlGenerationWebSite.Models
+@using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
+
+@{
+    var metadata = ViewData.ModelMetadata;
+}
+
+<h5>Template for Int32 - LackModel</h5>
+<div class="col-md-3">MetadataKind: '@metadata.MetadataKind'</div>
+<div class="col-md-3">ModelType: '@metadata.ModelType.Name'</div>
+@if (metadata.MetadataKind == ModelMetadataKind.Property)
+{
+    <div class="col-md-3">PropertyName: '@metadata.PropertyName'</div>
+}
+
+@{
+    ViewData.Model = 78.9;
+    metadata = ViewData.ModelMetadata;
+}
+
+<h5>Template for Int32 - LackModel after setting Model to 78.9</h5>
+<div class="col-md-3">MetadataKind: '@metadata.MetadataKind'</div>
+<div class="col-md-3">ModelType: '@metadata.ModelType.Name'</div>
+@if (metadata.MetadataKind == ModelMetadataKind.Property)
+{
+    <div class="col-md-3">PropertyName: '@metadata.PropertyName'</div>
+}

--- a/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/DisplayTemplates/Int32.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/DisplayTemplates/Int32.cshtml
@@ -1,0 +1,15 @@
+﻿@using HtmlGenerationWebSite.Models
+@using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
+@model int?
+
+@{
+    var metadata = ViewData.ModelMetadata;
+}
+
+<h5>Template for Int32</h5>
+<div class="col-md-3">MetadataKind: '@metadata.MetadataKind'</div>
+<div class="col-md-3">ModelType: '@metadata.ModelType.Name'</div>
+@if (metadata.MetadataKind == ModelMetadataKind.Property)
+{
+    <div class="col-md-3">PropertyName: '@metadata.PropertyName'</div>
+}

--- a/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/DisplayTemplates/Int64 - LackModel.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/DisplayTemplates/Int64 - LackModel.cshtml
@@ -1,0 +1,22 @@
+﻿@using HtmlGenerationWebSite.Components
+@using HtmlGenerationWebSite.Models
+@using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
+
+@{
+    var metadata = ViewData.ModelMetadata;
+}
+
+<h5>Template for Int64</h5>
+<div class="col-md-3">MetadataKind: '@metadata.MetadataKind'</div>
+<div class="col-md-3">ModelType: '@metadata.ModelType.Name'</div>
+@if (metadata.MetadataKind == ModelMetadataKind.Property)
+{
+    <div class="col-md-3">PropertyName: '@metadata.PropertyName'</div>
+}
+
+<div class="row">
+    @Html.Partial(partialViewName: "LackModel.cshtml")
+</div>
+<div class="row">
+    @(await Component.InvokeAsync<CheckViewData___LackModel>())
+</div>

--- a/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/DisplayTemplates/Int64.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/DisplayTemplates/Int64.cshtml
@@ -1,0 +1,15 @@
+﻿@using HtmlGenerationWebSite.Models
+@using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
+@model long?
+
+@{
+    var metadata = ViewData.ModelMetadata;
+}
+
+<h5>Template for Int64</h5>
+<div class="col-md-3">MetadataKind: '@metadata.MetadataKind'</div>
+<div class="col-md-3">ModelType: '@metadata.ModelType.Name'</div>
+@if (metadata.MetadataKind == ModelMetadataKind.Property)
+{
+    <div class="col-md-3">PropertyName: '@metadata.PropertyName'</div>
+}

--- a/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/DisplayTemplates/LackModel.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/DisplayTemplates/LackModel.cshtml
@@ -1,0 +1,14 @@
+﻿@using HtmlGenerationWebSite.Models
+@using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
+
+@{
+    var metadata = ViewData.ModelMetadata;
+}
+
+<h5>Template / partial for ... - LackModel</h5>
+<div class="col-md-3">MetadataKind: '@metadata.MetadataKind'</div>
+<div class="col-md-3">ModelType: '@metadata.ModelType.Name'</div>
+@if (metadata.MetadataKind == ModelMetadataKind.Property)
+{
+    <div class="col-md-3">PropertyName: '@metadata.PropertyName'</div>
+}

--- a/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/DisplayTemplates/TemplateModel.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/DisplayTemplates/TemplateModel.cshtml
@@ -1,0 +1,15 @@
+﻿@using HtmlGenerationWebSite.Models
+@using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
+@model TemplateModel
+
+@{
+    var metadata = ViewData.ModelMetadata;
+}
+
+<h5>Template for TemplateModel</h5>
+<div class="col-md-3">MetadataKind: '@metadata.MetadataKind'</div>
+<div class="col-md-3">ModelType: '@metadata.ModelType.Name'</div>
+@if (metadata.MetadataKind == ModelMetadataKind.Property)
+{
+    <div class="col-md-3">PropertyName: '@metadata.PropertyName'</div>
+}

--- a/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/DisplayTemplates/ViewModel.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/DisplayTemplates/ViewModel.cshtml
@@ -1,0 +1,15 @@
+﻿@using HtmlGenerationWebSite.Models
+@using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
+@model ViewModel
+
+@{
+    var metadata = ViewData.ModelMetadata;
+}
+
+<h5>Template for ViewModel</h5>
+<div class="col-md-3">MetadataKind: '@metadata.MetadataKind'</div>
+<div class="col-md-3">ModelType: '@metadata.ModelType.Name'</div>
+@if (metadata.MetadataKind == ModelMetadataKind.Property)
+{
+    <div class="col-md-3">PropertyName: '@metadata.PropertyName'</div>
+}

--- a/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/PartialForViewModel.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/PartialForViewModel.cshtml
@@ -1,0 +1,15 @@
+﻿@using HtmlGenerationWebSite.Models
+@using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
+@model ViewModel
+
+@{
+    var metadata = ViewData.ModelMetadata;
+}
+
+<h5>Partial for ViewModel</h5>
+<div class="col-md-3">MetadataKind: '@metadata.MetadataKind'</div>
+<div class="col-md-3">ModelType: '@metadata.ModelType.Name'</div>
+@if (metadata.MetadataKind == ModelMetadataKind.Property)
+{
+    <div class="col-md-3">PropertyName: '@metadata.PropertyName'</div>
+}

--- a/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/ViewModel.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/CheckViewData/ViewModel.cshtml
@@ -1,0 +1,40 @@
+﻿@using HtmlGenerationWebSite.Components
+@using HtmlGenerationWebSite.Models
+@using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
+
+@* Need the model directive in top-level view. Otherwise the controller would have to set the ViewData property. *@
+@* Put another way, Controller lacks the View<TModel>([...,] TModel) overloads that ViewComponent has. *@
+@model ViewModel
+
+@{
+    var metadata = ViewData.ModelMetadata;
+}
+
+<div class="row">
+    <h4>View Model index</h4>
+    <div class="col-md-3">MetadataKind: '@metadata.MetadataKind'</div>
+    <div class="col-md-3">ModelType: '@metadata.ModelType.Name'</div>
+    @if (metadata.MetadataKind == ModelMetadataKind.Property)
+    {
+        <div class="col-md-3">PropertyName: '@metadata.PropertyName'</div>
+    }
+</div>
+
+<div class="row">
+    @Html.DisplayFor(m => m, templateName: "LackModel")
+</div>
+<div class="row">
+    @Html.Partial(partialViewName: "DisplayTemplates/LackModel.cshtml")
+</div>
+<div class="row">
+    @(await Component.InvokeAsync<CheckViewData___LackModel>())
+</div>
+<div class="row">
+    @Html.DisplayFor(m => m.Integer, templateName: "Int32 - LackModel")
+</div>
+<div class="row">
+    @Html.DisplayFor(m => m.NullableLong, templateName: "Int64 - LackModel")
+</div>
+<div class="row">
+    @Html.DisplayFor(m => m.Template, templateName: "LackModel")
+</div>

--- a/test/WebSites/HtmlGenerationWebSite/project.json
+++ b/test/WebSites/HtmlGenerationWebSite/project.json
@@ -6,11 +6,15 @@
     "emitEntryPoint": true,
     "preserveCompilationContext": true
   },
+  "content": [
+    "Views"
+  ],
   "dependencies": {
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TagHelpers": "1.0.0-*",
-    "Microsoft.AspNetCore.Mvc.TestConfiguration": "1.0.0"
+    "Microsoft.AspNetCore.Mvc.TestConfiguration": "1.0.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*"
   },
   "frameworks": {
     "net451": {},
@@ -20,7 +24,7 @@
         "portable-net451+win8"
       ],
       "dependencies": {
-          "NETStandard.Library": "1.5.0-*"
+        "NETStandard.Library": "1.5.0-*"
       }
     }
   }

--- a/test/WebSites/HtmlGenerationWebSite/wwwroot/web.config
+++ b/test/WebSites/HtmlGenerationWebSite/wwwroot/web.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="httpPlatformHandler" path="*" verb="*" modules="httpPlatformHandler" resourceType="Unspecified" />
+    </handlers>
+    <httpPlatform processPath="%DNX_PATH%" arguments="%DNX_ARGS%" forwardWindowsAuthToken="false" startupTimeLimit="3600" stdoutLogEnabled="false" />
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
- #4116
- greatly simplify rules for `ModelMetadata`; entirely remove metadata changes when Model is updated
- update `HtmlHelper.RenderPartialCoreAsync()` to ensure metadata is _not_ copied unless using existing model
- note existing functional tests did not need to change

nits:
- do not call `virtual SetModel()` method from constructor; now mostly redundant
- add some missing doc comments
- fix doc comment property versus type confusion; never need to specify `ViewDataDictionary.` prefix