### PR TITLE
Changed min/max parameter order in StringLengthAttributeAdapter

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.DataAnnotations/Internal/StringLengthAttributeAdapter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.DataAnnotations/Internal/StringLengthAttributeAdapter.cs
@@ -54,8 +54,8 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
             return GetErrorMessage(
                 validationContext.ModelMetadata,
                 validationContext.ModelMetadata.GetDisplayName(),
-                Attribute.MinimumLength,
-                Attribute.MaximumLength);
+                Attribute.MaximumLength,
+                Attribute.MinimumLength);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/DataAnnotationsModelValidatorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/DataAnnotationsModelValidatorTest.cs
@@ -417,7 +417,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
                     {
                         new StringLengthAttribute(length) { ErrorMessage = LocalizationKey, MinimumLength = 1},
                         string.Empty,
-                        new object[] { nameof(SampleModel), 1, length }
+                        new object[] { nameof(SampleModel), length, 1 }
                     },
                     {
                         new RangeAttribute(0, length) { ErrorMessage = LocalizationKey },

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/StringLengthAttributeAdapterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/StringLengthAttributeAdapterTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
             var expectedMessage = "Property must not be longer than '8' characters.";
 
             var stringLocalizer = new Mock<IStringLocalizer>();
-            var expectedProperties = new object[] { "Length", 0, 8 };
+            var expectedProperties = new object[] { "Length", 8, 0 };
 
             stringLocalizer.Setup(s => s[attribute.ErrorMessage, expectedProperties])
                 .Returns(new LocalizedString(attribute.ErrorMessage, expectedMessage));

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/StringLengthAttributeAdapterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/StringLengthAttributeAdapterTest.cs
@@ -23,9 +23,9 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
             var metadata = provider.GetMetadataForProperty(typeof(string), "Length");
 
             var attribute = new StringLengthAttribute(8);
-            attribute.ErrorMessage = "Property must not be longer than '{1}' characters.";
+            attribute.ErrorMessage = "Property must not be longer than '{1}' characters and not shorter than '{2}' characters.";
 
-            var expectedMessage = "Property must not be longer than '8' characters.";
+            var expectedMessage = "Property must not be longer than '8' characters and not shorter than '0' characters.";
 
             var stringLocalizer = new Mock<IStringLocalizer>();
             var expectedProperties = new object[] { "Length", 8, 0 };

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/StringLengthAttributeAdapterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/StringLengthAttributeAdapterTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
     {
         [Fact]
         [ReplaceCulture]
-        public void AddValidation_WithMaxLength_AddsAttributes_Localize()
+        public void AddValidation_WithMaxLengthAndMinLength_AddsAttributes_Localize()
         {
             // Arrange
             var provider = TestModelMetadataProvider.CreateDefaultProvider();


### PR DESCRIPTION
This fixes #4864.