### PR TITLE
TempData convenience property added to ViewComponent

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponent.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponent.cs
@@ -173,6 +173,17 @@ namespace Microsoft.AspNetCore.Mvc
         }
 
         /// <summary>
+        /// Gets the <see cref="ITempDataDictionary"/>.
+        /// </summary>
+        public ITempDataDictionary TempData
+        {
+            get
+            {
+                return ViewComponentContext.TempData;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the <see cref="ICompositeViewEngine"/>.
         /// </summary>
         public ICompositeViewEngine ViewEngine

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/ViewComponentContext.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/ViewComponentContext.cs
@@ -123,6 +123,14 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
         public ViewDataDictionary ViewData => ViewContext.ViewData;
 
         /// <summary>
+        /// Gets the <see cref="ITempDataDictionary"/>.
+        /// </summary>
+        /// <remarks>
+        /// This is an alias for <c>ViewContext.TempData</c>.
+        /// </remarks>
+        public ITempDataDictionary TempData => ViewContext.TempData;
+
+        /// <summary>
         /// Gets the <see cref="TextWriter"/> for output.
         /// </summary>
         /// <remarks>

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponents/ViewComponentContextTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponents/ViewComponentContextTest.cs
@@ -25,11 +25,12 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
             var httpContext = new DefaultHttpContext();
             var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
             var viewData = new ViewDataDictionary(new EmptyModelMetadataProvider());
+            var tempData = new TempDataDictionary(httpContext, new SessionStateTempDataProvider());
             var viewContext = new ViewContext(
                 actionContext,
                 NullView.Instance,
                 viewData,
-                new TempDataDictionary(httpContext, new SessionStateTempDataProvider()),
+                tempData,
                 TextWriter.Null,
                 new HtmlHelperOptions());
 
@@ -46,11 +47,13 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
             // Assert
             // New ViewContext but initial View and TextWriter copied over.
             Assert.NotSame(viewContext, viewComponentContext.ViewContext);
+            Assert.Same(tempData, viewComponentContext.TempData);
             Assert.Same(viewContext.View, viewComponentContext.ViewContext.View);
             Assert.Same(viewContext.Writer, viewComponentContext.ViewContext.Writer);
 
             // Double-check the convenience properties.
             Assert.Same(viewComponentContext.ViewContext.ViewData, viewComponentContext.ViewData);
+            Assert.Same(viewComponentContext.ViewContext.TempData, viewComponentContext.TempData);
             Assert.Same(viewComponentContext.ViewContext.Writer, viewComponentContext.Writer);
 
             // New VDD instance but initial ModelMetadata copied over.


### PR DESCRIPTION
Fixes #4728

I tried to add some unit tests but in `ViewContext`'s constructor we have to instantiate a `TempDataDictionary` and it needs `HttpContext` and  `ITempDataProvider`...
So if the tests are required I need some help there :)
