### PR TITLE
[Perf]  Replace Activator.CreateInstance with cached delegate in RazorPageFactoryProvider

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/CompilerCache.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/CompilerCache.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             foreach (var item in precompiledViews)
             {
-                var cacheEntry = new CompilerCacheResult(new CompilationResult(item.Value));
+                var cacheEntry = new CompilerCacheResult(item.Key, new CompilationResult(item.Value));
                 _cache.Set(GetNormalizedPath(item.Key), Task.FromResult(cacheEntry));
             }
         }
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
                 var normalizedPath = GetNormalizedPath(relativePath);
                 if (!_cache.TryGetValue(normalizedPath, out cacheEntry))
                 {
-                    cacheEntry = CreateCacheEntry(normalizedPath, compile);
+                    cacheEntry = CreateCacheEntry(relativePath, normalizedPath, compile);
                 }
             }
 
@@ -97,6 +97,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
         }
 
         private Task<CompilerCacheResult> CreateCacheEntry(
+            string relativePath,
             string normalizedPath,
             Func<RelativeFileInfo, CompilationResult> compile)
         {
@@ -148,7 +149,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
                     var compilationResult = compile(relativeFileInfo);
                     compilationResult.EnsureSuccessful();
                     compilationTaskSource.SetResult(
-                        new CompilerCacheResult(compilationResult, cacheEntryOptions.ExpirationTokens));
+                        new CompilerCacheResult(relativePath, compilationResult, cacheEntryOptions.ExpirationTokens));
                 }
                 catch (Exception ex)
                 {

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/CompilerCacheResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/CompilerCacheResult.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using Microsoft.AspNetCore.Mvc.Razor.Compilation;
 using Microsoft.Extensions.Primitives;
 
@@ -37,9 +38,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
                 throw new ArgumentNullException(nameof(expirationTokens));
             }
 
-            CompilationResult = compilationResult;
-            Success = true;
             ExpirationTokens = expirationTokens;
+            PageCreator = Expression.Lambda<Func<object>>(Expression.New(compilationResult.CompiledType)).Compile();
         }
 
         /// <summary>
@@ -55,16 +55,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
                 throw new ArgumentNullException(nameof(expirationTokens));
             }
 
-            CompilationResult = default(CompilationResult);
-            Success = false;
             ExpirationTokens = expirationTokens;
+            PageCreator = null;
         }
-
-        /// <summary>
-        /// The <see cref="Compilation.CompilationResult"/>.
-        /// </summary>
-        /// <remarks>This property is not available when <see cref="Success"/> is <c>false</c>.</remarks>
-        public CompilationResult CompilationResult { get; }
 
         /// <summary>
         /// <see cref="IChangeToken"/> instances that indicate when this result has expired.
@@ -74,6 +67,12 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
         /// <summary>
         /// Gets a value that determines if the view was successfully found and compiled.
         /// </summary>
-        public bool Success { get; }
+        public bool Success => PageCreator != null;
+
+        /// <summary>
+        /// Gets a delegate that creates an instance of the <see cref="CompilationResult.CompiledType"/>.
+        /// </summary>
+        public Func<object> PageCreator { get; }
+
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/CompilerCacheResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/CompilerCacheResult.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc.Razor.Compilation;
@@ -20,7 +19,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
         /// Initializes a new instance of <see cref="CompilerCacheResult"/> with the specified
         /// <see cref="Compilation.CompilationResult"/>.
         /// </summary>
-        /// <param name="relativePath">Application relative path to the view file.</param>
+        /// <param name="relativePath">Path of the view file relative to the application base.</param>
         /// <param name="compilationResult">The <see cref="Compilation.CompilationResult"/>.</param>
         public CompilerCacheResult(string relativePath, CompilationResult compilationResult)
             : this(relativePath, compilationResult, new IChangeToken[0])
@@ -31,7 +30,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
         /// Initializes a new instance of <see cref="CompilerCacheResult"/> with the specified
         /// <see cref="Compilation.CompilationResult"/>.
         /// </summary>
-        /// <param name="relativePath">Application relative path to the view file.</param>
+        /// <param name="relativePath">Path of the view file relative to the application base.</param>
         /// <param name="compilationResult">The <see cref="Compilation.CompilationResult"/>.</param>
         /// <param name="expirationTokens">One or more <see cref="IChangeToken"/> instances that indicate when
         /// this result has expired.</param>
@@ -47,9 +46,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             var newExpression = Expression.New(compiledType);
 
-            var pathProperty = compiledType.GetProperty(nameof(IRazorPage.Path)) ?? 
-                (MemberInfo)compiledType.GetField(nameof(IRazorPage.Path));
-            Debug.Assert(pathProperty != null);
+            var pathProperty = compiledType.GetProperty(nameof(IRazorPage.Path));
 
             var propertyBindExpression = Expression.Bind(pathProperty, Expression.Constant(relativePath));
             var objectInitializeExpression = Expression.MemberInit(newExpression, propertyBindExpression);

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/DefaultRazorPageFactoryProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/DefaultRazorPageFactoryProvider.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var result = CompilerCache.GetOrAdd(relativePath, _compileDelegate);
             if (result.Success)
             {
-                var pageFactory = GetPageFactory(result.CompilationResult.CompiledType, relativePath);
+                var pageFactory = GetPageFactory(result.PageCreator, relativePath);
                 return new RazorPageFactoryResult(pageFactory, result.ExpirationTokens);
             }
             else
@@ -74,18 +74,19 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
         /// <summary>
         /// Creates a factory for <see cref="IRazorPage"/>.
         /// </summary>
-        /// <param name="compiledType">The <see cref="Type"/> to produce an instance of <see cref="IRazorPage"/>
+        /// <param name="pageCreator">The <see cref="Func{Object}"/> to produce an instance of <see cref="IRazorPage"/>
         /// from.</param>
         /// <param name="relativePath">The application relative path of the page.</param>
-        /// <returns>A factory for <paramref name="compiledType"/>.</returns>
-        protected virtual Func<IRazorPage> GetPageFactory(Type compiledType, string relativePath)
+        /// <returns>A factory for <see cref="IRazorPage"/>.</returns>
+        protected virtual Func<IRazorPage> GetPageFactory(Func<object> pageCreator, string relativePath)
         {
             return () =>
             {
-                var page = (IRazorPage)Activator.CreateInstance(compiledType);
+                var page = (IRazorPage)pageCreator();
                 page.Path = relativePath;
                 return page;
             };
         }
+
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/DefaultRazorPageFactoryProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/DefaultRazorPageFactoryProvider.cs
@@ -62,31 +62,12 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var result = CompilerCache.GetOrAdd(relativePath, _compileDelegate);
             if (result.Success)
             {
-                var pageFactory = GetPageFactory(result.PageCreator, relativePath);
-                return new RazorPageFactoryResult(pageFactory, result.ExpirationTokens);
+                return new RazorPageFactoryResult(result.PageFactory, result.ExpirationTokens);
             }
             else
             {
                 return new RazorPageFactoryResult(result.ExpirationTokens);
             }
         }
-
-        /// <summary>
-        /// Creates a factory for <see cref="IRazorPage"/>.
-        /// </summary>
-        /// <param name="pageCreator">The <see cref="Func{Object}"/> to produce an instance of <see cref="IRazorPage"/>
-        /// from.</param>
-        /// <param name="relativePath">The application relative path of the page.</param>
-        /// <returns>A factory for <see cref="IRazorPage"/>.</returns>
-        protected virtual Func<IRazorPage> GetPageFactory(Func<object> pageCreator, string relativePath)
-        {
-            return () =>
-            {
-                var page = (IRazorPage)pageCreator();
-                page.Path = relativePath;
-                return page;
-            };
-        }
-
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/CompilerCacheTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/CompilerCacheTest.cs
@@ -58,7 +58,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert
             Assert.True(result.Success);
-            Assert.Same(type, result.PageCreator().GetType());
+            Assert.IsType<TestView>(result.PageFactory());
+            Assert.Same(ViewPath, result.PageFactory().Path);
         }
 
         [Theory]
@@ -80,13 +81,14 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var result1 = cache.GetOrAdd(@"Areas\Finances\Views\Home\Index.cshtml", _ => expected);
 
             // Assert - 1
-            Assert.Same(type, result1.PageCreator().GetType());
+            Assert.IsType<TestView>(result1.PageFactory());
 
             // Act - 2
             var result2 = cache.GetOrAdd(relativePath, ThrowsIfCalled);
 
             // Assert - 2
-            Assert.Same(type, result2.PageCreator().GetType());
+            Assert.IsType<TestView>(result2.PageFactory());
+            Assert.Same(result1.PageFactory, result2.PageFactory);
         }
 
         [Fact]
@@ -104,7 +106,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert 1
             Assert.True(result1.Success);
-            Assert.Same(expected.CompiledType, result1.PageCreator().GetType());
+            Assert.IsType<TestView>(result1.PageFactory());
 
             // Act 2
             // Delete the file from the file system and set it's expiration token.
@@ -131,7 +133,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert 1
             Assert.True(result1.Success);
-            Assert.Same(typeof(TestView), result1.PageCreator().GetType());
+            Assert.IsType<TestView>(result1.PageFactory());
 
             // Act 2
             // Verify we're getting cached results.
@@ -139,7 +141,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert 2
             Assert.True(result2.Success);
-            Assert.Same(expected1.CompiledType, result2.PageCreator().GetType());
+            Assert.IsType<TestView>(result2.PageFactory());
 
             // Act 3
             fileProvider.GetChangeToken(ViewPath).HasChanged = true;
@@ -147,7 +149,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert 3
             Assert.True(result3.Success);
-            Assert.Same(expected2.CompiledType, result3.PageCreator().GetType());
+            Assert.IsType<DifferentView>(result3.PageFactory());
         }
 
         [Theory]
@@ -166,7 +168,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert 1
             Assert.True(result1.Success);
-            Assert.Same(expected1.CompiledType, result1.PageCreator().GetType());
+            Assert.IsType<TestView>(result1.PageFactory());
 
             // Act 2
             // Verify we're getting cached results.
@@ -174,7 +176,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert 2
             Assert.True(result2.Success);
-            Assert.Same(expected1.CompiledType, result2.PageCreator().GetType());
+            Assert.IsType<TestView>(result2.PageFactory());
 
             // Act 3
             fileProvider.GetChangeToken(globalImportPath).HasChanged = true;
@@ -182,7 +184,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert 2
             Assert.True(result3.Success);
-            Assert.Same(expected2.CompiledType, result3.PageCreator().GetType());
+            Assert.IsType<DifferentView>(result3.PageFactory());
         }
 
         [Fact]
@@ -201,14 +203,14 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert 1
             Assert.True(result1.Success);
-            Assert.Same(type, result1.PageCreator().GetType());
+            Assert.IsType<TestView>(result1.PageFactory());
 
             // Act 2
             var result2 = cache.GetOrAdd(ViewPath, ThrowsIfCalled);
 
             // Assert 2
             Assert.True(result2.Success);
-            Assert.Same(type, result2.PageCreator().GetType());
+            Assert.IsType<TestView>(result2.PageFactory());
             mockFileProvider.Verify(v => v.GetFileInfo(ViewPath), Times.Once());
         }
 
@@ -224,7 +226,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert
             Assert.True(result.Success);
-            Assert.Same(typeof(PreCompile), result.PageCreator().GetType());
+            Assert.IsType<PreCompile>(result.PageFactory());
+            Assert.Same(PrecompiledViewsPath, result.PageFactory().Path);
         }
 
         [Fact]
@@ -241,7 +244,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert
             Assert.True(result.Success);
-            Assert.Same(typeof(PreCompile), result.PageCreator().GetType());
+            Assert.IsType<PreCompile>(result.PageFactory());
         }
 
         [Theory]
@@ -259,7 +262,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert
             Assert.True(result.Success);
-            Assert.Same(typeof(PreCompile), result.PageCreator().GetType());
+            Assert.IsType<PreCompile>(result.PageFactory());
         }
 
         [Fact]
@@ -275,21 +278,21 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var result1 = cache.GetOrAdd(ViewPath, _ => expected);
 
             // Assert 1
-            Assert.Same(typeof(TestView), result1.PageCreator().GetType());
+            Assert.IsType<TestView>(result1.PageFactory());
 
             // Act 2
             var result2 = cache.GetOrAdd(ViewPath, ThrowsIfCalled);
 
             // Assert 2
             Assert.True(result2.Success);
-            Assert.Same(typeof(TestView), result2.PageCreator().GetType());
+            Assert.IsType<TestView>(result2.PageFactory());
 
             // Act 3
             var result3 = cache.GetOrAdd(PrecompiledViewsPath, ThrowsIfCalled);
 
             // Assert 3
             Assert.True(result2.Success);
-            Assert.Same(typeof(PreCompile), result3.PageCreator().GetType());
+            Assert.IsType<PreCompile>(result3.PageFactory());
         }
 
         [Theory]
@@ -313,7 +316,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var result = cache.GetOrAdd(relativePath, ThrowsIfCalled);
 
             // Assert
-            Assert.Same(expected, result.PageCreator().GetType());
+            Assert.IsType<PreCompile>(result.PageFactory());
+            Assert.Same(viewPath, result.PageFactory().Path);
         }
 
         [Theory]
@@ -335,7 +339,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var result = cache.GetOrAdd("/Areas/Finances/Views/Home/Index.cshtml", ThrowsIfCalled);
 
             // Assert
-            Assert.Same(expected, result.PageCreator().GetType());
+            Assert.IsType<PreCompile>(result.PageFactory());
         }
 
         [Fact]
@@ -442,7 +446,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             // Assert
             var result1 = task1.Result;
             var result2 = task2.Result;
-            Assert.Same(result1.PageCreator().GetType(), result2.PageCreator().GetType());
+            Assert.Same(result1.PageFactory, result2.PageFactory);
         }
 
         [Fact]
@@ -481,7 +485,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var result = cache.GetOrAdd(ViewPath, _ => new CompilationResult(typeof(TestView)));
 
             // Assert - 2
-            Assert.Same(typeof(TestView), result.PageCreator().GetType());
+            Assert.IsType<TestView>(result.PageFactory());
         }
 
         [Fact]
@@ -509,16 +513,28 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             Assert.Same(compilationResult.CompilationFailures, ex.CompilationFailures);
         }
 
-        private class TestView
+        private class TestView : RazorPage
         {
+            public override Task ExecuteAsync()
+            {
+                throw new NotImplementedException();
+            }
         }
 
-        private class PreCompile
+        private class PreCompile : RazorPage
         {
+            public override Task ExecuteAsync()
+            {
+                throw new NotImplementedException();
+            }
         }
 
-        public class DifferentView
+        public class DifferentView : RazorPage
         {
+            public override Task ExecuteAsync()
+            {
+                throw new NotImplementedException();
+            }
         }
 
         private CompilationResult ThrowsIfCalled(RelativeFileInfo file)

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/CompilerCacheTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/CompilerCacheTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert
             Assert.True(result.Success);
-            Assert.Same(type, result.CompilationResult.CompiledType);
+            Assert.Same(type, result.PageCreator().GetType());
         }
 
         [Theory]
@@ -80,13 +80,13 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var result1 = cache.GetOrAdd(@"Areas\Finances\Views\Home\Index.cshtml", _ => expected);
 
             // Assert - 1
-            Assert.Same(type, result1.CompilationResult.CompiledType);
+            Assert.Same(type, result1.PageCreator().GetType());
 
             // Act - 2
             var result2 = cache.GetOrAdd(relativePath, ThrowsIfCalled);
 
             // Assert - 2
-            Assert.Same(type, result2.CompilationResult.CompiledType);
+            Assert.Same(type, result2.PageCreator().GetType());
         }
 
         [Fact]
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert 1
             Assert.True(result1.Success);
-            Assert.Same(expected.CompiledType, result1.CompilationResult.CompiledType);
+            Assert.Same(expected.CompiledType, result1.PageCreator().GetType());
 
             // Act 2
             // Delete the file from the file system and set it's expiration token.
@@ -131,7 +131,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert 1
             Assert.True(result1.Success);
-            Assert.Same(typeof(TestView), result1.CompilationResult.CompiledType);
+            Assert.Same(typeof(TestView), result1.PageCreator().GetType());
 
             // Act 2
             // Verify we're getting cached results.
@@ -139,7 +139,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert 2
             Assert.True(result2.Success);
-            Assert.Same(expected1.CompiledType, result2.CompilationResult.CompiledType);
+            Assert.Same(expected1.CompiledType, result2.PageCreator().GetType());
 
             // Act 3
             fileProvider.GetChangeToken(ViewPath).HasChanged = true;
@@ -147,7 +147,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert 3
             Assert.True(result3.Success);
-            Assert.Same(expected2.CompiledType, result3.CompilationResult.CompiledType);
+            Assert.Same(expected2.CompiledType, result3.PageCreator().GetType());
         }
 
         [Theory]
@@ -166,7 +166,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert 1
             Assert.True(result1.Success);
-            Assert.Same(expected1.CompiledType, result1.CompilationResult.CompiledType);
+            Assert.Same(expected1.CompiledType, result1.PageCreator().GetType());
 
             // Act 2
             // Verify we're getting cached results.
@@ -174,7 +174,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert 2
             Assert.True(result2.Success);
-            Assert.Same(expected1.CompiledType, result2.CompilationResult.CompiledType);
+            Assert.Same(expected1.CompiledType, result2.PageCreator().GetType());
 
             // Act 3
             fileProvider.GetChangeToken(globalImportPath).HasChanged = true;
@@ -182,7 +182,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert 2
             Assert.True(result3.Success);
-            Assert.Same(expected2.CompiledType, result3.CompilationResult.CompiledType);
+            Assert.Same(expected2.CompiledType, result3.PageCreator().GetType());
         }
 
         [Fact]
@@ -201,14 +201,14 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert 1
             Assert.True(result1.Success);
-            Assert.Same(type, result1.CompilationResult.CompiledType);
+            Assert.Same(type, result1.PageCreator().GetType());
 
             // Act 2
             var result2 = cache.GetOrAdd(ViewPath, ThrowsIfCalled);
 
             // Assert 2
             Assert.True(result2.Success);
-            Assert.Same(type, result2.CompilationResult.CompiledType);
+            Assert.Same(type, result2.PageCreator().GetType());
             mockFileProvider.Verify(v => v.GetFileInfo(ViewPath), Times.Once());
         }
 
@@ -224,7 +224,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert
             Assert.True(result.Success);
-            Assert.Same(typeof(PreCompile), result.CompilationResult.CompiledType);
+            Assert.Same(typeof(PreCompile), result.PageCreator().GetType());
         }
 
         [Fact]
@@ -241,7 +241,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert
             Assert.True(result.Success);
-            Assert.Same(typeof(PreCompile), result.CompilationResult.CompiledType);
+            Assert.Same(typeof(PreCompile), result.PageCreator().GetType());
         }
 
         [Theory]
@@ -259,7 +259,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             // Assert
             Assert.True(result.Success);
-            Assert.Same(typeof(PreCompile), result.CompilationResult.CompiledType);
+            Assert.Same(typeof(PreCompile), result.PageCreator().GetType());
         }
 
         [Fact]
@@ -275,21 +275,21 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var result1 = cache.GetOrAdd(ViewPath, _ => expected);
 
             // Assert 1
-            Assert.Same(typeof(TestView), result1.CompilationResult.CompiledType);
+            Assert.Same(typeof(TestView), result1.PageCreator().GetType());
 
             // Act 2
             var result2 = cache.GetOrAdd(ViewPath, ThrowsIfCalled);
 
             // Assert 2
             Assert.True(result2.Success);
-            Assert.Same(typeof(TestView), result2.CompilationResult.CompiledType);
+            Assert.Same(typeof(TestView), result2.PageCreator().GetType());
 
             // Act 3
             var result3 = cache.GetOrAdd(PrecompiledViewsPath, ThrowsIfCalled);
 
             // Assert 3
             Assert.True(result2.Success);
-            Assert.Same(typeof(PreCompile), result3.CompilationResult.CompiledType);
+            Assert.Same(typeof(PreCompile), result3.PageCreator().GetType());
         }
 
         [Theory]
@@ -313,7 +313,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var result = cache.GetOrAdd(relativePath, ThrowsIfCalled);
 
             // Assert
-            Assert.Same(expected, result.CompilationResult.CompiledType);
+            Assert.Same(expected, result.PageCreator().GetType());
         }
 
         [Theory]
@@ -335,7 +335,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var result = cache.GetOrAdd("/Areas/Finances/Views/Home/Index.cshtml", ThrowsIfCalled);
 
             // Assert
-            Assert.Same(expected, result.CompilationResult.CompiledType);
+            Assert.Same(expected, result.PageCreator().GetType());
         }
 
         [Fact]
@@ -442,7 +442,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             // Assert
             var result1 = task1.Result;
             var result2 = task2.Result;
-            Assert.Same(result1.CompilationResult.CompiledType, result2.CompilationResult.CompiledType);
+            Assert.Same(result1.PageCreator().GetType(), result2.PageCreator().GetType());
         }
 
         [Fact]
@@ -481,7 +481,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var result = cache.GetOrAdd(ViewPath, _ => new CompilationResult(typeof(TestView)));
 
             // Assert - 2
-            Assert.Same(typeof(TestView), result.CompilationResult.CompiledType);
+            Assert.Same(typeof(TestView), result.PageCreator().GetType());
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/CompilerCacheTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/CompilerCacheTest.cs
@@ -50,8 +50,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var fileProvider = new TestFileProvider();
             fileProvider.AddFile(ViewPath, "some content");
             var cache = new CompilerCache(fileProvider);
-            var type = typeof(TestView);
-            var expected = new CompilationResult(type);
+            var expected = new CompilationResult(typeof(TestView));
 
             // Act
             var result = cache.GetOrAdd(ViewPath, _ => expected);
@@ -74,8 +73,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var fileProvider = new TestFileProvider();
             fileProvider.AddFile(viewPath, "some content");
             var cache = new CompilerCache(fileProvider);
-            var type = typeof(TestView);
-            var expected = new CompilationResult(type);
+            var expected = new CompilationResult(typeof(TestView));
 
             // Act - 1
             var result1 = cache.GetOrAdd(@"Areas\Finances\Views\Home\Index.cshtml", _ => expected);
@@ -98,8 +96,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var fileProvider = new TestFileProvider();
             fileProvider.AddFile(ViewPath, "some content");
             var cache = new CompilerCache(fileProvider);
-            var type = typeof(TestView);
-            var expected = new CompilationResult(type);
+            var expected = new CompilationResult(typeof(TestView));
 
             // Act 1
             var result1 = cache.GetOrAdd(ViewPath, _ => expected);
@@ -195,8 +192,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var fileProvider = mockFileProvider.Object;
             fileProvider.AddFile(ViewPath, "some content");
             var cache = new CompilerCache(fileProvider);
-            var type = typeof(TestView);
-            var expected = new CompilationResult(type);
+            var expected = new CompilationResult(typeof(TestView));
 
             // Act 1
             var result1 = cache.GetOrAdd(ViewPath, _ => expected);

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/DefaultRazorPageFactoryProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/DefaultRazorPageFactoryProviderTest.cs
@@ -45,6 +45,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
         public void CreateFactory_ReturnsExpirationTokensFromCompilerCache_ForSuccessfulResults()
         {
             // Arrange
+            var relativePath = "/file-exists";
             var expirationTokens = new[]
             {
                 Mock.Of<IChangeToken>(),
@@ -53,7 +54,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var compilerCache = new Mock<ICompilerCache>();
             compilerCache
                 .Setup(f => f.GetOrAdd(It.IsAny<string>(), It.IsAny<Func<RelativeFileInfo, CompilationResult>>()))
-                .Returns(new CompilerCacheResult(new CompilationResult(typeof(object)), expirationTokens));
+                .Returns(new CompilerCacheResult(relativePath, new CompilationResult(typeof(TestRazorPage)), expirationTokens));
             var compilerCacheProvider = new Mock<ICompilerCacheProvider>();
             compilerCacheProvider
                 .SetupGet(c => c.Cache)
@@ -63,7 +64,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
                 compilerCacheProvider.Object);
 
             // Act
-            var result = factoryProvider.CreateFactory("/file-exists");
+            var result = factoryProvider.CreateFactory(relativePath);
 
             // Assert
             Assert.True(result.Success);
@@ -74,10 +75,11 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
         public void CreateFactory_ProducesDelegateThatSetsPagePath()
         {
             // Arrange
+            var relativePath = "/file-exists";
             var compilerCache = new Mock<ICompilerCache>();
             compilerCache
                 .Setup(f => f.GetOrAdd(It.IsAny<string>(), It.IsAny<Func<RelativeFileInfo, CompilationResult>>()))
-                .Returns(new CompilerCacheResult(new CompilationResult(typeof(TestRazorPage)), new IChangeToken[0]));
+                .Returns(new CompilerCacheResult(relativePath, new CompilationResult(typeof(TestRazorPage)), new IChangeToken[0]));
             var compilerCacheProvider = new Mock<ICompilerCacheProvider>();
             compilerCacheProvider
                 .SetupGet(c => c.Cache)
@@ -87,7 +89,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
                 compilerCacheProvider.Object);
 
             // Act
-            var result = factoryProvider.CreateFactory("/file-exists");
+            var result = factoryProvider.CreateFactory(relativePath);
 
             // Assert
             Assert.True(result.Success);


### PR DESCRIPTION
Fixes #4470

Isolated changes corresponding to RazorPageFactoryProvider from #4524 for simplicity. For more details please refer to #4524 

Scenario: https://github.com/aspnet/Performance/tree/dev/testapp/HelloWorldMvc

Before Optimization
--------------------------
![image](https://cloud.githubusercontent.com/assets/8011073/14792823/fbbc40d0-0ad0-11e6-92e8-57c6146fe87c.png)

After Optimization
----------------------
![image](https://cloud.githubusercontent.com/assets/8011073/14793013/e9d08fa6-0ad1-11e6-8339-11039f7f4a92.png)
