### PR TITLE
Fix #4801 Rename ValidationExcludeFilter

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcCoreMvcOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcCoreMvcOptionsSetup.cs
@@ -86,11 +86,11 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             options.ModelValidatorProviders.Add(new DefaultModelValidatorProvider());
 
             // Add types to be excluded from Validation
-            options.ModelMetadataDetailsProviders.Add(new ValidationExcludeFilter(typeof(Type)));
-            options.ModelMetadataDetailsProviders.Add(new ValidationExcludeFilter(typeof(Uri)));
-            options.ModelMetadataDetailsProviders.Add(new ValidationExcludeFilter(typeof(CancellationToken)));
-            options.ModelMetadataDetailsProviders.Add(new ValidationExcludeFilter(typeof(IFormFile)));
-            options.ModelMetadataDetailsProviders.Add(new ValidationExcludeFilter(typeof(IFormCollection)));
+            options.ModelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider(typeof(Type)));
+            options.ModelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider(typeof(Uri)));
+            options.ModelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider(typeof(CancellationToken)));
+            options.ModelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider(typeof(IFormFile)));
+            options.ModelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider(typeof(IFormCollection)));
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/SuppressChildValidationMetadataProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/SuppressChildValidationMetadataProvider.cs
@@ -6,22 +6,22 @@ using System.Diagnostics;
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 
-namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
+namespace Microsoft.AspNetCore.Mvc.ModelBinding
 {
     /// <summary>
     /// An <see cref="IValidationMetadataProvider"/> which configures <see cref="ModelMetadata.ValidateChildren"/> to
     /// <c>false</c> for matching types.
     /// </summary>
-    public class ValidationExcludeFilter : IValidationMetadataProvider
+    public class SuppressChildValidationMetadataProvider : IValidationMetadataProvider
     {
         /// <summary>
-        /// Creates a new <see cref="ValidationExcludeFilter"/> for the given <paramref name="type"/>.
+        /// Creates a new <see cref="SuppressChildValidationMetadataProvider"/> for the given <paramref name="type"/>.
         /// </summary>
         /// <param name="type">
         /// The <see cref="Type"/>. This <see cref="Type"/> and all assignable values will have
         /// <see cref="ModelMetadata.ValidateChildren"/> set to <c>false</c>.
         /// </param>
-        public ValidationExcludeFilter(Type type)
+        public SuppressChildValidationMetadataProvider(Type type)
         {
             if (type == null)
             {
@@ -32,13 +32,13 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
         }
 
         /// <summary>
-        /// Creates a new <see cref="ValidationExcludeFilter"/> for the given <paramref name="fullTypeName"/>.
+        /// Creates a new <see cref="SuppressChildValidationMetadataProvider"/> for the given <paramref name="fullTypeName"/>.
         /// </summary>
         /// <param name="fullTypeName">
         /// The type full name. This type and all of its subclasses will have
         /// <see cref="ModelMetadata.ValidateChildren"/> set to <c>false</c>.
         /// </param>
-        public ValidationExcludeFilter(string fullTypeName)
+        public SuppressChildValidationMetadataProvider(string fullTypeName)
         {
             if (fullTypeName == null)
             {

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Json/Internal/MvcJsonMvcOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Json/Internal/MvcJsonMvcOptionsSetup.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Buffers;
-using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.ObjectPool;
 using Microsoft.Extensions.Options;
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Json.Internal
 
             options.FormatterMappings.SetMediaTypeMappingForFormat("json", MediaTypeHeaderValue.Parse("application/json"));
 
-            options.ModelMetadataDetailsProviders.Add(new ValidationExcludeFilter(typeof(JToken)));
+            options.ModelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider(typeof(JToken)));
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/MvcXmlDataContractSerializerMvcOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/MvcXmlDataContractSerializerMvcOptionsSetup.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
-using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
@@ -32,8 +32,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
             options.OutputFormatters.Add(new XmlDataContractSerializerOutputFormatter());
             options.InputFormatters.Add(new XmlDataContractSerializerInputFormatter());
 
-            options.ModelMetadataDetailsProviders.Add(new ValidationExcludeFilter("System.Xml.Linq.XObject"));
-            options.ModelMetadataDetailsProviders.Add(new ValidationExcludeFilter("System.Xml.XmlNode"));
+            options.ModelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider("System.Xml.Linq.XObject"));
+            options.ModelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider("System.Xml.XmlNode"));
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.WebApiCompatShim/WebApiCompatShimOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.Mvc.WebApiCompatShim/WebApiCompatShimOptionsSetup.cs
@@ -3,7 +3,7 @@
 
 using System.Net.Http;
 using System.Net.Http.Formatting;
-using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -33,8 +33,8 @@ namespace Microsoft.AspNetCore.Mvc.WebApiCompatShim
             // Add a formatter to write out an HttpResponseMessage to the response
             options.OutputFormatters.Insert(0, new HttpResponseMessageOutputFormatter());
 
-            options.ModelMetadataDetailsProviders.Add(new ValidationExcludeFilter(typeof(HttpRequestMessage)));
-            options.ModelMetadataDetailsProviders.Add(new ValidationExcludeFilter(typeof(HttpResponseMessage)));
+            options.ModelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider(typeof(HttpRequestMessage)));
+            options.ModelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider(typeof(HttpResponseMessage)));
         }
 
         public void Configure(WebApiCompatShimOptions options)

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/DefaultObjectValidatorTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/DefaultObjectValidatorTests.cs
@@ -1068,10 +1068,10 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
         private static DefaultObjectValidator CreateValidator(Type excludedType)
         {
-            var excludeFilters = new List<ValidationExcludeFilter>();
+            var excludeFilters = new List<SuppressChildValidationMetadataProvider>();
             if (excludedType != null)
             {
-                excludeFilters.Add(new ValidationExcludeFilter(excludedType));
+                excludeFilters.Add(new SuppressChildValidationMetadataProvider(excludedType));
             }
 
             var metadataProvider = TestModelMetadataProvider.CreateDefaultProvider(excludeFilters.ToArray());

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/ValidationIntegrationTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/ValidationIntegrationTests.cs
@@ -1272,7 +1272,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
                 },
                 options =>
                 {
-                    options.ModelMetadataDetailsProviders.Add(new ValidationExcludeFilter(typeof(Address)));
+                    options.ModelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider(typeof(Address)));
                     testOptions = options;
                 });
 

--- a/test/Microsoft.AspNetCore.Mvc.Test/MvcOptionsSetupTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Test/MvcOptionsSetupTest.cs
@@ -162,44 +162,44 @@ namespace Microsoft.AspNetCore.Mvc
                 provider => Assert.IsType<DefaultValidationMetadataProvider>(provider),
                 provider =>
                 {
-                    var excludeFilter = Assert.IsType<ValidationExcludeFilter>(provider);
+                    var excludeFilter = Assert.IsType<SuppressChildValidationMetadataProvider>(provider);
                     Assert.Equal(typeof(Type), excludeFilter.Type);
                 },
                 provider =>
                 {
-                    var excludeFilter = Assert.IsType<ValidationExcludeFilter>(provider);
+                    var excludeFilter = Assert.IsType<SuppressChildValidationMetadataProvider>(provider);
                     Assert.Equal(typeof(Uri), excludeFilter.Type);
                 },
                 provider =>
                 {
-                    var excludeFilter = Assert.IsType<ValidationExcludeFilter>(provider);
+                    var excludeFilter = Assert.IsType<SuppressChildValidationMetadataProvider>(provider);
                     Assert.Equal(typeof(CancellationToken), excludeFilter.Type);
                 },
                 provider =>
                 {
-                    var excludeFilter = Assert.IsType<ValidationExcludeFilter>(provider);
+                    var excludeFilter = Assert.IsType<SuppressChildValidationMetadataProvider>(provider);
                     Assert.Equal(typeof(IFormFile), excludeFilter.Type);
                 },
                 provider =>
                 {
-                    var excludeFilter = Assert.IsType<ValidationExcludeFilter>(provider);
+                    var excludeFilter = Assert.IsType<SuppressChildValidationMetadataProvider>(provider);
                     Assert.Equal(typeof(IFormCollection), excludeFilter.Type);
                 },
                 provider => Assert.IsType<DataAnnotationsMetadataProvider>(provider),
                 provider =>
                 {
-                    var excludeFilter = Assert.IsType<ValidationExcludeFilter>(provider);
+                    var excludeFilter = Assert.IsType<SuppressChildValidationMetadataProvider>(provider);
                     Assert.Equal(typeof(JToken), excludeFilter.Type);
                 },
                 provider => Assert.IsType<DataMemberRequiredBindingMetadataProvider>(provider),
                 provider =>
                 {
-                    var excludeFilter = Assert.IsType<ValidationExcludeFilter>(provider);
+                    var excludeFilter = Assert.IsType<SuppressChildValidationMetadataProvider>(provider);
                     Assert.Equal(typeof(XObject).FullName, excludeFilter.FullTypeName);
                 },
                 provider =>
                 {
-                    var excludeFilter = Assert.IsType<ValidationExcludeFilter>(provider);
+                    var excludeFilter = Assert.IsType<SuppressChildValidationMetadataProvider>(provider);
                     Assert.Equal(typeof(XmlNode).FullName, excludeFilter.FullTypeName);
                 });
         }

--- a/test/WebSites/FormatterWebSite/Startup.cs
+++ b/test/WebSites/FormatterWebSite/Startup.cs
@@ -4,7 +4,7 @@
 using System.IO;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace FormatterWebSite
@@ -15,8 +15,8 @@ namespace FormatterWebSite
         {
             services.AddMvc(options =>
             {
-                options.ModelMetadataDetailsProviders.Add(new ValidationExcludeFilter(typeof(Developer)));
-                options.ModelMetadataDetailsProviders.Add(new ValidationExcludeFilter(typeof(Supplier)));
+                options.ModelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider(typeof(Developer)));
+                options.ModelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider(typeof(Supplier)));
 
                 options.InputFormatters.Add(new StringInputFormatter());
             })


### PR DESCRIPTION
'ValidationExcludeFilter' -> 'SuppressChildValidationMetadataProvider'

Also moved to .ModelBinding for improved discoverability. There aren't
many reasons user code would have a using for .Validation.