### PR TITLE
Use regular PDBs on full desktop when possible

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/DefaultRoslynCompilationService.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/DefaultRoslynCompilationService.cs
@@ -27,6 +27,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
     /// </summary>
     public class DefaultRoslynCompilationService : ICompilationService
     {
+        private readonly DebugInformationFormat _pdbFormat = SymbolsUtility.SupportsFullPdbGeneration() ?
+            DebugInformationFormat.Pdb :
+            DebugInformationFormat.PortablePdb;
         private readonly ApplicationPartManager _partManager;
         private readonly IFileProvider _fileProvider;
         private readonly Action<RoslynCompilationContext> _compilationCallback;
@@ -116,7 +119,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
                     var result = compilation.Emit(
                         assemblyStream,
                         pdbStream,
-                        options: new EmitOptions(debugInformationFormat: DebugInformationFormat.PortablePdb));
+                        options: new EmitOptions(debugInformationFormat: _pdbFormat));
 
                     if (!result.Success)
                     {

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/SymbolsUtility.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/SymbolsUtility.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.AspNetCore.Mvc.Razor.Internal
+{
+    /// <summary>
+    /// Utility type for determining if a platform supports full pdb file generation.
+    /// </summary>
+    public class SymbolsUtility
+    {
+        private const string SymWriterGuid = "0AE2DEB0-F901-478b-BB9F-881EE8066788";
+
+        /// <summary>
+        /// Determines if the current platform supports full pdb generation.
+        /// </summary>
+        /// <returns><c>true</c> if full pdb generation is supported; <c>false</c> otherwise.</returns>
+        public static bool SupportsFullPdbGeneration()
+        {
+            if (Type.GetType("Mono.Runtime") != null)
+            {
+                return false;
+            }
+
+            try
+            {
+                // Check for the pdb writer component that roslyn uses to generate pdbs
+                var type = Marshal.GetTypeFromCLSID(new Guid(SymWriterGuid));
+                if (type != null)
+                {
+                    // This line will throw if pdb generation is not supported.
+                    Activator.CreateInstance(type);
+                    return true;
+                }
+            }
+            catch
+            {
+            }
+
+            return false;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ErrorPageTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ErrorPageTests.cs
@@ -4,10 +4,9 @@
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text.Encodings.Web;
 using System.Threading.Tasks;
-#if !NETCOREAPP1_0
-using Microsoft.AspNetCore.Testing.xunit;
-#endif
+using Microsoft.AspNetCore.Mvc.Razor.Internal;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests
@@ -24,17 +23,13 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
         public HttpClient Client { get; }
 
-#if NETCOREAPP1_0
         [Theory]
-#else
-        [ConditionalTheory]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "aspnet/Mvc#3587")]
-#endif
         [InlineData("CompilationFailure", "Cannot implicitly convert type &#x27;int&#x27; to &#x27;string&#x27;")]
-        [InlineData("ParserError", "The code block is missing a closing &quot;}&quot; character.  Make sure you " +
-                                    "have a matching &quot;}&quot; character for all the &quot;{&quot; characters " +
-                                    "within this block, and that none of the &quot;}&quot; characters are being " +
-                                    "interpreted as markup.")]
+        [InlineData("ParserError",
+            "The code block is missing a closing &quot;}&quot; character.  Make sure you " +
+            "have a matching &quot;}&quot; character for all the &quot;{&quot; characters " +
+            "within this block, and that none of the &quot;}&quot; characters are being " +
+            "interpreted as markup.")]
         public async Task CompilationFailuresAreListedByErrorPageMiddleware(string action, string expected)
         {
             // Arrange
@@ -67,6 +62,34 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal(expectedMediaType, response.Content.Headers.ContentType);
             var content = await response.Content.ReadAsStringAsync();
             Assert.Contains("/Views/ErrorFromViewImports/_ViewImports.cshtml", content);
+            Assert.Contains(expectedMessage, content);
+        }
+
+        [Fact]
+        public async Task RuntimeErrorAreListedByErrorPageMiddleware()
+        {
+            // The desktop CLR does not correctly read the stack trace from portable PDBs. However generating full pdbs
+            // is only supported on machines with CLSID_CorSymWriter available. On desktop, we'll skip this test on 
+            // machines without this component.
+#if NET451
+            if (!SymbolsUtility.SupportsFullPdbGeneration())
+            {
+                return;
+            }
+#endif
+
+            // Arrange
+            var expectedMessage = HtmlEncoder.Default.Encode("throw new Exception(\"Error from view\");");
+            var expectedMediaType = MediaTypeHeaderValue.Parse("text/html; charset=utf-8");
+
+            // Act
+            var response = await Client.GetAsync("http://localhost/RuntimeError");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.Equal(expectedMediaType, response.Content.Headers.ContentType);
+            var content = await response.Content.ReadAsStringAsync();
+            Assert.Contains("/Views/ErrorPageMiddleware/RuntimeError.cshtml", content);
             Assert.Contains(expectedMessage, content);
         }
     }

--- a/test/WebSites/ErrorPageMiddlewareWebSite/ErrorPageMiddlewareController.cs
+++ b/test/WebSites/ErrorPageMiddlewareWebSite/ErrorPageMiddlewareController.cs
@@ -24,5 +24,8 @@ namespace ErrorPageMiddlewareWebSite
         {
             return View("~/Views/ErrorFromViewImports/Index.cshtml");
         }
+
+        [HttpGet("/RuntimeError")]
+        public IActionResult RuntimeError() => View();
     }
 }

--- a/test/WebSites/ErrorPageMiddlewareWebSite/Views/ErrorPageMiddleware/RuntimeError.cshtml
+++ b/test/WebSites/ErrorPageMiddlewareWebSite/Views/ErrorPageMiddleware/RuntimeError.cshtml
@@ -1,0 +1,3 @@
+@{
+  throw new Exception("Error from view");
+}


### PR DESCRIPTION
Add a test to verify exceptions thrown from views is pretty printed by diagnostics middleware

Fixes https://github.com/aspnet/Diagnostics/issues/293
Fixes #4737