### PR TITLE
Fix for #4666 - reduce modelbinders created

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/PlaceholderBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/PlaceholderBinder.cs
@@ -2,8 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 
-namespace Microsoft.AspNetCore.Mvc.ModelBinding.Internal
+namespace Microsoft.AspNetCore.Mvc.Internal
 {
     // Used as a placeholder to break cycles while building a tree of model binders in ModelBinderFactory.
     //

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ModelBinderFactoryTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ModelBinderFactoryTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Internal;
@@ -342,6 +343,244 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             Assert.Same(modelBinder, result);
         }
 
+        [Fact]
+        public void CreateBinder_Caches_NonRootNodes()
+        {
+            // Arrange
+            var metadataProvider = new TestModelMetadataProvider();
+
+            var options = new TestOptionsManager<MvcOptions>();
+
+            IModelBinder inner = null;
+
+            var widgetProvider = new TestModelBinderProvider(c =>
+            {
+                if (c.Metadata.ModelType == typeof(Widget))
+                {
+                    var binder = c.CreateBinder(c.Metadata.Properties[nameof(Widget.Id)]);
+                    if (inner == null)
+                    {
+                        inner = binder;
+                    }
+                    else
+                    {
+                        Assert.Same(inner, binder);
+                    }
+
+                    return Mock.Of<IModelBinder>();
+                }
+
+                return null;
+            });
+
+            var widgetIdProvider = new TestModelBinderProvider(c =>
+            {
+                Assert.Equal(typeof(WidgetId), c.Metadata.ModelType);
+                return Mock.Of<IModelBinder>();
+            });
+
+            options.Value.ModelBinderProviders.Add(widgetProvider);
+            options.Value.ModelBinderProviders.Add(widgetIdProvider);
+
+            var factory = new ModelBinderFactory(metadataProvider, options);
+
+            var context = new ModelBinderFactoryContext()
+            {
+                Metadata = metadataProvider.GetMetadataForType(typeof(Widget)),
+                CacheToken = null, // We want the outermost provider to run twice.
+            };
+
+            // Act
+            var result1 = factory.CreateBinder(context);
+            var result2 = factory.CreateBinder(context);
+
+            // Assert
+            Assert.NotSame(result1, result2);
+
+            Assert.Equal(2, widgetProvider.SuccessCount);
+            Assert.Equal(1, widgetIdProvider.SuccessCount);
+        }
+
+        [Fact]
+        public void CreateBinder_Caches_NonRootNodes_WhenNonRootNodeReturnsNull()
+        {
+            // Arrange
+            var metadataProvider = new TestModelMetadataProvider();
+
+            var options = new TestOptionsManager<MvcOptions>();
+
+            IModelBinder inner = null;
+
+            var widgetProvider = new TestModelBinderProvider(c =>
+            {
+                if (c.Metadata.ModelType == typeof(Widget))
+                {
+                    var binder = c.CreateBinder(c.Metadata.Properties[nameof(Widget.Id)]);
+                    Assert.IsType<NoOpBinder>(binder);
+                    if (inner == null)
+                    {
+                        inner = binder;
+                    }
+                    else
+                    {
+                        Assert.Same(inner, binder);
+                    }
+
+                    return Mock.Of<IModelBinder>();
+                }
+
+                return null;
+            });
+
+            var widgetIdProvider = new TestModelBinderProvider(c =>
+            {
+                Assert.Equal(typeof(WidgetId), c.Metadata.ModelType);
+                return null;
+            });
+
+            options.Value.ModelBinderProviders.Add(widgetProvider);
+            options.Value.ModelBinderProviders.Add(widgetIdProvider);
+
+            var factory = new ModelBinderFactory(metadataProvider, options);
+
+            var context = new ModelBinderFactoryContext()
+            {
+                Metadata = metadataProvider.GetMetadataForType(typeof(Widget)),
+                CacheToken = null, // We want the outermost provider to run twice.
+            };
+
+            // Act
+            var result1 = factory.CreateBinder(context);
+            var result2 = factory.CreateBinder(context);
+
+            // Assert
+            Assert.NotSame(result1, result2);
+
+            Assert.Equal(2, widgetProvider.SuccessCount);
+            Assert.Equal(0, widgetIdProvider.SuccessCount);
+        }
+
+        // The fact that we use the ModelMetadata as the token is important for caching
+        // and sharing with TryUpdateModel.
+        [Fact]
+        public void CreateBinder_Caches_NonRootNodes_UsesModelMetadataAsToken()
+        {
+            // Arrange
+            var metadataProvider = new TestModelMetadataProvider();
+
+            var options = new TestOptionsManager<MvcOptions>();
+
+            IModelBinder inner = null;
+
+            var widgetProvider = new TestModelBinderProvider(c =>
+            {
+                if (c.Metadata.ModelType == typeof(Widget))
+                {
+                    inner = c.CreateBinder(c.Metadata.Properties[nameof(Widget.Id)]);
+                    return Mock.Of<IModelBinder>();
+                }
+
+                return null;
+            });
+
+            var widgetIdProvider = new TestModelBinderProvider(c =>
+            {
+                Assert.Equal(typeof(WidgetId), c.Metadata.ModelType);
+                return Mock.Of<IModelBinder>();
+            });
+
+            options.Value.ModelBinderProviders.Add(widgetProvider);
+            options.Value.ModelBinderProviders.Add(widgetIdProvider);
+
+            var factory = new ModelBinderFactory(metadataProvider, options);
+
+            var context = new ModelBinderFactoryContext()
+            {
+                Metadata = metadataProvider.GetMetadataForType(typeof(Widget)),
+                CacheToken = null,
+            };
+
+            // Act 1
+            var result1 = factory.CreateBinder(context);
+
+            context.Metadata = context.Metadata.Properties[nameof(Widget.Id)];
+            context.CacheToken = context.Metadata;
+
+            // Act 2
+            var result2 = factory.CreateBinder(context);
+
+            // Assert
+            Assert.Same(inner, result2);
+            Assert.Equal(1, widgetProvider.SuccessCount);
+            Assert.Equal(1, widgetIdProvider.SuccessCount);
+        }
+
+        // This is a really wierd case, but I wanted to make sure it's covered so it doesn't
+        // blow up in wierd ways.
+        //
+        // If a binder provider tries to recursively create itself, but then returns null, we've
+        // already returned and possibly cached the PlaceholderBinder instance, we want to make sure that
+        // instance won't nullref.
+        [Fact]
+        public void CreateBinder_Caches_NonRootNodes_FixesUpPlaceholderBinder()
+        {
+            // Arrange
+            var metadataProvider = new TestModelMetadataProvider();
+
+            var options = new TestOptionsManager<MvcOptions>();
+
+            IModelBinder inner = null;
+            IModelBinder innerInner = null;
+
+            var widgetProvider = new TestModelBinderProvider(c =>
+            {
+                if (c.Metadata.ModelType == typeof(Widget))
+                {
+                    inner = c.CreateBinder(c.Metadata.Properties[nameof(Widget.Id)]);
+                    return Mock.Of<IModelBinder>();
+                }
+
+                return null;
+            });
+
+            var widgetIdProvider = new TestModelBinderProvider(c =>
+            {
+                Assert.Equal(typeof(WidgetId), c.Metadata.ModelType);
+                innerInner = c.CreateBinder(c.Metadata);
+                return null;
+            });
+
+            options.Value.ModelBinderProviders.Add(widgetProvider);
+            options.Value.ModelBinderProviders.Add(widgetIdProvider);
+
+            var factory = new ModelBinderFactory(metadataProvider, options);
+
+            var context = new ModelBinderFactoryContext()
+            {
+                Metadata = metadataProvider.GetMetadataForType(typeof(Widget)),
+                CacheToken = null,
+            };
+
+            // Act 1
+            var result1 = factory.CreateBinder(context);
+
+            context.Metadata = context.Metadata.Properties[nameof(Widget.Id)];
+            context.CacheToken = context.Metadata;
+
+            // Act 2
+            var result2 = factory.CreateBinder(context);
+
+            // Assert
+            Assert.Same(inner, result2);
+            Assert.NotSame(inner, innerInner);
+
+            var placeholder = Assert.IsType<PlaceholderBinder>(innerInner);
+            Assert.IsType<NoOpBinder>(placeholder.Inner);
+
+            Assert.Equal(1, widgetProvider.SuccessCount);
+            Assert.Equal(0, widgetIdProvider.SuccessCount);
+        }
+
         private class Widget
         {
             public WidgetId Id { get; set; }
@@ -365,9 +604,17 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 _factory = factory;
             }
 
+            public int SuccessCount { get; private set; }
+
             public IModelBinder GetBinder(ModelBinderProviderContext context)
             {
-                return _factory(context);
+                var binder = _factory(context);
+                if (binder != null)
+                {
+                    SuccessCount++;
+                }
+
+                return binder;
             }
         }
     }


### PR DESCRIPTION
This change to ModelBinderFactory makes the caching much more aggressive,
by caching all non-root binders. There's some trickiness here around
making sure we have the right behavior when all providers return null. See
the tests and comments.

I also kept the change I made for a temporary workaround to use a
dictionary rather than a "stack" for cycle breaking.  This seems like an
overall improvement in clarity.