### PR TITLE
[Fixes #4633] Datetime? and DateTimeOffset? values on InputTagHelper are not rendered correctly

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/DefaultAssemblyPartDiscoveryProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/DefaultAssemblyPartDiscoveryProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
     // Discovers assemblies that are part of the MVC application using the DependencyContext.
     public static class DefaultAssemblyPartDiscoveryProvider
     {
-        internal static HashSet<string> ReferenceAssemblies { get; } = new HashSet<string>(StringComparer.Ordinal)
+        internal static HashSet<string> ReferenceAssemblies { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "Microsoft.AspNetCore.Mvc",
             "Microsoft.AspNetCore.Mvc.Abstractions",
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             public CandidateResolver(IReadOnlyList<RuntimeLibrary> dependencies, ISet<string> referenceAssemblies)
             {
                 _dependencies = dependencies
-                    .ToDictionary(d => d.Name, d => CreateDependency(d, referenceAssemblies));
+                    .ToDictionary(d => d.Name, d => CreateDependency(d, referenceAssemblies), StringComparer.OrdinalIgnoreCase);
             }
 
             private Dependency CreateDependency(RuntimeLibrary library, ISet<string> referenceAssemblies)

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/InputTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/InputTagHelper.cs
@@ -356,7 +356,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             else if (_rfc3339Formats.TryGetValue(inputType, out rfc3339Format) &&
                 ViewContext.Html5DateRenderingMode == Html5DateRenderingMode.Rfc3339 &&
                 !modelExplorer.Metadata.HasNonDefaultEditFormat &&
-                (typeof(DateTime) == modelExplorer.ModelType || typeof(DateTimeOffset) == modelExplorer.ModelType))
+                (typeof(DateTime) == modelExplorer.Metadata.UnderlyingOrModelType || typeof(DateTimeOffset) == modelExplorer.Metadata.UnderlyingOrModelType))
             {
                 // Rfc3339 mode _may_ override EditFormatString in a limited number of cases e.g. EditFormatString
                 // must be a default format (i.e. came from a built-in [DataType] attribute).

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/DefaultAssemblyPartDiscoveryProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/DefaultAssemblyPartDiscoveryProviderTest.cs
@@ -63,6 +63,12 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                      GetLibrary("Bar", "Microsoft.AspNetCore.Mvc"),
                      GetLibrary("Qux", "Not.Mvc.Assembly", "Unofficial.Microsoft.AspNetCore.Mvc"),
                      GetLibrary("Baz", "Microsoft.AspNetCore.Mvc.Abstractions"),
+                     GetLibrary("Microsoft.AspNetCore.Mvc.Core"),
+                     GetLibrary("Microsoft.AspNetCore.Mvc"),
+                     GetLibrary("Not.Mvc.Assembly"),
+                     GetLibrary("Unofficial.Microsoft.AspNetCore.Mvc"),
+                     GetLibrary("Microsoft.AspNetCore.Mvc.Abstractions"),
+
                 },
                 Enumerable.Empty<RuntimeFallbacks>());
 
@@ -71,6 +77,45 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
             // Assert
             Assert.Equal(new[] { "Foo", "Bar", "Baz" }, candidates.Select(a => a.Name));
+        }
+
+        [Fact]
+        public void GetCandidateLibraries_ReturnsLibrariesWithTransitiveReferencesToAnyMvcAssembly()
+        {
+            // Arrange
+            var expectedLibraries = new[] { "Foo", "Bar", "Baz", "LibraryA", "LibraryB", "LibraryC", "LibraryE", "LibraryG", "LibraryH" };
+
+            var dependencyContext = new DependencyContext(
+                new TargetInfo("framework", "runtime", "signature", isPortable: true),
+                CompilationOptions.Default,
+                new CompilationLibrary[0],
+                new[]
+                {
+                     GetLibrary("Foo", "Bar"),
+                     GetLibrary("Bar", "Microsoft.AspNetCore.Mvc"),
+                     GetLibrary("Qux", "Not.Mvc.Assembly", "Unofficial.Microsoft.AspNetCore.Mvc"),
+                     GetLibrary("Baz", "Microsoft.AspNetCore.Mvc.Abstractions"),
+                     GetLibrary("Microsoft.AspNetCore.Mvc"),
+                     GetLibrary("Not.Mvc.Assembly"),
+                     GetLibrary("Microsoft.AspNetCore.Mvc.Abstractions"),
+                     GetLibrary("Unofficial.Microsoft.AspNetCore.Mvc"),
+                     GetLibrary("LibraryA", "LibraryB"),
+                     GetLibrary("LibraryB","LibraryC"),
+                     GetLibrary("LibraryC", "LibraryD", "Microsoft.AspNetCore.Mvc.Abstractions"),
+                     GetLibrary("LibraryD"),
+                     GetLibrary("LibraryE","LibraryF","LibraryG"),
+                     GetLibrary("LibraryF"),
+                     GetLibrary("LibraryG", "LibraryH"),
+                     GetLibrary("LibraryH", "LibraryI", "Microsoft.AspNetCore.Mvc"),
+                     GetLibrary("LibraryI")
+                },
+                Enumerable.Empty<RuntimeFallbacks>());
+
+            // Act
+            var candidates = DefaultAssemblyPartDiscoveryProvider.GetCandidateLibraries(dependencyContext);
+
+            // Assert
+            Assert.Equal(expectedLibraries, candidates.Select(a => a.Name));
         }
 
         [Fact]
@@ -84,11 +129,13 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 new[]
                 {
                      GetLibrary("MvcSandbox", "Microsoft.AspNetCore.Mvc.Core", "Microsoft.AspNetCore.Mvc"),
-                     GetLibrary("Microsoft.AspNetCore.Mvc.TagHelpers", "Microsoft.AspNetCore.Mvc.Razor"),
-                     GetLibrary("Microsoft.AspNetCore.Mvc", "Microsoft.AspNetCore.Mvc.Abstractions", "Microsoft.AspNetCore.Mvc.Core"),
                      GetLibrary("Microsoft.AspNetCore.Mvc.Core", "Microsoft.AspNetCore.HttpAbstractions"),
+                     GetLibrary("Microsoft.AspNetCore.HttpAbstractions"),
+                     GetLibrary("Microsoft.AspNetCore.Mvc", "Microsoft.AspNetCore.Mvc.Abstractions", "Microsoft.AspNetCore.Mvc.Core"),
+                     GetLibrary("Microsoft.AspNetCore.Mvc.Abstractions"),
+                     GetLibrary("Microsoft.AspNetCore.Mvc.TagHelpers", "Microsoft.AspNetCore.Mvc.Razor"),
+                     GetLibrary("Microsoft.AspNetCore.Mvc.Razor"),
                      GetLibrary("ControllersAssembly", "Microsoft.AspNetCore.Mvc"),
-
                 },
                 Enumerable.Empty<RuntimeFallbacks>());
 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/DefaultAssemblyPartDiscoveryProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/DefaultAssemblyPartDiscoveryProviderTest.cs
@@ -80,6 +80,37 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         [Fact]
+        public void GetCandidateLibraries_LibraryNameComparisonsAreCaseInsensitive()
+        {
+            // Arrange
+            var dependencyContext = new DependencyContext(
+                new TargetInfo("framework", "runtime", "signature", isPortable: true),
+                CompilationOptions.Default,
+                new CompilationLibrary[0],
+                new[]
+                {
+                     GetLibrary("Foo", "MICROSOFT.ASPNETCORE.MVC.CORE"),
+                     GetLibrary("Bar", "microsoft.aspnetcore.mvc"),
+                     GetLibrary("Qux", "Not.Mvc.Assembly", "Unofficial.Microsoft.AspNetCore.Mvc"),
+                     GetLibrary("Baz", "mIcRoSoFt.AsPnEtCoRe.MvC.aBsTrAcTiOnS"),
+                     GetLibrary("Microsoft.AspNetCore.Mvc.Core"),
+                     GetLibrary("LibraryA", "LIBRARYB"),
+                     GetLibrary("LibraryB", "microsoft.aspnetcore.mvc"),
+                     GetLibrary("Microsoft.AspNetCore.Mvc"),
+                     GetLibrary("Not.Mvc.Assembly"),
+                     GetLibrary("Unofficial.Microsoft.AspNetCore.Mvc"),
+                     GetLibrary("Microsoft.AspNetCore.Mvc.Abstractions"),
+                },
+                Enumerable.Empty<RuntimeFallbacks>());
+
+            // Act
+            var candidates = DefaultAssemblyPartDiscoveryProvider.GetCandidateLibraries(dependencyContext);
+
+            // Assert
+            Assert.Equal(new[] { "Foo", "Bar", "Baz", "LibraryA", "LibraryB" }, candidates.Select(a => a.Name));
+        }
+
+        [Fact]
         public void GetCandidateLibraries_ReturnsLibrariesWithTransitiveReferencesToAnyMvcAssembly()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/InputTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/InputTagHelperTest.cs
@@ -854,6 +854,9 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         [InlineData("DateTimeLocal", Html5DateRenderingMode.Rfc3339, "{0:yyyy-MM-ddTHH:mm:ss.fff}", "datetime-local")]
         [InlineData("Time", Html5DateRenderingMode.CurrentCulture, "{0:t}", "time")]    // Format from [DataType].
         [InlineData("Time", Html5DateRenderingMode.Rfc3339, "{0:HH:mm:ss.fff}", "time")]
+        [InlineData("NullableDate", Html5DateRenderingMode.Rfc3339, "{0:yyyy-MM-dd}", "date")]
+        [InlineData("NullableDateTime", Html5DateRenderingMode.Rfc3339, "{0:yyyy-MM-ddTHH:mm:ss.fffK}", "datetime")]
+        [InlineData("NullableDateTimeOffset", Html5DateRenderingMode.Rfc3339, "{0:yyyy-MM-ddTHH:mm:ss.fffK}", "datetime")]
         public async Task ProcessAsync_CallsGenerateTextBox_AddsExpectedAttributesForRfc3339(
             string propertyName,
             Html5DateRenderingMode dateRenderingMode,
@@ -995,6 +998,13 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             public DateTime DateTime { get; set; }
 
             public DateTimeOffset DateTimeOffset { get; set; }
+
+            [DataType(DataType.Date)]
+            public DateTime? NullableDate { get; set; }
+
+            public DateTime? NullableDateTime { get; set; }
+
+            public DateTimeOffset? NullableDateTimeOffset { get; set; }
 
             [DataType("datetime-local")]
             public DateTime DateTimeLocal { get; set; }


### PR DESCRIPTION
We weren't handling nullable types correctly, this fix uses modelExplorer.Metadata.UnderlyingOrModelType which returns the underlying type 'T' for Nullable<T> types or the type 'T' directly otherwise.