### PR TITLE
Change our cached task to a field

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/TaskCache.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/TaskCache.cs
@@ -7,23 +7,18 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 {
     public static class TaskCache
     {
-#if NET451
-        static readonly Task _completedTask = Task.FromResult(0);
-#endif
 
-        /// <summary>Gets a task that's already been completed successfully.</summary>
-        /// <remarks>May not always return the same instance.</remarks>        
-        public static Task CompletedTask
-        {
-            get
-            {
+        /// <summary>
+        /// A <see cref="Task"/> that's already completed successfully.
+        /// </summary>
+        /// <remarks>
+        /// We're caching this in a static readonly field to avoid the volatile lookup done
+        /// by <c>Task.CompletedTask</c>
+        /// </remarks>
 #if NET451
-                return _completedTask;
+        public static readonly Task CompletedTask = Task.FromResult(0);
 #else
-                return Task.CompletedTask;
+        public static readonly Task CompletedTask = Task.CompletedTask;
 #endif
-            }
-        }
     }
-
 }


### PR DESCRIPTION
This makes it more inlinable and saves a volatile lookup on netstandard.