### PR TITLE
[Perf] Avoid ViewBuffers for writing bound TagHelper attribute values.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.Host/MvcRazorHost.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Host/MvcRazorHost.cs
@@ -106,6 +106,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor
                     FormatInvalidIndexerAssignmentMethodName = "InvalidTagHelperIndexerAssignment",
                     StartTagHelperWritingScopeMethodName = "StartTagHelperWritingScope",
                     EndTagHelperWritingScopeMethodName = "EndTagHelperWritingScope",
+                    BeginWriteTagHelperAttributeMethodName = "BeginWriteTagHelperAttribute",
+                    EndWriteTagHelperAttributeMethodName = "EndWriteTagHelperAttribute",
 
                     // Can't use nameof because IHtmlHelper is (also) not accessible here.
                     MarkAsHtmlEncodedMethodName = HtmlHelperPropertyName + ".Raw",

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Properties/Resources.Designer.cs
@@ -478,6 +478,22 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             return string.Format(CultureInfo.CurrentCulture, GetString("ViewLocationFormatsIsRequired"), p0);
         }
 
+        /// <summary>
+        /// Nesting of TagHelper attribute writing scopes is not supported.
+        /// </summary>
+        internal static string RazorPage_NestingAttributeWritingScopesNotSupported
+        {
+            get { return GetString("RazorPage_NestingAttributeWritingScopesNotSupported"); }
+        }
+
+        /// <summary>
+        /// Nesting of TagHelper attribute writing scopes is not supported.
+        /// </summary>
+        internal static string FormatRazorPage_NestingAttributeWritingScopesNotSupported()
+        {
+            return GetString("RazorPage_NestingAttributeWritingScopesNotSupported");
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Resources.resx
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Resources.resx
@@ -206,4 +206,7 @@
   <data name="ViewLocationFormatsIsRequired" xml:space="preserve">
     <value>'{0}' cannot be empty. These locations are required to locate a view for rendering.</value>
   </data>
+  <data name="RazorPage_NestingAttributeWritingScopesNotSupported" xml:space="preserve">
+    <value>Nesting of TagHelper attribute writing scopes is not supported.</value>
+  </data>
 </root>

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/ModelExpressionTagHelper.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Host.Test/TestFiles/Output/Runtime/ModelExpressionTagHelper.cs
@@ -13,7 +13,7 @@ namespace AspNetCore
     {
         #line hidden
         #pragma warning disable 0414
-        private global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContent __tagHelperStringValueBuffer = null;
+        private string __tagHelperStringValueBuffer = null;
         #pragma warning restore 0414
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = null;


### PR DESCRIPTION
This PR has changes that enables fixing  https://github.com/aspnet/Razor/issues/717 in Razor. Currently, writing TagHelper attribute uses the same code as the TagHelper content writing. This uses StartTagHelperWritingScope and EndTagHelperWritingScope which is expensive for writing attributes as these methods uses ViewBuffer, ViewBufferTextWriter. We an use simple StringWriter for writing attributes. Also, as attribute writing is not nested, we can use a shared writer within the RazorPage. The RazorPage has two new methods special cased for writing TagHelper attributes using the shared StringWriter.