### PR TITLE
Fixing functional test random failure

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/HtmlGenerationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/HtmlGenerationTest.cs
@@ -339,7 +339,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal(expected1, response1.Trim());
 
             // Act - 2
-            await Task.Delay(TimeSpan.FromSeconds(1));
+            await Task.Delay(TimeSpan.FromSeconds(2));
             var response2 = await Client.GetStringAsync("/catalog/3");
 
             // Assert - 2


### PR DESCRIPTION
This code is waiting 1 second before requesting the same view/cached tag helper:

```html
<cache expires-after="TimeSpan.FromSeconds(1)" priority="CacheItemPriority.Low">
Cached content for @ViewBag.ProductId
</cache>
```

which expires after 1 second itself. Sometimes is returns the cached value where it expects a new value. I am proposing to wait for 2 seconds instead.
