### PR TITLE
Remove Key from ModelBindingResult

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelBindingResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelBindingResult.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding
@@ -15,39 +14,24 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         /// <summary>
         /// Creates a <see cref="ModelBindingResult"/> representing a failed model binding operation.
         /// </summary>
-        /// <param name="key">The key of the current model binding operation.</param>
         /// <returns>A <see cref="ModelBindingResult"/> representing a failed model binding operation.</returns>
-        public static ModelBindingResult Failed(string key)
+        public static ModelBindingResult Failed()
         {
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-
-            return new ModelBindingResult(key, model: null, isModelSet: false);
+            return new ModelBindingResult(model: null, isModelSet: false);
         }
         
         /// <summary>
         /// Creates a <see cref="ModelBindingResult"/> representing a successful model binding operation.
         /// </summary>
-        /// <param name="key">The key of the current model binding operation.</param>
         /// <param name="model">The model value. May be <c>null.</c></param>
         /// <returns>A <see cref="ModelBindingResult"/> representing a successful model bind.</returns>
-        public static ModelBindingResult Success(
-            string key,
-            object model)
+        public static ModelBindingResult Success(object model)
         {
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-
-            return new ModelBindingResult(key, model, isModelSet: true);
+            return new ModelBindingResult( model, isModelSet: true);
         }
 
-        private ModelBindingResult(string key, object model, bool isModelSet)
+        private ModelBindingResult(object model, bool isModelSet)
         {
-            Key = key;
             Model = model;
             IsModelSet = isModelSet;
         }
@@ -56,16 +40,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         /// Gets the model associated with this context.
         /// </summary>
         public object Model { get; }
-
-        /// <summary>
-        /// <para>
-        /// Gets the model name which was used to bind the model.
-        /// </para>
-        /// <para>
-        /// This property can be used during validation to add model state for a bound model.
-        /// </para>
-        /// </summary>
-        public string Key { get; }
 
         /// <summary>
         /// <para>
@@ -96,7 +70,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         public override int GetHashCode()
         {
             var hashCodeCombiner = HashCodeCombiner.Start();
-            hashCodeCombiner.Add(Key, StringComparer.OrdinalIgnoreCase);
             hashCodeCombiner.Add(IsModelSet);
             hashCodeCombiner.Add(Model);
 
@@ -107,7 +80,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         public bool Equals(ModelBindingResult other)
         {
             return
-                string.Equals(Key, other.Key, StringComparison.OrdinalIgnoreCase) &&
                 IsModelSet == other.IsModelSet &&
                 object.Equals(Model, other.Model);
         }
@@ -115,17 +87,13 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         /// <inheritdoc />
         public override string ToString()
         {
-            if (Key == null)
+            if (IsModelSet)
             {
-                return "No Result";
-            }
-            else if (IsModelSet)
-            {
-                return $"Success {Key} -> '{Model}'";
+                return $"Success '{Model}'";
             }
             else
             {
-                return $"Failed {Key}";
+                return $"Failed";
             }
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerArgumentBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerArgumentBinder.cs
@@ -194,7 +194,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 _validator.Validate(
                     controllerContext,
                     modelBindingContext.ValidationState,
-                    modelBindingResult.Value.Key,
+                    modelBindingContext.ModelName,
                     modelBindingResult.Value.Model);
             }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/DefaultModelBindingContext.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/DefaultModelBindingContext.cs
@@ -185,11 +185,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             }
             set
             {
-                if (value.HasValue && value.Value == default(ModelBindingResult))
-                {
-                    throw new ArgumentException(nameof(ModelBindingResult));
-                }
-
                 _state.Result = value;
             }
         }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/NoOpBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/NoOpBinder.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
         public Task BindModelAsync(ModelBindingContext bindingContext)
         {
-            bindingContext.Result = ModelBindingResult.Failed(bindingContext.ModelName);
+            bindingContext.Result = ModelBindingResult.Failed();
             return TaskCache.CompletedTask;
         }
     }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/BinderTypeModelBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/BinderTypeModelBinder.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
 
             if (bindingContext.Result == null)
             {
-                bindingContext.Result = ModelBindingResult.Failed(bindingContext.ModelName);
+                bindingContext.Result = ModelBindingResult.Failed();
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/BodyModelBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/BodyModelBinder.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 // This model binder is the only handler for the Body binding source and it cannot run twice. Always
                 // tell the model binding system to skip other model binders and never to fall back i.e. indicate a
                 // fatal error.
-                bindingContext.Result = ModelBindingResult.Failed(modelBindingKey);
+                bindingContext.Result = ModelBindingResult.Failed();
                 return;
             }
 
@@ -109,11 +109,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 {
                     // Formatter encountered an error. Do not use the model it returned. As above, tell the model
                     // binding system to skip other model binders and never to fall back.
-                    bindingContext.Result = ModelBindingResult.Failed(modelBindingKey);
+                    bindingContext.Result = ModelBindingResult.Failed();
                     return;
                 }
 
-                bindingContext.Result = ModelBindingResult.Success(modelBindingKey, model);
+                bindingContext.Result = ModelBindingResult.Success(model);
                 return;
             }
             catch (Exception ex)
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 // This model binder is the only handler for the Body binding source and it cannot run twice. Always
                 // tell the model binding system to skip other model binders and never to fall back i.e. indicate a
                 // fatal error.
-                bindingContext.Result = ModelBindingResult.Failed(modelBindingKey);
+                bindingContext.Result = ModelBindingResult.Failed();
                 return;
             }
         }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/ByteArrayModelBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/ByteArrayModelBinder.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var valueProviderResult = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);
             if (valueProviderResult == ValueProviderResult.None)
             {
-                bindingContext.Result = ModelBindingResult.Failed(bindingContext.ModelName);
+                bindingContext.Result = ModelBindingResult.Failed();
                 return TaskCache.CompletedTask;
             }
 
@@ -34,14 +34,14 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var value = valueProviderResult.FirstValue;
             if (string.IsNullOrEmpty(value))
             {
-                bindingContext.Result = ModelBindingResult.Failed(bindingContext.ModelName);
+                bindingContext.Result = ModelBindingResult.Failed();
                 return TaskCache.CompletedTask;
             }
 
             try
             {
                 var model = Convert.FromBase64String(value);
-                bindingContext.Result = ModelBindingResult.Success(bindingContext.ModelName, model);
+                bindingContext.Result = ModelBindingResult.Success(model);
                 return TaskCache.CompletedTask;
             }
             catch (Exception exception)
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
 
             // Matched the type (byte[]) only this binder supports. As in missing data cases, always tell the model
             // binding system to skip other model binders i.e. return non-null.
-            bindingContext.Result = ModelBindingResult.Failed(bindingContext.ModelName);
+            bindingContext.Result = ModelBindingResult.Failed();
             return TaskCache.CompletedTask;
         }
     }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/CancellationTokenModelBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/CancellationTokenModelBinder.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             // DO NOT simplify this code by removing the cast.
             var model = (object)bindingContext.HttpContext.RequestAborted;
             bindingContext.ValidationState.Add(model, new ValidationStateEntry() { SuppressValidation = true });
-            bindingContext.Result = ModelBindingResult.Success(bindingContext.ModelName, model);
+            bindingContext.Result = ModelBindingResult.Success(model);
 
             return TaskCache.CompletedTask;
         }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/CollectionModelBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/CollectionModelBinder.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                         model = CreateEmptyCollection(bindingContext.ModelType);
                     }
 
-                    bindingContext.Result = ModelBindingResult.Success(bindingContext.ModelName, model);
+                    bindingContext.Result = ModelBindingResult.Success(model);
                 }
 
                 return;
@@ -110,7 +110,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                     valueProviderResult);
             }
 
-            bindingContext.Result = ModelBindingResult.Success(bindingContext.ModelName, model);
+            bindingContext.Result = ModelBindingResult.Success(model);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/FormCollectionModelBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/FormCollectionModelBinder.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 model = new EmptyFormCollection();
             }
             
-            bindingContext.Result = ModelBindingResult.Success(bindingContext.ModelName, model);
+            bindingContext.Result = ModelBindingResult.Success(model);
         }
 
         private class EmptyFormCollection : IFormCollection

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/FormFileModelBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/FormFileModelBinder.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             {
                 // Silently fail and stop other model binders running if unable to create an instance or use the
                 // current instance.
-                bindingContext.Result = ModelBindingResult.Failed(bindingContext.ModelName);
+                bindingContext.Result = ModelBindingResult.Failed();
                 return;
             }
 
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 if (postedFiles.Count == 0)
                 {
                     // Silently fail if the named file does not exist in the request.
-                    bindingContext.Result = ModelBindingResult.Failed(bindingContext.ModelName);
+                    bindingContext.Result = ModelBindingResult.Failed();
                     return;
                 }
 
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 {
                     // Silently fail if no files match. Will bind to an empty collection (treat empty as a success
                     // case and not reach here) if binding to a top-level object.
-                    bindingContext.Result = ModelBindingResult.Failed(bindingContext.ModelName);
+                    bindingContext.Result = ModelBindingResult.Failed();
                     return;
                 }
 
@@ -111,7 +111,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 rawValue: null,
                 attemptedValue: null);
 
-            bindingContext.Result = ModelBindingResult.Success(bindingContext.ModelName, value);
+            bindingContext.Result = ModelBindingResult.Success(value);
         }
 
         private async Task GetFormFilesAsync(

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/HeaderModelBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/HeaderModelBinder.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 // Silently fail if unable to create an instance or use the current instance. Also reach here in the
                 // typeof(string) case if the header does not exist in the request and in the
                 // typeof(IEnumerable<string>) case if the header does not exist and this is not a top-level object.
-                bindingContext.Result = ModelBindingResult.Failed(bindingContext.ModelName);
+                bindingContext.Result = ModelBindingResult.Failed();
             }
             else
             {
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                     request.Headers.GetCommaSeparatedValues(headerName),
                     request.Headers[headerName]);
 
-                bindingContext.Result = ModelBindingResult.Success(bindingContext.ModelName, model);
+                bindingContext.Result = ModelBindingResult.Success(model);
             }
 
             return TaskCache.CompletedTask;

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/ServicesModelBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/ServicesModelBinder.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
 
             bindingContext.ValidationState.Add(model, new ValidationStateEntry() { SuppressValidation = true });
 
-            bindingContext.Result = ModelBindingResult.Success(bindingContext.ModelName, model);
+            bindingContext.Result = ModelBindingResult.Success(model);
             return TaskCache.CompletedTask;
         }
     }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/SimpleTypeModelBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/SimpleTypeModelBinder.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             if (valueProviderResult == ValueProviderResult.None)
             {
                 // no entry
-                bindingContext.Result = ModelBindingResult.Failed(bindingContext.ModelName);
+                bindingContext.Result = ModelBindingResult.Failed();
                 return TaskCache.CompletedTask;
             }
 
@@ -77,12 +77,12 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                         bindingContext.ModelMetadata.ModelBindingMessageProvider.ValueMustNotBeNullAccessor(
                             valueProviderResult.ToString()));
 
-                    bindingContext.Result = ModelBindingResult.Failed(bindingContext.ModelName);
+                    bindingContext.Result = ModelBindingResult.Failed();
                     return TaskCache.CompletedTask;
                 }
                 else
                 {
-                    bindingContext.Result = ModelBindingResult.Success(bindingContext.ModelName, model);
+                    bindingContext.Result = ModelBindingResult.Success(model);
                     return TaskCache.CompletedTask;
                 }
             }
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
 
                 // Were able to find a converter for the type but conversion failed.
                 // Tell the model binding system to skip other model binders.
-                bindingContext.Result = ModelBindingResult.Failed(bindingContext.ModelName);
+                bindingContext.Result = ModelBindingResult.Failed();
                 return TaskCache.CompletedTask;
             }
         }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Internal/ModelBindingHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Internal/ModelBindingHelper.cs
@@ -455,7 +455,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Internal
                 objectModelValidator.Validate(
                     actionContext,
                     modelBindingContext.ValidationState,
-                    modelBindingResult.Value.Key,
+                    modelBindingContext.ModelName,
                     modelBindingResult.Value.Model);
 
                 return modelState.IsValid;

--- a/src/Microsoft.AspNetCore.Mvc.WebApiCompatShim/HttpRequestMessage/HttpRequestMessageModelBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.WebApiCompatShim/HttpRequestMessage/HttpRequestMessageModelBinder.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Mvc.WebApiCompatShim
         {
             var model = bindingContext.HttpContext.GetHttpRequestMessage();
             bindingContext.ValidationState.Add(model, new ValidationStateEntry() { SuppressValidation = true });
-            bindingContext.Result = ModelBindingResult.Success(bindingContext.ModelName, model);
+            bindingContext.Result = ModelBindingResult.Success(model);
 
             return TaskCache.CompletedTask;
         }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerArgumentBinderTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerArgumentBinderTests.cs
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 .Callback((ModelBindingContext context) =>
                 {
                     context.ModelMetadata = metadataProvider.GetMetadataForType(typeof(string));
-                    context.Result = ModelBindingResult.Success(string.Empty, value);
+                    context.Result = ModelBindingResult.Success(value);
                 })
                 .Returns(TaskCache.CompletedTask);
             var factory = GetModelBinderFactory(binder.Object);
@@ -374,7 +374,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             var controller = new TestController();
             var arguments = new Dictionary<string, object>(StringComparer.Ordinal);
 
-            var binder = new StubModelBinder(ModelBindingResult.Success(string.Empty, model: null));
+            var binder = new StubModelBinder(ModelBindingResult.Success(model: null));
             var factory = GetModelBinderFactory(binder);
             var argumentBinder = GetArgumentBinder(factory);
 
@@ -406,7 +406,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             var controller = new TestController();
             var arguments = new Dictionary<string, object>(StringComparer.Ordinal);
 
-            var binder = new StubModelBinder(ModelBindingResult.Success(key: string.Empty, model: null));
+            var binder = new StubModelBinder(ModelBindingResult.Success(model: null));
             var factory = GetModelBinderFactory(binder);
             var argumentBinder = GetArgumentBinder(factory);
 
@@ -548,11 +548,11 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 object model;
                 if (inputPropertyValues.TryGetValue(bindingContext.FieldName, out model))
                 {
-                    bindingContext.Result = ModelBindingResult.Success(bindingContext.ModelName, model);
+                    bindingContext.Result = ModelBindingResult.Success( model);
                 }
                 else
                 {
-                    bindingContext.Result = ModelBindingResult.Failed(bindingContext.ModelName);
+                    bindingContext.Result = ModelBindingResult.Failed();
                 }
             });
 
@@ -605,7 +605,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 .Setup(b => b.BindModelAsync(It.IsAny<DefaultModelBindingContext>()))
                 .Returns<DefaultModelBindingContext>(mbc =>
                 {
-                    mbc.Result = ModelBindingResult.Success(string.Empty, model);
+                    mbc.Result = ModelBindingResult.Success(model);
                     return TaskCache.CompletedTask;
                 });
 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/ArrayModelBinderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/ArrayModelBinderTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
+            Assert.True(result.IsModelSet);
 
             var array = Assert.IsType<int[]>(result.Model);
             Assert.Equal(new[] { 42, 84 }, array);
@@ -59,10 +59,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(context);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
-
             Assert.Empty(Assert.IsType<string[]>(result.Model));
-            Assert.Equal("modelName", result.Key);
             Assert.True(result.IsModelSet);
         }
 
@@ -134,7 +131,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.True(result.IsModelSet);
             Assert.Same(model, result.Model);
 
@@ -153,7 +149,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 if (value != ValueProviderResult.None)
                 {
                     var model = value.ConvertTo(mbc.ModelType);
-                    return ModelBindingResult.Success(mbc.ModelName, model);
+                    return ModelBindingResult.Success(model);
                 }
                 return null;
             });

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/BinderTypeModelBinderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/BinderTypeModelBinderTest.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
@@ -26,7 +26,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var binderResult = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), binderResult);
             Assert.False(binderResult.IsModelSet);
         }
 
@@ -116,8 +115,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
 
             public Task BindModelAsync(ModelBindingContext bindingContext)
             {
-                bindingContext.Result = ModelBindingResult.Success(bindingContext.ModelName, _model);
-                return Task.FromResult(0);
+                bindingContext.Result = ModelBindingResult.Success(_model);
+                return TaskCache.CompletedTask;
             }
         }
     }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/ByteArrayModelBinderTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/ByteArrayModelBinderTests.cs
@@ -29,7 +29,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             // Assert
             Assert.NotNull(binderResult);
             Assert.False(binderResult.IsModelSet);
-            Assert.Equal("foo", binderResult.Key);
             Assert.Null(binderResult.Model);
 
             var modelState = Assert.Single(bindingContext.ModelState);
@@ -100,7 +99,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             // Assert
             Assert.NotNull(binderResult);
             Assert.False(binderResult.IsModelSet);
-            Assert.Equal("foo", binderResult.Key);
             Assert.Null(binderResult.Model);
 
             Assert.Empty(bindingContext.ModelState); // No submitted data for "foo".

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/CancellationTokenModelBinderTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/CancellationTokenModelBinderTests.cs
@@ -23,7 +23,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.True(result.IsModelSet);
             Assert.Equal(bindingContext.HttpContext.RequestAborted, result.Model);
         }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/CollectionModelBinderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/CollectionModelBinderTest.cs
@@ -84,7 +84,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.True(result.IsModelSet);
 
             var list = Assert.IsAssignableFrom<IList<int>>(result.Model);
@@ -116,7 +115,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.True(result.IsModelSet);
 
             Assert.Same(list, result.Model);
@@ -143,7 +141,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.True(result.IsModelSet);
 
             var list = Assert.IsAssignableFrom<IList<int>>(result.Model);
@@ -170,7 +167,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.True(result.IsModelSet);
 
             Assert.Same(list, result.Model);
@@ -192,7 +188,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.True(result.IsModelSet);
             Assert.NotNull(result.Model);
 
@@ -236,10 +231,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(context);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
-
             Assert.Empty(Assert.IsType<List<string>>(result.Model));
-            Assert.Equal("modelName", result.Key);
             Assert.True(result.IsModelSet);
         }
 
@@ -269,11 +261,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(context);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
-
             Assert.Same(list, result.Model);
             Assert.Empty(list);
-            Assert.Equal("modelName", result.Key);
             Assert.True(result.IsModelSet);
         }
 
@@ -343,7 +332,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var elementBinder = new StubModelBinder(mbc =>
             {
                 Assert.Equal("someName", mbc.ModelName);
-                mbc.Result = ModelBindingResult.Success(mbc.ModelName, 42);
+                mbc.Result = ModelBindingResult.Success(42);
             });
 
             var modelBinder = new CollectionModelBinder<int>(elementBinder);
@@ -395,11 +384,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 var model = value.ConvertTo(mbc.ModelType);
                 if (model == null)
                 {
-                    return ModelBindingResult.Failed(mbc.ModelName);
+                    return ModelBindingResult.Failed();
                 }
                 else
                 {
-                    return ModelBindingResult.Success(mbc.ModelName, model);
+                    return ModelBindingResult.Success(model);
                 }
             });
         }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/ComplexTypeModelBinderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/ComplexTypeModelBinderTest.cs
@@ -540,7 +540,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var bindingContext = CreateContext(GetMetadataForType(model.GetType()), model);
 
             var binder = CreateBinder(bindingContext.ModelMetadata);
-            binder.Results[property] = ModelBindingResult.Failed("theModel.Age");
+            binder.Results[property] = ModelBindingResult.Failed();
 
             // Act
             await binder.BindModelAsync(bindingContext);
@@ -575,7 +575,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var binder = CreateBinder(bindingContext.ModelMetadata);
 
             var property = GetMetadataForProperty(model.GetType(), nameof(ModelWithDataMemberIsRequired.Age));
-            binder.Results[property] = ModelBindingResult.Failed("theModel.Age");
+            binder.Results[property] = ModelBindingResult.Failed();
 
             // Act
             await binder.BindModelAsync(bindingContext);
@@ -612,7 +612,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             // Attempt to set non-Nullable property to null. BindRequiredAttribute should not be relevant in this
             // case because the property did have a result.
             var property = GetMetadataForProperty(model.GetType(), nameof(ModelWithBindRequired.Age));
-            binder.Results[property] = ModelBindingResult.Success("theModel.Age", model: null);
+            binder.Results[property] = ModelBindingResult.Success(model: null);
 
             // Act
             await binder.BindModelAsync(bindingContext);
@@ -642,7 +642,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var binder = CreateBinder(bindingContext.ModelMetadata);
 
             var property = GetMetadataForProperty(model.GetType(), nameof(BindingOptionalProperty.ValueTypeRequired));
-            binder.Results[property] = ModelBindingResult.Failed("theModel.ValueTypeRequired");
+            binder.Results[property] = ModelBindingResult.Failed();
 
             // Act
             await binder.BindModelAsync(bindingContext);
@@ -662,7 +662,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var binder = CreateBinder(bindingContext.ModelMetadata);
 
             var property = GetMetadataForProperty(model.GetType(), nameof(NullableValueTypeProperty.NullableValueType));
-            binder.Results[property] = ModelBindingResult.Failed("theModel.NullableValueType");
+            binder.Results[property] = ModelBindingResult.Failed();
 
             // Act
             await binder.BindModelAsync(bindingContext);
@@ -684,7 +684,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var binder = CreateBinder(bindingContext.ModelMetadata);
 
             var property = GetMetadataForProperty(model.GetType(), nameof(Person.ValueTypeRequired));
-            binder.Results[property] = ModelBindingResult.Failed("theModel." + nameof(Person.ValueTypeRequired));
+            binder.Results[property] = ModelBindingResult.Failed();
 
             // Act
             await binder.BindModelAsync(bindingContext);
@@ -706,9 +706,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var binder = CreateBinder(bindingContext.ModelMetadata);
 
             var property = GetMetadataForProperty(model.GetType(), nameof(Person.ValueTypeRequired));
-            binder.Results[property] = ModelBindingResult.Success(
-                key: "theModel." + nameof(Person.ValueTypeRequired),
-                model: 57);
+            binder.Results[property] = ModelBindingResult.Success(model: 57);
 
             // Act
             await binder.BindModelAsync(bindingContext);
@@ -736,18 +734,14 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
 
             foreach (var property in containerMetadata.Properties)
             {
-                binder.Results[property] = ModelBindingResult.Failed(property.PropertyName);
+                binder.Results[property] = ModelBindingResult.Failed();
             }
 
             var firstNameProperty = containerMetadata.Properties[nameof(model.FirstName)];
-            binder.Results[firstNameProperty] = ModelBindingResult.Success(
-                nameof(model.FirstName),
-                "John");
+            binder.Results[firstNameProperty] = ModelBindingResult.Success("John");
 
             var lastNameProperty = containerMetadata.Properties[nameof(model.LastName)];
-            binder.Results[lastNameProperty] = ModelBindingResult.Success(
-                nameof(model.LastName),
-                "Doe");
+            binder.Results[lastNameProperty] = ModelBindingResult.Success("Doe");
 
             // Act
             await binder.BindModelAsync(bindingContext);
@@ -769,11 +763,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var metadata = GetMetadataForType(typeof(Person));
             var propertyMetadata = metadata.Properties[nameof(model.PropertyWithDefaultValue)];
 
-            var result = ModelBindingResult.Failed("foo");
+            var result = ModelBindingResult.Failed();
             var binder = CreateBinder(bindingContext.ModelMetadata);
 
             // Act
-            binder.SetPropertyPublic(bindingContext, propertyMetadata, result);
+            binder.SetPropertyPublic(bindingContext, "foo", propertyMetadata, result);
 
             // Assert
             var person = Assert.IsType<Person>(bindingContext.Model);
@@ -792,12 +786,12 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var propertyMetadata = metadata.Properties[nameof(model.PropertyWithInitializedValue)];
 
             // The null model value won't be used because IsModelBound = false.
-            var result = ModelBindingResult.Failed("foo");
+            var result = ModelBindingResult.Failed();
 
             var binder = CreateBinder(bindingContext.ModelMetadata);
 
             // Act
-            binder.SetPropertyPublic(bindingContext, propertyMetadata, result);
+            binder.SetPropertyPublic(bindingContext, "foo", propertyMetadata, result);
 
             // Assert
             var person = Assert.IsType<Person>(bindingContext.Model);
@@ -816,12 +810,12 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var propertyMetadata = metadata.Properties[nameof(model.PropertyWithInitializedValueAndDefault)];
 
             // The null model value won't be used because IsModelBound = false.
-            var result = ModelBindingResult.Failed("foo");
+            var result = ModelBindingResult.Failed();
 
             var binder = CreateBinder(bindingContext.ModelMetadata);
 
             // Act
-            binder.SetPropertyPublic(bindingContext, propertyMetadata, result);
+            binder.SetPropertyPublic(bindingContext, "foo", propertyMetadata, result);
 
             // Assert
             var person = Assert.IsType<Person>(bindingContext.Model);
@@ -839,11 +833,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var metadata = GetMetadataForType(typeof(Person));
             var propertyMetadata = metadata.Properties[nameof(model.NonUpdateableProperty)];
 
-            var result = ModelBindingResult.Failed("foo");
+            var result = ModelBindingResult.Failed();
             var binder = CreateBinder(bindingContext.ModelMetadata);
 
             // Act
-            binder.SetPropertyPublic(bindingContext, propertyMetadata, result);
+            binder.SetPropertyPublic(bindingContext, "foo", propertyMetadata, result);
 
             // Assert
             // If didn't throw, success!
@@ -882,14 +876,12 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var metadata = GetMetadataForType(type);
 
             var propertyMetadata = bindingContext.ModelMetadata.Properties[propertyName];
-            var result = ModelBindingResult.Success(
-                propertyName,
-                new Simple { Name = "Hanna" });
+            var result = ModelBindingResult.Success(new Simple { Name = "Hanna" });
 
             var binder = CreateBinder(bindingContext.ModelMetadata);
 
             // Act
-            binder.SetPropertyPublic(bindingContext, propertyMetadata, result);
+            binder.SetPropertyPublic(bindingContext, propertyName, propertyMetadata, result);
 
             // Assert
             Assert.Equal("Joe", propertyAccessor(model));
@@ -908,12 +900,12 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var propertyMetadata = GetMetadataForProperty(model.GetType(), nameof(CollectionContainer.ReadOnlyList));
 
             var bindingContext = CreateContext(modelMetadata, model);
-            var result = ModelBindingResult.Success(propertyMetadata.PropertyName, new List<string>() { "hi" });
+            var result = ModelBindingResult.Success(new List<string>() { "hi" });
 
             var binder = CreateBinder(bindingContext.ModelMetadata);
 
             // Act
-            binder.SetPropertyPublic(bindingContext, propertyMetadata, result);
+            binder.SetPropertyPublic(bindingContext, propertyMetadata.PropertyName, propertyMetadata, result);
 
             // Assert
             Assert.Same(originalCollection, model.ReadOnlyList);
@@ -930,11 +922,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var metadata = GetMetadataForType(typeof(Person));
             var propertyMetadata = bindingContext.ModelMetadata.Properties[nameof(model.DateOfBirth)];
 
-            var result = ModelBindingResult.Success("foo", new DateTime(2001, 1, 1));
+            var result = ModelBindingResult.Success(new DateTime(2001, 1, 1));
             var binder = CreateBinder(bindingContext.ModelMetadata);
 
             // Act
-            binder.SetPropertyPublic(bindingContext, propertyMetadata, result);
+            binder.SetPropertyPublic(bindingContext, "foo", propertyMetadata, result);
 
             // Assert
             Assert.True(bindingContext.ModelState.IsValid);
@@ -956,11 +948,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var metadata = GetMetadataForType(typeof(Person));
             var propertyMetadata = bindingContext.ModelMetadata.Properties[nameof(model.DateOfDeath)];
 
-            var result = ModelBindingResult.Success("foo", new DateTime(1800, 1, 1));
+            var result = ModelBindingResult.Success(new DateTime(1800, 1, 1));
             var binder = CreateBinder(bindingContext.ModelMetadata);
 
             // Act
-            binder.SetPropertyPublic(bindingContext, propertyMetadata, result);
+            binder.SetPropertyPublic(bindingContext, "foo", propertyMetadata, result);
 
             // Assert
             Assert.Equal("Date of death can't be before date of birth." + Environment.NewLine
@@ -980,11 +972,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var metadata = GetMetadataForType(typeof(ModelWhosePropertySetterThrows));
             var propertyMetadata = bindingContext.ModelMetadata.Properties[nameof(model.NameNoAttribute)];
 
-            var result = ModelBindingResult.Success("foo.NameNoAttribute", model: null);
+            var result = ModelBindingResult.Success(model: null);
             var binder = CreateBinder(bindingContext.ModelMetadata);
 
             // Act
-            binder.SetPropertyPublic(bindingContext, propertyMetadata, result);
+            binder.SetPropertyPublic(bindingContext, "foo.NameNoAttribute", propertyMetadata, result);
 
             // Assert
             Assert.False(bindingContext.ModelState.IsValid);
@@ -1363,18 +1355,20 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
 
             public virtual void SetPropertyPublic(
                 ModelBindingContext bindingContext,
+                string modelName,
                 ModelMetadata propertyMetadata,
                 ModelBindingResult result)
             {
-                base.SetProperty(bindingContext, propertyMetadata, result);
+                base.SetProperty(bindingContext, modelName, propertyMetadata, result);
             }
 
             protected override void SetProperty(
                 ModelBindingContext bindingContext,
+                string modelName,
                 ModelMetadata propertyMetadata,
                 ModelBindingResult result)
             {
-                SetPropertyPublic(bindingContext, propertyMetadata, result);
+                SetPropertyPublic(bindingContext, modelName, propertyMetadata, result);
             }
         }
     }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/DictionaryModelBinderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/DictionaryModelBinderTest.cs
@@ -150,7 +150,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
 
             // Assert
             Assert.True(result.IsModelSet);
-            Assert.Equal(modelName, result.Key);
 
             var resultDictionary = Assert.IsAssignableFrom<IDictionary<string, string>>(result.Model);
             Assert.Equal(dictionary, resultDictionary);
@@ -186,9 +185,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(context);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.True(result.IsModelSet);
-            Assert.Equal("prefix", result.Key);
 
             var resultDictionary = Assert.IsAssignableFrom<IDictionary<string, string>>(result.Model);
             Assert.Empty(resultDictionary);
@@ -238,9 +235,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(context);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.True(result.IsModelSet);
-            Assert.Equal("prefix", result.Key);
 
             var resultDictionary = Assert.IsAssignableFrom<IDictionary<long, int>>(result.Model);
             Assert.Equal(dictionary, resultDictionary);
@@ -287,9 +282,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(context);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.True(result.IsModelSet);
-            Assert.Equal("prefix", result.Key);
 
             var resultDictionary = Assert.IsAssignableFrom<IDictionary<int, ModelWithProperties>>(result.Model);
             Assert.Equal(dictionary, resultDictionary);
@@ -335,9 +328,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(context);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.True(result.IsModelSet);
-            Assert.Equal(modelName, result.Key);
 
             var resultDictionary = Assert.IsAssignableFrom<SortedDictionary<string, string>>(result.Model);
             Assert.Equal(expectedDictionary, resultDictionary);
@@ -366,10 +357,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(context);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
-
             Assert.Empty(Assert.IsType<Dictionary<string, string>>(result.Model));
-            Assert.Equal("modelName", result.Key);
             Assert.True(result.IsModelSet);
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/FormCollectionModelBinderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/FormCollectionModelBinderTest.cs
@@ -32,9 +32,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.True(result.IsModelSet);
-
             Assert.Empty(bindingContext.ValidationState);
 
             var form = Assert.IsAssignableFrom<IFormCollection>(result.Model);
@@ -55,7 +53,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
+            Assert.True(result.IsModelSet);
             var form = Assert.IsAssignableFrom<IFormCollection>(result.Model);
             Assert.Empty(form);
         }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/FormFileModelBinderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/FormFileModelBinderTest.cs
@@ -29,7 +29,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.True(result.IsModelSet);
 
             var entry = bindingContext.ValidationState[result.Model];
@@ -51,7 +50,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.True(result.IsModelSet);
 
             var entry = bindingContext.ValidationState[result.Model];
@@ -84,7 +82,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.True(result.IsModelSet);
             Assert.IsAssignableFrom(destinationType, result.Model);
             Assert.Equal(formFiles, result.Model as IEnumerable<IFormFile>);
@@ -103,7 +100,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
+            Assert.True(result.IsModelSet);
             var file = Assert.IsAssignableFrom<IFormFile>(result.Model);
             Assert.Equal("file1.txt", file.FileName);
         }
@@ -121,7 +118,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.False(result.IsModelSet);
             Assert.Null(result.Model);
         }
@@ -140,7 +136,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.False(result.IsModelSet);
             Assert.Null(result.Model);
         }
@@ -167,7 +162,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.True(result.IsModelSet);
             var file = Assert.IsAssignableFrom<IFormFile>(result.Model);
 
@@ -188,7 +182,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.False(result.IsModelSet);
             Assert.Null(result.Model);
         }
@@ -207,7 +200,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.False(result.IsModelSet);
             Assert.Null(result.Model);
         }
@@ -225,7 +217,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.False(result.IsModelSet);
             Assert.Null(result.Model);
         }
@@ -243,7 +234,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.False(result.IsModelSet);
             Assert.Null(result.Model);
         }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/HeaderModelBinderTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/HeaderModelBinderTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(modelBindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
+            Assert.False(result.IsModelSet);
         }
 
         [Fact]
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(modelBindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
+            Assert.True(result.IsModelSet);
             Assert.Equal(headerValue.Split(','), result.Model);
         }
 
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(modelBindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
+            Assert.True(result.IsModelSet);
             Assert.Equal(headerValue, result.Model);
         }
 
@@ -95,7 +95,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(modelBindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.True(result.IsModelSet);
             Assert.IsAssignableFrom(destinationType, result.Model);
             Assert.Equal(headerValue.Split(','), result.Model as IEnumerable<string>);
@@ -117,9 +116,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(modelBindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.False(result.IsModelSet);
-            Assert.Equal("modelName", result.Key);
             Assert.Null(result.Model);
         }
 
@@ -139,9 +136,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(modelBindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.False(result.IsModelSet);
-            Assert.Equal("modelName", result.Key);
             Assert.Null(result.Model);
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/KeyValuePairModelBinderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/KeyValuePairModelBinderTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
+            Assert.False(result.IsModelSet);
             Assert.Null(result.Model);
             Assert.False(bindingContext.ModelState.IsValid);
             Assert.Equal("someName", bindingContext.ModelName);
@@ -90,7 +90,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
+            Assert.True(result.IsModelSet);
             Assert.Equal(new KeyValuePair<int, string>(42, "some-value"), result.Model);
         }
 
@@ -106,11 +106,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             ModelBindingResult? innerResult;
             if (isSuccess)
             {
-                innerResult = ModelBindingResult.Success("somename.Key", model);
+                innerResult = ModelBindingResult.Success(model);
             }
             else
             {
-                innerResult = ModelBindingResult.Failed("somename.Key");
+                innerResult = ModelBindingResult.Failed();
             }
 
             var innerBinder = new StubModelBinder(context =>
@@ -125,7 +125,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var binder = new KeyValuePairModelBinder<int, string>(innerBinder, innerBinder);
 
             // Act
-            var result = await binder.TryBindStrongModel<int>(bindingContext, innerBinder, "Key");
+            var result = await binder.TryBindStrongModel<int>(bindingContext, innerBinder, "Key", "someName.Key");
 
             // Assert
             Assert.Equal(innerResult.Value, result);
@@ -155,11 +155,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(context);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
-
             var model = Assert.IsType<KeyValuePair<string, string>>(result.Model);
             Assert.Equal(default(KeyValuePair<string, string>), model);
-            Assert.Equal("modelName", result.Key);
             Assert.True(result.IsModelSet);
         }
 
@@ -226,7 +223,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 if (mbc.ModelType == typeof(int) && success)
                 {
                     var model = 42;
-                    return ModelBindingResult.Success(mbc.ModelName, model);
+                    return ModelBindingResult.Success(model);
                 }
                 return null;
             });
@@ -240,7 +237,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 if (mbc.ModelType == typeof(string) && success)
                 {
                     var model = "some-value";
-                    return ModelBindingResult.Success(mbc.ModelName, model);
+                    return ModelBindingResult.Success(model);
                 }
                 return null;
             });

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/ServicesModelBinderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/ServicesModelBinderTest.cs
@@ -25,10 +25,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(modelBindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.True(result.IsModelSet);
             Assert.NotNull(result.Model);
-            Assert.Equal("modelName", result.Key);
 
             var entry = modelBindingContext.ValidationState[result.Model];
             Assert.True(entry.SuppressValidation);

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/SimpleTypeModelBinderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/SimpleTypeModelBinderTest.cs
@@ -53,7 +53,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
             Assert.False(result.IsModelSet);
         }
 
@@ -104,7 +103,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.NotEqual(default(ModelBindingResult), result);
+            Assert.False(result.IsModelSet);
             Assert.Null(result.Model);
             Assert.False(bindingContext.ModelState.IsValid);
             var error = Assert.Single(bindingContext.ModelState["theModelName"].Errors);
@@ -122,7 +121,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var result = await binder.BindModelResultAsync(bindingContext);
 
             // Assert
-            Assert.Equal(ModelBindingResult.Failed("theModelName"), result);
+            Assert.Equal(ModelBindingResult.Failed(), result);
             Assert.Empty(bindingContext.ModelState);
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ModelBindingHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ModelBindingHelperTest.cs
@@ -11,11 +11,9 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.DataAnnotations.Internal;
-using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Internal;
-using Microsoft.AspNetCore.Mvc.ModelBinding.Test;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using Moq;
 using Xunit;
@@ -31,7 +29,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 return new TheoryData<ModelBindingResult?>
                 {
                     null,
-                    ModelBindingResult.Failed("someKey"),
+                    ModelBindingResult.Failed(),
                 };
             }
         }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ModelBindingResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ModelBindingResultTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding.Test
@@ -12,14 +11,12 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Test
         public void Success_SetsProperties()
         {
             // Arrange
-            var key = "someName";
             var model = "some model";
 
             // Act
-            var result = ModelBindingResult.Success(key, model);
+            var result = ModelBindingResult.Success(model);
 
             // Assert
-            Assert.Same(key, result.Key);
             Assert.True(result.IsModelSet);
             Assert.Same(model, result.Model);
         }
@@ -27,14 +24,10 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Test
         [Fact]
         public void Failed_SetsProperties()
         {
-            // Arrange
-            var key = "someName";
-
-            // Act
-            var result = ModelBindingResult.Failed(key);
+            // Arrange & Act
+            var result = ModelBindingResult.Failed();
 
             // Assert
-            Assert.Same(key, result.Key);
             Assert.False(result.IsModelSet);
             Assert.Null(result.Model);
         }

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/BinderTypeBasedModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/BinderTypeBasedModelBinderIntegrationTest.cs
@@ -181,8 +181,8 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             // Assert
 
             // ModelBindingResult
+            Assert.True(modelBindingResult.IsModelSet);
             Assert.Equal("Success", modelBindingResult.Model);
-            Assert.Equal("CustomParameter", modelBindingResult.Key);
 
             // ModelState
             Assert.True(modelState.IsValid);
@@ -225,7 +225,6 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
 
             // ModelBindingResult
             Assert.True(modelBindingResult.IsModelSet);
-            Assert.Equal(string.Empty, modelBindingResult.Key);
 
             // Model
             var boundPerson = Assert.IsType<Person>(modelBindingResult.Model);
@@ -264,7 +263,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             // Assert
 
             // ModelBindingResult
-            Assert.Equal("CustomParameter", modelBindingResult.Key);
+            Assert.True(modelBindingResult.IsModelSet);
 
             // Model
             var boundPerson = Assert.IsType<Person>(modelBindingResult.Model);
@@ -301,7 +300,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
                     new string[] { address.Street },
                     address.Street);
 
-                bindingContext.Result = ModelBindingResult.Success(bindingContext.ModelName, address);
+                bindingContext.Result = ModelBindingResult.Success(address);
                 return TaskCache.CompletedTask;
             }
         }
@@ -322,7 +321,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
                     new string[] { model },
                     model);
 
-                bindingContext.Result =ModelBindingResult.Success(bindingContext.ModelName, model);
+                bindingContext.Result =ModelBindingResult.Success(model);
                 return TaskCache.CompletedTask;
             }
         }
@@ -337,7 +336,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
                 }
                 Debug.Assert(bindingContext.Result == null);
 
-                bindingContext.Result =  ModelBindingResult.Success(bindingContext.ModelName, model: null);
+                bindingContext.Result =  ModelBindingResult.Success(model: null);
                 return TaskCache.CompletedTask;
             }
         }
@@ -352,7 +351,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
                 }
                 Debug.Assert(bindingContext.Result == null);
 
-                bindingContext.Result = ModelBindingResult.Failed(bindingContext.ModelName);
+                bindingContext.Result = ModelBindingResult.Failed();
                 return TaskCache.CompletedTask;
             }
         }

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/GenericModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/GenericModelBinderIntegrationTest.cs
@@ -186,7 +186,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
                     return TaskCache.CompletedTask;
                 }
 
-                bindingContext.Result = ModelBindingResult.Success(bindingContext.ModelName, new Address());
+                bindingContext.Result = ModelBindingResult.Success(new Address());
                 return TaskCache.CompletedTask;
             }
         }

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/ModelPrefixSelectionIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/ModelPrefixSelectionIntegrationTest.cs
@@ -51,7 +51,6 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
-            Assert.Equal("parameter", modelBindingResult.Key);
 
             var model = Assert.IsType<Person1>(modelBindingResult.Model);
             Assert.Null(model.Name);
@@ -101,7 +100,6 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
-            Assert.Equal("parameter", modelBindingResult.Key);
 
             var model = Assert.IsType<Person2>(modelBindingResult.Model);
             Assert.Null(model.Name);
@@ -141,7 +139,6 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
-            Assert.Equal(string.Empty, modelBindingResult.Key);
 
             var model = Assert.IsType<Person3>(modelBindingResult.Model);
             Assert.Null(model.Name);
@@ -191,7 +188,6 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
-            Assert.Equal(string.Empty, modelBindingResult.Key);
 
             var model = Assert.IsType<Person4>(modelBindingResult.Model);
             Assert.Null(model.Name);
@@ -238,7 +234,6 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
 
             // Assert
             Assert.True(modelBindingResult.IsModelSet);
-            Assert.Equal(string.Empty, modelBindingResult.Key);
 
             var model = Assert.IsType<Person5>(modelBindingResult.Model);
             Assert.Null(model.Name);

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/SimpleTypeModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/SimpleTypeModelBinderIntegrationTest.cs
@@ -462,7 +462,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             // Assert
 
             // ModelBindingResult
-            Assert.Equal(ModelBindingResult.Failed(string.Empty), modelBindingResult);
+            Assert.Equal(ModelBindingResult.Failed(), modelBindingResult);
 
             // ModelState
             Assert.True(modelState.IsValid);


### PR DESCRIPTION
Removing the key from MBR because it's just bloat. It's not really used for anything. This simplifies a lot of code, next change will simplify more.

FYI a lot of the test changes are because now `default(ModelBindingResult) == ModelBindingResult.Failed()`

/cc @kichalla