### PR TITLE
[Perf] Razor Generate code to preallocate TagHelperAttributes for bound string typed attributes

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.Host/MvcRazorHost.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Host/MvcRazorHost.cs
@@ -117,7 +117,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor
                     TagHelperOutputIsContentModifiedPropertyName = nameof(TagHelperOutput.IsContentModified),
                     TagHelperOutputContentPropertyName = nameof(TagHelperOutput.Content),
                     ExecutionContextSetOutputContentAsyncMethodName = nameof(TagHelperExecutionContext.SetOutputContentAsync),
-                })
+                    TagHelperAttributeValuePropertyName = nameof(TagHelperAttribute.Value),
+        })
             {
                 BeginContextMethodName = "BeginContext",
                 EndContextMethodName = "EndContext"


### PR DESCRIPTION
This change is related to the Razor code change https://github.com/aspnet/Razor/pull/765 