### PR TITLE
Split up MvcRouteHandler

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/Abstractions/ActionDescriptor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/Abstractions/ActionDescriptor.cs
@@ -16,7 +16,6 @@ namespace Microsoft.AspNetCore.Mvc.Abstractions
             Id = Guid.NewGuid().ToString();
             Properties = new Dictionary<object, object>();
             RouteValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            RouteValueDefaults = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -31,8 +30,6 @@ namespace Microsoft.AspNetCore.Mvc.Abstractions
         public IDictionary<string, string> RouteValues { get; set; }
 
         public AttributeRouteInfo AttributeRouteInfo { get; set; }
-
-        public IDictionary<string, object> RouteValueDefaults { get; set; }
 
         /// <summary>
         /// The set of constraints for this action. Must all be satisfied for the action to be selected.

--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ActionConstraints/ActionSelectorCandidate.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ActionConstraints/ActionSelectorCandidate.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Mvc.ActionConstraints
     /// <summary>
     /// A candidate action for action selection.
     /// </summary>
-    public class ActionSelectorCandidate
+    public struct ActionSelectorCandidate
     {
         /// <summary>
         /// Creates a new <see cref="ActionSelectorCandidate"/>.
@@ -33,11 +33,11 @@ namespace Microsoft.AspNetCore.Mvc.ActionConstraints
         /// <summary>
         /// The <see cref="ActionDescriptor"/> representing a candiate for selection.
         /// </summary>
-        public ActionDescriptor Action { get; private set; }
+        public ActionDescriptor Action { get; }
 
         /// <summary>
         /// The list of <see cref="IActionConstraint"/> instances associated with <see name="Action"/>.
         /// </summary>
-        public IReadOnlyList<IActionConstraint> Constraints { get; private set; }
+        public IReadOnlyList<IActionConstraint> Constraints { get; }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ApplicationModels/AttributeRouteModel.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ApplicationModels/AttributeRouteModel.cs
@@ -198,7 +198,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
             return result.Substring(startIndex, subStringLength);
         }
 
-        public static string ReplaceTokens(string template, IDictionary<string, object> values)
+        public static string ReplaceTokens(string template, IDictionary<string, string> values)
         {
             var builder = new StringBuilder();
             var state = TemplateParserState.Plaintext;
@@ -340,7 +340,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
                                 .Replace("[[", "[")
                                 .Replace("]]", "]");
 
-                            object value;
+                            string value;
                             if (!values.TryGetValue(token, out value))
                             {
                                 // Value not found

--- a/src/Microsoft.AspNetCore.Mvc.Core/Builder/MvcApplicationBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Builder/MvcApplicationBuilderExtensions.cs
@@ -3,9 +3,7 @@
 
 using System;
 using Microsoft.AspNetCore.Mvc.Core;
-using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
-using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -96,9 +94,7 @@ namespace Microsoft.AspNetCore.Builder
 
             // Adding the attribute route comes after running the user-code because
             // we want to respect any changes to the DefaultHandler.
-            routes.Routes.Insert(0, AttributeRouting.CreateAttributeMegaRoute(
-                routes.DefaultHandler,
-                app.ApplicationServices));
+            routes.Routes.Insert(0, AttributeRouting.CreateAttributeMegaRoute(app.ApplicationServices));
 
             return app.UseRouter(routes.Build());
         }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ConsumesAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ConsumesAttribute.cs
@@ -142,7 +142,7 @@ namespace Microsoft.AspNetCore.Mvc
             }
 
             var firstCandidate = context.Candidates[0];
-            if (firstCandidate != context.CurrentCandidate)
+            if (firstCandidate.Action != context.CurrentCandidate.Action)
             {
                 // If the current candidate is not same as the first candidate,
                 // we need not probe other candidates to see if they apply.
@@ -157,7 +157,7 @@ namespace Microsoft.AspNetCore.Mvc
             // 3). If we have no matches, then we choose the first constraint to return true.It will later return a 415
             foreach (var candidate in context.Candidates)
             {
-                if (candidate == firstCandidate)
+                if (candidate.Action == firstCandidate.Action)
                 {
                     continue;
                 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
@@ -217,9 +217,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddSingleton<RedirectToRouteResultExecutor>();
 
             //
-            // Setup default handler
+            // Route Handlers
             //
-            services.TryAddSingleton<MvcRouteHandler>();
+            services.TryAddSingleton<MvcRouteHandler>(); // Only one per app
+            services.TryAddTransient<MvcAttributeRouteHandler>(); // Many per app
         }
 
         private static void ConfigureDefaultServices(IServiceCollection services)

--- a/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/IActionSelector.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/IActionSelector.cs
@@ -36,9 +36,12 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
         /// <param name="context">The <see cref="RouteContext"/> associated with the current request.</param>
         /// <param name="candidates">The set of <see cref="ActionDescriptor"/> candidates.</param>
         /// <returns>The best <see cref="ActionDescriptor"/> candidate for the current request or <c>null</c>.</returns>
+        /// <exception cref="Internal.AmbiguousActionException">
+        /// Thrown when action selection results in an ambiguity.
+        /// </exception>
         /// <remarks>
         /// <para>
-        /// Invokes action constrains associated with the candidates.
+        /// Invokes action constraints associated with the candidates.
         /// </para>
         /// <para>
         /// Used by conventional routing after calling <see cref="SelectCandidates"/> to apply action constraints and

--- a/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/IActionSelector.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/IActionSelector.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Routing;
 
@@ -12,13 +13,41 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
     public interface IActionSelector
     {
         /// <summary>
-        /// Selects an <see cref="ActionDescriptor"/> for the request associated with <paramref name="context"/>.
+        /// Selects a set of <see cref="ActionDescriptor"/> candidates for the current request associated with
+        /// <paramref name="context"/>.
         /// </summary>
-        /// <param name="context">The <see cref="RouteContext"/> for the current request.</param>
-        /// <returns>An <see cref="ActionDescriptor"/> or <c>null</c> if no action can be selected.</returns>
-        /// <exception cref="Internal.AmbiguousActionException">
-        /// Thrown when action selection results in an ambiguity.
-        /// </exception>
-        ActionDescriptor Select(RouteContext context);
+        /// <param name="context">The <see cref="RouteContext"/> associated with the current request.</param>
+        /// <returns>A set of <see cref="ActionDescriptor"/> candidates or <c>null</c>.</returns>
+        /// <remarks>
+        /// <para>
+        /// Used by conventional routing to select the set of actions that match the route values for the
+        /// current request. Action constraints associated with the candidates are not invoked by this method
+        /// </para>
+        /// <para>
+        /// Attribute routing does not call this method.
+        /// </para>
+        /// </remarks>
+        IReadOnlyList<ActionDescriptor> SelectCandidates(RouteContext context);
+
+        /// <summary>
+        /// Selects the best <see cref="ActionDescriptor"/> candidate from <paramref name="candidates"/> for the 
+        /// current request associated with <paramref name="context"/>.
+        /// </summary>
+        /// <param name="context">The <see cref="RouteContext"/> associated with the current request.</param>
+        /// <param name="candidates">The set of <see cref="ActionDescriptor"/> candidates.</param>
+        /// <returns>The best <see cref="ActionDescriptor"/> candidate for the current request or <c>null</c>.</returns>
+        /// <remarks>
+        /// <para>
+        /// Invokes action constrains associated with the candidates.
+        /// </para>
+        /// <para>
+        /// Used by conventional routing after calling <see cref="SelectCandidates"/> to apply action constraints and
+        /// disambiguate between multiple candidates.
+        /// </para>
+        /// <para>
+        /// Used by attribute routing to apply action constraints and disambiguate between multiple candidates.
+        /// </para>
+        /// </remarks>
+        ActionDescriptor SelectBestCandidate(RouteContext context, IReadOnlyList<ActionDescriptor> candidates);
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ActionSelectionDecisionTree.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ActionSelectionDecisionTree.cs
@@ -6,9 +6,9 @@ using System.Collections.Generic;
 #if NET451
 using System.ComponentModel;
 #endif
+using System.Linq;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
-using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.DecisionTree;
 
@@ -27,8 +27,9 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         {
             Version = actions.Version;
 
+            var conventionalRoutedActions = actions.Items.Where(a => a.AttributeRouteInfo?.Template == null).ToArray();
             _root = DecisionTreeBuilder<ActionDescriptor>.GenerateTree(
-                actions.Items,
+                conventionalRoutedActions,
                 new ActionDescriptorClassifier());
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ActionSelector.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ActionSelector.cs
@@ -39,8 +39,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             _actionConstraintCache = actionConstraintCache;
         }
 
-        /// <inheritdoc />
-        public ActionDescriptor Select(RouteContext context)
+        public IReadOnlyList<ActionDescriptor> SelectCandidates(RouteContext context)
         {
             if (context == null)
             {
@@ -48,14 +47,27 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             }
 
             var tree = _decisionTreeProvider.DecisionTree;
-            var matchingRouteValues = tree.Select(context.RouteData.Values);
+            return tree.Select(context.RouteData.Values);
+        }
+
+        public ActionDescriptor SelectBestCandidate(RouteContext context, IReadOnlyList<ActionDescriptor> candidates1)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (candidates1 == null)
+            {
+                throw new ArgumentNullException(nameof(candidates1));
+            }
 
             var candidates = new List<ActionSelectorCandidate>();
 
             // Perf: Avoid allocations
-            for (var i = 0; i < matchingRouteValues.Count; i++)
+            for (var i = 0; i < candidates1.Count; i++)
             {
-                var action = matchingRouteValues[i];
+                var action = candidates1[i];
                 var constraints = _actionConstraintCache.GetActionConstraints(context.HttpContext, action);
                 candidates.Add(new ActionSelectorCandidate(action, constraints));
             }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ActionSelector.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ActionSelector.cs
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 candidates.Add(new ActionSelectorCandidate(action, constraints));
             }
 
-            var matches = EvaluateActionConstraints(context, candidates, startingOrder: null);
+            var matches = EvaluateActionConstraintsCore(context, candidates, startingOrder: null);
 
             List<ActionDescriptor> results = null;
             if (matches != null)
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             return results;
         }
 
-        private IReadOnlyList<ActionSelectorCandidate> EvaluateActionConstraints(
+        private IReadOnlyList<ActionSelectorCandidate> EvaluateActionConstraintsCore(
             RouteContext context,
             IReadOnlyList<ActionSelectorCandidate> candidates,
             int? startingOrder)
@@ -217,7 +217,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             // If we have matches with constraints, those are 'better' so try to keep processing those
             if (actionsWithConstraint.Count > 0)
             {
-                var matches = EvaluateActionConstraints(context, actionsWithConstraint, order);
+                var matches = EvaluateActionConstraintsCore(context, actionsWithConstraint, order);
                 if (matches?.Count > 0)
                 {
                     return matches;
@@ -231,7 +231,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             }
             else
             {
-                return EvaluateActionConstraints(context, actionsWithoutConstraint, order);
+                return EvaluateActionConstraintsCore(context, actionsWithoutConstraint, order);
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/AttributeRoute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/AttributeRoute.cs
@@ -8,32 +8,27 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Core;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
-using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Template;
 using Microsoft.AspNetCore.Routing.Tree;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Mvc.Internal
 {
     public class AttributeRoute : IRouter
     {
-        private readonly IRouter _handler;
         private readonly IActionDescriptorCollectionProvider _actionDescriptorCollectionProvider;
         private readonly IServiceProvider _services;
+        private readonly Func<ActionDescriptor[], IRouter> _handlerFactory;
 
         private TreeRouter _router;
 
         public AttributeRoute(
-            IRouter handler,
             IActionDescriptorCollectionProvider actionDescriptorCollectionProvider,
-            IServiceProvider services)
+            IServiceProvider services,
+            Func<ActionDescriptor[], IRouter> handlerFactory)
         {
-            if (handler == null)
-            {
-                throw new ArgumentNullException(nameof(handler));
-            }
-
             if (actionDescriptorCollectionProvider == null)
             {
                 throw new ArgumentNullException(nameof(actionDescriptorCollectionProvider));
@@ -44,9 +39,14 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 throw new ArgumentNullException(nameof(services));
             }
 
-            _handler = handler;
+            if (handlerFactory == null)
+            {
+                _handlerFactory = handlerFactory;
+            }
+
             _actionDescriptorCollectionProvider = actionDescriptorCollectionProvider;
             _services = services;
+            _handlerFactory = handlerFactory;
         }
 
         /// <inheritdoc />
@@ -88,10 +88,16 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             // action by expected route values, and then use the TemplateBinder to generate the link.
             foreach (var routeInfo in routeInfos)
             {
+                var defaults = new RouteValueDictionary();
+                foreach (var kvp in routeInfo.ActionDescriptor.RouteValues)
+                {
+                    defaults.Add(kvp.Key, kvp.Value);
+                }
+
                 builder.MapOutbound(
-                    _handler,
+                    NullRouter.Instance,
                     routeInfo.RouteTemplate, 
-                    new RouteValueDictionary(routeInfo.ActionDescriptor.RouteValueDefaults),
+                    defaults,
                     routeInfo.RouteName, 
                     routeInfo.Order);
             }
@@ -99,37 +105,27 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             // We're creating one AttributeRouteMatchingEntry per group, so we need to identify the distinct set of
             // groups. It's guaranteed that all members of the group have the same template and precedence,
             // so we only need to hang on to a single instance of the RouteInfo for each group.
-            var distinctRouteInfosByGroup = GroupRouteInfosByGroupId(routeInfos);
-            foreach (var routeInfo in distinctRouteInfosByGroup)
+            var groups = GroupRouteInfos(routeInfos);
+            foreach (var group in groups)
             {
+                var handler = _handlerFactory(group.ToArray());
+
                 // Note that because we only support 'inline' defaults, each routeInfo group also has the same
                 // set of defaults. 
                 //
                 // We then inject the route group as a default for the matcher so it gets passed back to MVC
                 // for use in action selection.
-                var entry = builder.MapInbound(
-                    _handler,
-                    routeInfo.RouteTemplate,
-                    routeInfo.RouteName,
-                    routeInfo.Order);
-
-                entry.Defaults[TreeRouter.RouteGroupKey] = routeInfo.RouteGroup;
+                builder.MapInbound(
+                    handler,
+                    group.Key.RouteTemplate,
+                    group.Key.RouteName,
+                    group.Key.Order);
             }
         }
 
-        private static IEnumerable<RouteInfo> GroupRouteInfosByGroupId(List<RouteInfo> routeInfos)
+        private static IEnumerable<IGrouping<RouteInfo, ActionDescriptor>> GroupRouteInfos(List<RouteInfo> routeInfos)
         {
-            var routeInfosByGroupId = new Dictionary<string, RouteInfo>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (var routeInfo in routeInfos)
-            {
-                if (!routeInfosByGroupId.ContainsKey(routeInfo.RouteGroup))
-                {
-                    routeInfosByGroupId.Add(routeInfo.RouteGroup, routeInfo);
-                }
-            }
-
-            return routeInfosByGroupId.Values;
+            return routeInfos.GroupBy(ri => ri, ri => ri.ActionDescriptor, RouteInfoEqualityComparer.Instance);
         }
 
         private static List<RouteInfo> GetRouteInfos(IReadOnlyList<ActionDescriptor> actions)
@@ -179,23 +175,9 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             Dictionary<string, RouteTemplate> templateCache,
             ActionDescriptor action)
         {
-            string value;
-            action.RouteValues.TryGetValue(TreeRouter.RouteGroupKey, out value);
-
-            if (string.IsNullOrEmpty(value))
-            {
-                // This can happen if an ActionDescriptor has a route template, but doesn't have one of our
-                // special route group constraints. This is a good indication that the user is using a 3rd party
-                // routing system, or has customized their ADs in a way that we can no longer understand them.
-                //
-                // We just treat this case as an 'opt-out' of our attribute routing system.
-                return null;
-            }
-
             var routeInfo = new RouteInfo()
             {
                 ActionDescriptor = action,
-                RouteGroup = value,
             };
 
             try
@@ -216,7 +198,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 return routeInfo;
             }
 
-            foreach (var kvp in action.RouteValueDefaults)
+            foreach (var kvp in action.RouteValues)
             {
                 foreach (var parameter in routeInfo.RouteTemplate.Parameters)
                 {
@@ -246,11 +228,66 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             
             public int Order { get; set; }
 
-            public string RouteGroup { get; set; }
-
             public string RouteName { get; set; }
 
             public RouteTemplate RouteTemplate { get; set; }
+        }
+
+        private class RouteInfoEqualityComparer : IEqualityComparer<RouteInfo>
+        {
+            public static readonly RouteInfoEqualityComparer Instance = new RouteInfoEqualityComparer();
+
+            public bool Equals(RouteInfo x, RouteInfo y)
+            {
+                if (x == null && y == null)
+                {
+                    return true;
+                }
+                else if (x == null ^ y == null)
+                {
+                    return false;
+                }
+                else if (x.Order != y.Order)
+                {
+                    return false;
+                }
+                else
+                {
+                    return string.Equals(
+                        x.RouteTemplate.TemplateText,
+                        y.RouteTemplate.TemplateText,
+                        StringComparison.OrdinalIgnoreCase);
+                }
+            }
+
+            public int GetHashCode(RouteInfo obj)
+            {
+                if (obj == null)
+                {
+                    return 0;
+                }
+
+                var hash = new HashCodeCombiner();
+                hash.Add(obj.Order);
+                hash.Add(obj.RouteTemplate.TemplateText, StringComparer.OrdinalIgnoreCase);
+                return hash;
+            }
+        }
+
+        // Used only to hook up link generation, and it doesn't need to do anything.
+        private class NullRouter : IRouter
+        {
+            public static readonly NullRouter Instance = new NullRouter();
+
+            public VirtualPathData GetVirtualPath(VirtualPathContext context)
+            {
+                return null;
+            }
+
+            public Task RouteAsync(RouteContext context)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/AttributeRoute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/AttributeRoute.cs
@@ -94,6 +94,8 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                     defaults.Add(kvp.Key, kvp.Value);
                 }
 
+                // We use the `NullRouter` as the route handler because we don't need to do anything for link
+                // generations. The TreeRouter does it all for us.
                 builder.MapOutbound(
                     NullRouter.Instance,
                     routeInfo.RouteTemplate, 

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/AttributeRoute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/AttributeRoute.cs
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
         private static IEnumerable<IGrouping<RouteInfo, ActionDescriptor>> GroupRouteInfos(List<RouteInfo> routeInfos)
         {
-            return routeInfos.GroupBy(ri => ri, ri => ri.ActionDescriptor, RouteInfoEqualityComparer.Instance);
+            return routeInfos.GroupBy(r => r, r => r.ActionDescriptor, RouteInfoEqualityComparer.Instance);
         }
 
         private static List<RouteInfo> GetRouteInfos(IReadOnlyList<ActionDescriptor> actions)

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/AttributeRouting.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/AttributeRouting.cs
@@ -25,7 +25,12 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             return new AttributeRoute(
                 services.GetRequiredService<IActionDescriptorCollectionProvider>(),
                 services,
-                (_) => new MvcAttributeRouteHandler(_));
+                actions => 
+                {
+                    var handler = services.GetRequiredService<MvcAttributeRouteHandler>();
+                    handler.Actions = actions;
+                    return handler;
+                });
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/AttributeRouting.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/AttributeRouting.cs
@@ -13,25 +13,19 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         /// <summary>
         /// Creates an attribute route using the provided services and provided target router.
         /// </summary>
-        /// <param name="target">The router to invoke when a route entry matches.</param>
         /// <param name="services">The application services.</param>
         /// <returns>An attribute route.</returns>
-        public static IRouter CreateAttributeMegaRoute(IRouter target, IServiceProvider services)
+        public static IRouter CreateAttributeMegaRoute(IServiceProvider services)
         {
-            if (target == null)
-            {
-                throw new ArgumentNullException(nameof(target));
-            }
-
             if (services == null)
             {
                 throw new ArgumentNullException(nameof(services));
             }
 
             return new AttributeRoute(
-                target,
                 services.GetRequiredService<IActionDescriptorCollectionProvider>(),
-                services);
+                services,
+                (_) => new MvcAttributeRouteHandler(_));
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcAttributeRouteHandler.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcAttributeRouteHandler.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Core;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Mvc.Internal
+{
+    public class MvcAttributeRouteHandler : IRouter
+    {
+        private readonly ActionDescriptor[] _actionDescriptors;
+
+        private bool _servicesRetrieved;
+
+        private IActionContextAccessor _actionContextAccessor;
+        private IActionInvokerFactory _actionInvokerFactory;
+        private IActionSelector _actionSelector;
+        private ILogger _logger;
+        private DiagnosticSource _diagnosticSource;
+
+        public MvcAttributeRouteHandler(ActionDescriptor[] actionDescriptors)
+        {
+            if (actionDescriptors == null)
+            {
+                throw new ArgumentNullException(nameof(actionDescriptors));
+            }
+
+            _actionDescriptors = actionDescriptors;
+        }
+
+        public VirtualPathData GetVirtualPath(VirtualPathContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            // We return null here because we're not responsible for generating the url, the route is.
+            return null;
+        }
+
+        public Task RouteAsync(RouteContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            EnsureServices(context.HttpContext);
+
+            var actionDescriptor = _actionSelector.SelectBestCandidate(context, _actionDescriptors);
+            if (actionDescriptor == null)
+            {
+                _logger.NoActionsMatched();
+                return TaskCache.CompletedTask;
+            }
+
+            foreach (var kvp in actionDescriptor.RouteValues)
+            {
+                if (!string.IsNullOrEmpty(kvp.Value))
+                {
+                    context.RouteData.Values[kvp.Key] = kvp.Value;
+                }
+            }
+
+            context.Handler = (c) => InvokeActionAsync(c, actionDescriptor);
+            return TaskCache.CompletedTask;
+        }
+
+        private async Task InvokeActionAsync(HttpContext httpContext, ActionDescriptor actionDescriptor)
+        {
+            var routeData = httpContext.GetRouteData();
+            try
+            {
+                _diagnosticSource.BeforeAction(actionDescriptor, httpContext, routeData);
+
+                using (_logger.ActionScope(actionDescriptor))
+                {
+                    _logger.ExecutingAction(actionDescriptor);
+
+                    var startTimestamp = _logger.IsEnabled(LogLevel.Information) ? Stopwatch.GetTimestamp() : 0;
+
+                    var actionContext = new ActionContext(httpContext, routeData, actionDescriptor);
+                    if (_actionContextAccessor != null)
+                    {
+                        _actionContextAccessor.ActionContext = actionContext;
+                    }
+
+                    var invoker = _actionInvokerFactory.CreateInvoker(actionContext);
+                    if (invoker == null)
+                    {
+                        throw new InvalidOperationException(
+                            Resources.FormatActionInvokerFactory_CouldNotCreateInvoker(
+                                actionDescriptor.DisplayName));
+                    }
+
+                    await invoker.InvokeAsync();
+
+                    _logger.ExecutedAction(actionDescriptor, startTimestamp);
+                }
+            }
+            finally
+            {
+                _diagnosticSource.AfterAction(actionDescriptor, httpContext, routeData);
+            }
+        }
+
+        private void EnsureServices(HttpContext context)
+        {
+            if (_servicesRetrieved)
+            {
+                return;
+            }
+
+            var services = context.RequestServices;
+
+            // The IActionContextAccessor is optional. We want to avoid the overhead of using CallContext
+            // if possible.
+            _actionContextAccessor = services.GetService<IActionContextAccessor>();
+
+            _actionInvokerFactory = services.GetRequiredService<IActionInvokerFactory>();
+            _actionSelector = services.GetRequiredService<IActionSelector>();
+            _diagnosticSource = services.GetRequiredService<DiagnosticSource>();
+
+            var factory = services.GetRequiredService<ILoggerFactory>();
+            _logger = factory.CreateLogger<MvcRouteHandler>();
+
+            _servicesRetrieved = true;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcRouteHandler.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcRouteHandler.cs
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 return TaskCache.CompletedTask;
             }
 
-            context.Handler = async (c) =>
+            context.Handler = (c) =>
             {
                 var routeData = c.GetRouteData();
 
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                             actionDescriptor.DisplayName));
                 }
 
-                await invoker.InvokeAsync();
+                return invoker.InvokeAsync();
             };
 
             return TaskCache.CompletedTask;

--- a/src/Microsoft.AspNetCore.Mvc.Razor/RazorViewEngine.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/RazorViewEngine.cs
@@ -91,8 +91,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         /// <remarks>
         /// The casing of a route value in <see cref="ActionContext.RouteData"/> is determined by the client.
         /// This making constructing paths for view locations in a case sensitive file system unreliable. Using the
-        /// <see cref="Abstractions.ActionDescriptor.RouteValueDefaults"/> for attribute routes and
-        /// <see cref="Abstractions.ActionDescriptor.RouteValues"/> for traditional routes to get route values
+        /// <see cref="Abstractions.ActionDescriptor.RouteValues"/> to get route values
         /// produces consistently cased results.
         /// </remarks>
         public static string GetNormalizedRouteValue(ActionContext context, string key)
@@ -115,22 +114,12 @@ namespace Microsoft.AspNetCore.Mvc.Razor
 
             var actionDescriptor = context.ActionDescriptor;
             string normalizedValue = null;
-            if (actionDescriptor.AttributeRouteInfo != null)
+
+            string value;
+            if (actionDescriptor.RouteValues.TryGetValue(key, out value) &&
+                !string.IsNullOrEmpty(value))
             {
-                object match;
-                if (actionDescriptor.RouteValueDefaults.TryGetValue(key, out match))
-                {
-                    normalizedValue = match?.ToString();
-                }
-            }
-            else
-            {
-                string value;
-                if (actionDescriptor.RouteValues.TryGetValue(key, out value) &&
-                    !string.IsNullOrEmpty(value))
-                {
-                    normalizedValue = value;
-                }
+                normalizedValue = value;
             }
 
             var stringRouteValue = routeValue?.ToString();

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/PartialViewResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/PartialViewResultExecutor.cs
@@ -179,22 +179,11 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
 
             var actionDescriptor = context.ActionDescriptor;
             string normalizedValue = null;
-            if (actionDescriptor.AttributeRouteInfo != null)
+            string value;
+            if (actionDescriptor.RouteValues.TryGetValue(ActionNameKey, out value) &&
+                !string.IsNullOrEmpty(value))
             {
-                object match;
-                if (actionDescriptor.RouteValueDefaults.TryGetValue(ActionNameKey, out match))
-                {
-                    normalizedValue = match?.ToString();
-                }
-            }
-            else
-            {
-                string value;
-                if (actionDescriptor.RouteValues.TryGetValue(ActionNameKey, out value) &&
-                    !string.IsNullOrEmpty(value))
-                {
-                    normalizedValue = value;
-                }
+                normalizedValue = value;
             }
 
             var stringRouteValue = routeValue?.ToString();

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ViewResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ViewResultExecutor.cs
@@ -193,22 +193,11 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
 
             var actionDescriptor = context.ActionDescriptor;
             string normalizedValue = null;
-            if (actionDescriptor.AttributeRouteInfo != null)
+            string value;
+            if (actionDescriptor.RouteValues.TryGetValue(ActionNameKey, out value) &&
+                !string.IsNullOrEmpty(value))
             {
-                object match;
-                if (actionDescriptor.RouteValueDefaults.TryGetValue(ActionNameKey, out match))
-                {
-                    normalizedValue = match?.ToString();
-                }
-            }
-            else
-            {
-                string value;
-                if (actionDescriptor.RouteValues.TryGetValue(ActionNameKey, out value) &&
-                    !string.IsNullOrEmpty(value))
-                {
-                    normalizedValue = value;
-                }
+                normalizedValue = value;
             }
 
             var stringRouteValue = routeValue?.ToString();

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ApplicationModel/AttributeRouteModelTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ApplicationModel/AttributeRouteModelTests.cs
@@ -146,17 +146,11 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
 
         [Theory]
         [MemberData(nameof(ReplaceTokens_ValueValuesData))]
-        public void ReplaceTokens_ValidValues(string template, object values, string expected)
+        public void ReplaceTokens_ValidValues(string template, Dictionary<string, string> values, string expected)
         {
             // Arrange
-            var valuesDictionary = values as IDictionary<string, object>;
-            if (valuesDictionary == null)
-            {
-                valuesDictionary = new RouteValueDictionary(values);
-            }
-
             // Act
-            var result = AttributeRouteModel.ReplaceTokens(template, valuesDictionary);
+            var result = AttributeRouteModel.ReplaceTokens(template, values);
 
             // Assert
             Assert.Equal(expected, result);
@@ -164,15 +158,9 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
 
         [Theory]
         [MemberData(nameof(ReplaceTokens_InvalidFormatValuesData))]
-        public void ReplaceTokens_InvalidFormat(string template, object values, string reason)
+        public void ReplaceTokens_InvalidFormat(string template, Dictionary<string, string> values, string reason)
         {
             // Arrange
-            var valuesDictionary = values as IDictionary<string, object>;
-            if (valuesDictionary == null)
-            {
-                valuesDictionary = new RouteValueDictionary(values);
-            }
-
             var expected = string.Format(
                 "The route template '{0}' has invalid syntax. {1}",
                 template,
@@ -180,7 +168,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
 
             // Act
             var ex = Assert.Throws<InvalidOperationException>(
-                () => { AttributeRouteModel.ReplaceTokens(template, valuesDictionary); });
+                () => { AttributeRouteModel.ReplaceTokens(template, values); });
 
             // Assert
             Assert.Equal(expected, ex.Message);
@@ -191,7 +179,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
         {
             // Arrange
             var template = "[area]/[controller]/[action2]";
-            var values = new RouteValueDictionary()
+            var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
                 { "area", "Help" },
                 { "controller", "Admin" },
@@ -428,49 +416,73 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
                 yield return new object[]
                 {
                     "[controller]/[action]",
-                    new { controller = "Home", action = "Index" },
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        { "controller", "Home" },
+                        { "action", "Index" }
+                    },
                     "Home/Index"
                 };
 
                 yield return new object[]
                 {
                     "[controller]",
-                    new { controller = "Home", action = "Index" },
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        { "controller", "Home" },
+                        { "action", "Index" }
+                    },
                     "Home"
                 };
 
                 yield return new object[]
                 {
                     "[controller][[",
-                    new { controller = "Home", action = "Index" },
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        { "controller", "Home" },
+                        { "action", "Index" }
+                    },
                     "Home["
                 };
 
                 yield return new object[]
                 {
                     "[coNTroller]",
-                    new { contrOLler = "Home", action = "Index" },
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        { "controller", "Home" },
+                        { "action", "Index" }
+                    },
                     "Home"
                 };
 
                 yield return new object[]
                 {
                     "thisisSomeText[action]",
-                    new { controller = "Home", action = "Index" },
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        { "controller", "Home" },
+                        { "action", "Index" }
+                    },
                     "thisisSomeTextIndex"
                 };
 
                 yield return new object[]
                 {
                     "[[-]][[/[[controller]]",
-                    new { controller = "Home", action = "Index" },
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        { "controller", "Home" },
+                        { "action", "Index" }
+                    },
                     "[-][/[controller]"
                 };
 
                 yield return new object[]
                 {
                     "[contr[[oller]/[act]]ion]",
-                    new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
                     {
                         { "contr[oller", "Home" },
                         { "act]ion", "Index" }
@@ -481,7 +493,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
                 yield return new object[]
                 {
                     "[controller][action]",
-                    new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
                     {
                         { "controller", "Home" },
                         { "action", "Index" }
@@ -492,7 +504,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
                 yield return new object[]
                 {
                     "[contr}oller]/[act{ion]/{id}",
-                    new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
                     {
                         { "contr}oller", "Home" },
                         { "act{ion", "Index" }
@@ -509,35 +521,35 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
                 yield return new object[]
                 {
                     "[",
-                    new { },
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
                     "A replacement token is not closed."
                 };
 
                 yield return new object[]
                 {
                     "text]",
-                    new { },
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
                     "Token delimiters ('[', ']') are imbalanced.",
                 };
 
                 yield return new object[]
                 {
                     "text]morecooltext",
-                    new { },
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
                     "Token delimiters ('[', ']') are imbalanced.",
                 };
 
                 yield return new object[]
                 {
                     "[action",
-                    new { },
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
                     "A replacement token is not closed.",
                 };
 
                 yield return new object[]
                 {
                     "[action]]][",
-                    new RouteValueDictionary()
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
                     {
                         { "action]", "Index" }
                     },
@@ -547,21 +559,21 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
                 yield return new object[]
                 {
                     "[action]]",
-                    new { },
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
                     "A replacement token is not closed."
                 };
 
                 yield return new object[]
                 {
                     "[ac[tion]",
-                    new { },
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
                     "An unescaped '[' token is not allowed inside of a replacement token. Use '[[' to escape."
                 };
 
                 yield return new object[]
                 {
                     "[]",
-                    new { },
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
                     "An empty replacement token ('[]') is not allowed.",
                 };
             }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Infrastructure/MvcRouteHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Infrastructure/MvcRouteHandlerTests.cs
@@ -49,40 +49,6 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
             Assert.Equal(expectedMessage, sink.Writes[0].State?.ToString());
         }
 
-        [Fact]
-<<<<<<< 53b890aab5c55b7573c2492abb397ef32afd08a6
-        public async Task RouteHandler_RemovesRouteGroupFromRouteValues()
-        {
-            // Arrange
-            var invoker = new Mock<IActionInvoker>();
-            invoker
-                .Setup(i => i.InvokeAsync())
-                .Returns(Task.FromResult(true));
-
-            var invokerFactory = new Mock<IActionInvokerFactory>();
-            invokerFactory
-                .Setup(f => f.CreateInvoker(It.IsAny<ActionContext>()))
-                .Returns<ActionContext>((c) =>
-                {
-                    return invoker.Object;
-                });
-
-            var context = CreateRouteContext();
-            var handler = CreateMvcRouteHandler(invokerFactory: invokerFactory.Object);
-
-            var originalRouteData = context.RouteData;
-            originalRouteData.Values.Add(TreeRouter.RouteGroupKey, "/Home/Test");
-
-            // Act
-            await handler.RouteAsync(context);
-
-            // Assert
-            Assert.Same(originalRouteData, context.RouteData);
-
-
-            Assert.False(context.RouteData.Values.ContainsKey(TreeRouter.RouteGroupKey));
-        }
-
         private MvcRouteHandler CreateMvcRouteHandler(
             ActionDescriptor actionDescriptor = null,
             IActionSelector actionSelector = null,

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Infrastructure/MvcRouteHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Infrastructure/MvcRouteHandlerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -28,8 +29,8 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
 
             var mockActionSelector = new Mock<IActionSelector>();
             mockActionSelector
-                .Setup(a => a.Select(It.IsAny<RouteContext>()))
-                .Returns<ActionDescriptor>(null);
+                .Setup(a => a.SelectCandidates(It.IsAny<RouteContext>()))
+                .Returns(new ActionDescriptor[0]);
 
             var context = CreateRouteContext();
 
@@ -49,6 +50,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
         }
 
         [Fact]
+<<<<<<< 53b890aab5c55b7573c2492abb397ef32afd08a6
         public async Task RouteHandler_RemovesRouteGroupFromRouteValues()
         {
             // Arrange
@@ -99,7 +101,12 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
             if (actionSelector == null)
             {
                 var mockActionSelector = new Mock<IActionSelector>();
-                mockActionSelector.Setup(a => a.Select(It.IsAny<RouteContext>()))
+                mockActionSelector
+                    .Setup(a => a.SelectCandidates(It.IsAny<RouteContext>()))
+                    .Returns(new ActionDescriptor[] { actionDescriptor });
+
+                mockActionSelector
+                    .Setup(a => a.SelectBestCandidate(It.IsAny<RouteContext>(), It.IsAny<IReadOnlyList<ActionDescriptor>>()))
                     .Returns(actionDescriptor);
                 actionSelector = mockActionSelector.Object;
             }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AttributeRoutingTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AttributeRoutingTest.cs
@@ -43,11 +43,10 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 "and can occur only at the end of the parameter. The '*' character marks a parameter as catch-all, " +
                 "and can occur only at the start of the parameter." + Environment.NewLine +
                 "Parameter name: routeTemplate";
-
-            var handler = CreateRouter();
+            
             var services = CreateServices(action);
 
-            var route = AttributeRouting.CreateAttributeMegaRoute(handler, services);
+            var route = AttributeRouting.CreateAttributeMegaRoute(services);
 
             // Act & Assert
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -63,7 +62,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         {
             // Arrange
             var action = CreateAction("DisallowedParameter", "{foo}/{action}");
-            action.RouteValueDefaults.Add("foo", "bleh");
+            action.RouteValues.Add("foo", "bleh");
 
             var expectedMessage =
                 "The following errors occurred with attribute routing information:" + Environment.NewLine +
@@ -71,11 +70,10 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 "For action: 'DisallowedParameter'" + Environment.NewLine +
                 "Error: The attribute route '{foo}/{action}' cannot contain a parameter named '{foo}'. " +
                 "Use '[foo]' in the route template to insert the value 'bleh'.";
-
-            var handler = CreateRouter();
+            
             var services = CreateServices(action);
 
-            var route = AttributeRouting.CreateAttributeMegaRoute(handler, services);
+            var route = AttributeRouting.CreateAttributeMegaRoute(services);
 
             // Act & Assert
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -91,10 +89,10 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         {
             // Arrange
             var action1 = CreateAction("DisallowedParameter1", "{foo}/{action}");
-            action1.RouteValueDefaults.Add("foo", "bleh");
+            action1.RouteValues.Add("foo", "bleh");
 
             var action2 = CreateAction("DisallowedParameter2", "cool/{action}");
-            action2.RouteValueDefaults.Add("action", "hey");
+            action2.RouteValues.Add("action", "hey");
 
             var expectedMessage =
                 "The following errors occurred with attribute routing information:" + Environment.NewLine +
@@ -106,11 +104,10 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 "For action: 'DisallowedParameter2'" + Environment.NewLine +
                 "Error: The attribute route 'cool/{action}' cannot contain a parameter named '{action}'. " +
                 "Use '[action]' in the route template to insert the value 'hey'.";
-
-            var handler = CreateRouter();
+            
             var services = CreateServices(action1, action2);
 
-            var route = AttributeRouting.CreateAttributeMegaRoute(handler, services);
+            var route = AttributeRouting.CreateAttributeMegaRoute(services);
 
             // Act & Assert
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -133,13 +130,11 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             action.MethodInfo = actionMethod;
             action.RouteValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
-                { TreeRouter.RouteGroupKey, "group" }
+                { "controller", "Home" },
+                { "action", "Index" },
             };
             action.AttributeRouteInfo = new AttributeRouteInfo();
             action.AttributeRouteInfo.Template = "{controller}/{action}";
-
-            action.RouteValueDefaults.Add("controller", "Home");
-            action.RouteValueDefaults.Add("action", "Index");
 
             var expectedMessage =
                 "The following errors occurred with attribute routing information:" + Environment.NewLine +
@@ -148,10 +143,9 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 "Error: The attribute route '{controller}/{action}' cannot contain a parameter named '{controller}'. " +
                 "Use '[controller]' in the route template to insert the value 'Home'.";
 
-            var handler = CreateRouter();
             var services = CreateServices(action);
 
-            var route = AttributeRouting.CreateAttributeMegaRoute(handler, services);
+            var route = AttributeRouting.CreateAttributeMegaRoute(services);
 
             // Act & Assert
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -167,17 +161,9 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             return new DisplayNameActionDescriptor()
             {
                 DisplayName = displayName,
-                RouteValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { TreeRouter.RouteGroupKey, "whatever" }
-                },
+                RouteValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
                 AttributeRouteInfo = new AttributeRouteInfo { Template = template },
             };
-        }
-
-        private static IRouter CreateRouter()
-        {
-            return Mock.Of<IRouter>();
         }
 
         private static IServiceProvider CreateServices(params ActionDescriptor[] actions)

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AttributeRoutingTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AttributeRoutingTest.cs
@@ -14,7 +14,6 @@ using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.AspNetCore.Routing.Tree;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RouteDataTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RouteDataTest.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                 {
                     typeof(RouteCollection).FullName,
                     typeof(AttributeRoute).FullName,
-                    typeof(MvcRouteHandler).FullName,
+                    typeof(MvcAttributeRouteHandler).FullName,
                 },
                 result.Routers);
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorViewEngineTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorViewEngineTest.cs
@@ -1148,12 +1148,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Test
             Assert.Equal(expected, result.SearchedLocations);
         }
 
-        [Theory]
-        // Looks in RouteValueDefaults
-        [InlineData(true)]
-        // Looks in RouteValues
-        [InlineData(false)]
-        public void FindPage_SelectsActionCaseInsensitively(bool isAttributeRouted)
+        [Fact]
+        public void FindPage_SelectsActionCaseInsensitively()
         {
             // The ActionDescriptor contains "Foo" and the RouteData contains "foo"
             // which matches the case of the constructor thus searching in the appropriate location.
@@ -1177,8 +1173,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Test
 
             var context = GetActionContextWithActionDescriptor(
                 routeValues,
-                routesInActionDescriptor,
-                isAttributeRouted);
+                routesInActionDescriptor);
 
             // Act
             var result = viewEngine.FindPage(context, "details");
@@ -1190,12 +1185,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Test
             pageFactory.Verify();
         }
 
-        [Theory]
-        // Looks in RouteValueDefaults
-        [InlineData(true)]
-        // Looks in RouteValues
-        [InlineData(false)]
-        public void FindPage_LooksForPages_UsingActionDescriptor_Controller(bool isAttributeRouted)
+        [Fact]
+        public void FindPage_LooksForPages_UsingActionDescriptor_Controller()
         {
             // Arrange
             var expected = new[]
@@ -1216,8 +1207,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Test
             var viewEngine = CreateViewEngine();
             var context = GetActionContextWithActionDescriptor(
                 routeValues,
-                routesInActionDescriptor,
-                isAttributeRouted);
+                routesInActionDescriptor);
 
             // Act
             var result = viewEngine.FindPage(context, "foo");
@@ -1228,12 +1218,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Test
             Assert.Equal(expected, result.SearchedLocations);
         }
 
-        [Theory]
-        // Looks in RouteValueDefaults
-        [InlineData(true)]
-        // Looks in RouteValues
-        [InlineData(false)]
-        public void FindPage_LooksForPages_UsingActionDescriptor_Areas(bool isAttributeRouted)
+        [Fact]
+        public void FindPage_LooksForPages_UsingActionDescriptor_Areas()
         {
             // Arrange
             var expected = new[]
@@ -1257,8 +1243,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Test
             var viewEngine = CreateViewEngine();
             var context = GetActionContextWithActionDescriptor(
                 routeValues,
-                routesInActionDescriptor,
-                isAttributeRouted);
+                routesInActionDescriptor);
 
             // Act
             var result = viewEngine.FindPage(context, "foo");
@@ -1269,10 +1254,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Test
             Assert.Equal(expected, result.SearchedLocations);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void FindPage_LooksForPages_UsesRouteValuesAsFallback(bool isAttributeRouted)
+        [Fact]
+        public void FindPage_LooksForPages_UsesRouteValuesAsFallback()
         {
             // Arrange
             var expected = new[]
@@ -1289,8 +1272,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Test
             var viewEngine = CreateViewEngine();
             var context = GetActionContextWithActionDescriptor(
                 routeValues,
-                new Dictionary<string, string>(),
-                isAttributeRouted);
+                new Dictionary<string, string>());
 
             // Act
             var result = viewEngine.FindPage(context, "bar");
@@ -1462,7 +1444,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Test
         }
 
         [Fact]
-        public void GetNormalizedRouteValue_ReturnsValueFromRouteValues_IfKeyHandlingIsRequired()
+        public void GetNormalizedRouteValue_ReturnsValueFromRouteValues()
         {
             // Arrange
             var key = "some-key";
@@ -1514,112 +1496,6 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Test
             var key = "some-key";
             var actionDescriptor = new ActionDescriptor();
             actionDescriptor.RouteValues.Add(key, null);
-
-            var actionContext = new ActionContext
-            {
-                ActionDescriptor = actionDescriptor,
-                RouteData = new RouteData()
-            };
-
-            actionContext.RouteData.Values[key] = "route-value";
-
-            // Act
-            var result = RazorViewEngine.GetNormalizedRouteValue(actionContext, key);
-
-            // Assert
-            Assert.Equal("route-value", result);
-        }
-
-        [Fact]
-        public void GetNormalizedRouteValue_UsesRouteValueDefaults_IfAttributeRouted()
-        {
-            // Arrange
-            var key = "some-key";
-            var actionDescriptor = new ActionDescriptor
-            {
-                AttributeRouteInfo = new AttributeRouteInfo(),
-            };
-            actionDescriptor.RouteValueDefaults[key] = "Route-Value";
-
-            var actionContext = new ActionContext
-            {
-                ActionDescriptor = actionDescriptor,
-                RouteData = new RouteData()
-            };
-
-            actionContext.RouteData.Values[key] = "route-value";
-
-            // Act
-            var result = RazorViewEngine.GetNormalizedRouteValue(actionContext, key);
-
-            // Assert
-            Assert.Equal("Route-Value", result);
-        }
-
-        [Fact]
-        public void GetNormalizedRouteValue_UsesRouteValue_IfRouteValueDefaultsDoesNotMatchRouteValue()
-        {
-            // Arrange
-            var key = "some-key";
-            var actionDescriptor = new ActionDescriptor
-            {
-                AttributeRouteInfo = new AttributeRouteInfo(),
-            };
-            actionDescriptor.RouteValueDefaults[key] = "different-value";
-
-            var actionContext = new ActionContext
-            {
-                ActionDescriptor = actionDescriptor,
-                RouteData = new RouteData()
-            };
-
-            actionContext.RouteData.Values[key] = "route-value";
-
-            // Act
-            var result = RazorViewEngine.GetNormalizedRouteValue(actionContext, key);
-
-            // Assert
-            Assert.Equal("route-value", result);
-        }
-
-        [Fact]
-        public void GetNormalizedRouteValue_ConvertsRouteDefaultToStringValue_IfAttributeRouted()
-        {
-            using (new CultureReplacer())
-            {
-                // Arrange
-                var key = "some-key";
-                var actionDescriptor = new ActionDescriptor
-                {
-                    AttributeRouteInfo = new AttributeRouteInfo(),
-                };
-                actionDescriptor.RouteValueDefaults[key] = 32;
-
-                var actionContext = new ActionContext
-                {
-                    ActionDescriptor = actionDescriptor,
-                    RouteData = new RouteData()
-                };
-
-                actionContext.RouteData.Values[key] = 32;
-
-                // Act
-                var result = RazorViewEngine.GetNormalizedRouteValue(actionContext, key);
-
-                // Assert
-                Assert.Equal("32", result);
-            }
-        }
-
-        [Fact]
-        public void GetNormalizedRouteValue_UsesRouteDataValue_IfKeyDoesNotExistInRouteDefaultValues()
-        {
-            // Arrange
-            var key = "some-key";
-            var actionDescriptor = new ActionDescriptor
-            {
-                AttributeRouteInfo = new AttributeRouteInfo(),
-            };
 
             var actionContext = new ActionContext
             {
@@ -1743,8 +1619,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Test
 
         private static ActionContext GetActionContextWithActionDescriptor(
             IDictionary<string, object> routeValues,
-            IDictionary<string, string> actionRouteValues,
-            bool isAttributeRouted)
+            IDictionary<string, string> actionRouteValues)
         {
             var httpContext = new DefaultHttpContext();
             var routeData = new RouteData();
@@ -1754,20 +1629,10 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Test
             }
 
             var actionDescriptor = new ActionDescriptor();
-            if (isAttributeRouted)
+
+            foreach (var kvp in actionRouteValues)
             {
-                actionDescriptor.AttributeRouteInfo = new AttributeRouteInfo();
-                foreach (var kvp in actionRouteValues)
-                {
-                    actionDescriptor.RouteValueDefaults.Add(kvp.Key, kvp.Value);
-                }
-            }
-            else
-            {
-                foreach (var kvp in actionRouteValues)
-                {
-                    actionDescriptor.RouteValues.Add(kvp.Key, kvp.Value);
-                }
+                actionDescriptor.RouteValues.Add(kvp.Key, kvp.Value);
             }
 
             return new ActionContext(httpContext, routeData, actionDescriptor);

--- a/test/WebSites/BasicWebSite/Areas/Area1/Views/RemoteAttribute_Home/Create.cshtml
+++ b/test/WebSites/BasicWebSite/Areas/Area1/Views/RemoteAttribute_Home/Create.cshtml
@@ -1,9 +1,9 @@
 ﻿@model BasicWebSite.Models.RemoteAttributeUser
 @{
     Layout = "_Layout.cshtml";
-    object areaObject;
-    ViewContext.ActionDescriptor.RouteValueDefaults.TryGetValue("area", out areaObject);
-    var areaName = (areaObject as string) ?? "root";
+    object areaName;
+    ViewContext.RouteData.Values.TryGetValue("area", out areaName);
+    areaName = areaName ?? "root";
     ViewBag.Title = "Create in " + areaName + " area.";
 }
 

--- a/test/WebSites/BasicWebSite/Areas/Area1/Views/RemoteAttribute_Home/Details.cshtml
+++ b/test/WebSites/BasicWebSite/Areas/Area1/Views/RemoteAttribute_Home/Details.cshtml
@@ -1,9 +1,9 @@
 ﻿@model BasicWebSite.Models.RemoteAttributeUser
 @{
     Layout = "_Layout.cshtml";
-    object areaObject;
-    ViewContext.ActionDescriptor.RouteValueDefaults.TryGetValue("area", out areaObject);
-    var areaName = (areaObject as string) ?? "root";
+    object areaName;
+    ViewContext.RouteData.Values.TryGetValue("area", out areaName);
+    areaName = areaName ?? "root";
     ViewBag.Title = "Details in " + areaName + " area.";
 }
 

--- a/test/WebSites/BasicWebSite/Views/RemoteAttribute_Home/Create.cshtml
+++ b/test/WebSites/BasicWebSite/Views/RemoteAttribute_Home/Create.cshtml
@@ -1,9 +1,9 @@
 ﻿@model BasicWebSite.Models.RemoteAttributeUser
 @{
     Layout = "_Layout.cshtml";
-    object areaObject;
-    ViewContext.ActionDescriptor.RouteValueDefaults.TryGetValue("area", out areaObject);
-    var areaName = (areaObject as string) ?? "root";
+    object areaName;
+    ViewContext.RouteData.Values.TryGetValue("area", out areaName);
+    areaName = areaName ?? "root";
     ViewBag.Title = "Create in " + areaName + " area.";
 }
 

--- a/test/WebSites/BasicWebSite/Views/RemoteAttribute_Home/Details.cshtml
+++ b/test/WebSites/BasicWebSite/Views/RemoteAttribute_Home/Details.cshtml
@@ -1,9 +1,9 @@
 ﻿@model BasicWebSite.Models.RemoteAttributeUser
 @{
     Layout = "_Layout.cshtml";
-    object areaObject;
-    ViewContext.ActionDescriptor.RouteValueDefaults.TryGetValue("area", out areaObject);
-    var areaName = (areaObject as string) ?? "root";
+    string areaName;
+    ViewContext.RouteData.Values.TryGetValue("area", out areaName);
+    areaName = areaName ?? "root";
     ViewBag.Title = "Details in " + areaName + " area.";
 }
 


### PR DESCRIPTION
This change splits up the conventional routing path from the attribute
routing path *inside* routing, instead of inside `MvcRouteHandler`. Each
attribute route group now gets its own instance of
`MvcAttributeRouteHandler` which just knows about the actions it can
reach.

This removes the concept of a route-group-token and removes the lookup
table entirely for attribute routing. This also means that the
`DefaultHandler` on `IRouteBuilder` will not be used for attribute routes,
which we are OK with for 1.0.0.

The action selector's functionality is now split into two methods. We
think this is OK for 1.0.0 because any customization of `IActionSelector`
up to now had to implement virtually the same policy as ours in order to
work with attribute routing. It should now be possible to customize the
selector in a meaningful way without interfering with attribute routing.