### PR TITLE
[Perf] Reduce DefaultTagHelperContent allocations in LinkTagHelper and ScriptTagHelper

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/LinkTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/LinkTagHelper.cs
@@ -256,7 +256,9 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 }
             }
 
-            var builder = new DefaultTagHelperContent();
+            var builder = output.PostElement;
+            builder.Clear();
+
             if (mode == Mode.GlobbedHref || mode == Mode.Fallback && !string.IsNullOrEmpty(HrefInclude))
             {
                 BuildGlobbedLinkTags(output.Attributes, builder);
@@ -278,8 +280,6 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
                 BuildFallbackBlock(builder);
             }
-
-            output.PostElement.SetHtmlContent(builder);
         }
 
         private void BuildGlobbedLinkTags(TagHelperAttributeList attributes, TagHelperContent builder)

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/ScriptTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/ScriptTagHelper.cs
@@ -239,7 +239,8 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 }
             }
 
-            var builder = new DefaultTagHelperContent();
+            var builder = output.PostElement;
+            builder.Clear();
 
             if (mode == Mode.GlobbedSrc || mode == Mode.Fallback && !string.IsNullOrEmpty(SrcInclude))
             {
@@ -262,8 +263,6 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
                 BuildFallbackBlock(output.Attributes, builder);
             }
-
-            output.PostElement.SetHtmlContent(builder);
         }
 
         private void BuildGlobbedScriptTags(
@@ -289,7 +288,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             }
         }
 
-        private void BuildFallbackBlock(TagHelperAttributeList attributes, DefaultTagHelperContent builder)
+        private void BuildFallbackBlock(TagHelperAttributeList attributes, TagHelperContent builder)
         {
             EnsureGlobbingUrlBuilder();
 


### PR DESCRIPTION
Fixes #4468
Saves one DefaultTagHelperContent object allocation per link/script tag per request.