### PR TITLE
[Fixes #4655] Make comparisons in DefaultAssemblyPartDiscoveryProvider case insensitive

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/DefaultAssemblyPartDiscoveryProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/DefaultAssemblyPartDiscoveryProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
     // Discovers assemblies that are part of the MVC application using the DependencyContext.
     public static class DefaultAssemblyPartDiscoveryProvider
     {
-        internal static HashSet<string> ReferenceAssemblies { get; } = new HashSet<string>(StringComparer.Ordinal)
+        internal static HashSet<string> ReferenceAssemblies { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "Microsoft.AspNetCore.Mvc",
             "Microsoft.AspNetCore.Mvc.Abstractions",
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             public CandidateResolver(IReadOnlyList<RuntimeLibrary> dependencies, ISet<string> referenceAssemblies)
             {
                 _dependencies = dependencies
-                    .ToDictionary(d => d.Name, d => CreateDependency(d, referenceAssemblies));
+                    .ToDictionary(d => d.Name, d => CreateDependency(d, referenceAssemblies), StringComparer.OrdinalIgnoreCase);
             }
 
             private Dependency CreateDependency(RuntimeLibrary library, ISet<string> referenceAssemblies)

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/DefaultAssemblyPartDiscoveryProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/DefaultAssemblyPartDiscoveryProviderTest.cs
@@ -80,6 +80,37 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         [Fact]
+        public void GetCandidateLibraries_LibraryNameComparisonsAreCaseInsensitive()
+        {
+            // Arrange
+            var dependencyContext = new DependencyContext(
+                new TargetInfo("framework", "runtime", "signature", isPortable: true),
+                CompilationOptions.Default,
+                new CompilationLibrary[0],
+                new[]
+                {
+                     GetLibrary("Foo", "MICROSOFT.ASPNETCORE.MVC.CORE"),
+                     GetLibrary("Bar", "microsoft.aspnetcore.mvc"),
+                     GetLibrary("Qux", "Not.Mvc.Assembly", "Unofficial.Microsoft.AspNetCore.Mvc"),
+                     GetLibrary("Baz", "mIcRoSoFt.AsPnEtCoRe.MvC.aBsTrAcTiOnS"),
+                     GetLibrary("Microsoft.AspNetCore.Mvc.Core"),
+                     GetLibrary("LibraryA", "LIBRARYB"),
+                     GetLibrary("LibraryB", "microsoft.aspnetcore.mvc"),
+                     GetLibrary("Microsoft.AspNetCore.Mvc"),
+                     GetLibrary("Not.Mvc.Assembly"),
+                     GetLibrary("Unofficial.Microsoft.AspNetCore.Mvc"),
+                     GetLibrary("Microsoft.AspNetCore.Mvc.Abstractions"),
+                },
+                Enumerable.Empty<RuntimeFallbacks>());
+
+            // Act
+            var candidates = DefaultAssemblyPartDiscoveryProvider.GetCandidateLibraries(dependencyContext);
+
+            // Assert
+            Assert.Equal(new[] { "Foo", "Bar", "Baz", "LibraryA", "LibraryB" }, candidates.Select(a => a.Name));
+        }
+
+        [Fact]
         public void GetCandidateLibraries_ReturnsLibrariesWithTransitiveReferencesToAnyMvcAssembly()
         {
             // Arrange


### PR DESCRIPTION
project.lock.json and .deps.json file use the casing on the users project.json file which causes problems when we discover the default list of application parts. This fix relaxes our criteria for comparing library names so that we don't fail because of the casing used in project.json or a change in the casing of the library name between versions.