### PR TITLE
Remove using Task.FromResult where possible

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/ActionResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ActionResult.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Internal;
 
 namespace Microsoft.AspNetCore.Mvc
 {
@@ -22,7 +23,7 @@ namespace Microsoft.AspNetCore.Mvc
         public virtual Task ExecuteResultAsync(ActionContext context)
         {
             ExecuteResult(context);
-            return Task.FromResult(true);
+            return TaskCache.CompletedTask;
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Mvc.Core/Formatters/HttpNoContentOutputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Formatters/HttpNoContentOutputFormatter.cs
@@ -3,6 +3,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Internal;
 
 namespace Microsoft.AspNetCore.Mvc.Formatters
 {
@@ -42,7 +43,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 response.StatusCode = StatusCodes.Status204NoContent;
             }
 
-            return Task.FromResult(true);
+            return TaskCache.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Formatters/HttpNotAcceptableOutputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Formatters/HttpNotAcceptableOutputFormatter.cs
@@ -3,6 +3,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Internal;
 
 namespace Microsoft.AspNetCore.Mvc.Formatters
 {
@@ -22,7 +23,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         {
             var response = context.HttpContext.Response;
             response.StatusCode = StatusCodes.Status406NotAcceptable;
-            return Task.FromResult(true);
+            return TaskCache.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Cors/Internal/DisableCorsAuthorizationFilter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Cors/Internal/DisableCorsAuthorizationFilter.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Mvc.Cors.Internal
@@ -47,7 +48,7 @@ namespace Microsoft.AspNetCore.Mvc.Cors.Internal
             }
 
             // Let the action be executed.
-            return Task.FromResult(true);
+            return TaskCache.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/NullView.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/NullView.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 
@@ -21,7 +22,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return Task.FromResult(0);
+            return TaskCache.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
Believe it or not, this one in ActionResult is showing in TechEmpower. I
did a pass on all of the product code since the cache task actually
improves the readability of the code :sunglasses: