### PR TITLE
Update Json.NET version

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/project.json
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/project.json
@@ -47,7 +47,7 @@
       "type": "build"
     },
     "Microsoft.Extensions.WebEncoders": "1.0.0-*",
-    "Newtonsoft.Json": "8.0.3",
+    "Newtonsoft.Json": "8.0.4-beta1",
     "System.Buffers": "4.0.0-*"
   },
   "frameworks": {
@@ -55,10 +55,7 @@
     "netstandard1.5": {
       "dependencies": {
         "System.Runtime.Serialization.Primitives": "4.1.1-*"
-      },
-      "imports": [
-        "portable-net451+win8"
-      ]
+      }
     }
   }
 }


### PR DESCRIPTION
Json.NET 8.0.4-beta1 targets .NETStandard 1.0, no more imports required.

#4711 