### PR TITLE
Add web.config to test sites

### DIFF
--- a/test/WebSites/ApiExplorerWebSite/Startup.cs
+++ b/test/WebSites/ApiExplorerWebSite/Startup.cs
@@ -47,6 +47,7 @@ namespace ApiExplorerWebSite
             var host = new WebHostBuilder()
                 .UseDefaultHostingConfiguration(args)
                 .UseKestrel()
+                .UseIISIntegration()
                 .UseStartup<Startup>()
                 .Build();
 

--- a/test/WebSites/ApiExplorerWebSite/project.json
+++ b/test/WebSites/ApiExplorerWebSite/project.json
@@ -1,12 +1,10 @@
 {
-  "commands": {
-    "web": "ApiExplorerWebSite"
-  },
   "compilationOptions": {
     "emitEntryPoint": true,
     "preserveCompilationContext": true
   },
   "dependencies": {
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.Formatters.Xml": "1.0.0-*",
@@ -24,5 +22,8 @@
           "NETStandard.Library": "1.5.0-*"
       }
     }
-  }
+  },
+  "content": [
+    "web.config"
+  ]
 }

--- a/test/WebSites/ApiExplorerWebSite/web.config
+++ b/test/WebSites/ApiExplorerWebSite/web.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+    </handlers>
+    <aspNetCore processPath=".\ApiExplorerWebSite.exe" arguments="" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" />
+  </system.webServer>
+</configuration>

--- a/test/WebSites/ApiExplorerWebSite/wwwroot/HelloWorld.htm
+++ b/test/WebSites/ApiExplorerWebSite/wwwroot/HelloWorld.htm
@@ -1,1 +1,0 @@
-HelloWorld

--- a/test/WebSites/ApplicationModelWebSite/Startup.cs
+++ b/test/WebSites/ApplicationModelWebSite/Startup.cs
@@ -38,6 +38,7 @@ namespace ApplicationModelWebSite
                 .UseDefaultHostingConfiguration(args)
                 .UseStartup<Startup>()
                 .UseKestrel()
+                .UseIISIntegration()
                 .Build();
 
             host.Run();

--- a/test/WebSites/ApplicationModelWebSite/project.json
+++ b/test/WebSites/ApplicationModelWebSite/project.json
@@ -1,12 +1,10 @@
 {
-  "commands": {
-    "web": "ApplicationModelWebSite"
-  },
   "compilationOptions": {
     "emitEntryPoint": true,
     "preserveCompilationContext": true
   },
   "dependencies": {
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TestConfiguration": "1.0.0",
@@ -23,5 +21,8 @@
           "NETStandard.Library": "1.5.0-*"
       }
     }
-  }
+  },
+  "content": [
+    "web.config"
+  ]
 }

--- a/test/WebSites/ApplicationModelWebSite/web.config
+++ b/test/WebSites/ApplicationModelWebSite/web.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+    </handlers>
+    <aspNetCore processPath=".\ApplicationModelWebSite.exe" arguments="" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" />
+  </system.webServer>
+</configuration>

--- a/test/WebSites/ApplicationModelWebSite/wwwroot/HelloWorld.htm
+++ b/test/WebSites/ApplicationModelWebSite/wwwroot/HelloWorld.htm
@@ -1,1 +1,0 @@
-HelloWorld

--- a/test/WebSites/BasicWebSite/Startup.cs
+++ b/test/WebSites/BasicWebSite/Startup.cs
@@ -59,6 +59,7 @@ namespace BasicWebSite
                 .UseDefaultHostingConfiguration(args)
                 .UseStartup<Startup>()
                 .UseKestrel()
+                .UseIISIntegration()
                 .Build();
 
             host.Run();

--- a/test/WebSites/BasicWebSite/project.json
+++ b/test/WebSites/BasicWebSite/project.json
@@ -1,7 +1,4 @@
 {
-  "commands": {
-    "web": "BasicWebSite"
-  },
   "compilationOptions": {
     "emitEntryPoint": true,
     "preserveCompilationContext": true
@@ -10,6 +7,7 @@
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.Formatters.Xml": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TestConfiguration": "1.0.0",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.Session": "1.0.0-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*"
@@ -26,9 +24,8 @@
       }
     }
   },
-  "exclude": [
-    "wwwroot",
-    "node_modules",
-    "bower_components"
+  "content": [
+    "Views",
+    "web.config"
   ]
 }

--- a/test/WebSites/BasicWebSite/web.config
+++ b/test/WebSites/BasicWebSite/web.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+    </handlers>
+    <aspNetCore processPath=".\BasicWebSite.exe" arguments="" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" />
+  </system.webServer>
+</configuration>

--- a/test/WebSites/BasicWebSite/wwwroot/web.config
+++ b/test/WebSites/BasicWebSite/wwwroot/web.config
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <system.webServer>
-    <handlers>
-      <add name="httpPlatformHandler" path="*" verb="*" modules="httpPlatformHandler" resourceType="Unspecified" />
-    </handlers>
-    <httpPlatform processPath="%DNX_PATH%" arguments="%DNX_ARGS%" forwardWindowsAuthToken="false" startupTimeLimit="3600" />
-  </system.webServer>
-</configuration>

--- a/test/WebSites/ControllersFromServicesWebSite/Startup.cs
+++ b/test/WebSites/ControllersFromServicesWebSite/Startup.cs
@@ -65,6 +65,7 @@ namespace ControllersFromServicesWebSite
                 .UseDefaultHostingConfiguration(args)
                 .UseStartup<Startup>()
                 .UseKestrel()
+                .UseIISIntegration()
                 .Build();
 
             host.Run();

--- a/test/WebSites/ControllersFromServicesWebSite/project.json
+++ b/test/WebSites/ControllersFromServicesWebSite/project.json
@@ -1,13 +1,11 @@
 {
-  "commands": {
-    "web": "ControllersFromServicesWebSite"
-  },
   "compilationOptions": {
     "emitEntryPoint": true,
     "preserveCompilationContext": true
   },
   "dependencies": {
     "ControllersFromServicesClassLibrary": "1.0.0",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TestConfiguration": "1.0.0",
@@ -24,5 +22,9 @@
           "NETStandard.Library": "1.5.0-*"
       }
     }
-  }
+  },
+  "content": [
+    "Views",
+    "web.config"
+  ]
 }

--- a/test/WebSites/ControllersFromServicesWebSite/web.config
+++ b/test/WebSites/ControllersFromServicesWebSite/web.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+    </handlers>
+    <aspNetCore processPath=".\ControllersFromServicesWebSite.exe" arguments="" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" />
+  </system.webServer>
+</configuration>

--- a/test/WebSites/ControllersFromServicesWebSite/wwwroot/HelloWorld.htm
+++ b/test/WebSites/ControllersFromServicesWebSite/wwwroot/HelloWorld.htm
@@ -1,1 +1,0 @@
-HelloWorld

--- a/test/WebSites/CorsWebSite/Startup.cs
+++ b/test/WebSites/CorsWebSite/Startup.cs
@@ -84,6 +84,7 @@ namespace CorsWebSite
                 .UseDefaultHostingConfiguration(args)
                 .UseStartup<Startup>()
                 .UseKestrel()
+                .UseIISIntegration()
                 .Build();
 
             host.Run();

--- a/test/WebSites/CorsWebSite/project.json
+++ b/test/WebSites/CorsWebSite/project.json
@@ -1,12 +1,10 @@
 {
-  "commands": {
-    "web": "CorsWebSite"
-  },
   "compilationOptions": {
     "emitEntryPoint": true,
     "preserveCompilationContext": true
   },
   "dependencies": {
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.Cors": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
@@ -25,5 +23,8 @@
           "NETStandard.Library": "1.5.0-*"
       }
     }
-  }
+  },
+  "content": [
+    "web.config"
+  ]
 }

--- a/test/WebSites/CorsWebSite/web.config
+++ b/test/WebSites/CorsWebSite/web.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+    </handlers>
+    <aspNetCore processPath=".\CorsWebSite.exe" arguments="" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" />
+  </system.webServer>
+</configuration>

--- a/test/WebSites/CorsWebSite/wwwroot/HelloWorld.htm
+++ b/test/WebSites/CorsWebSite/wwwroot/HelloWorld.htm
@@ -1,1 +1,0 @@
-HelloWorld

--- a/test/WebSites/ErrorPageMiddlewareWebSite/Startup.cs
+++ b/test/WebSites/ErrorPageMiddlewareWebSite/Startup.cs
@@ -29,6 +29,7 @@ namespace ErrorPageMiddlewareWebSite
                 .UseDefaultHostingConfiguration(args)
                 .UseStartup<Startup>()
                 .UseKestrel()
+                .UseIISIntegration()
                 .Build();
 
             host.Run();

--- a/test/WebSites/ErrorPageMiddlewareWebSite/project.json
+++ b/test/WebSites/ErrorPageMiddlewareWebSite/project.json
@@ -1,12 +1,10 @@
 {
-  "commands": {
-    "web": "ErrorPageMiddlewareWebSite"
-  },
   "compilationOptions": {
     "emitEntryPoint": true,
     "preserveCompilationContext": true
   },
   "dependencies": {
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
@@ -24,5 +22,9 @@
           "NETStandard.Library": "1.5.0-*"
       }
     }
-  }
+  },
+  "content": [
+    "Views",
+    "web.config"
+  ]
 }

--- a/test/WebSites/ErrorPageMiddlewareWebSite/web.config
+++ b/test/WebSites/ErrorPageMiddlewareWebSite/web.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+    </handlers>
+    <aspNetCore processPath=".\ErrorPageMiddlewareWebSite.exe" arguments="" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" />
+  </system.webServer>
+</configuration>

--- a/test/WebSites/ErrorPageMiddlewareWebSite/wwwroot/HelloWorld.htm
+++ b/test/WebSites/ErrorPageMiddlewareWebSite/wwwroot/HelloWorld.htm
@@ -1,1 +1,0 @@
-HelloWorld

--- a/test/WebSites/FilesWebSite/Startup.cs
+++ b/test/WebSites/FilesWebSite/Startup.cs
@@ -31,6 +31,7 @@ namespace FilesWebSite
                 .UseDefaultHostingConfiguration(args)
                 .UseStartup<Startup>()
                 .UseKestrel()
+                .UseIISIntegration()
                 .Build();
 
             host.Run();

--- a/test/WebSites/FilesWebSite/project.json
+++ b/test/WebSites/FilesWebSite/project.json
@@ -1,13 +1,11 @@
 {
-  "commands": {
-    "web": "FilesWebSite"
-  },
   "compilationOptions": {
     "emitEntryPoint": true,
     "preserveCompilationContext": true
   },
   "resource": "EmbeddedResources/**",
   "dependencies": {
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TestConfiguration": "1.0.0",
@@ -25,5 +23,9 @@
           "NETStandard.Library": "1.5.0-*"
       }
     }
-  }
+  },
+  "content": [
+    "sample.txt",
+    "web.config"
+  ]
 }

--- a/test/WebSites/FilesWebSite/web.config
+++ b/test/WebSites/FilesWebSite/web.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+    </handlers>
+    <aspNetCore processPath=".\FilesWebSite.exe" arguments="" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" />
+  </system.webServer>
+</configuration>

--- a/test/WebSites/FilesWebSite/wwwroot/HelloWorld.htm
+++ b/test/WebSites/FilesWebSite/wwwroot/HelloWorld.htm
@@ -1,1 +1,0 @@
-HelloWorld

--- a/test/WebSites/FiltersWebSite/Startup.cs
+++ b/test/WebSites/FiltersWebSite/Startup.cs
@@ -59,7 +59,6 @@ namespace FiltersWebSite
         {
             app.UseCultureReplacer();
 
-
             app.UseMiddleware<AuthorizeBasicMiddleware>("Interactive");
             app.UseMiddleware<AuthorizeBasicMiddleware>("Api");
             app.UseMiddleware<ErrorReporterMiddleware>();
@@ -73,6 +72,7 @@ namespace FiltersWebSite
                 .UseDefaultHostingConfiguration(args)
                 .UseStartup<Startup>()
                 .UseKestrel()
+                .UseIISIntegration()
                 .Build();
 
             host.Run();

--- a/test/WebSites/FiltersWebSite/project.json
+++ b/test/WebSites/FiltersWebSite/project.json
@@ -1,12 +1,10 @@
 {
-  "commands": {
-    "web": "FiltersWebSite"
-  },
   "compilationOptions": {
     "emitEntryPoint": true,
     "preserveCompilationContext": true
   },
   "dependencies": {
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.Authentication": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
@@ -25,5 +23,8 @@
           "NETStandard.Library": "1.5.0-*"
       }
     }
-  }
+  },
+  "content": [
+    "web.config"
+  ]
 }

--- a/test/WebSites/FiltersWebSite/web.config
+++ b/test/WebSites/FiltersWebSite/web.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+    </handlers>
+    <aspNetCore processPath=".\FiltersWebSite.exe" arguments="" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" />
+  </system.webServer>
+</configuration>

--- a/test/WebSites/FiltersWebSite/wwwroot/HelloWorld.htm
+++ b/test/WebSites/FiltersWebSite/wwwroot/HelloWorld.htm
@@ -1,1 +1,0 @@
-HelloWorld

--- a/test/WebSites/FormatterWebSite/Startup.cs
+++ b/test/WebSites/FormatterWebSite/Startup.cs
@@ -40,6 +40,7 @@ namespace FormatterWebSite
                 .UseDefaultHostingConfiguration(args)
                 .UseStartup<Startup>()
                 .UseKestrel()
+                .UseIISIntegration()
                 .Build();
 
             host.Run();

--- a/test/WebSites/FormatterWebSite/project.json
+++ b/test/WebSites/FormatterWebSite/project.json
@@ -1,12 +1,10 @@
 {
-  "commands": {
-    "web": "FormatterWebSite"
-  },
   "compilationOptions": {
     "emitEntryPoint": true,
     "preserveCompilationContext": true
   },
   "dependencies": {
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.Formatters.Xml": "1.0.0-*",
@@ -24,5 +22,8 @@
           "NETStandard.Library": "1.5.0-*"
       }
     }
-  }
+  },
+  "content": [
+    "web.config"
+  ]
 }

--- a/test/WebSites/FormatterWebSite/web.config
+++ b/test/WebSites/FormatterWebSite/web.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+    </handlers>
+    <aspNetCore processPath=".\FormatterWebSite.exe" arguments="" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" />
+  </system.webServer>
+</configuration>

--- a/test/WebSites/FormatterWebSite/wwwroot/HelloWorld.htm
+++ b/test/WebSites/FormatterWebSite/wwwroot/HelloWorld.htm
@@ -1,1 +1,0 @@
-HelloWorld

--- a/test/WebSites/HtmlGenerationWebSite/Startup.cs
+++ b/test/WebSites/HtmlGenerationWebSite/Startup.cs
@@ -48,6 +48,7 @@ namespace HtmlGenerationWebSite
                 .UseDefaultHostingConfiguration(args)
                 .UseStartup<Startup>()
                 .UseKestrel()
+                .UseIISIntegration()
                 .Build();
 
             host.Run();

--- a/test/WebSites/HtmlGenerationWebSite/project.json
+++ b/test/WebSites/HtmlGenerationWebSite/project.json
@@ -1,12 +1,10 @@
 {
-  "commands": {
-    "web": "HtmlGenerationWebSite"
-  },
   "compilationOptions": {
     "emitEntryPoint": true,
     "preserveCompilationContext": true
   },
   "dependencies": {
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TagHelpers": "1.0.0-*",
@@ -23,5 +21,10 @@
           "NETStandard.Library": "1.5.0-*"
       }
     }
-  }
+  },
+  "content": [
+    "Views",
+    "wwwroot",
+    "web.config"
+  ]
 }

--- a/test/WebSites/HtmlGenerationWebSite/web.config
+++ b/test/WebSites/HtmlGenerationWebSite/web.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+    </handlers>
+    <aspNetCore processPath=".\HtmlGenerationWebSite.exe" arguments="" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" />
+  </system.webServer>
+</configuration>

--- a/test/WebSites/HtmlGenerationWebSite/wwwroot/HelloWorld.htm
+++ b/test/WebSites/HtmlGenerationWebSite/wwwroot/HelloWorld.htm
@@ -1,1 +1,0 @@
-HelloWorld

--- a/test/WebSites/RazorPageExecutionInstrumentationWebSite/Startup.cs
+++ b/test/WebSites/RazorPageExecutionInstrumentationWebSite/Startup.cs
@@ -50,6 +50,7 @@ namespace RazorPageExecutionInstrumentationWebSite
                 .UseDefaultHostingConfiguration(args)
                 .UseStartup<Startup>()
                 .UseKestrel()
+                .UseIISIntegration()
                 .Build();
 
             host.Run();

--- a/test/WebSites/RazorPageExecutionInstrumentationWebSite/project.json
+++ b/test/WebSites/RazorPageExecutionInstrumentationWebSite/project.json
@@ -3,12 +3,10 @@
     "emitEntryPoint": true,
     "preserveCompilationContext": true
   },
-  "commands": {
-    "web": "RazorPageExecutionInstrumentationWebSite"
-  },
   "dependencies": {
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TestConfiguration": "1.0.0",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
     "Microsoft.Extensions.DiagnosticAdapter": "1.0.0-*"
@@ -24,5 +22,9 @@
           "NETStandard.Library": "1.5.0-*"
       }
     }
-  }
+  },
+  "content": [
+    "Views",
+    "web.config"
+  ]
 }

--- a/test/WebSites/RazorPageExecutionInstrumentationWebSite/web.config
+++ b/test/WebSites/RazorPageExecutionInstrumentationWebSite/web.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+    </handlers>
+    <aspNetCore processPath=".\RazorPageExecutionInstrumentationWebSite.exe" arguments="" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" />
+  </system.webServer>
+</configuration>

--- a/test/WebSites/RazorPageExecutionInstrumentationWebSite/wwwroot/HelloWorld.htm
+++ b/test/WebSites/RazorPageExecutionInstrumentationWebSite/wwwroot/HelloWorld.htm
@@ -1,1 +1,0 @@
-HelloWorld

--- a/test/WebSites/RazorWebSite/Startup.cs
+++ b/test/WebSites/RazorWebSite/Startup.cs
@@ -67,6 +67,7 @@ namespace RazorWebSite
                 .UseDefaultHostingConfiguration(args)
                 .UseStartup<Startup>()
                 .UseKestrel()
+                .UseIISIntegration()
                 .Build();
 
             host.Run();

--- a/test/WebSites/RazorWebSite/project.json
+++ b/test/WebSites/RazorWebSite/project.json
@@ -1,7 +1,4 @@
 {
-  "commands": {
-    "web": "RazorWebSite"
-  },
   "compilationOptions": {
     "emitEntryPoint": true,
     "preserveCompilationContext": true
@@ -11,6 +8,7 @@
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.Localization": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TestConfiguration": "1.0.0",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*"
   },
@@ -36,5 +34,9 @@
           "NETStandard.Library": "1.5.0-*"
       }
     }
-  }
+  },
+  "content": [
+    "Views",
+    "web.config"
+  ]
 }

--- a/test/WebSites/RazorWebSite/web.config
+++ b/test/WebSites/RazorWebSite/web.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+    </handlers>
+    <aspNetCore processPath=".\RazorWebSite.exe" arguments="" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" />
+  </system.webServer>
+</configuration>

--- a/test/WebSites/RazorWebSite/wwwroot/HelloWorld.htm
+++ b/test/WebSites/RazorWebSite/wwwroot/HelloWorld.htm
@@ -1,1 +1,0 @@
-HelloWorld

--- a/test/WebSites/RoutingWebSite/Startup.cs
+++ b/test/WebSites/RoutingWebSite/Startup.cs
@@ -47,6 +47,7 @@ namespace RoutingWebSite
                 .UseDefaultHostingConfiguration(args)
                 .UseStartup<Startup>()
                 .UseKestrel()
+                .UseIISIntegration()
                 .Build();
 
             host.Run();

--- a/test/WebSites/RoutingWebSite/project.json
+++ b/test/WebSites/RoutingWebSite/project.json
@@ -3,12 +3,10 @@
     "emitEntryPoint": true,
     "preserveCompilationContext": true
   },
-  "commands": {
-    "web": "RoutingWebSite"
-  },
   "dependencies": {
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TestConfiguration": "1.0.0",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*"
   },
@@ -23,5 +21,8 @@
           "NETStandard.Library": "1.5.0-*"
       }
     }
-  }
+  },
+  "content": [
+    "web.config"
+  ]
 }

--- a/test/WebSites/RoutingWebSite/web.config
+++ b/test/WebSites/RoutingWebSite/web.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+    </handlers>
+    <aspNetCore processPath=".\RoutingWebSite.exe" arguments="" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" />
+  </system.webServer>
+</configuration>

--- a/test/WebSites/RoutingWebSite/wwwroot/HelloWorld.htm
+++ b/test/WebSites/RoutingWebSite/wwwroot/HelloWorld.htm
@@ -1,1 +1,0 @@
-HelloWorld

--- a/test/WebSites/SimpleWebSite/Startup.cs
+++ b/test/WebSites/SimpleWebSite/Startup.cs
@@ -35,6 +35,7 @@ namespace SimpleWebSite
                 .UseDefaultHostingConfiguration(args)
                 .UseStartup<Startup>()
                 .UseKestrel()
+                .UseIISIntegration()
                 .Build();
 
             host.Run();

--- a/test/WebSites/SimpleWebSite/project.json
+++ b/test/WebSites/SimpleWebSite/project.json
@@ -3,11 +3,9 @@
     "emitEntryPoint": true,
     "preserveCompilationContext": true
   },
-  "commands": {
-    "web": "SimpleWebSite"
-  },
   "dependencies": {
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*"
   },
   "frameworks": {
@@ -21,5 +19,8 @@
           "NETStandard.Library": "1.5.0-*"
       }
     }
-  }
+  },
+  "content": [
+    "web.config"
+  ]
 }

--- a/test/WebSites/SimpleWebSite/web.config
+++ b/test/WebSites/SimpleWebSite/web.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+    </handlers>
+    <aspNetCore processPath=".\SimpleWebSite.exe" arguments="" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" />
+  </system.webServer>
+</configuration>

--- a/test/WebSites/SimpleWebSite/wwwroot/web.config
+++ b/test/WebSites/SimpleWebSite/wwwroot/web.config
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <system.webServer>
-    <handlers>
-      <add name="httpPlatformHandler" path="*" verb="*" modules="httpPlatformHandler" resourceType="Unspecified"/>
-    </handlers>
-    <httpPlatform processPath="%DNX_PATH%" arguments="%DNX_ARGS%" stdoutLogEnabled="false" startupTimeLimit="3600"/>
-  </system.webServer>
-</configuration>

--- a/test/WebSites/TagHelpersWebSite/Startup.cs
+++ b/test/WebSites/TagHelpersWebSite/Startup.cs
@@ -28,6 +28,7 @@ namespace TagHelpersWebSite
                 .UseDefaultHostingConfiguration(args)
                 .UseStartup<Startup>()
                 .UseKestrel()
+                .UseIISIntegration()
                 .Build();
 
             host.Run();

--- a/test/WebSites/TagHelpersWebSite/project.json
+++ b/test/WebSites/TagHelpersWebSite/project.json
@@ -5,13 +5,11 @@
     "warningsAsErrors": true,
     "preserveCompilationContext": true
   },
-  "commands": {
-    "web": "TagHelpersWebSite"
-  },
   "dependencies": {
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TagHelpers": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TestConfiguration": "1.0.0",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*"
   },
@@ -26,5 +24,9 @@
           "NETStandard.Library": "1.5.0-*"
       }
     }
-  }
+  },
+  "content": [
+    "Views",
+    "web.config"
+  ]
 }

--- a/test/WebSites/TagHelpersWebSite/web.config
+++ b/test/WebSites/TagHelpersWebSite/web.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+    </handlers>
+    <aspNetCore processPath=".\TagHelpersWebSite.exe" arguments="" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" />
+  </system.webServer>
+</configuration>

--- a/test/WebSites/TagHelpersWebSite/wwwroot/HelloWorld.htm
+++ b/test/WebSites/TagHelpersWebSite/wwwroot/HelloWorld.htm
@@ -1,1 +1,0 @@
-HelloWorld

--- a/test/WebSites/TagHelpersWebSite/wwwroot/web.config
+++ b/test/WebSites/TagHelpersWebSite/wwwroot/web.config
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <system.webServer>
-    <handlers>
-      <add name="httpPlatformHandler" path="*" verb="*" modules="httpPlatformHandler" resourceType="Unspecified" />
-    </handlers>
-    <httpPlatform processPath="%DNX_PATH%" arguments="%DNX_ARGS%" forwardWindowsAuthToken="false" startupTimeLimit="3600" />
-  </system.webServer>
-</configuration>

--- a/test/WebSites/VersioningWebSite/Startup.cs
+++ b/test/WebSites/VersioningWebSite/Startup.cs
@@ -32,6 +32,7 @@ namespace VersioningWebSite
                 .UseDefaultHostingConfiguration(args)
                 .UseStartup<Startup>()
                 .UseKestrel()
+                .UseIISIntegration()
                 .Build();
 
             host.Run();

--- a/test/WebSites/VersioningWebSite/project.json
+++ b/test/WebSites/VersioningWebSite/project.json
@@ -3,12 +3,10 @@
     "emitEntryPoint": true,
     "preserveCompilationContext": true
   },
-  "commands": {
-    "web": "VersioningWebSite"
-  },
   "dependencies": {
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TestConfiguration": "1.0.0",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*"
   },
@@ -23,5 +21,8 @@
           "NETStandard.Library": "1.5.0-*"
       }
     }
-  }
+  },
+  "content": [
+    "web.config"
+  ]
 }

--- a/test/WebSites/VersioningWebSite/web.config
+++ b/test/WebSites/VersioningWebSite/web.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+    </handlers>
+    <aspNetCore processPath=".\VersioningWebSite.exe" arguments="" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" />
+  </system.webServer>
+</configuration>

--- a/test/WebSites/VersioningWebSite/wwwroot/HelloWorld.htm
+++ b/test/WebSites/VersioningWebSite/wwwroot/HelloWorld.htm
@@ -1,1 +1,0 @@
-HelloWorld

--- a/test/WebSites/WebApiCompatShimWebSite/Startup.cs
+++ b/test/WebSites/WebApiCompatShimWebSite/Startup.cs
@@ -39,6 +39,7 @@ namespace WebApiCompatShimWebSite
                 .UseDefaultHostingConfiguration(args)
                 .UseStartup<Startup>()
                 .UseKestrel()
+                .UseIISIntegration()
                 .Build();
 
             host.Run();

--- a/test/WebSites/WebApiCompatShimWebSite/project.json
+++ b/test/WebSites/WebApiCompatShimWebSite/project.json
@@ -3,13 +3,11 @@
     "emitEntryPoint": true,
     "preserveCompilationContext": true
   },
-  "commands": {
-    "web": "WebApiCompatShimWebSite"
-  },
   "dependencies": {
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TestConfiguration": "1.0.0",
     "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*"
   },
@@ -26,5 +24,8 @@
           "System.Diagnostics.Tracing": "4.1.0-*"
       }
     }
-  }
+  },
+  "content": [
+    "web.config"
+  ]
 }

--- a/test/WebSites/WebApiCompatShimWebSite/web.config
+++ b/test/WebSites/WebApiCompatShimWebSite/web.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+    </handlers>
+    <aspNetCore processPath=".\WebApiCompatShimWebSite.exe" arguments="" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" />
+  </system.webServer>
+</configuration>

--- a/test/WebSites/WebApiCompatShimWebSite/wwwroot/HelloWorld.htm
+++ b/test/WebSites/WebApiCompatShimWebSite/wwwroot/HelloWorld.htm
@@ -1,1 +1,0 @@
-HelloWorld

--- a/test/WebSites/XmlFormattersWebSite/Startup.cs
+++ b/test/WebSites/XmlFormattersWebSite/Startup.cs
@@ -83,6 +83,7 @@ namespace XmlFormattersWebSite
                 .UseDefaultHostingConfiguration(args)
                 .UseStartup<Startup>()
                 .UseKestrel()
+                .UseIISIntegration()
                 .Build();
 
             host.Run();

--- a/test/WebSites/XmlFormattersWebSite/project.json
+++ b/test/WebSites/XmlFormattersWebSite/project.json
@@ -3,13 +3,11 @@
     "emitEntryPoint": true,
     "preserveCompilationContext": true
   },
-  "commands": {
-    "web": "XmlFormattersWebSite"
-  },
   "dependencies": {
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.Formatters.Xml": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TestConfiguration": "1.0.0",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*"
   },
@@ -25,5 +23,8 @@
           "System.Linq.Queryable": "4.0.1-*"
       }
     }
-  }
+  },
+  "content": [
+    "web.config"
+  ]
 }

--- a/test/WebSites/XmlFormattersWebSite/web.config
+++ b/test/WebSites/XmlFormattersWebSite/web.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+    </handlers>
+    <aspNetCore processPath=".\XmlFormattersWebSite.exe" arguments="" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" />
+  </system.webServer>
+</configuration>

--- a/test/WebSites/XmlFormattersWebSite/wwwroot/HelloWorld.htm
+++ b/test/WebSites/XmlFormattersWebSite/wwwroot/HelloWorld.htm
@@ -1,1 +1,0 @@
-HelloWorld


### PR DESCRIPTION
Follow up for https://github.com/aspnet/Mvc/pull/4433. This time, I'm also updating the tests sites. Although the functional tests will not run behind IIS, we decided to add IISIntegration so the sites themselves can be launched from Visual Studios.

cc @ryanbrandenburg @Tratcher @NTaylorMullen 