### PR TITLE
[Perf] Cache the ModelMetadata for known type "object"

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ViewDataDictionaryControllerPropertyActivator.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ViewDataDictionaryControllerPropertyActivator.cs
@@ -49,7 +49,6 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 
         private ViewDataDictionary GetViewDataDictionary(ControllerContext context)
         {
-            var serviceProvider = context.HttpContext.RequestServices;
             return new ViewDataDictionary(
                 _modelMetadataProvider,
                 context.ModelState);

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Metadata/DefaultModelMetadataProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Metadata/DefaultModelMetadataProviderTest.cs
@@ -45,6 +45,20 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
         }
 
         [Fact]
+        public void GetMetadataForObjectType_Cached()
+        {
+            // Arrange
+            var provider = CreateProvider();
+
+            // Act
+            var metadata1 = provider.GetMetadataForType(typeof(object));
+            var metadata2 = provider.GetMetadataForType(typeof(object));
+
+            // Assert
+            Assert.Same(metadata1, metadata2);
+        }
+
+        [Fact]
         public void GetMetadataForProperties_IncludesAllProperties()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/ModelMetadataProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/ModelMetadataProviderTest.cs
@@ -1074,9 +1074,14 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
             protected override DefaultMetadataDetails CreateTypeDetails(ModelMetadataIdentity key)
             {
                 var entry = base.CreateTypeDetails(key);
-                return new DefaultMetadataDetails(
-                    key,
-                    new ModelAttributes(_attributes.Concat(entry.ModelAttributes.TypeAttributes).ToArray()));
+                if (_attributes?.Length > 0)
+                {
+                    return new DefaultMetadataDetails(
+                        key,
+                        new ModelAttributes(_attributes.Concat(entry.ModelAttributes.TypeAttributes).ToArray()));
+                }
+
+                return entry;
             }
 
             protected override DefaultMetadataDetails[] CreatePropertyDetails(ModelMetadataIdentity key)


### PR DESCRIPTION
Fixes #4377 

Scenario : https://github.com/aspnet/Performance/tree/dev/testapp/HelloWorldMvc
Before Optimization
-----------------------
![image](https://cloud.githubusercontent.com/assets/8011073/14748966/b416c176-0871-11e6-9dd9-66d337eacdac.png)


After Optimization
----------------------
![image](https://cloud.githubusercontent.com/assets/8011073/14748955/9aa76074-0871-11e6-9ade-62f0d400aa26.png)

