### PR TITLE
[Perf] Replace Activator.CreateInstance with cached delegate

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionExecutor.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             object instance,
             IDictionary<string, object> actionArguments)
         {
-            var orderedArguments = PrepareArguments(actionArguments, actionMethodExecutor.MethodInfo.GetParameters());
+            var orderedArguments = PrepareArguments(actionArguments, actionMethodExecutor);
             return ExecuteAsync(actionMethodExecutor, instance, orderedArguments);
         }
 
@@ -30,8 +30,9 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
         public static object[] PrepareArguments(
             IDictionary<string, object> actionParameters,
-            ParameterInfo[] declaredParameterInfos)
+            ObjectMethodExecutor actionMethodExecutor)
         {
+            var declaredParameterInfos = actionMethodExecutor.MethodInfo.GetParameters();
             var count = declaredParameterInfos.Length;
             if (count == 0)
             {
@@ -58,7 +59,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                         if (defaultValueAttribute?.Value == null)
                         {
                             value = parameterInfo.ParameterType.GetTypeInfo().IsValueType
-                                ? Activator.CreateInstance(parameterInfo.ParameterType)
+                                ? actionMethodExecutor.CreateParameterObject(index)
                                 : null;
                         }
                         else

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionInvoker.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionInvoker.cs
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
             var arguments = ControllerActionExecutor.PrepareArguments(
                 actionExecutingContext.ActionArguments,
-                actionMethodInfo.GetParameters());
+                methodExecutor);
 
             Logger.ActionMethodExecuting(actionExecutingContext, arguments);
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/CollectionModelBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/CollectionModelBinder.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Internal;
@@ -20,6 +21,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
     /// <typeparam name="TElement">Type of elements in the collection.</typeparam>
     public class CollectionModelBinder<TElement> : ICollectionModelBinder
     {
+        private Func<object> _modelCreate;
+
         /// <summary>
         /// Creates a new <see cref="CollectionModelBinder{TElement}"/>.
         /// </summary>
@@ -147,7 +150,14 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         /// <returns>An instance of <paramref name="targetType"/>.</returns>
         protected object CreateInstance(Type targetType)
         {
-            return Activator.CreateInstance(targetType);
+            if (_modelCreate == null)
+            {
+                _modelCreate = Expression.
+                    Lambda<Func<object>>(Expression.New(targetType)).
+                    Compile();
+            }
+
+            return _modelCreate();
         }
 
         // Used when the ValueProvider contains the collection to be bound as a single element, e.g. the raw value

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/ComplexTypeModelBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/ComplexTypeModelBinder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Internal;
@@ -15,6 +16,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
     public class ComplexTypeModelBinder : IModelBinder
     {
         private readonly IDictionary<ModelMetadata, IModelBinder> _propertyBinders;
+        private Func<object> _modelCreate;
 
         /// <summary>
         /// Creates a new <see cref="ComplexTypeModelBinder"/>.
@@ -343,9 +345,16 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 throw new ArgumentNullException(nameof(bindingContext));
             }
 
-            // If the Activator throws an exception, we want to propagate it back up the call stack, since the
+            // If model create throws an exception, we want to propagate it back up the call stack, since the
             // application developer should know that this was an invalid type to try to bind to.
-            return Activator.CreateInstance(bindingContext.ModelType);
+            if (_modelCreate == null)
+            {
+                _modelCreate = Expression.
+                    Lambda<Func<object>>(Expression.New(bindingContext.ModelType)).
+                    Compile();
+            }
+
+            return _modelCreate();
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/CompilerCacheResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/CompilerCacheResult.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using Microsoft.AspNetCore.Mvc.Razor.Compilation;
 using Microsoft.Extensions.Primitives;
 
@@ -40,6 +41,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             CompilationResult = compilationResult;
             Success = true;
             ExpirationTokens = expirationTokens;
+            PageCreate = Expression.Lambda<Func<object>>(Expression.New(compilationResult.CompiledType)).Compile();
         }
 
         /// <summary>
@@ -58,6 +60,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             CompilationResult = default(CompilationResult);
             Success = false;
             ExpirationTokens = expirationTokens;
+            PageCreate = null;
         }
 
         /// <summary>
@@ -75,5 +78,11 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
         /// Gets a value that determines if the view was successfully found and compiled.
         /// </summary>
         public bool Success { get; }
+
+        /// <summary>
+        /// Gets a Func to create the view.
+        /// </summary>
+        /// <remarks>This property is not available when <see cref="Success"/> is <c>false</c>.</remarks>
+        public Func<object> PageCreate { get; }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/DefaultRazorPageFactoryProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/DefaultRazorPageFactoryProvider.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var result = CompilerCache.GetOrAdd(relativePath, _compileDelegate);
             if (result.Success)
             {
-                var pageFactory = GetPageFactory(result.CompilationResult.CompiledType, relativePath);
+                var pageFactory = GetPageFactory(result.PageCreate, relativePath);
                 return new RazorPageFactoryResult(pageFactory, result.ExpirationTokens);
             }
             else
@@ -74,15 +74,15 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
         /// <summary>
         /// Creates a factory for <see cref="IRazorPage"/>.
         /// </summary>
-        /// <param name="compiledType">The <see cref="Type"/> to produce an instance of <see cref="IRazorPage"/>
+        /// <param name="pageCreate">The <see cref="Func{Object}"/> to produce an instance of <see cref="IRazorPage"/>
         /// from.</param>
         /// <param name="relativePath">The application relative path of the page.</param>
-        /// <returns>A factory for <paramref name="compiledType"/>.</returns>
-        protected virtual Func<IRazorPage> GetPageFactory(Type compiledType, string relativePath)
+        /// <returns>A factory for <see cref="IRazorPage"/>.</returns>
+        protected virtual Func<IRazorPage> GetPageFactory(Func<object> pageCreate, string relativePath)
         {
             return () =>
             {
-                var page = (IRazorPage)Activator.CreateInstance(compiledType);
+                var page = (IRazorPage)pageCreate();
                 page.Path = relativePath;
                 return page;
             };

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/DefaultViewComponentInvoker.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/DefaultViewComponentInvoker.cs
@@ -102,9 +102,9 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
             using (_logger.ViewComponentScope(context))
             {
                 var method = context.ViewComponentDescriptor.MethodInfo;
-                var arguments = ControllerActionExecutor.PrepareArguments(context.Arguments, method.GetParameters());
-
                 var methodExecutor = _viewComponentInvokerCache.GetViewComponentMethodExecutor(context);
+
+                var arguments = ControllerActionExecutor.PrepareArguments(context.Arguments, methodExecutor);
 
                 _diagnosticSource.BeforeViewComponent(context, component);
                 _logger.ViewComponentExecuting(context, arguments);
@@ -129,10 +129,11 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
             using (_logger.ViewComponentScope(context))
             {
                 var method = context.ViewComponentDescriptor.MethodInfo;
+                var methodExecutor = _viewComponentInvokerCache.GetViewComponentMethodExecutor(context);
+
                 var arguments = ControllerActionExecutor.PrepareArguments(
                     context.Arguments,
-                    method.GetParameters());
-                var methodExecutor = _viewComponentInvokerCache.GetViewComponentMethodExecutor(context);
+                    methodExecutor);
 
                 _diagnosticSource.BeforeViewComponent(context, component);
                 _logger.ViewComponentExecuting(context, arguments);


### PR DESCRIPTION
Fixes #4470 
Places that are fixed are 
1. ControllerActionExecutor.cs(61):
2.DefaultRazorPageFactoryProvider.cs
3.ComplexTypeModelBinder.cs(348):
4.CollectionModelBinder.cs(150):

1. Benefit in using the cached delegate in .DefaultRazorPageFactoryProvider.cs
Scenario: https://github.com/aspnet/Performance/tree/dev/testapp/HelloWorldMvc 
Before Optimization
--------------------------
![image](https://cloud.githubusercontent.com/assets/8011073/14792823/fbbc40d0-0ad0-11e6-92e8-57c6146fe87c.png)


After Optimization
-----------------------

![image](https://cloud.githubusercontent.com/assets/8011073/14793013/e9d08fa6-0ad1-11e6-8339-11039f7f4a92.png)


2. Benefit in using cached delegate in ComplexTypeModelBinder.cs and ControllerActionExecutor.cs(61):
Scenario: https://github.com/aspnet/Performance/tree/dev/testapp/BigModelBinding (slight change in the controller to accept a value type argument with no default value)

Before Optimization
-------------------------
![image](https://cloud.githubusercontent.com/assets/8011073/14792787/c293e0a6-0ad0-11e6-91db-38d14b00fb52.png)

After Optimization
------------------------
![image](https://cloud.githubusercontent.com/assets/8011073/14792799/d104b2c8-0ad0-11e6-98d4-8c6320a494f1.png)


In most cases, we do invoke default constructor which is relatively inexpensive as compared to parameterized constructors. However, Activator does have a ActivatorCache with size limit as 16. With large number of views or arguments/models there is a possibility of not hitting the cache and going through the slow path of security checks etc. This fix proactively prevents those costs.