### PR TITLE
[Perf] Avoid Service Provider lookups when activating common Singleton properties of a Razor Page

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor/RazorPageActivator.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/RazorPageActivator.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Razor.Internal;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -29,13 +30,28 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         private readonly ConcurrentDictionary<Type, PageActivationInfo> _activationInfo;
         private readonly IModelMetadataProvider _metadataProvider;
 
+        // Value accessors for common singleton properties activated in a RazorPage.
+        private Func<ViewContext, object> _urlHelperAccessor;
+        private Func<ViewContext, object> _jsonHelperAccessor;
+        private Func<ViewContext, object> _diagnosticSourceAccessor;
+        private Func<ViewContext, object> _htmlEncoderAccessor;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="RazorPageActivator"/> class.
         /// </summary>
-        public RazorPageActivator(IModelMetadataProvider metadataProvider)
+        public RazorPageActivator(
+            IModelMetadataProvider metadataProvider,
+            IUrlHelperFactory urlHelperFactory,
+            IJsonHelper jsonHelper,
+            DiagnosticSource diagnosticSource,
+            HtmlEncoder htmlEncoder)
         {
             _activationInfo = new ConcurrentDictionary<Type, PageActivationInfo>();
             _metadataProvider = metadataProvider;
+            _urlHelperAccessor = context => urlHelperFactory.GetUrlHelper(context);
+            _jsonHelperAccessor = context => jsonHelper;
+            _diagnosticSourceAccessor = context => diagnosticSource;
+            _htmlEncoderAccessor = context => htmlEncoder;
         }
 
         /// <inheritdoc />
@@ -160,12 +176,19 @@ namespace Microsoft.AspNetCore.Mvc.Razor
                 // W.r.t. specificity of above condition: Users are much more likely to inject their own
                 // IUrlHelperFactory than to create a class implementing IUrlHelper (or a sub-interface) and inject
                 // that. But the second scenario is supported. (Note the class must implement ICanHasViewContext.)
-                valueAccessor = context =>
-                {
-                    var serviceProvider = context.HttpContext.RequestServices;
-                    var factory = serviceProvider.GetRequiredService<IUrlHelperFactory>();
-                    return factory.GetUrlHelper(context);
-                };
+                valueAccessor = _urlHelperAccessor;
+            }
+            else if (property.PropertyType == typeof(IJsonHelper))
+            {
+                valueAccessor = _jsonHelperAccessor;
+            }
+            else if (property.PropertyType == typeof(DiagnosticSource))
+            {
+                valueAccessor = _diagnosticSourceAccessor;
+            }
+            else if (property.PropertyType == typeof(HtmlEncoder))
+            {
+                valueAccessor = _htmlEncoderAccessor;
             }
             else
             {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorPageCreateTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorPageCreateTagHelperTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -14,10 +15,12 @@ using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Razor.Internal;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.WebEncoders.Testing;
 using Moq;
 using Xunit;
 
@@ -66,7 +69,13 @@ namespace Microsoft.AspNetCore.Mvc.Razor
 
         private static TestRazorPage CreateTestRazorPage()
         {
-            var activator = new RazorPageActivator(new EmptyModelMetadataProvider());
+            var activator = new RazorPageActivator(
+                new EmptyModelMetadataProvider(),
+                new UrlHelperFactory(),
+                new JsonHelper(new Formatters.JsonOutputFormatter()),
+                new DiagnosticListener("Microsoft.AspNetCore"),
+                new HtmlTestEncoder());
+
             var serviceProvider = new Mock<IServiceProvider>();
             var typeActivator = new TypeActivatorCache();
             var tagHelperActivator = new DefaultTagHelperActivator(typeActivator);

--- a/test/Microsoft.AspNetCore.Mvc.Test/MvcOptionsSetupTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Test/MvcOptionsSetupTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -240,6 +241,7 @@ namespace Microsoft.AspNetCore.Mvc
         {
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddSingleton(new ApplicationPartManager());
+            serviceCollection.AddSingleton<DiagnosticSource>(new DiagnosticListener("Microsoft.AspNetCore.Mvc"));
             serviceCollection.AddMvc();
             serviceCollection
                 .AddSingleton<ObjectPoolProvider, DefaultObjectPoolProvider>()


### PR DESCRIPTION
Fixes #4244
Some of the common singleton properties that are activated on a Razor Page for every request are of types IJsonHelper, HtmlEncoder, DiagnosticSource, IUrlHelperFactory. For every request, these properties are activated by looking up in the service provider. The cost of these lookups can be avoided by special casing their activation in RazorPageActivator.

Scenario: https://github.com/aspnet/Performance/tree/dev/testapp/HelloWorldMvc 
bottom up sampling of Hello World MVC app 
Before optimization
------------------------ 
![image](https://cloud.githubusercontent.com/assets/8011073/14538705/e4e3788a-0231-11e6-8aec-ac8a9ad1b973.png)

After optimization
----------------------
![image](https://cloud.githubusercontent.com/assets/8011073/14538714/f143bc98-0231-11e6-82c0-dc7e2b7b09c9.png)

