### PR TITLE
Modify test to look for assembly names rather than absolute paths

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ApplicationParts/AssemblyPartTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ApplicationParts/AssemblyPartTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using Xunit;
@@ -60,7 +61,9 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationParts
 
             // Assert
             Assert.Contains(assembly.Location, references);
-            Assert.Contains(typeof(AssemblyPart).GetTypeInfo().Assembly.Location, references);
+            Assert.Contains(
+                typeof(AssemblyPart).GetTypeInfo().Assembly.GetName().Name, 
+                references.Select(Path.GetFileNameWithoutExtension));
         }
 
         [Fact]


### PR DESCRIPTION
This workaround an issue \ bug with the results returned by DependencyContext where
the path uses a mix of forward and back slashes which causes comparison with Assembly.Location that only
uses forward slashes to fail.