### PR TITLE
Fixing race in distributed cache tag helper

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/DistributedCacheTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/DistributedCacheTagHelper.cs
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
             IHtmlContent content = null;
 
-            // Create a cancellation token that will be used 
+            // Create a cancellation token that will be used
             // to release the task from the memory cache.
             var tokenSource = new CancellationTokenSource();
 
@@ -109,6 +109,6 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
             return options;
         }
-        
+
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/DistributedCacheTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/DistributedCacheTagHelperTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 {
     public class DistributedCacheTagHelperTest
     {
-        
+
         [Fact]
         public async Task ProcessAsync_DoesNotCache_IfDisabled()
         {


### PR DESCRIPTION
If an exception is thrown by an instance, another awaiting request could grab the worker task, and get into an infinite loop.
The fix removes the worker task before warning other requests to acquire another worker task or process it themselves.

Checked with @JunTaoLuo on his box it couldn't be repro-ed with the fix, but currently running it 100 times to be sure.