### PR TITLE
[Perf]  Fast Generate Url for specific cases to avoid string allocations

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Routing/UrlHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Routing/UrlHelper.cs
@@ -223,7 +223,7 @@ namespace Microsoft.AspNetCore.Mvc.Routing
         /// <param name="pathData">The <see cref="VirtualPathData"/>.</param>
         /// <param name="fragment">The URL fragment.</param>
         /// <returns>The generated URL.</returns>
-        internal virtual string GenerateUrl(string protocol, string host, VirtualPathData pathData, string fragment)
+        protected virtual string GenerateUrl(string protocol, string host, VirtualPathData pathData, string fragment)
         {
             if (pathData == null)
             {
@@ -294,14 +294,16 @@ namespace Microsoft.AspNetCore.Mvc.Routing
                 if (pathData.VirtualPath.Length == 0)
                 {
                     url = "/";
+                    return true;
                 }
                 else if (pathData.VirtualPath.StartsWith("/", StringComparison.Ordinal))
                 {
                     url = pathData.VirtualPath;
+                    return true;
                 }
             }
 
-            return (url != null);
+            return false;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Routing/UrlHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Routing/UrlHelper.cs
@@ -223,7 +223,7 @@ namespace Microsoft.AspNetCore.Mvc.Routing
         /// <param name="pathData">The <see cref="VirtualPathData"/>.</param>
         /// <param name="fragment">The URL fragment.</param>
         /// <returns>The generated URL.</returns>
-        protected virtual string GenerateUrl(string protocol, string host, VirtualPathData pathData, string fragment)
+        internal virtual string GenerateUrl(string protocol, string host, VirtualPathData pathData, string fragment)
         {
             if (pathData == null)
             {
@@ -232,6 +232,15 @@ namespace Microsoft.AspNetCore.Mvc.Routing
 
             // VirtualPathData.VirtualPath returns string.Empty instead of null.
             Debug.Assert(pathData.VirtualPath != null);
+
+            // Perf: In most of the common cases, GenerateUrl is called with a null protocol, host and fragment. 
+            // In such cases, we might not need to build any URL as the url generated is mostly same as the virtual path available in pathData.
+            // For such common cases, this FastGenerateUrl method saves a string allocation per GenerateUrl call.
+            string url;
+            if (TryFastGenerateUrl(protocol, host, pathData, fragment, out url))
+            {
+                return url;
+            }
 
             var builder = GetStringBuilder();
             try
@@ -265,6 +274,34 @@ namespace Microsoft.AspNetCore.Mvc.Routing
                 // Clear the StringBuilder so that it can reused for the next call.
                 builder.Clear();
             }
+        }
+
+        private bool TryFastGenerateUrl(
+            string protocol, 
+            string host, 
+            VirtualPathData pathData, 
+            string fragment,
+            out string url)
+        {
+            var pathBase = HttpContext.Request.PathBase;
+            url = null;
+
+            if (string.IsNullOrEmpty(protocol) 
+                && string.IsNullOrEmpty(host) 
+                && string.IsNullOrEmpty(fragment)
+                && !pathBase.HasValue)
+            {
+                if (pathData.VirtualPath.Length == 0)
+                {
+                    url = "/";
+                }
+                else if (pathData.VirtualPath.StartsWith("/", StringComparison.Ordinal))
+                {
+                    url = pathData.VirtualPath;
+                }
+            }
+
+            return (url != null);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Routing/UrlHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Routing/UrlHelperTest.cs
@@ -943,6 +943,7 @@ namespace Microsoft.AspNetCore.Mvc.Routing
         [InlineData(null, null, null, "/", null, "/")]
         [InlineData(null, null, null, "/", null, "/")]
         [InlineData(null, null, null, "/Hello", null, "/Hello" )]
+        [InlineData(null, null, null, "Hello", null, "/Hello")]
         [InlineData(null, null, null, "/Hello", null, "/Hello")]
         [InlineData("/", null, null, "", null, "/")]
         [InlineData("/hello/", null, null, "/world", null, "/hello/world")]
@@ -1033,13 +1034,13 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             return new UrlHelper(actionContext);
         }
 
-        private static UrlHelper CreateUrlHelper(string appBase, IRouter router)
+        private static TestUrlHelper CreateUrlHelper(string appBase, IRouter router)
         {
             var services = CreateServices();
             var context = CreateHttpContext(services, appBase);
             var actionContext = CreateActionContext(context, router);
 
-            return new UrlHelper(actionContext);
+            return new TestUrlHelper(actionContext);
         }
 
         private static UrlHelper CreateUrlHelperWithRouteCollection(
@@ -1124,6 +1125,23 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             {
                 context.Handler = (c) => Task.FromResult(0);
                 return Task.FromResult(false);
+            }
+        }
+
+        private class TestUrlHelper : UrlHelper
+        {
+            public TestUrlHelper(ActionContext actionContext) :
+                base(actionContext)
+            {
+
+            }
+            public new string GenerateUrl(string protocol, string host, VirtualPathData pathData, string fragment)
+            {
+                return base.GenerateUrl(
+                    protocol,
+                    host,
+                    pathData,
+                    fragment);
             }
         }
     }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Routing/UrlHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Routing/UrlHelperTest.cs
@@ -939,6 +939,37 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             Assert.Equal(expected, builder.ToString());
         }
 
+        [Theory]
+        [InlineData(null, null, null, "/", null, "/")]
+        [InlineData(null, null, null, "/", null, "/")]
+        [InlineData(null, null, null, "/Hello", null, "/Hello" )]
+        [InlineData(null, null, null, "/Hello", null, "/Hello")]
+        [InlineData("/", null, null, "", null, "/")]
+        [InlineData("/hello/", null, null, "/world", null, "/hello/world")]
+        [InlineData("/hello/", "https", "myhost", "/world", "fragment-value", "https://myhost/hello/world#fragment-value")]
+        public void GenerateUrl_FastAndSlowPathsReturnsExpected(
+            string appBase,
+            string protocol,
+            string host,
+            string virtualPath,
+            string fragment,
+            string expected)
+        {
+            // Arrage
+            var router = Mock.Of<IRouter>();
+            var pathData = new VirtualPathData(router, virtualPath)
+            {
+                VirtualPath = virtualPath
+            };
+            var urlHelper = CreateUrlHelper(appBase, router);
+
+            // Act
+            var url = urlHelper.GenerateUrl(protocol, host, pathData, fragment);
+
+            // Assert
+            Assert.Equal(expected, url);
+        }
+
         private static HttpContext CreateHttpContext(
             IServiceProvider services,
             string appRoot)


### PR DESCRIPTION
Reference Issue #4593 

loadtest with 3000 requests for the home page of the MusicStore app. 

Before 
--------
![image](https://cloud.githubusercontent.com/assets/8011073/15256452/5d1f3714-18f6-11e6-86ae-f9010beaf03a.png)

After
------
![image](https://cloud.githubusercontent.com/assets/8011073/15256470/7e73eb8a-18f6-11e6-8fb4-55ff62d770bc.png)

Total savings 1.18% savings in total bytes allocated. 
Saves 22 string allocations per request to the Home page. 
