### PR TITLE
changed GetFormat of FormatFilter to virtual

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Formatters/FormatFilter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Formatters/FormatFilter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         }
 
         /// <inheritdoc />
-        public string GetFormat(ActionContext context)
+        public virtual string GetFormat(ActionContext context)
         {
             object obj;
             if (context.RouteData.Values.TryGetValue("format", out obj))


### PR DESCRIPTION
Allows me to use a custom query string (instead of the hardcoded `format`) or extract format in any other funky way from the `ActionContext`.
 
I can now subclass `FormatFilter` with my own implementation of `GetFormat`, register this custom implementation in the DI and then have `FormatFilterAttribute` pick it up automatically.