### PR TITLE
Add `AdditionalCompilationReferences` option to `RazorViewEngineOptions`.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor/RazorViewEngineOptions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/RazorViewEngineOptions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc.Razor.Compilation;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.FileProviders;
 
@@ -89,6 +90,12 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         /// </para>
         /// </remarks>
         public IList<string> AreaViewLocationFormats { get; } = new List<string>();
+
+        /// <summary>
+        /// Gets the <see cref="MetadataReference" /> instances that should be included in Razor compilation, along with
+        /// those discovered by <see cref="MetadataReferenceFeatureProvider" />s.
+        /// </summary>
+        public IList<MetadataReference> AdditionalCompilationReferences { get; } = new List<MetadataReference>();
 
         /// <summary>
         /// Gets or sets the callback that is used to customize Razor compilation

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/DefaultRoslynCompilationServiceTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/DefaultRoslynCompilationServiceTest.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Razor.Compilation;
@@ -316,6 +318,34 @@ public class MyNonCustomDefinedClass {}
             Assert.NotNull(result.CompiledType);
         }
 
+        [Fact]
+        public void GetCompilationReferences_CombinesApplicationPartAndOptionMetadataReferences()
+        {
+            // Arrange
+            var options = new RazorViewEngineOptions();
+            var objectAssemblyLocation = typeof(object).GetTypeInfo().Assembly.Location;
+            var objectAssemblyMetadataReference = MetadataReference.CreateFromFile(objectAssemblyLocation);
+            options.AdditionalCompilationReferences.Add(objectAssemblyMetadataReference);
+            var applicationPartManager = GetApplicationPartManager();
+            var compilationService = new TestRoslynCompilationService(applicationPartManager, options);
+            var feature = new MetadataReferenceFeature();
+            applicationPartManager.PopulateFeature(feature);
+            var partReferences = feature.MetadataReferences;
+            var expectedReferences = new List<MetadataReference>();
+            expectedReferences.AddRange(partReferences);
+            expectedReferences.Add(objectAssemblyMetadataReference);
+            var expectedReferenceDisplays = expectedReferences.Select(reference => reference.Display);
+
+            // Act
+            var references = compilationService.GetCompilationReferencesPublic();
+            var referenceDisplays = references.Select(reference => reference.Display);
+
+            // Assert
+            Assert.NotNull(references);
+            Assert.NotEmpty(references);
+            Assert.Equal(expectedReferenceDisplays, referenceDisplays);
+        }
+
         private static DiagnosticDescriptor GetDiagnosticDescriptor(string messageFormat)
         {
             return new DiagnosticDescriptor(
@@ -374,6 +404,16 @@ public class MyNonCustomDefinedClass {}
                 GetAccessor(options),
                 GetFileProviderAccessor(fileProvider),
                 NullLoggerFactory.Instance);
+        }
+
+        private class TestRoslynCompilationService : DefaultRoslynCompilationService
+        {
+            public TestRoslynCompilationService(ApplicationPartManager partManager, RazorViewEngineOptions options)
+                : base(partManager, GetAccessor(options), GetFileProviderAccessor(), NullLoggerFactory.Instance)
+            {
+            }
+
+            public IList<MetadataReference> GetCompilationReferencesPublic() => GetCompilationReferences();
         }
     }
 }


### PR DESCRIPTION
- `AdditionalCompilationReferences` is a purely additive option to add `MetadataReference` instances to be used for Razor compilation.
- Added a test to validate the compilation references get combined with the `ApplicationPartManager`s metadata references.

#4497