### PR TITLE
Improve handling of custom `ValidationAttribute`s and their `ValidationResult`s

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/ModelNames.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/ModelNames.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Globalization;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding
@@ -23,14 +24,20 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             {
                 return propertyName ?? string.Empty;
             }
-            else if (string.IsNullOrEmpty(propertyName))
+
+            if (string.IsNullOrEmpty(propertyName))
             {
                 return prefix ?? string.Empty;
             }
-            else
+
+            if (propertyName.StartsWith("[", StringComparison.Ordinal))
             {
-                return prefix + "." + propertyName;
+                // The propertyName might represent an indexer access, in which case combining
+                // with a 'dot' would be invalid. This case occurs only when called from ValidationVisitor.
+                return prefix + propertyName;
             }
+
+            return prefix + "." + propertyName;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.DataAnnotations/Internal/DataAnnotationsModelValidator.cs
+++ b/src/Microsoft.AspNetCore.Mvc.DataAnnotations/Internal/DataAnnotationsModelValidator.cs
@@ -79,7 +79,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
             }
 
             var metadata = validationContext.ModelMetadata;
-            var memberName = metadata.PropertyName ?? metadata.ModelType.Name;
+            var memberName = metadata.PropertyName;
             var container = validationContext.Container;
 
             var context = new ValidationContext(
@@ -94,31 +94,52 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
             var result = Attribute.GetValidationResult(validationContext.Model, context);
             if (result != ValidationResult.Success)
             {
-                // ModelValidationResult.MemberName is used by invoking validators (such as ModelValidator) to
-                // construct the ModelKey for ModelStateDictionary. When validating at type level we want to append
-                // the returned MemberNames if specified (e.g. person.Address.FirstName). For property validation, the
-                // ModelKey can be constructed using the ModelMetadata and we should ignore MemberName (we don't want
-                // (person.Name.Name). However the invoking validator does not have a way to distinguish between these
-                // two cases. Consequently we'll only set MemberName if this validation returns a MemberName that is
-                // different from the property being validated.
-
-                var errorMemberName = result.MemberNames.FirstOrDefault();
-                if (string.Equals(errorMemberName, memberName, StringComparison.Ordinal))
-                {
-                    errorMemberName = null;
-                }
-
-                string errorMessage = null;
+                string errorMessage;
                 if (_stringLocalizer != null &&
                     !string.IsNullOrEmpty(Attribute.ErrorMessage) &&
                     string.IsNullOrEmpty(Attribute.ErrorMessageResourceName) &&
                     Attribute.ErrorMessageResourceType == null)
                 {
-                    errorMessage = GetErrorMessage(validationContext);
+                    errorMessage = GetErrorMessage(validationContext) ?? result.ErrorMessage;
+                }
+                else
+                {
+                    errorMessage = result.ErrorMessage;
                 }
 
-                var validationResult = new ModelValidationResult(errorMemberName, errorMessage ?? result.ErrorMessage);
-                return new ModelValidationResult[] { validationResult };
+                var validationResults = new List<ModelValidationResult>();
+                if (result.MemberNames != null)
+                {
+                    foreach (var resultMemberName in result.MemberNames)
+                    {
+                        // ModelValidationResult.MemberName is used by invoking validators (such as ModelValidator) to
+                        // append construct the ModelKey for ModelStateDictionary. When validating at type level we
+                        // want the returned MemberNames if specified (e.g. "person.Address.FirstName"). For property
+                        // validation, the ModelKey can be constructed using the ModelMetadata and we should ignore
+                        // MemberName (we don't want "person.Name.Name"). However the invoking validator does not have
+                        // a way to distinguish between these two cases. Consequently we'll only set MemberName if this
+                        // validation returns a MemberName that is different from the property being validated.
+                        ModelValidationResult validationResult;
+                        if (string.Equals(resultMemberName, memberName, StringComparison.Ordinal))
+                        {
+                            validationResult = new ModelValidationResult(memberName: null, message: errorMessage);
+                        }
+                        else
+                        {
+                            validationResult = new ModelValidationResult(resultMemberName, errorMessage);
+                        }
+
+                        validationResults.Add(validationResult);
+                    }
+                }
+
+                if (validationResults.Count == 0)
+                {
+                    // result.MemberNames was null or empty.
+                    validationResults.Add(new ModelValidationResult(memberName: null, message: errorMessage));
+                }
+
+                return validationResults;
             }
 
             return Enumerable.Empty<ModelValidationResult>();


### PR DESCRIPTION
- #3595 sub-items 2 through 4
- handle an indexer name in `ValidationResult.MemberNames`
 - aligns `ModelNames.CreatePropertyModelName()` with `TemplateInfo.GetFullHtmlFieldName()`
- handle multiple elements in `ValidationResult.MemberNames`
 - later elements previously ignored
- set `ValidationContext.MemberName` to `null` when no property name is available
 - using type name for a member name was just wrong