### PR TITLE
Fix #4803 - Move some types internal

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Controllers/DefaultControllerFactory.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Controllers/DefaultControllerFactory.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Microsoft.AspNetCore.Mvc.Core;
+using Microsoft.AspNetCore.Mvc.Internal;
 
 namespace Microsoft.AspNetCore.Mvc.Controllers
 {

--- a/src/Microsoft.AspNetCore.Mvc.Core/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 ServiceDescriptor.Transient<IActionInvokerProvider, ControllerActionInvokerProvider>());
 
             // These are stateless
-            services.TryAddSingleton<IControllerArgumentBinder, ControllerArgumentBinder>();
+            services.TryAddSingleton<IControllerArgumentBinder, DefaultControllerArgumentBinder>();
             services.TryAddSingleton<ControllerActionInvokerCache>();
             services.TryAddEnumerable(
                 ServiceDescriptor.Singleton<IFilterProvider, DefaultFilterProvider>());

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/DefaultControllerArgumentBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/DefaultControllerArgumentBinder.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Abstractions;
-using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Core;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
@@ -18,17 +17,17 @@ namespace Microsoft.AspNetCore.Mvc.Internal
     /// Provides a default implementation of <see cref="IControllerArgumentBinder"/>.
     /// Uses ModelBinding to populate action parameters.
     /// </summary>
-    public class ControllerArgumentBinder : IControllerArgumentBinder
+    public class DefaultControllerArgumentBinder : IControllerArgumentBinder
     {
         private static readonly MethodInfo CallPropertyAddRangeOpenGenericMethod =
-            typeof(ControllerArgumentBinder).GetTypeInfo().GetDeclaredMethod(
+            typeof(DefaultControllerArgumentBinder).GetTypeInfo().GetDeclaredMethod(
                 nameof(CallPropertyAddRange));
 
         private readonly IModelBinderFactory _modelBinderFactory;
         private readonly IModelMetadataProvider _modelMetadataProvider;
         private readonly IObjectModelValidator _validator;
 
-        public ControllerArgumentBinder(
+        public DefaultControllerArgumentBinder(
             IModelMetadataProvider modelMetadataProvider,
             IModelBinderFactory modelBinderFactory,
             IObjectModelValidator validator)

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/IControllerArgumentBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/IControllerArgumentBinder.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace Microsoft.AspNetCore.Mvc.Controllers
+namespace Microsoft.AspNetCore.Mvc.Internal
 {
     /// <summary>
     /// Provides a dictionary of action arguments.

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/IControllerPropertyActivator.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/IControllerPropertyActivator.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.AspNetCore.Mvc.Controllers
+namespace Microsoft.AspNetCore.Mvc.Internal
 {
     public interface IControllerPropertyActivator
     {

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/DependencyInjection/MvcViewFeaturesMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/DependencyInjection/MvcViewFeaturesMvcCoreBuilderExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewComponents;
 using Microsoft.AspNetCore.Mvc.ViewEngines;

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ViewDataDictionaryControllerPropertyActivator.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ViewDataDictionaryControllerPropertyActivator.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
-using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Internal;
 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerActionInvokerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerActionInvokerTest.cs
@@ -2458,7 +2458,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
             var metadataProvider = new EmptyModelMetadataProvider();
 
-            var argumentBinder = new ControllerArgumentBinder(
+            var argumentBinder = new DefaultControllerArgumentBinder(
                     metadataProvider,
                     TestModelBinderFactory.CreateDefault(metadataProvider),
                     new DefaultObjectValidator(metadataProvider, new IModelValidatorProvider[0]));

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/DefaultControllerArgumentBinderTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/DefaultControllerArgumentBinderTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.Internal
 {
-    public class ControllerArgumentBinderTests
+    public class DefaultControllerArgumentBinderTests
     {
         [Fact]
         public async Task BindActionArgumentsAsync_DoesNotAddActionArguments_IfBinderReturnsNull()
@@ -645,7 +645,11 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 })
                 .Returns(modelBinder.Object);
 
-            var argumentBinder = new ControllerArgumentBinder(metadataProvider, factory.Object, CreateMockValidator());
+            var argumentBinder = new DefaultControllerArgumentBinder(
+                metadataProvider,
+                factory.Object, 
+                CreateMockValidator());
+
             var controllerContext = GetControllerContext();
             controllerContext.ActionDescriptor.Parameters.Add(parameterDescriptor);
 
@@ -688,7 +692,11 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 })
                 .Returns(modelBinder.Object);
 
-            var argumentBinder = new ControllerArgumentBinder(metadataProvider, factory.Object, CreateMockValidator());
+            var argumentBinder = new DefaultControllerArgumentBinder(
+                metadataProvider, 
+                factory.Object, 
+                CreateMockValidator());
+
             var valueProvider = new SimpleValueProvider
             {
                 { expectedModelName, new object() },
@@ -752,7 +760,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             return TestModelBinderFactory.Create(provider.Object);
         }
 
-        private static ControllerArgumentBinder GetArgumentBinder(
+        private static DefaultControllerArgumentBinder GetArgumentBinder(
             IModelBinderFactory factory = null,
             IObjectModelValidator validator = null)
         {
@@ -766,7 +774,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 factory = TestModelBinderFactory.CreateDefault();
             }
 
-            return new ControllerArgumentBinder(
+            return new DefaultControllerArgumentBinder(
                 TestModelMetadataProvider.CreateDefaultProvider(),
                 factory,
                 validator);

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/ModelBindingTestHelper.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/ModelBindingTestHelper.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             return context;
         }
 
-        public static ControllerArgumentBinder GetArgumentBinder(
+        public static DefaultControllerArgumentBinder GetArgumentBinder(
             MvcOptions options = null,
             IModelBinderProvider binderProvider = null)
         {
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             }
         }
 
-        public static ControllerArgumentBinder GetArgumentBinder(
+        public static DefaultControllerArgumentBinder GetArgumentBinder(
             IModelMetadataProvider metadataProvider, 
             IModelBinderProvider binderProvider = null)
         {
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
                 options.Value.ModelBinderProviders.Insert(0, binderProvider);
             }
 
-            return new ControllerArgumentBinder(
+            return new DefaultControllerArgumentBinder(
                 metadataProvider,
                 new ModelBinderFactory(metadataProvider, options),
                 GetObjectValidator(metadataProvider, options));


### PR DESCRIPTION
Moves IControllerArgumentBinder and IControllerPropertyActivator into
.Internal. Also renames ControllerArgumentBinder ->
DefaultControllerArgumentBinder for consistency with other controller
extensibility types.

We don't think these are 100% baked for our long term maintenance of the
product, and want to reserve the ability to make changes in the future.