### PR TITLE
Changed the form tag helpers execution order to be more explicit.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/FormTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/FormTagHelper.cs
@@ -41,14 +41,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             Generator = generator;
         }
 
+        // This TagHelper's order must be lower than the RenderAtEndOfFormTagHelper. I.e it must be executed before
+        // RenderAtEndOfFormTagHelper does.
         /// <inheritdoc />
-        public override int Order
-        {
-            get
-            {
-                return -1000;
-            }
-        }
+        public override int Order => -1000;
 
         [HtmlAttributeNotBound]
         [ViewContext]

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/RenderAtEndOfFormTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/RenderAtEndOfFormTagHelper.cs
@@ -18,7 +18,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
     [HtmlTargetElement("form")]
     public class RenderAtEndOfFormTagHelper : TagHelper
     {
-        public override int Order => -1000;
+        // This TagHelper's order must be greater than the FormTagHelper's. I.e it must be executed after
+        // FormTaghelper does.
+        /// <inheritdoc />
+        public override int Order => -900;
 
         [HtmlAttributeNotBound]
         [ViewContext]


### PR DESCRIPTION
[Fixes #4824] Fix Travis failure for test Microsoft.AspNetCore.Mvc.FunctionalTests.TagHelpersTest.ReregisteringAntiforgeryTokenInsideFormTagHelper_DoesNotAddDuplicateAntiforgeryTokenFields

@rynowak @dougbu @NTaylorMullen 

Travis build succeeded: https://travis-ci.org/aspnet/Mvc/builds/136761441