### PR TITLE
Remove usage of `async void` in unit tests

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ObjectMethodExecutorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ObjectMethodExecutorTest.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         [Fact]
-        public async void ExecuteValueMethodAsync()
+        public async Task ExecuteValueMethodAsync()
         {
             var executor = GetExecutorForMethod("ValueMethodAsync");
             var result = await executor.ExecuteAsync(
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         [Fact]
-        public async void ExecuteValueMethodWithReturnTypeAsync()
+        public async Task ExecuteValueMethodWithReturnTypeAsync()
         {
             var executor = GetExecutorForMethod("ValueMethodWithReturnTypeAsync");
             var result = await executor.ExecuteAsync(
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         [Fact]
-        public async void ExecuteValueMethodUpdateValueAsync()
+        public async Task ExecuteValueMethodUpdateValueAsync()
         {
             var executor = GetExecutorForMethod("ValueMethodUpdateValueAsync");
             var parameter = new TestObject();
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         [Fact]
-        public async void ExecuteValueMethodWithReturnTypeThrowsExceptionAsync()
+        public async Task ExecuteValueMethodWithReturnTypeThrowsExceptionAsync()
         {
             var executor = GetExecutorForMethod("ValueMethodWithReturnTypeThrowsExceptionAsync");
             var parameter = new TestObject();

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/RedirectToActionResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/RedirectToActionResultTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Mvc
     public class RedirectToActionResultTest
     {
         [Fact]
-        public async void RedirectToAction_Execute_PassesCorrectValuesToRedirect()
+        public async Task RedirectToAction_Execute_PassesCorrectValuesToRedirect()
         {
             // Arrange
             var expectedUrl = "SampleAction";

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/RedirectToRouteResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/RedirectToRouteResultTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Mvc
     {
         [Theory]
         [MemberData(nameof(RedirectToRouteData))]
-        public async void RedirectToRoute_Execute_PassesCorrectValuesToRedirect(object values)
+        public async Task RedirectToRoute_Execute_PassesCorrectValuesToRedirect(object values)
         {
             // Arrange
             var expectedUrl = "SampleAction";


### PR DESCRIPTION
Yes I know xUnit supports it, but it's non-standard and it shouldn't show
up anywhere in our codebase.