### PR TITLE
Special-case use of `razorPage.Model` property in `ExpressionMetadataProvider`

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ExpressionMetadataProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ExpressionMetadataProvider.cs
@@ -51,10 +51,12 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
                     var memberExpression = (MemberExpression)expression.Body;
                     propertyName = memberExpression.Member is PropertyInfo ? memberExpression.Member.Name : null;
                     if (string.Equals(propertyName, "Model", StringComparison.Ordinal) &&
-                        memberExpression.Type == typeof(TModel))
+                        memberExpression.Type == typeof(TModel) &&
+                        memberExpression.Expression.NodeType == ExpressionType.Constant)
                     {
-                        // Special case the Model property in RazorPage<TModel>. (m => Model) should behave
-                        // identically to (m => m).
+                        // Special case the Model property in RazorPage<TModel>. (m => Model) should behave identically
+                        // to (m => m). But do the more complicated thing for (m => m.Model) since that is a slightly
+                        // different beast.)
                         return FromModel(viewData, metadataProvider);
                     }
 

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ExpressionMetadataProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ExpressionMetadataProvider.cs
@@ -50,6 +50,14 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
                     // Property/field access is always legal
                     var memberExpression = (MemberExpression)expression.Body;
                     propertyName = memberExpression.Member is PropertyInfo ? memberExpression.Member.Name : null;
+                    if (string.Equals(propertyName, "Model", StringComparison.Ordinal) &&
+                        memberExpression.Type == typeof(TModel))
+                    {
+                        // Special case the Model property in RazorPage<TModel>. (m => Model) should behave
+                        // identically to (m => m).
+                        return FromModel(viewData, metadataProvider);
+                    }
+
                     containerType = memberExpression.Expression.Type;
                     legalExpression = true;
                     break;

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Order.Encoded.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Order.Encoded.html
@@ -70,7 +70,7 @@
         </div>
         <div>
             <label class="order" for="HtmlEncode[[Customer_Gender]]">HtmlEncode[[Gender]]</label>
-            <input type="HtmlEncode[[radio]]" value="HtmlEncode[[Male]]" data-val="HtmlEncode[[true]]" data-val-required="HtmlEncode[[The Model field is required.]]" id="HtmlEncode[[Customer_Gender]]" name="HtmlEncode[[Customer.Gender]]" /> Male
+            <input type="HtmlEncode[[radio]]" value="HtmlEncode[[Male]]" data-val="HtmlEncode[[true]]" data-val-required="HtmlEncode[[The Gender field is required.]]" id="HtmlEncode[[Customer_Gender]]" name="HtmlEncode[[Customer.Gender]]" /> Male
 <input type="HtmlEncode[[radio]]" value="HtmlEncode[[Female]]" checked="HtmlEncode[[checked]]" id="HtmlEncode[[Customer_Gender]]" name="HtmlEncode[[Customer.Gender]]" /> Female
             <span class="HtmlEncode[[field-validation-valid]]" data-valmsg-for="HtmlEncode[[Customer.Gender]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
         </div>

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Order.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Order.html
@@ -70,7 +70,7 @@
         </div>
         <div>
             <label class="order" for="Customer_Gender">Gender</label>
-            <input type="radio" value="Male" data-val="true" data-val-required="The Model field is required." id="Customer_Gender" name="Customer.Gender" /> Male
+            <input type="radio" value="Male" data-val="true" data-val-required="The Gender field is required." id="Customer_Gender" name="Customer.Gender" /> Male
 <input type="radio" value="Female" checked="checked" id="Customer_Gender" name="Customer.Gender" /> Female
             <span class="field-validation-valid" data-valmsg-for="Customer.Gender" data-valmsg-replace="true"></span>
         </div>

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Internal/ExpressionMetadataProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Internal/ExpressionMetadataProviderTest.cs
@@ -1,13 +1,91 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
 {
     public class ExpressionMetadataProviderTest
     {
+        [Fact]
+        public void FromLambdaExpression_GetsExpectedMetadata_ForIdentityExpression()
+        {
+            // Arrange
+            var provider = new EmptyModelMetadataProvider();
+            var viewData = new ViewDataDictionary<TestModel>(provider);
+
+            // Act
+            var explorer = ExpressionMetadataProvider.FromLambdaExpression(m => m, viewData, provider);
+
+            // Assert
+            Assert.NotNull(explorer);
+            Assert.NotNull(explorer.Metadata);
+            Assert.Equal(ModelMetadataKind.Type, explorer.Metadata.MetadataKind);
+            Assert.Equal(typeof(TestModel), explorer.ModelType);
+            Assert.Null(explorer.Model);
+        }
+
+        [Fact]
+        public void FromLambdaExpression_GetsExpectedMetadata_ForPropertyExpression()
+        {
+            // Arrange
+            var provider = new EmptyModelMetadataProvider();
+            var viewData = new ViewDataDictionary<TestModel>(provider);
+
+            // Act
+            var explorer = ExpressionMetadataProvider.FromLambdaExpression(m => m.SelectedCategory, viewData, provider);
+
+            // Assert
+            Assert.NotNull(explorer);
+            Assert.NotNull(explorer.Metadata);
+            Assert.Equal(ModelMetadataKind.Property, explorer.Metadata.MetadataKind);
+            Assert.Equal(typeof(Category), explorer.ModelType);
+            Assert.Null(explorer.Model);
+        }
+
+        [Fact]
+        public void FromLambdaExpression_GetsExpectedMetadata_ForIndexerExpression()
+        {
+            // Arrange
+            var provider = new EmptyModelMetadataProvider();
+            var viewData = new ViewDataDictionary<TestModel[]>(provider);
+
+            // Act
+            var explorer = ExpressionMetadataProvider.FromLambdaExpression(m => m[23], viewData, provider);
+
+            // Assert
+            Assert.NotNull(explorer);
+            Assert.NotNull(explorer.Metadata);
+            Assert.Equal(ModelMetadataKind.Type, explorer.Metadata.MetadataKind);
+            Assert.Equal(typeof(TestModel), explorer.ModelType);
+            Assert.Null(explorer.Model);
+        }
+
+        [Fact]
+        public void FromLambdaExpression_GetsExpectedMetadata_ForLongerExpression()
+        {
+            // Arrange
+            var provider = new EmptyModelMetadataProvider();
+            var viewData = new ViewDataDictionary<TestModel[]>(provider);
+            var index = 42;
+
+            // Act
+            var explorer = ExpressionMetadataProvider.FromLambdaExpression(
+                m => m[index].SelectedCategory.CategoryId,
+                viewData,
+                provider);
+
+            // Assert
+            Assert.NotNull(explorer);
+            Assert.NotNull(explorer.Metadata);
+            Assert.Equal(ModelMetadataKind.Property, explorer.Metadata.MetadataKind);
+            Assert.Equal(typeof(int), explorer.ModelType);
+            Assert.Null(explorer.Model);
+        }
+
         [Fact]
         public void FromLambaExpression_SetsContainerAsExpected()
         {
@@ -25,6 +103,31 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
 
             // Assert
             Assert.Same(myModel, metadata.Container.Model);
+        }
+
+        [Theory]
+        [InlineData(null, ModelMetadataKind.Type, typeof(TestModel))]
+        [InlineData("", ModelMetadataKind.Type, typeof(TestModel))]
+        [InlineData("SelectedCategory", ModelMetadataKind.Property, typeof(Category))]
+        [InlineData("SelectedCategory.CategoryName", ModelMetadataKind.Type, typeof(string))]
+        public void FromStringExpression_GetsExpectedMetadata(
+            string expression,
+            ModelMetadataKind expectedKind,
+            Type expectedType)
+        {
+            // Arrange
+            var provider = new EmptyModelMetadataProvider();
+            var viewData = new ViewDataDictionary<TestModel>(provider);
+
+            // Act
+            var explorer = ExpressionMetadataProvider.FromStringExpression(expression, viewData, provider);
+
+            // Assert
+            Assert.NotNull(explorer);
+            Assert.NotNull(explorer.Metadata);
+            Assert.Equal(expectedKind, explorer.Metadata.MetadataKind);
+            Assert.Equal(expectedType, explorer.ModelType);
+            Assert.Null(explorer.Model);
         }
 
         [Fact]
@@ -53,6 +156,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
         private class Category
         {
             public int CategoryId { get; set; }
+
             public string CategoryName { get; set; }
         }
     }


### PR DESCRIPTION
- #3978
- better-aligns `ExpressionMetadataProvider` with `ExpressionHelper`

nit: mock less in `RazorPageCreateModelExpressionTest`