### PR TITLE
Repair failing functional test

### DIFF
--- a/test/WebSites/RoutingWebSite/Controllers/TeamController.cs
+++ b/test/WebSites/RoutingWebSite/Controllers/TeamController.cs
@@ -63,8 +63,8 @@ namespace RoutingWebSite
             return Content(Url.Action(), "text/plain");
         }
 
-        [HttpGet("/TeamName/{*Name}/")]
-        public ActionResult GetTeam(string name = "DefaultName")
+        [HttpGet("/TeamName/{*Name=DefaultName}/")]
+        public ActionResult GetTeam(string name)
         {
             return _generator.Generate("/TeamName/" + name);
         }


### PR DESCRIPTION
I recently consolidated some code in routing that made the behavior for
attribute routes and conventional routes more consistent. So now, a
catch-all will add a null value to the RVD if it doesn't capture any text,
but will NOT trounce an existing value in the RVD.

This test depended on the behavior where attribute routes didn't ever add
a null value for a catch-all. The fix is to just add a default to the
catch-all.