### PR TITLE
Quick fix: Simplify `OrderUsingHtmlHelpers.cshtml` layout

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.OrderUsingHtmlHelpers.Encoded.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.OrderUsingHtmlHelpers.Encoded.html
@@ -4,7 +4,8 @@
     <title></title>
 </head>
 <body>
-<form action="HtmlEncode[[/UrlEncode[[HtmlGeneration_Order]]/UrlEncode[[Submit]]]]" method="HtmlEncode[[post]]">        <div>
+<form action="HtmlEncode[[/UrlEncode[[HtmlGeneration_Order]]/UrlEncode[[Submit]]]]" method="HtmlEncode[[post]]">
+        <div>
             <label class="HtmlEncode[[order]]" for="HtmlEncode[[Shipping]]">HtmlEncode[[Shipping]]</label>
             <input id="HtmlEncode[[Shipping]]" name="HtmlEncode[[Shipping]]" size="HtmlEncode[[50]]" type="HtmlEncode[[text]]" value="HtmlEncode[[Your shipping method is UPSP]]" />
         </div>
@@ -74,6 +75,8 @@
         </div>
         <div class="HtmlEncode[[validation-summary-valid order]]" data-valmsg-summary="HtmlEncode[[true]]"><ul><li style="display:none"></li>
 </ul></div>
-        <input id="HtmlEncode[[Customer_Key]]" name="HtmlEncode[[Customer.Key]]" type="HtmlEncode[[hidden]]" value="HtmlEncode[[KeyA]]" />        <input type="submit"/>
-    <input name="HtmlEncode[[__RequestVerificationToken]]" type="hidden" value="{0}" /><input name="HtmlEncode[[NeedSpecialHandle]]" type="HtmlEncode[[hidden]]" value="HtmlEncode[[false]]" /></form></body>
+        <input id="HtmlEncode[[Customer_Key]]" name="HtmlEncode[[Customer.Key]]" type="HtmlEncode[[hidden]]" value="HtmlEncode[[KeyA]]" />
+        <input type="submit"/>
+    <input name="HtmlEncode[[__RequestVerificationToken]]" type="hidden" value="{0}" /><input name="HtmlEncode[[NeedSpecialHandle]]" type="HtmlEncode[[hidden]]" value="HtmlEncode[[false]]" /></form>
+</body>
 </html>

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.OrderUsingHtmlHelpers.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.OrderUsingHtmlHelpers.html
@@ -4,7 +4,8 @@
     <title></title>
 </head>
 <body>
-<form action="/HtmlGeneration_Order/Submit" method="post">        <div>
+<form action="/HtmlGeneration_Order/Submit" method="post">
+        <div>
             <label class="order" for="Shipping">Shipping</label>
             <input id="Shipping" name="Shipping" size="50" type="text" value="Your shipping method is UPSP" />
         </div>
@@ -74,6 +75,8 @@
         </div>
         <div class="validation-summary-valid order" data-valmsg-summary="true"><ul><li style="display:none"></li>
 </ul></div>
-        <input id="Customer_Key" name="Customer.Key" type="hidden" value="KeyA" />        <input type="submit"/>
-    <input name="__RequestVerificationToken" type="hidden" value="{0}" /><input name="NeedSpecialHandle" type="hidden" value="false" /></form></body>
+        <input id="Customer_Key" name="Customer.Key" type="hidden" value="KeyA" />
+        <input type="submit"/>
+    <input name="__RequestVerificationToken" type="hidden" value="{0}" /><input name="NeedSpecialHandle" type="hidden" value="false" /></form>
+</body>
 </html>

--- a/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/OrderUsingHtmlHelpers.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/OrderUsingHtmlHelpers.cshtml
@@ -11,9 +11,9 @@
     <title></title>
 </head>
 <body>
-    @* Use comments and <text/> elements to force whitespace in generated HTML. *@@using (
-Html.BeginForm(actionName: "Submit", controllerName: "HtmlGeneration_Order"))
-    {<text></text>
+    @* Use <text/> element to force whitespace in generated HTML. *@
+    @using (Html.BeginForm(actionName: "Submit", controllerName: "HtmlGeneration_Order"))
+    {<text>
         <div>
             @Html.LabelFor(m => m.Shipping, htmlAttributes: new { @class = "order" })
             @Html.TextBoxFor(m => m.Shipping, format: "Your shipping method is {0}", htmlAttributes: new { size = "50" })
@@ -74,11 +74,11 @@ Html.BeginForm(actionName: "Submit", controllerName: "HtmlGeneration_Order"))
             @Html.LabelFor(m => m.Customer.Gender, htmlAttributes: new { @class = "order" })
             @Html.EditorFor(model => model.Customer.Gender, templateName: "GenderUsingHtmlHelpers")
             @Html.ValidationMessageFor(m => m.Customer.Gender)
-        </div><text>
-        </text>@Html.ValidationSummary(message: null, htmlAttributes: new { @class = "order" })<text>
-        </text>@Html.HiddenFor(m => m.Customer.Key)<text></text>
-        <input type="submit"/><text>
-    </text>@Html.AntiForgeryToken();
-    }@**@
+        </div>
+        @Html.ValidationSummary(message: null, htmlAttributes: new { @class = "order" })
+        @Html.HiddenFor(m => m.Customer.Key)
+        <input type="submit"/>
+    </text>}
+
 </body>
 </html>


### PR DESCRIPTION
- intent was to make HTML helper output close to the tag helper output but it got over-complicated
- the output files for `Order.cshtml` and `OrderUsingHtmlHelpers.cshtml` now differ only in attribute order
 - i.e. HTML helpers output attribute alphabetically while tag helpers output them in order added