### PR TITLE
Remove extra options to manipulate `JsonSerializerSettings`

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonInputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonInputFormatter.cs
@@ -14,7 +14,7 @@ using Newtonsoft.Json;
 namespace Microsoft.AspNetCore.Mvc.Formatters
 {
     /// <summary>
-    /// An <see cref="TextInputFormatter"/> for JSON content.
+    /// A <see cref="TextInputFormatter"/> for JSON content.
     /// </summary>
     public class JsonInputFormatter : TextInputFormatter
     {
@@ -23,29 +23,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         private readonly ObjectPoolProvider _objectPoolProvider;
         private ObjectPool<JsonSerializer> _jsonSerializerPool;
         private JsonSerializerSettings _serializerSettings;
-
-        /// <summary>
-        /// Initializes a new instance of <see cref="JsonInputFormatter"/>.
-        /// </summary>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        public JsonInputFormatter(ILogger logger)
-            : this(logger, SerializerSettingsProvider.CreateSerializerSettings())
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of <see cref="JsonInputFormatter"/>.
-        /// </summary>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        /// <param name="serializerSettings">The <see cref="JsonSerializerSettings"/>.</param>
-        public JsonInputFormatter(ILogger logger, JsonSerializerSettings serializerSettings)
-            : this(
-                  logger,
-                  serializerSettings,
-                  ArrayPool<char>.Shared,
-                  new DefaultObjectPoolProvider())
-        {
-        }
 
         /// <summary>
         /// Initializes a new instance of <see cref="JsonInputFormatter"/>.

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonInputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonInputFormatter.cs
@@ -27,7 +27,11 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         /// Initializes a new instance of <see cref="JsonInputFormatter"/>.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/>.</param>
-        /// <param name="serializerSettings">The <see cref="JsonSerializerSettings"/>.</param>
+        /// <param name="serializerSettings">
+        /// The <see cref="JsonSerializerSettings"/>. Should be either the application-wide settings
+        /// (<see cref="MvcJsonOptions.SerializerSettings"/>) or an instance
+        /// <see cref="JsonSerializerSettingsProvider.CreateSerializerSettings"/> initially returned.
+        /// </param>
         /// <param name="charPool">The <see cref="ArrayPool{Char}"/>.</param>
         /// <param name="objectPoolProvider">The <see cref="ObjectPoolProvider"/>.</param>
         public JsonInputFormatter(

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonInputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonInputFormatter.cs
@@ -22,7 +22,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         private readonly ILogger _logger;
         private readonly ObjectPoolProvider _objectPoolProvider;
         private ObjectPool<JsonSerializer> _jsonSerializerPool;
-        private JsonSerializerSettings _serializerSettings;
 
         /// <summary>
         /// Initializes a new instance of <see cref="JsonInputFormatter"/>.
@@ -58,7 +57,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             }
 
             _logger = logger;
-            _serializerSettings = serializerSettings;
+            SerializerSettings = serializerSettings;
             _charPool = new JsonArrayPool<char>(charPool);
             _objectPoolProvider = objectPoolProvider;
 
@@ -70,28 +69,13 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="JsonSerializerSettings"/> used to configure the <see cref="JsonSerializer"/>.
+        /// Gets the <see cref="JsonSerializerSettings"/> used to configure the <see cref="JsonSerializer"/>.
         /// </summary>
         /// <remarks>
         /// Any modifications to the <see cref="JsonSerializerSettings"/> object after this
         /// <see cref="JsonInputFormatter"/> has been used will have no effect.
         /// </remarks>
-        public JsonSerializerSettings SerializerSettings
-        {
-            get
-            {
-                return _serializerSettings;
-            }
-            set
-            {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
-
-                _serializerSettings = value;
-            }
-        }
+        protected JsonSerializerSettings SerializerSettings { get; }
 
         /// <inheritdoc />
         public override Task<InputFormatterResult> ReadRequestBodyAsync(

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonOutputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonOutputFormatter.cs
@@ -7,13 +7,12 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Formatters.Json.Internal;
-using Microsoft.AspNetCore.Mvc.Internal;
 using Newtonsoft.Json;
 
 namespace Microsoft.AspNetCore.Mvc.Formatters
 {
     /// <summary>
-    /// An output formatter that specializes in writing JSON content.
+    /// A <see cref="TextOutputFormatter"/> for JSON content.
     /// </summary>
     public class JsonOutputFormatter : TextOutputFormatter
     {
@@ -25,16 +24,11 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         // the serializer and invalidate it when the settings change.
         private JsonSerializer _serializer;
 
-        public JsonOutputFormatter()
-            : this(SerializerSettingsProvider.CreateSerializerSettings(), ArrayPool<char>.Shared)
-        {
-        }
-
-        public JsonOutputFormatter(JsonSerializerSettings serializerSettings)
-            : this(serializerSettings, ArrayPool<char>.Shared)
-        {
-        }
-
+        /// <summary>
+        /// Initializes a new <see cref="JsonOutputFormatter"/> instance.
+        /// </summary>
+        /// <param name="serializerSettings">The <see cref="JsonSerializerSettings"/>.</param>
+        /// <param name="charPool">The <see cref="ArrayPool{Char}"/>.</param>
         public JsonOutputFormatter(JsonSerializerSettings serializerSettings, ArrayPool<char> charPool)
         {
             if (serializerSettings == null)
@@ -157,7 +151,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 WriteObject(writer, context.Object);
 
                 // Perf: call FlushAsync to call WriteAsync on the stream with any content left in the TextWriter's
-                // buffers. This is better than just letting dispose handle it (which would result in a synchronous 
+                // buffers. This is better than just letting dispose handle it (which would result in a synchronous
                 // write).
                 await writer.FlushAsync();
             }

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonOutputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonOutputFormatter.cs
@@ -25,7 +25,11 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         /// <summary>
         /// Initializes a new <see cref="JsonOutputFormatter"/> instance.
         /// </summary>
-        /// <param name="serializerSettings">The <see cref="JsonSerializerSettings"/>.</param>
+        /// <param name="serializerSettings">
+        /// The <see cref="JsonSerializerSettings"/>. Should be either the application-wide settings
+        /// (<see cref="MvcJsonOptions.SerializerSettings"/>) or an instance
+        /// <see cref="JsonSerializerSettingsProvider.CreateSerializerSettings"/> initially returned.
+        /// </param>
         /// <param name="charPool">The <see cref="ArrayPool{Char}"/>.</param>
         public JsonOutputFormatter(JsonSerializerSettings serializerSettings, ArrayPool<char> charPool)
         {

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonOutputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonOutputFormatter.cs
@@ -18,8 +18,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
     {
         private readonly IArrayPool<char> _charPool;
 
-        private JsonSerializerSettings _serializerSettings;
-
         // Perf: JsonSerializers are relatively expensive to create, and are thread safe. We cache
         // the serializer and invalidate it when the settings change.
         private JsonSerializer _serializer;
@@ -41,7 +39,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 throw new ArgumentNullException(nameof(charPool));
             }
 
-            _serializerSettings = serializerSettings;
+            SerializerSettings = serializerSettings;
             _charPool = new JsonArrayPool<char>(charPool);
 
             SupportedEncodings.Add(Encoding.UTF8);
@@ -51,31 +49,13 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="JsonSerializerSettings"/> used to configure the <see cref="JsonSerializer"/>.
+        /// Gets the <see cref="JsonSerializerSettings"/> used to configure the <see cref="JsonSerializer"/>.
         /// </summary>
         /// <remarks>
         /// Any modifications to the <see cref="JsonSerializerSettings"/> object after this
         /// <see cref="JsonOutputFormatter"/> has been used will have no effect.
         /// </remarks>
-        public JsonSerializerSettings SerializerSettings
-        {
-            get
-            {
-                return _serializerSettings;
-            }
-            set
-            {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
-
-                _serializerSettings = value;
-
-                // If the settings change, then invalidate the cached serializer.
-                _serializer = null;
-            }
-        }
+        protected JsonSerializerSettings SerializerSettings { get; }
 
         /// <summary>
         /// Writes the given <paramref name="value"/> as JSON using the given

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonPatchInputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonPatchInputFormatter.cs
@@ -14,17 +14,18 @@ using Newtonsoft.Json;
 
 namespace Microsoft.AspNetCore.Mvc.Formatters
 {
+    /// <summary>
+    /// A <see cref="TextInputFormatter"/> for JSON Patch (application/json-patch+json) content.
+    /// </summary>
     public class JsonPatchInputFormatter : JsonInputFormatter
     {
-        public JsonPatchInputFormatter(ILogger logger)
-            : this(
-                  logger,
-                  SerializerSettingsProvider.CreateSerializerSettings(),
-                  ArrayPool<char>.Shared,
-                  new DefaultObjectPoolProvider())
-        {
-        }
-
+        /// <summary>
+        /// Initializes a new <see cref="JsonPatchInputFormatter"/> instance.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger"/>.</param>
+        /// <param name="serializerSettings">The <see cref="JsonSerializerSettings"/>.</param>
+        /// <param name="charPool">The <see cref="ArrayPool{Char}"/>.</param>
+        /// <param name="objectPoolProvider">The <see cref="ObjectPoolProvider"/>.</param>
         public JsonPatchInputFormatter(
             ILogger logger,
             JsonSerializerSettings serializerSettings,

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonPatchInputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonPatchInputFormatter.cs
@@ -23,8 +23,11 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         /// Initializes a new <see cref="JsonPatchInputFormatter"/> instance.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/>.</param>
-        /// <param name="serializerSettings">The <see cref="JsonSerializerSettings"/>.</param>
-        /// <param name="charPool">The <see cref="ArrayPool{Char}"/>.</param>
+        /// <param name="serializerSettings">
+        /// The <see cref="JsonSerializerSettings"/>. Should be either the application-wide settings
+        /// (<see cref="MvcJsonOptions.SerializerSettings"/>) or an instance
+        /// <see cref="JsonSerializerSettingsProvider.CreateSerializerSettings"/> initially returned.
+        /// </param>/// <param name="charPool">The <see cref="ArrayPool{Char}"/>.</param>
         /// <param name="objectPoolProvider">The <see cref="ObjectPoolProvider"/>.</param>
         public JsonPatchInputFormatter(
             ILogger logger,

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonSerializerSettingsProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonSerializerSettingsProvider.cs
@@ -3,12 +3,12 @@
 
 using Newtonsoft.Json;
 
-namespace Microsoft.AspNetCore.Mvc.Formatters.Json
+namespace Microsoft.AspNetCore.Mvc.Formatters
 {
     /// <summary>
     /// Helper class which provides <see cref="JsonSerializerSettings"/>.
     /// </summary>
-    public static class SerializerSettingsProvider
+    public static class JsonSerializerSettingsProvider
     {
         private const int DefaultMaxDepth = 32;
 

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Json/MvcJsonOptions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Json/MvcJsonOptions.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Mvc.Formatters.Json.Internal;
+using Microsoft.AspNetCore.Mvc.Formatters.Json;
 using Newtonsoft.Json;
 
 namespace Microsoft.AspNetCore.Mvc

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Json/MvcJsonOptions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Json/MvcJsonOptions.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Mvc.Formatters.Json;
+using Microsoft.AspNetCore.Mvc.Formatters;
 using Newtonsoft.Json;
 
 namespace Microsoft.AspNetCore.Mvc
@@ -14,6 +14,7 @@ namespace Microsoft.AspNetCore.Mvc
         /// <summary>
         /// Gets the <see cref="JsonSerializerSettings"/> that are used by this application.
         /// </summary>
-        public JsonSerializerSettings SerializerSettings { get; } = SerializerSettingsProvider.CreateSerializerSettings();
+        public JsonSerializerSettings SerializerSettings { get; } =
+            JsonSerializerSettingsProvider.CreateSerializerSettings();
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Json/SerializerSettingsProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Json/SerializerSettingsProvider.cs
@@ -3,7 +3,7 @@
 
 using Newtonsoft.Json;
 
-namespace Microsoft.AspNetCore.Mvc.Formatters.Json.Internal
+namespace Microsoft.AspNetCore.Mvc.Formatters.Json
 {
     /// <summary>
     /// Helper class which provides <see cref="JsonSerializerSettings"/>.

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/JsonHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/JsonHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.Globalization;
 using System.IO;
 using Microsoft.AspNetCore.Html;
@@ -17,19 +18,29 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
     public class JsonHelper : IJsonHelper
     {
         private readonly JsonOutputFormatter _jsonOutputFormatter;
+        private readonly ArrayPool<char> _charPool;
 
         /// <summary>
         /// Initializes a new instance of <see cref="JsonHelper"/> that is backed by <paramref name="jsonOutputFormatter"/>.
         /// </summary>
         /// <param name="jsonOutputFormatter">The <see cref="JsonOutputFormatter"/> used to serialize JSON.</param>
-        public JsonHelper(JsonOutputFormatter jsonOutputFormatter)
+        /// <param name="charPool">
+        /// The <see cref="ArrayPool{Char}"/> for use with custom <see cref="JsonSerializerSettings"/> (see
+        /// <see cref="Serialize(object, JsonSerializerSettings)"/>).
+        /// </param>
+        public JsonHelper(JsonOutputFormatter jsonOutputFormatter, ArrayPool<char> charPool)
         {
             if (jsonOutputFormatter == null)
             {
                 throw new ArgumentNullException(nameof(jsonOutputFormatter));
             }
+            if (charPool == null)
+            {
+                throw new ArgumentNullException(nameof(charPool));
+            }
 
             _jsonOutputFormatter = jsonOutputFormatter;
+            _charPool = charPool;
         }
 
         /// <inheritdoc />
@@ -46,7 +57,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 throw new ArgumentNullException(nameof(serializerSettings));
             }
 
-            var jsonOutputFormatter = new JsonOutputFormatter(serializerSettings);
+            var jsonOutputFormatter = new JsonOutputFormatter(serializerSettings, _charPool);
 
             return SerializeInternal(jsonOutputFormatter, value);
         }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/CreatedAtActionResultTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/CreatedAtActionResultTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -14,6 +15,7 @@ using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Testing;
 using Moq;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc
@@ -88,7 +90,9 @@ namespace Microsoft.AspNetCore.Mvc
         {
             var options = new TestOptionsManager<MvcOptions>();
             options.Value.OutputFormatters.Add(new StringOutputFormatter());
-            options.Value.OutputFormatters.Add(new JsonOutputFormatter());
+            options.Value.OutputFormatters.Add(new JsonOutputFormatter(
+                new JsonSerializerSettings(),
+                ArrayPool<char>.Shared));
 
             var services = new ServiceCollection();
             services.AddSingleton(new ObjectResultExecutor(

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/CreatedAtRouteResultTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/CreatedAtRouteResultTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -14,6 +15,7 @@ using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Testing;
 using Moq;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc
@@ -103,7 +105,9 @@ namespace Microsoft.AspNetCore.Mvc
         {
             var options = new TestOptionsManager<MvcOptions>();
             options.Value.OutputFormatters.Add(new StringOutputFormatter());
-            options.Value.OutputFormatters.Add(new JsonOutputFormatter());
+            options.Value.OutputFormatters.Add(new JsonOutputFormatter(
+                new JsonSerializerSettings(),
+                ArrayPool<char>.Shared));
 
             var services = new ServiceCollection();
             services.AddSingleton(new ObjectResultExecutor(

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/CreatedResultTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/CreatedResultTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -12,6 +13,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Testing;
 using Moq;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc
@@ -89,7 +91,9 @@ namespace Microsoft.AspNetCore.Mvc
         {
             var options = new TestOptionsManager<MvcOptions>();
             options.Value.OutputFormatters.Add(new StringOutputFormatter());
-            options.Value.OutputFormatters.Add(new JsonOutputFormatter());
+            options.Value.OutputFormatters.Add(new JsonOutputFormatter(
+                new JsonSerializerSettings(),
+                ArrayPool<char>.Shared));
 
             var services = new ServiceCollection();
             services.AddSingleton(new ObjectResultExecutor(

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/FormatFilterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/FormatFilterTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Buffers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -10,6 +11,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using Moq;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.Formatters
@@ -442,7 +444,9 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 // Set up default output formatters.
                 Options.OutputFormatters.Add(new HttpNoContentOutputFormatter());
                 Options.OutputFormatters.Add(new StringOutputFormatter());
-                Options.OutputFormatters.Add(new JsonOutputFormatter());
+                Options.OutputFormatters.Add(new JsonOutputFormatter(
+                    new JsonSerializerSettings(),
+                    ArrayPool<char>.Shared));
 
                 // Set up default mapping for json extensions to content type
                 Options.FormatterMappings.SetMediaTypeMappingForFormat(

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/HttpNotFoundObjectResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/HttpNotFoundObjectResultTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -9,6 +10,7 @@ using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Testing;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc
@@ -68,7 +70,9 @@ namespace Microsoft.AspNetCore.Mvc
         {
             var options = new TestOptionsManager<MvcOptions>();
             options.Value.OutputFormatters.Add(new StringOutputFormatter());
-            options.Value.OutputFormatters.Add(new JsonOutputFormatter());
+            options.Value.OutputFormatters.Add(new JsonOutputFormatter(
+                new JsonSerializerSettings(),
+                ArrayPool<char>.Shared));
 
             var services = new ServiceCollection();
             services.AddSingleton(new ObjectResultExecutor(

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/HttpOkObjectResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/HttpOkObjectResultTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
@@ -10,6 +11,7 @@ using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Testing;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc
@@ -69,7 +71,9 @@ namespace Microsoft.AspNetCore.Mvc
         {
             var options = new TestOptionsManager<MvcOptions>();
             options.Value.OutputFormatters.Add(new StringOutputFormatter());
-            options.Value.OutputFormatters.Add(new JsonOutputFormatter());
+            options.Value.OutputFormatters.Add(new JsonOutputFormatter(
+                new JsonSerializerSettings(),
+                ArrayPool<char>.Shared));
 
             var services = new ServiceCollection();
             services.AddSingleton(new ObjectResultExecutor(

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Json.Test/JsonInputFormatterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Json.Test/JsonInputFormatterTest.cs
@@ -341,12 +341,10 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         public void Constructor_UsesSerializerSettings()
         {
             // Arrange
-            var logger = GetLogger();
+            var serializerSettings = new JsonSerializerSettings();
 
             // Act
-            var serializerSettings = new JsonSerializerSettings();
-            var jsonFormatter =
-                new JsonInputFormatter(logger, serializerSettings, ArrayPool<char>.Shared, _objectPoolProvider);
+            var jsonFormatter = new TestableJsonInputFormatter(serializerSettings);
 
             // Assert
             Assert.Same(serializerSettings, jsonFormatter.SerializerSettings);
@@ -397,7 +395,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 MaxDepth = 2,
                 DateTimeZoneHandling = DateTimeZoneHandling.RoundtripKind,
             };
-            var formatter = new TestableJsonInputFormatter(GetLogger(), settings);
+            var formatter = new TestableJsonInputFormatter(settings);
 
             // Act
             var actual = formatter.CreateJsonSerializer();
@@ -410,10 +408,12 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
         private class TestableJsonInputFormatter : JsonInputFormatter
         {
-            public TestableJsonInputFormatter(ILogger logger, JsonSerializerSettings settings)
-                : base(logger, settings, ArrayPool<char>.Shared, _objectPoolProvider)
+            public TestableJsonInputFormatter(JsonSerializerSettings settings)
+                : base(GetLogger(), settings, ArrayPool<char>.Shared, _objectPoolProvider)
             {
             }
+
+            public new JsonSerializerSettings SerializerSettings => base.SerializerSettings;
 
             public new JsonSerializer CreateJsonSerializer() => base.CreateJsonSerializer();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Json.Test/JsonInputFormatterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Json.Test/JsonInputFormatterTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -11,6 +12,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
+using Microsoft.Extensions.ObjectPool;
 using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -20,6 +22,9 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 {
     public class JsonInputFormatterTest
     {
+        private static readonly ObjectPoolProvider _objectPoolProvider = new DefaultObjectPoolProvider();
+        private static readonly JsonSerializerSettings _serializerSettings = new JsonSerializerSettings();
+
         [Theory]
         [InlineData("application/json", true)]
         [InlineData("application/*", false)]
@@ -36,7 +41,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             // Arrange
             var loggerMock = GetLogger();
 
-            var formatter = new JsonInputFormatter(loggerMock);
+            var formatter =
+                new JsonInputFormatter(loggerMock, _serializerSettings, ArrayPool<char>.Shared, _objectPoolProvider);
             var contentBytes = Encoding.UTF8.GetBytes("content");
 
             var httpContext = GetHttpContext(contentBytes, contentType: requestContentType);
@@ -61,7 +67,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         {
             // Arrange
             var loggerMock = GetLogger();
-            var formatter = new JsonInputFormatter(loggerMock);
+            var formatter =
+                new JsonInputFormatter(loggerMock, _serializerSettings, ArrayPool<char>.Shared, _objectPoolProvider);
 
             // Act
             var mediaType = formatter.SupportedMediaTypes[0];
@@ -87,7 +94,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         {
             // Arrange
             var logger = GetLogger();
-            var formatter = new JsonInputFormatter(logger);
+            var formatter =
+                new JsonInputFormatter(logger, _serializerSettings, ArrayPool<char>.Shared, _objectPoolProvider);
             var contentBytes = Encoding.UTF8.GetBytes(content);
 
             var httpContext = GetHttpContext(contentBytes);
@@ -114,7 +122,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             // Arrange
             var content = "{name: 'Person Name', Age: '30'}";
             var logger = GetLogger();
-            var formatter = new JsonInputFormatter(logger);
+            var formatter =
+                new JsonInputFormatter(logger, _serializerSettings, ArrayPool<char>.Shared, _objectPoolProvider);
             var contentBytes = Encoding.UTF8.GetBytes(content);
 
             var httpContext = GetHttpContext(contentBytes);
@@ -143,7 +152,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             // Arrange
             var content = "[0, 23, 300]";
             var logger = GetLogger();
-            var formatter = new JsonInputFormatter(logger);
+            var formatter =
+                new JsonInputFormatter(logger, _serializerSettings, ArrayPool<char>.Shared, _objectPoolProvider);
             var contentBytes = Encoding.UTF8.GetBytes(content);
 
             var modelState = new ModelStateDictionary();
@@ -176,7 +186,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             // Arrange
             var content = "[0, 23, 300]";
             var logger = GetLogger();
-            var formatter = new JsonInputFormatter(logger);
+            var formatter =
+                new JsonInputFormatter(logger, _serializerSettings, ArrayPool<char>.Shared, _objectPoolProvider);
             var contentBytes = Encoding.UTF8.GetBytes(content);
 
             var modelState = new ModelStateDictionary();
@@ -205,7 +216,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             // Arrange
             var content = "{name: 'Person Name', Age: 'not-an-age'}";
             var logger = GetLogger();
-            var formatter = new JsonInputFormatter(logger);
+            var formatter =
+                new JsonInputFormatter(logger, _serializerSettings, ArrayPool<char>.Shared, _objectPoolProvider);
             var contentBytes = Encoding.UTF8.GetBytes(content);
 
             var modelState = new ModelStateDictionary();
@@ -235,7 +247,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             // Arrange
             var content = "[0, 23, 300]";
             var logger = GetLogger();
-            var formatter = new JsonInputFormatter(logger);
+            var formatter =
+                new JsonInputFormatter(logger, _serializerSettings, ArrayPool<char>.Shared, _objectPoolProvider);
             var contentBytes = Encoding.UTF8.GetBytes(content);
 
             var modelState = new ModelStateDictionary();
@@ -264,7 +277,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             // Arrange
             var content = "[{name: 'Name One', Age: 30}, {name: 'Name Two', Small: 300}]";
             var logger = GetLogger();
-            var formatter = new JsonInputFormatter(logger);
+            var formatter =
+                new JsonInputFormatter(logger, _serializerSettings, ArrayPool<char>.Shared, _objectPoolProvider);
             var contentBytes = Encoding.UTF8.GetBytes(content);
 
             var modelState = new ModelStateDictionary();
@@ -294,7 +308,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             // Arrange
             var content = "{name: 'Person Name', Age: 'not-an-age'}";
             var logger = GetLogger();
-            var formatter = new JsonInputFormatter(logger);
+            var formatter =
+                new JsonInputFormatter(logger, _serializerSettings, ArrayPool<char>.Shared, _objectPoolProvider);
             var contentBytes = Encoding.UTF8.GetBytes(content);
 
             var modelState = new ModelStateDictionary();
@@ -323,19 +338,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         }
 
         [Fact]
-        public void Creates_SerializerSettings_ByDefault()
-        {
-            // Arrange
-            var logger = GetLogger();
-
-            // Act
-            var jsonFormatter = new JsonInputFormatter(logger);
-
-            // Assert
-            Assert.NotNull(jsonFormatter.SerializerSettings);
-        }
-
-        [Fact]
         public void Constructor_UsesSerializerSettings()
         {
             // Arrange
@@ -343,43 +345,11 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
             // Act
             var serializerSettings = new JsonSerializerSettings();
-            var jsonFormatter = new JsonInputFormatter(logger, serializerSettings);
+            var jsonFormatter =
+                new JsonInputFormatter(logger, serializerSettings, ArrayPool<char>.Shared, _objectPoolProvider);
 
             // Assert
             Assert.Same(serializerSettings, jsonFormatter.SerializerSettings);
-        }
-
-        [Fact]
-        public async Task ChangesTo_DefaultSerializerSettings_TakesEffect()
-        {
-            // Arrange
-            // missing password property here
-            var contentBytes = Encoding.UTF8.GetBytes("{ \"UserName\" : \"John\"}");
-            var logger = GetLogger();
-            var jsonFormatter = new JsonInputFormatter(logger);
-            // by default we ignore missing members, so here explicitly changing it
-            jsonFormatter.SerializerSettings.MissingMemberHandling = MissingMemberHandling.Error;
-
-            var modelState = new ModelStateDictionary();
-            var httpContext = GetHttpContext(contentBytes, "application/json;charset=utf-8");
-            var provider = new EmptyModelMetadataProvider();
-            var metadata = provider.GetMetadataForType(typeof(UserLogin));
-            var inputFormatterContext = new InputFormatterContext(
-                httpContext,
-                modelName: string.Empty,
-                modelState: modelState,
-                metadata: metadata,
-                readerFactory: new TestHttpRequestStreamReaderFactory().CreateReader);
-
-            // Act
-            var result = await jsonFormatter.ReadAsync(inputFormatterContext);
-
-            // Assert
-            Assert.True(result.HasError);
-            Assert.False(modelState.IsValid);
-
-            var modelErrorMessage = modelState.Values.First().Errors[0].Exception.Message;
-            Assert.Contains("Required property 'Password' not found in JSON", modelErrorMessage);
         }
 
         [Fact]
@@ -389,12 +359,11 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             // missing password property here
             var contentBytes = Encoding.UTF8.GetBytes("{ \"UserName\" : \"John\"}");
             var logger = GetLogger();
-            var jsonFormatter = new JsonInputFormatter(logger);
+
             // by default we ignore missing members, so here explicitly changing it
-            jsonFormatter.SerializerSettings = new JsonSerializerSettings()
-            {
-                MissingMemberHandling = MissingMemberHandling.Error
-            };
+            var serializerSettings = new JsonSerializerSettings { MissingMemberHandling = MissingMemberHandling.Error };
+            var jsonFormatter =
+                new JsonInputFormatter(logger, serializerSettings, ArrayPool<char>.Shared, _objectPoolProvider);
 
             var modelState = new ModelStateDictionary();
             var httpContext = GetHttpContext(contentBytes, "application/json;charset=utf-8");
@@ -442,7 +411,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         private class TestableJsonInputFormatter : JsonInputFormatter
         {
             public TestableJsonInputFormatter(ILogger logger, JsonSerializerSettings settings)
-                : base(logger, settings)
+                : base(logger, settings, ArrayPool<char>.Shared, _objectPoolProvider)
             {
             }
 

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Json.Test/JsonOutputFormatterTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Json.Test/JsonOutputFormatterTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -30,7 +31,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         {
             // Arrange
             // Act
-            var jsonFormatter = new JsonOutputFormatter();
+            var jsonFormatter = new JsonOutputFormatter(new JsonSerializerSettings(), ArrayPool<char>.Shared);
 
             // Assert
             Assert.NotNull(jsonFormatter.SerializerSettings);
@@ -43,7 +44,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             // Act
             var serializerSettings = new JsonSerializerSettings();
             var logger = GetLogger();
-            var jsonFormatter = new JsonInputFormatter(logger, serializerSettings);
+            var jsonFormatter = new JsonOutputFormatter(serializerSettings, ArrayPool<char>.Shared);
 
             // Assert
             Assert.Same(serializerSettings, jsonFormatter.SerializerSettings);
@@ -60,7 +61,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 Formatting = Formatting.Indented
             });
 
-            var jsonFormatter = new JsonOutputFormatter();
+            var jsonFormatter = new JsonOutputFormatter(new JsonSerializerSettings(), ArrayPool<char>.Shared);
             jsonFormatter.SerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
             jsonFormatter.SerializerSettings.Formatting = Formatting.Indented;
             var outputFormatterContext = GetOutputFormatterContext(person, typeof(User));
@@ -87,7 +88,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 person,
                 SerializerSettingsProvider.CreateSerializerSettings());
 
-            var jsonFormatter = new JsonOutputFormatter();
+            var jsonFormatter = new JsonOutputFormatter(new JsonSerializerSettings(), ArrayPool<char>.Shared);
 
             // This will create a serializer - which gets cached.
             var outputFormatterContext1 = GetOutputFormatterContext(person, typeof(User));
@@ -123,7 +124,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 Formatting = Formatting.Indented
             });
 
-            var jsonFormatter = new JsonOutputFormatter();
+            var jsonFormatter = new JsonOutputFormatter(new JsonSerializerSettings(), ArrayPool<char>.Shared);
 
             // This will create a serializer - which gets cached.
             var outputFormatterContext1 = GetOutputFormatterContext(person, typeof(User));
@@ -162,7 +163,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 Formatting = Formatting.Indented
             });
 
-            var jsonFormatter = new JsonOutputFormatter();
+            var jsonFormatter = new JsonOutputFormatter(new JsonSerializerSettings(), ArrayPool<char>.Shared);
             jsonFormatter.SerializerSettings = new JsonSerializerSettings()
             {
                 ContractResolver = new CamelCasePropertyNamesContractResolver(),
@@ -189,7 +190,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         {
             // Arrange
             var beforeMessage = "Hello World";
-            var formatter = new JsonOutputFormatter();
+            var formatter = new JsonOutputFormatter(new JsonSerializerSettings(), ArrayPool<char>.Shared);
             var before = new JValue(beforeMessage);
             var memStream = new MemoryStream();
             var outputFormatterContext = GetOutputFormatterContext(
@@ -246,7 +247,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             bool isDefaultEncoding)
         {
             // Arrange
-            var formatter = new JsonOutputFormatter();
+            var formatter = new JsonOutputFormatter(new JsonSerializerSettings(), ArrayPool<char>.Shared);
             var formattedContent = "\"" + content + "\"";
             var mediaType = MediaTypeHeaderValue.Parse(string.Format("application/json; charset={0}", encodingAsString));
             var encoding = CreateOrGetSupportedEncoding(formatter, encodingAsString, isDefaultEncoding);

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Json.Test/JsonPatchInputFormatterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Json.Test/JsonPatchInputFormatterTest.cs
@@ -2,28 +2,34 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
+using Microsoft.Extensions.ObjectPool;
 using Moq;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.Formatters
 {
     public class JsonPatchInputFormatterTest
     {
+        private static readonly ObjectPoolProvider _objectPoolProvider = new DefaultObjectPoolProvider();
+        private static readonly JsonSerializerSettings _serializerSettings = new JsonSerializerSettings();
+
         [Fact]
         public async Task JsonPatchInputFormatter_ReadsOneOperation_Successfully()
         {
             // Arrange
             var logger = GetLogger();
-            var formatter = new JsonPatchInputFormatter(logger);
+            var formatter =
+                new JsonPatchInputFormatter(logger, _serializerSettings, ArrayPool<char>.Shared, _objectPoolProvider);
             var content = "[{\"op\":\"add\",\"path\":\"Customer/Name\",\"value\":\"John\"}]";
             var contentBytes = Encoding.UTF8.GetBytes(content);
 
@@ -54,7 +60,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         {
             // Arrange
             var logger = GetLogger();
-            var formatter = new JsonPatchInputFormatter(logger);
+            var formatter =
+                new JsonPatchInputFormatter(logger, _serializerSettings, ArrayPool<char>.Shared, _objectPoolProvider);
             var content = "[{\"op\": \"add\", \"path\" : \"Customer/Name\", \"value\":\"John\"}," +
                 "{\"op\": \"remove\", \"path\" : \"Customer/Name\"}]";
             var contentBytes = Encoding.UTF8.GetBytes(content);
@@ -92,7 +99,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         {
             // Arrange
             var logger = GetLogger();
-            var formatter = new JsonPatchInputFormatter(logger);
+            var formatter =
+                new JsonPatchInputFormatter(logger, _serializerSettings, ArrayPool<char>.Shared, _objectPoolProvider);
             var content = "[{\"op\": \"add\", \"path\" : \"Customer/Name\", \"value\":\"John\"}]";
             var contentBytes = Encoding.UTF8.GetBytes(content);
 
@@ -121,7 +129,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         {
             // Arrange
             var logger = GetLogger();
-            var formatter = new JsonPatchInputFormatter(logger);
+            var formatter =
+                new JsonPatchInputFormatter(logger, _serializerSettings, ArrayPool<char>.Shared, _objectPoolProvider);
             var content = "[{\"op\": \"add\", \"path\" : \"Customer/Name\", \"value\":\"John\"}]";
             var contentBytes = Encoding.UTF8.GetBytes(content);
 
@@ -151,7 +160,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 $"'{typeof(Customer).FullName}' because the type requires a JSON object ";
 
             var logger = GetLogger();
-            var formatter = new JsonPatchInputFormatter(logger);
+            var formatter =
+                new JsonPatchInputFormatter(logger, _serializerSettings, ArrayPool<char>.Shared, _objectPoolProvider);
             var content = "[{\"op\": \"add\", \"path\" : \"Customer/Name\", \"value\":\"John\"}]";
             var contentBytes = Encoding.UTF8.GetBytes(content);
 

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/BasicTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/BasicTests.cs
@@ -7,7 +7,6 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
-using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -248,11 +247,13 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
         public async Task JsonHelperWithSettings_RendersJson()
         {
             // Arrange
-            var json = JsonConvert.SerializeObject(new BasicWebSite.Models.Person()
-            {
-                Id = 9000,
-                Name = "John <b>Smith</b>"
-            }, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
+            var json = JsonConvert.SerializeObject(
+                new BasicWebSite.Models.Person()
+                {
+                    Id = 9000,
+                    Name = "John <b>Smith</b>"
+                },
+                new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
 
             var expectedBody = string.Format(
                 @"<script type=""text/javascript"">

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/TestMvcOptions.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/TestMvcOptions.cs
@@ -5,6 +5,7 @@ using System.Buffers;
 using Microsoft.AspNetCore.Mvc.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.DataAnnotations.Internal;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Formatters.Json.Internal;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/TestMvcOptions.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/TestMvcOptions.cs
@@ -4,8 +4,7 @@
 using System.Buffers;
 using Microsoft.AspNetCore.Mvc.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.DataAnnotations.Internal;
-using Microsoft.AspNetCore.Mvc.Formatters.Json;
-using Microsoft.AspNetCore.Mvc.Formatters.Json.Internal;
+using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
@@ -33,7 +32,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
                 collection.BuildServiceProvider());
 
             var loggerFactory = new LoggerFactory();
-            var serializerSettings = SerializerSettingsProvider.CreateSerializerSettings();
+            var serializerSettings = JsonSerializerSettingsProvider.CreateSerializerSettings();
 
             MvcJsonMvcOptionsSetup.ConfigureMvc(
                 Value,

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/TestMvcOptions.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/TestMvcOptions.cs
@@ -4,8 +4,8 @@
 using System.Buffers;
 using Microsoft.AspNetCore.Mvc.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.DataAnnotations.Internal;
+using Microsoft.AspNetCore.Mvc.Formatters.Json;
 using Microsoft.AspNetCore.Mvc.Formatters.Json.Internal;
-using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorPageActivatorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorPageActivatorTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
@@ -19,6 +20,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.WebEncoders.Testing;
 using Moq;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.Razor
@@ -32,7 +34,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             var modelMetadataProvider = new EmptyModelMetadataProvider();
             var modelExpressionProvider = new ModelExpressionProvider(modelMetadataProvider, new ExpressionTextCache());
             var urlHelperFactory = new UrlHelperFactory();
-            var jsonHelper = new JsonHelper(new JsonOutputFormatter());
+            var jsonHelper = new JsonHelper(
+                new JsonOutputFormatter(new JsonSerializerSettings(), ArrayPool<char>.Shared),
+                ArrayPool<char>.Shared);
             var htmlEncoder = new HtmlTestEncoder();
             var diagnosticSource = new DiagnosticListener("Microsoft.AspNetCore");
             var activator = new RazorPageActivator(
@@ -47,7 +51,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
 
             var myService = new MyService();
             var helper = Mock.Of<IHtmlHelper<object>>();
-            
+
             var serviceProvider = new ServiceCollection()
                 .AddSingleton(myService)
                 .AddSingleton(helper)
@@ -92,7 +96,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             var activator = new RazorPageActivator(
                 modelMetadataProvider,
                 new UrlHelperFactory(),
-                new JsonHelper(new JsonOutputFormatter()),
+                new JsonHelper(
+                    new JsonOutputFormatter(new JsonSerializerSettings(), ArrayPool<char>.Shared),
+                    ArrayPool<char>.Shared),
                 new DiagnosticListener("Microsoft.AspNetCore"),
                 new HtmlTestEncoder(),
                 modelExpressionProvider);
@@ -131,7 +137,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             var activator = new RazorPageActivator(
                 modelMetadataProvider,
                 new UrlHelperFactory(),
-                new JsonHelper(new JsonOutputFormatter()),
+                new JsonHelper(
+                    new JsonOutputFormatter(new JsonSerializerSettings(), ArrayPool<char>.Shared),
+                    ArrayPool<char>.Shared),
                 new DiagnosticListener("Microsoft.AspNetCore.Mvc"),
                 new HtmlTestEncoder(),
                 modelExpressionProvider);
@@ -179,7 +187,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             var activator = new RazorPageActivator(
                 modelMetadataProvider,
                 new UrlHelperFactory(),
-                new JsonHelper(new JsonOutputFormatter()),
+                new JsonHelper(
+                    new JsonOutputFormatter(new JsonSerializerSettings(), ArrayPool<char>.Shared),
+                    ArrayPool<char>.Shared),
                 new DiagnosticListener("Microsoft.AspNetCore.Mvc"),
                 new HtmlTestEncoder(),
                 modelExpressionProvider);
@@ -226,7 +236,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             var activator = new RazorPageActivator(
                 modelMetadataProvider,
                 new UrlHelperFactory(),
-                new JsonHelper(new JsonOutputFormatter()),
+                new JsonHelper(
+                    new JsonOutputFormatter(new JsonSerializerSettings(), ArrayPool<char>.Shared),
+                    ArrayPool<char>.Shared),
                 new DiagnosticListener("Microsoft.AspNetCore.Mvc"),
                 new HtmlTestEncoder(),
                 modelExpressionProvider);
@@ -270,7 +282,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             var activator = new RazorPageActivator(
                 modelMetadataProvider,
                 new UrlHelperFactory(),
-                new JsonHelper(new JsonOutputFormatter()),
+                new JsonHelper(
+                    new JsonOutputFormatter(new JsonSerializerSettings(), ArrayPool<char>.Shared),
+                    ArrayPool<char>.Shared),
                 new DiagnosticListener("Microsoft.AspNetCore.Mvc"),
                 new HtmlTestEncoder(),
                 modelExpressionProvider);
@@ -306,7 +320,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             var activator = new RazorPageActivator(
                 modelMetadataProvider,
                 new UrlHelperFactory(),
-                new JsonHelper(new JsonOutputFormatter()),
+                new JsonHelper(
+                    new JsonOutputFormatter(new JsonSerializerSettings(), ArrayPool<char>.Shared),
+                    ArrayPool<char>.Shared),
                 new DiagnosticListener("Microsoft.AspNetCore.Mvc"),
                 new HtmlTestEncoder(),
                 modelExpressionProvider);

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorPageCreateTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorPageCreateTagHelperTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -10,7 +11,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
-using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Razor.Internal;
@@ -23,6 +24,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.WebEncoders.Testing;
 using Moq;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.Razor
@@ -75,7 +77,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             var activator = new RazorPageActivator(
                 modelMetadataProvider,
                 new UrlHelperFactory(),
-                new JsonHelper(new Formatters.JsonOutputFormatter()),
+                new JsonHelper(
+                    new JsonOutputFormatter(new JsonSerializerSettings(), ArrayPool<char>.Shared),
+                    ArrayPool<char>.Shared),
                 new DiagnosticListener("Microsoft.AspNetCore"),
                 new HtmlTestEncoder(),
                 modelExpressionProvider);

--- a/test/Microsoft.AspNetCore.Mvc.Test/MvcOptionsSetupTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Test/MvcOptionsSetupTest.cs
@@ -204,33 +204,6 @@ namespace Microsoft.AspNetCore.Mvc
                 });
         }
 
-        [Fact]
-        public void Setup_JsonFormattersUseSerializerSettings()
-        {
-            // Arrange
-            var services = GetServiceProvider(s =>
-            {
-                s.AddTransient<ILoggerFactory, LoggerFactory>();
-            });
-
-            // Act
-            var options = services.GetRequiredService<IOptions<MvcOptions>>().Value;
-            var jsonOptions = services.GetRequiredService<IOptions<MvcJsonOptions>>().Value;
-
-            // Assert
-            var jsonInputFormatters = options.InputFormatters.OfType<JsonInputFormatter>();
-            foreach (var jsonInputFormatter in jsonInputFormatters)
-            {
-                Assert.Same(jsonOptions.SerializerSettings, jsonInputFormatter.SerializerSettings);
-            }
-
-            var jsonOuputFormatters = options.OutputFormatters.OfType<JsonOutputFormatter>();
-            foreach (var jsonOuputFormatter in jsonOuputFormatters)
-            {
-                Assert.Same(jsonOptions.SerializerSettings, jsonOuputFormatter.SerializerSettings);
-            }
-        }
-
         private static T GetOptions<T>(Action<IServiceCollection> action = null)
             where T : class, new()
         {

--- a/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/BadRequestErrorMessageResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/BadRequestErrorMessageResultTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Buffers;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -12,6 +13,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace System.Web.Http
@@ -67,7 +69,9 @@ namespace System.Web.Http
         {
             var options = new OptionsManager<MvcOptions>(new IConfigureOptions<MvcOptions>[] { });
             options.Value.OutputFormatters.Add(new StringOutputFormatter());
-            options.Value.OutputFormatters.Add(new JsonOutputFormatter());
+            options.Value.OutputFormatters.Add(new JsonOutputFormatter(
+                new JsonSerializerSettings(),
+                ArrayPool<char>.Shared));
 
             var services = new ServiceCollection();
             services.AddSingleton(new ObjectResultExecutor(

--- a/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/ExceptionResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/ExceptionResultTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Buffers;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -12,6 +13,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace System.Web.Http
@@ -67,7 +69,9 @@ namespace System.Web.Http
         {
             var options = new OptionsManager<MvcOptions>(new IConfigureOptions<MvcOptions>[] { });
             options.Value.OutputFormatters.Add(new StringOutputFormatter());
-            options.Value.OutputFormatters.Add(new JsonOutputFormatter());
+            options.Value.OutputFormatters.Add(new JsonOutputFormatter(
+                new JsonSerializerSettings(),
+                ArrayPool<char>.Shared));
 
             var services = new ServiceCollection();
             services.AddSingleton(new ObjectResultExecutor(

--- a/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/InvalidModelStateResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/InvalidModelStateResultTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Buffers;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -13,6 +14,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace System.Web.Http
@@ -80,7 +82,9 @@ namespace System.Web.Http
         {
             var options = new OptionsManager<MvcOptions>(new IConfigureOptions<MvcOptions>[] { });
             options.Value.OutputFormatters.Add(new StringOutputFormatter());
-            options.Value.OutputFormatters.Add(new JsonOutputFormatter());
+            options.Value.OutputFormatters.Add(new JsonOutputFormatter(
+                new JsonSerializerSettings(),
+                ArrayPool<char>.Shared));
 
             var services = new ServiceCollection();
             services.AddSingleton(new ObjectResultExecutor(

--- a/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/NegotiatedContentResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/NegotiatedContentResultTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Buffers;
 using System.IO;
 using System.Net;
 using System.Threading.Tasks;
@@ -13,6 +14,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace System.Web.Http
@@ -68,7 +70,9 @@ namespace System.Web.Http
         {
             var options = new OptionsManager<MvcOptions>(new IConfigureOptions<MvcOptions>[] { });
             options.Value.OutputFormatters.Add(new StringOutputFormatter());
-            options.Value.OutputFormatters.Add(new JsonOutputFormatter());
+            options.Value.OutputFormatters.Add(new JsonOutputFormatter(
+                new JsonSerializerSettings(),
+                ArrayPool<char>.Shared));
 
             var services = new ServiceCollection();
             services.AddSingleton(new ObjectResultExecutor(

--- a/test/WebSites/ApiExplorerWebSite/Startup.cs
+++ b/test/WebSites/ApiExplorerWebSite/Startup.cs
@@ -24,9 +24,23 @@ namespace ApiExplorerWebSite
                 options.Conventions.Add(new ApiExplorerVisibilityDisabledConvention(
                     typeof(ApiExplorerVisbilityDisabledByConventionController)));
 
+                JsonOutputFormatter jsonOutputFormatter = null;
+                for (var i = 0; i < options.OutputFormatters.Count; i++)
+                {
+                    var formatter = options.OutputFormatters[i];
+                    jsonOutputFormatter = formatter as JsonOutputFormatter;
+                    if (jsonOutputFormatter != null)
+                    {
+                        break;
+                    }
+                }
+
                 options.OutputFormatters.Clear();
-                options.OutputFormatters.Add(new JsonOutputFormatter());
                 options.OutputFormatters.Add(new XmlDataContractSerializerOutputFormatter());
+                if (jsonOutputFormatter != null)
+                {
+                    options.OutputFormatters.Add(jsonOutputFormatter);
+                }
             });
 
             services.AddSingleton<ApiExplorerDataFilter>();

--- a/test/WebSites/ApiExplorerWebSite/Startup.cs
+++ b/test/WebSites/ApiExplorerWebSite/Startup.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
+using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Formatters;
@@ -24,23 +25,11 @@ namespace ApiExplorerWebSite
                 options.Conventions.Add(new ApiExplorerVisibilityDisabledConvention(
                     typeof(ApiExplorerVisbilityDisabledByConventionController)));
 
-                JsonOutputFormatter jsonOutputFormatter = null;
-                for (var i = 0; i < options.OutputFormatters.Count; i++)
-                {
-                    var formatter = options.OutputFormatters[i];
-                    jsonOutputFormatter = formatter as JsonOutputFormatter;
-                    if (jsonOutputFormatter != null)
-                    {
-                        break;
-                    }
-                }
+                var jsonOutputFormatter = options.OutputFormatters.OfType<JsonOutputFormatter>().First();
 
                 options.OutputFormatters.Clear();
+                options.OutputFormatters.Add(jsonOutputFormatter);
                 options.OutputFormatters.Add(new XmlDataContractSerializerOutputFormatter());
-                if (jsonOutputFormatter != null)
-                {
-                    options.OutputFormatters.Add(jsonOutputFormatter);
-                }
             });
 
             services.AddSingleton<ApiExplorerDataFilter>();

--- a/test/WebSites/BasicWebSite/Controllers/ContentNegotiation/FallbackOnTypeBasedMatchController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/ContentNegotiation/FallbackOnTypeBasedMatchController.cs
@@ -4,13 +4,29 @@
 using BasicWebSite.Formatters;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace BasicWebSite.Controllers.ContentNegotiation
 {
     public class FallbackOnTypeBasedMatchController : Controller
     {
+        private readonly IOptions<MvcOptions> _mvcOptions;
+        private readonly JsonOutputFormatter _jsonOutputFormatter;
+
+        public FallbackOnTypeBasedMatchController(IOptions<MvcOptions> mvcOptions)
+        {
+            _mvcOptions = mvcOptions;
+
+            for (var i = 0; i < mvcOptions.Value.OutputFormatters.Count; i++)
+            {
+                _jsonOutputFormatter = mvcOptions.Value.OutputFormatters[i] as JsonOutputFormatter;
+                if (_jsonOutputFormatter != null)
+                {
+                    break;
+                }
+            }
+        }
+
         public int UseTheFallback_WithDefaultFormatters(int input)
         {
             return input;
@@ -25,7 +41,7 @@ namespace BasicWebSite.Controllers.ContentNegotiation
             // JsonOutputFormatter cannot write in the first attempt because it does not support the
             // request content type.
             objectResult.Formatters.Add(new PlainTextFormatter());
-            objectResult.Formatters.Add(new JsonOutputFormatter());
+            objectResult.Formatters.Add(_jsonOutputFormatter);
 
             return objectResult;
         }
@@ -46,17 +62,16 @@ namespace BasicWebSite.Controllers.ContentNegotiation
             var objectResult = new ObjectResult(input);
             objectResult.Formatters.Add(new HttpNotAcceptableOutputFormatter());
             objectResult.Formatters.Add(new PlainTextFormatter());
-            objectResult.Formatters.Add(new JsonOutputFormatter());
+            objectResult.Formatters.Add(_jsonOutputFormatter);
+
             return objectResult;
         }
 
         public IActionResult OverrideTheFallback_WithDefaultFormatters(int input)
         {
             var objectResult = new ObjectResult(input);
-            var optionsAccessor = HttpContext.RequestServices
-                .GetRequiredService<IOptions<MvcOptions>>();
             objectResult.Formatters.Add(new HttpNotAcceptableOutputFormatter());
-            foreach (var formatter in optionsAccessor.Value.OutputFormatters)
+            foreach (var formatter in _mvcOptions.Value.OutputFormatters)
             {
                 objectResult.Formatters.Add(formatter);
             }

--- a/test/WebSites/BasicWebSite/Controllers/ContentNegotiation/FallbackOnTypeBasedMatchController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/ContentNegotiation/FallbackOnTypeBasedMatchController.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using BasicWebSite.Formatters;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters;
@@ -16,15 +17,7 @@ namespace BasicWebSite.Controllers.ContentNegotiation
         public FallbackOnTypeBasedMatchController(IOptions<MvcOptions> mvcOptions)
         {
             _mvcOptions = mvcOptions;
-
-            for (var i = 0; i < mvcOptions.Value.OutputFormatters.Count; i++)
-            {
-                _jsonOutputFormatter = mvcOptions.Value.OutputFormatters[i] as JsonOutputFormatter;
-                if (_jsonOutputFormatter != null)
-                {
-                    break;
-                }
-            }
+            _jsonOutputFormatter = mvcOptions.Value.OutputFormatters.OfType<JsonOutputFormatter>().First();
         }
 
         public int UseTheFallback_WithDefaultFormatters(int input)

--- a/test/WebSites/BasicWebSite/Controllers/ContentNegotiation/NormalController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/ContentNegotiation/NormalController.cs
@@ -1,17 +1,62 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Buffers;
 using BasicWebSite.Formatters;
 using BasicWebSite.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 
 namespace BasicWebSite.Controllers.ContentNegotiation
 {
     public class NormalController : Controller
     {
+        private JsonOutputFormatter _indentingFormatter;
+
+        public NormalController(IOptions<MvcJsonOptions> jsonOptions, ArrayPool<char> charPool)
+        {
+            var defaultSettings = jsonOptions.Value.SerializerSettings;
+            var settings = new JsonSerializerSettings
+            {
+                Binder = defaultSettings.Binder,
+                CheckAdditionalContent = defaultSettings.CheckAdditionalContent,
+                ConstructorHandling = defaultSettings.ConstructorHandling,
+                Context = defaultSettings.Context,
+                ContractResolver = defaultSettings.ContractResolver,
+                Converters = defaultSettings.Converters,
+                Culture = defaultSettings.Culture,
+                DateFormatHandling = defaultSettings.DateFormatHandling,
+                DateFormatString = defaultSettings.DateFormatString,
+                DateParseHandling = defaultSettings.DateParseHandling,
+                DateTimeZoneHandling = defaultSettings.DateTimeZoneHandling,
+                DefaultValueHandling = defaultSettings.DefaultValueHandling,
+                EqualityComparer = defaultSettings.EqualityComparer,
+                Error = defaultSettings.Error,
+                FloatFormatHandling = defaultSettings.FloatFormatHandling,
+                FloatParseHandling = defaultSettings.FloatParseHandling,
+                // Just one change from the global defaults.
+                Formatting = Formatting.Indented,
+                MaxDepth = defaultSettings.MaxDepth,
+                MetadataPropertyHandling = defaultSettings.MetadataPropertyHandling,
+                MissingMemberHandling = defaultSettings.MissingMemberHandling,
+                NullValueHandling = defaultSettings.NullValueHandling,
+                ObjectCreationHandling = defaultSettings.ObjectCreationHandling,
+                PreserveReferencesHandling = defaultSettings.PreserveReferencesHandling,
+                ReferenceLoopHandling = defaultSettings.ReferenceLoopHandling,
+                // ReferenceResolver property is obsolete; use only ReferenceResolverProvider.
+                ReferenceResolverProvider = defaultSettings.ReferenceResolverProvider,
+                StringEscapeHandling = defaultSettings.StringEscapeHandling,
+                TraceWriter = defaultSettings.TraceWriter,
+                TypeNameAssemblyFormat = defaultSettings.TypeNameAssemblyFormat,
+                TypeNameHandling = defaultSettings.TypeNameHandling,
+            };
+
+            _indentingFormatter = new JsonOutputFormatter(settings, charPool);
+        }
+
         public override void OnActionExecuted(ActionExecutedContext context)
         {
             var result = context.Result as ObjectResult;
@@ -19,10 +64,7 @@ namespace BasicWebSite.Controllers.ContentNegotiation
             {
                 result.Formatters.Add(new PlainTextFormatter());
                 result.Formatters.Add(new CustomFormatter("application/custom"));
-
-                var jsonFormatter = new JsonOutputFormatter();
-                jsonFormatter.SerializerSettings.Formatting = Formatting.Indented;
-                result.Formatters.Add(jsonFormatter);
+                result.Formatters.Add(_indentingFormatter);
             }
 
             base.OnActionExecuted(context);

--- a/test/WebSites/BasicWebSite/Controllers/ContentNegotiation/NormalController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/ContentNegotiation/NormalController.cs
@@ -7,7 +7,6 @@ using BasicWebSite.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Formatters;
-using Microsoft.AspNetCore.Mvc.Formatters.Json;
 using Newtonsoft.Json;
 
 namespace BasicWebSite.Controllers.ContentNegotiation
@@ -19,7 +18,7 @@ namespace BasicWebSite.Controllers.ContentNegotiation
 
         static NormalController()
         {
-            _indentedSettings = SerializerSettingsProvider.CreateSerializerSettings();
+            _indentedSettings = JsonSerializerSettingsProvider.CreateSerializerSettings();
             _indentedSettings.Formatting = Formatting.Indented;
         }
 

--- a/test/WebSites/BasicWebSite/Controllers/ContentNegotiation/NormalController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/ContentNegotiation/NormalController.cs
@@ -7,54 +7,25 @@ using BasicWebSite.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Formatters;
-using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.Mvc.Formatters.Json;
 using Newtonsoft.Json;
 
 namespace BasicWebSite.Controllers.ContentNegotiation
 {
     public class NormalController : Controller
     {
-        private JsonOutputFormatter _indentingFormatter;
+        private static readonly JsonSerializerSettings _indentedSettings;
+        private readonly JsonOutputFormatter _indentingFormatter;
 
-        public NormalController(IOptions<MvcJsonOptions> jsonOptions, ArrayPool<char> charPool)
+        static NormalController()
         {
-            var defaultSettings = jsonOptions.Value.SerializerSettings;
-            var settings = new JsonSerializerSettings
-            {
-                Binder = defaultSettings.Binder,
-                CheckAdditionalContent = defaultSettings.CheckAdditionalContent,
-                ConstructorHandling = defaultSettings.ConstructorHandling,
-                Context = defaultSettings.Context,
-                ContractResolver = defaultSettings.ContractResolver,
-                Converters = defaultSettings.Converters,
-                Culture = defaultSettings.Culture,
-                DateFormatHandling = defaultSettings.DateFormatHandling,
-                DateFormatString = defaultSettings.DateFormatString,
-                DateParseHandling = defaultSettings.DateParseHandling,
-                DateTimeZoneHandling = defaultSettings.DateTimeZoneHandling,
-                DefaultValueHandling = defaultSettings.DefaultValueHandling,
-                EqualityComparer = defaultSettings.EqualityComparer,
-                Error = defaultSettings.Error,
-                FloatFormatHandling = defaultSettings.FloatFormatHandling,
-                FloatParseHandling = defaultSettings.FloatParseHandling,
-                // Just one change from the global defaults.
-                Formatting = Formatting.Indented,
-                MaxDepth = defaultSettings.MaxDepth,
-                MetadataPropertyHandling = defaultSettings.MetadataPropertyHandling,
-                MissingMemberHandling = defaultSettings.MissingMemberHandling,
-                NullValueHandling = defaultSettings.NullValueHandling,
-                ObjectCreationHandling = defaultSettings.ObjectCreationHandling,
-                PreserveReferencesHandling = defaultSettings.PreserveReferencesHandling,
-                ReferenceLoopHandling = defaultSettings.ReferenceLoopHandling,
-                // ReferenceResolver property is obsolete; use only ReferenceResolverProvider.
-                ReferenceResolverProvider = defaultSettings.ReferenceResolverProvider,
-                StringEscapeHandling = defaultSettings.StringEscapeHandling,
-                TraceWriter = defaultSettings.TraceWriter,
-                TypeNameAssemblyFormat = defaultSettings.TypeNameAssemblyFormat,
-                TypeNameHandling = defaultSettings.TypeNameHandling,
-            };
+            _indentedSettings = SerializerSettingsProvider.CreateSerializerSettings();
+            _indentedSettings.Formatting = Formatting.Indented;
+        }
 
-            _indentingFormatter = new JsonOutputFormatter(settings, charPool);
+        public NormalController(ArrayPool<char> charPool)
+        {
+            _indentingFormatter = new JsonOutputFormatter(_indentedSettings, charPool);
         }
 
         public override void OnActionExecuted(ActionExecutedContext context)

--- a/test/WebSites/BasicWebSite/Controllers/JsonResultController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/JsonResultController.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Net.Http.Headers;
+using Microsoft.AspNetCore.Mvc.Formatters.Json;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -10,7 +10,13 @@ namespace BasicWebSite.Controllers
 {
     public class JsonResultController : Controller
     {
-        private static JsonSerializerSettings _customSerializerSettings;
+        private static readonly JsonSerializerSettings _customSerializerSettings;
+
+        static JsonResultController()
+        {
+            _customSerializerSettings = SerializerSettingsProvider.CreateSerializerSettings();
+            _customSerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
+        }
 
         public JsonResult Plain()
         {
@@ -26,14 +32,6 @@ namespace BasicWebSite.Controllers
 
         public JsonResult CustomSerializerSettings()
         {
-            if (_customSerializerSettings == null)
-            {
-                _customSerializerSettings = new JsonSerializerSettings
-                {
-                    ContractResolver = new CamelCasePropertyNamesContractResolver()
-                };
-            }
-
             return Json(new { Message = "hello" }, _customSerializerSettings);
         }
 

--- a/test/WebSites/BasicWebSite/Controllers/JsonResultController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/JsonResultController.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Formatters.Json;
+using Microsoft.AspNetCore.Mvc.Formatters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -14,7 +14,7 @@ namespace BasicWebSite.Controllers
 
         static JsonResultController()
         {
-            _customSerializerSettings = SerializerSettingsProvider.CreateSerializerSettings();
+            _customSerializerSettings = JsonSerializerSettingsProvider.CreateSerializerSettings();
             _customSerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
         }
 

--- a/test/WebSites/BasicWebSite/Views/Home/JsonHelperWithSettingsInView.cshtml
+++ b/test/WebSites/BasicWebSite/Views/Home/JsonHelperWithSettingsInView.cshtml
@@ -1,8 +1,8 @@
-﻿@using Microsoft.AspNetCore.Mvc.Formatters.Json
+﻿@using Microsoft.AspNetCore.Mvc.Formatters
 @using Newtonsoft.Json
 @using Newtonsoft.Json.Serialization
 @{
-    var settings = SerializerSettingsProvider.CreateSerializerSettings();
+    var settings = JsonSerializerSettingsProvider.CreateSerializerSettings();
     settings.ContractResolver = new CamelCasePropertyNamesContractResolver();
 }
 <script type="text/javascript">

--- a/test/WebSites/BasicWebSite/Views/Home/JsonHelperWithSettingsInView.cshtml
+++ b/test/WebSites/BasicWebSite/Views/Home/JsonHelperWithSettingsInView.cshtml
@@ -1,5 +1,10 @@
-﻿@using Newtonsoft.Json
+﻿@using Microsoft.AspNetCore.Mvc.Formatters.Json
+@using Newtonsoft.Json
 @using Newtonsoft.Json.Serialization
+@{
+    var settings = SerializerSettingsProvider.CreateSerializerSettings();
+    settings.ContractResolver = new CamelCasePropertyNamesContractResolver();
+}
 <script type="text/javascript">
-    var json = @Json.Serialize(Model, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
+    var json = @Json.Serialize(Model, settings);
 </script>

--- a/test/WebSites/FiltersWebSite/Controllers/ResourceFilterController.cs
+++ b/test/WebSites/FiltersWebSite/Controllers/ResourceFilterController.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Newtonsoft.Json;
 
 namespace FiltersWebSite.Controllers
 {
@@ -31,7 +33,9 @@ namespace FiltersWebSite.Controllers
 
             public ShortCircuitWithFormatterAttribute()
             {
-                _formatters = new IOutputFormatter[] { new JsonOutputFormatter() };
+                _formatters = new IOutputFormatter[] { new JsonOutputFormatter(
+                    new JsonSerializerSettings(),
+                    ArrayPool<char>.Shared) };
             }
 
             public void OnResourceExecuted(ResourceExecutedContext context)

--- a/test/WebSites/FormatterWebSite/Controllers/JsonFormatterController.cs
+++ b/test/WebSites/FormatterWebSite/Controllers/JsonFormatterController.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Buffers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters;
@@ -21,8 +22,11 @@ namespace FormatterWebSite.Controllers
                 Name = "John Williams"
             };
 
-            var jsonFormatter = new JsonOutputFormatter();
-            jsonFormatter.SerializerSettings.Formatting = Formatting.Indented;
+            var settings = new JsonSerializerSettings
+            {
+                Formatting = Formatting.Indented,
+            };
+            var jsonFormatter = new JsonOutputFormatter(settings, ArrayPool<char>.Shared);
 
             var objectResult = new ObjectResult(user);
             objectResult.Formatters.Add(jsonFormatter);

--- a/test/WebSites/FormatterWebSite/Controllers/JsonFormatterController.cs
+++ b/test/WebSites/FormatterWebSite/Controllers/JsonFormatterController.cs
@@ -5,7 +5,6 @@ using System.Buffers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters;
-using Microsoft.AspNetCore.Mvc.Formatters.Json;
 using Newtonsoft.Json;
 
 namespace FormatterWebSite.Controllers
@@ -17,7 +16,7 @@ namespace FormatterWebSite.Controllers
 
         static JsonFormatterController()
         {
-            _indentedSettings = SerializerSettingsProvider.CreateSerializerSettings();
+            _indentedSettings = JsonSerializerSettingsProvider.CreateSerializerSettings();
             _indentedSettings.Formatting = Formatting.Indented;
         }
 

--- a/test/WebSites/FormatterWebSite/Controllers/JsonFormatterController.cs
+++ b/test/WebSites/FormatterWebSite/Controllers/JsonFormatterController.cs
@@ -5,12 +5,27 @@ using System.Buffers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Formatters.Json;
 using Newtonsoft.Json;
 
 namespace FormatterWebSite.Controllers
 {
     public class JsonFormatterController : Controller
     {
+        private static readonly JsonSerializerSettings _indentedSettings;
+        private readonly JsonOutputFormatter _indentingFormatter;
+
+        static JsonFormatterController()
+        {
+            _indentedSettings = SerializerSettingsProvider.CreateSerializerSettings();
+            _indentedSettings.Formatting = Formatting.Indented;
+        }
+
+        public JsonFormatterController(ArrayPool<char> charPool)
+        {
+            _indentingFormatter = new JsonOutputFormatter(_indentedSettings, charPool);
+        }
+
         public IActionResult ReturnsIndentedJson()
         {
             var user = new User()
@@ -22,14 +37,8 @@ namespace FormatterWebSite.Controllers
                 Name = "John Williams"
             };
 
-            var settings = new JsonSerializerSettings
-            {
-                Formatting = Formatting.Indented,
-            };
-            var jsonFormatter = new JsonOutputFormatter(settings, ArrayPool<char>.Shared);
-
             var objectResult = new ObjectResult(user);
-            objectResult.Formatters.Add(jsonFormatter);
+            objectResult.Formatters.Add(_indentingFormatter);
 
             return objectResult;
         }

--- a/test/WebSites/WebApiCompatShimWebSite/Controllers/ActionResults/ActionResultController.cs
+++ b/test/WebSites/WebApiCompatShimWebSite/Controllers/ActionResults/ActionResultController.cs
@@ -7,7 +7,7 @@ using System.Net.Http;
 using System.Text;
 using System.Web.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Formatters.Json;
+using Microsoft.AspNetCore.Mvc.Formatters;
 using Newtonsoft.Json;
 
 namespace WebApiCompatShimWebSite
@@ -18,7 +18,7 @@ namespace WebApiCompatShimWebSite
 
         static ActionResultController()
         {
-            _indentedSettings = SerializerSettingsProvider.CreateSerializerSettings();
+            _indentedSettings = JsonSerializerSettingsProvider.CreateSerializerSettings();
             _indentedSettings.Formatting = Formatting.Indented;
         }
 

--- a/test/WebSites/WebApiCompatShimWebSite/Controllers/ActionResults/ActionResultController.cs
+++ b/test/WebSites/WebApiCompatShimWebSite/Controllers/ActionResults/ActionResultController.cs
@@ -7,12 +7,21 @@ using System.Net.Http;
 using System.Text;
 using System.Web.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Formatters.Json;
 using Newtonsoft.Json;
 
 namespace WebApiCompatShimWebSite
 {
     public class ActionResultController : ApiController
     {
+        private static readonly JsonSerializerSettings _indentedSettings;
+
+        static ActionResultController()
+        {
+            _indentedSettings = SerializerSettingsProvider.CreateSerializerSettings();
+            _indentedSettings.Formatting = Formatting.Indented;
+        }
+
         public IActionResult GetBadRequest()
         {
             return BadRequest();
@@ -82,15 +91,12 @@ namespace WebApiCompatShimWebSite
 
         public IActionResult GetJsonSettings()
         {
-            return Json(CreateUser(), new JsonSerializerSettings() { Formatting = Formatting.Indented });
+            return Json(CreateUser(), _indentedSettings);
         }
 
         public IActionResult GetJsonSettingsEncoding()
         {
-            return Json(
-                CreateUser(),
-                new JsonSerializerSettings() { Formatting = Formatting.Indented },
-                Encoding.UTF32);
+            return Json(CreateUser(), _indentedSettings, Encoding.UTF32);
         }
 
         public IActionResult GetNotFound()


### PR DESCRIPTION
- #4339: remove non-recommended JSON formatter constructors
 - affects `JsonInputFormatter`, `JsonOutputFormatter`, `JsonPatchInputFormatter`
 - `JsonOutputFormatter` cleanup also impacts `JsonHelper`
 - make `SerializerSettingsProvider` class public and use it
- #4409: make `SerializerSetings` properties get-only and `protected`
 - affects `JsonInputFormatter`, `JsonOutputFormatter`

Recommended patterns:
- change `JsonSerializerSettings` values in `MvcJsonOptions` for almost all customizations
- find `JsonOutputFormatter` in `MvcOptions.OutputFormatters` when limiting per-result formatters
- start with `SerializerSettingsProvider.CreateSerializerSettings()` when customizing a per-result formatter