### PR TITLE
Fixed null reference on ModelStateDictionary.ChildNodes when calling Clear

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelStateDictionary.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelStateDictionary.cs
@@ -633,7 +633,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             HasRecordedMaxModelError = false;
             ErrorCount = 0;
             _root.Reset();
-            _root.ChildNodes.Clear();
+            _root.ChildNodes?.Clear();
         }
 
         /// <inheritdoc />

--- a/test/Microsoft.AspNetCore.Mvc.Abstractions.Test/ModelBinding/ModelStateDictionaryTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Abstractions.Test/ModelBinding/ModelStateDictionaryTest.cs
@@ -126,6 +126,22 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         }
 
         [Fact]
+        public void Clear_RemovesAllEntries_IfDictionaryIsEmpty()
+        {
+            // Arrange
+            var dictionary = new ModelStateDictionary();
+
+            // Act
+            dictionary.Clear();
+
+            // Assert
+            Assert.Equal(0, dictionary.Count);
+            Assert.Equal(0, dictionary.ErrorCount);
+            Assert.Empty(dictionary);
+        	Assert.Equal(ModelValidationState.Valid, dictionary.ValidationState);
+        }
+
+        [Fact]
         public void MarkFieldSkipped_MarksFieldAsSkipped_IfStateIsUnvalidated()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.Abstractions.Test/ModelBinding/ModelStateDictionaryTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Abstractions.Test/ModelBinding/ModelStateDictionaryTest.cs
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             Assert.Equal(0, dictionary.Count);
             Assert.Equal(0, dictionary.ErrorCount);
             Assert.Empty(dictionary);
-        	Assert.Equal(ModelValidationState.Valid, dictionary.ValidationState);
+            Assert.Equal(ModelValidationState.Valid, dictionary.ValidationState);
         }
 
         [Fact]


### PR DESCRIPTION
Clearing an empty ModelStateDictionary results in a null reference exception
- Added a null check on ModelStateDictionary.ChildNodes before calling Clear
- Added a unit test to test clearing an empty ModelStateDictionary