### PR TITLE
Perf: Use RouteValueDictionary in AnchorTagHelper rather than creating a new Dictionary

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/AnchorTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/AnchorTagHelper.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.AspNetCore.Routing;
 
 namespace Microsoft.AspNetCore.Mvc.TagHelpers
 {
@@ -180,22 +181,17 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             }
             else
             {
-                IDictionary<string, object> routeValues = null;
+                RouteValueDictionary routeValues = null;
                 if (_routeValues != null && _routeValues.Count > 0)
                 {
-                    // Convert from Dictionary<string, string> to Dictionary<string, object>.
-                    routeValues = new Dictionary<string, object>(_routeValues.Count, StringComparer.OrdinalIgnoreCase);
-                    foreach (var routeValue in _routeValues)
-                    {
-                        routeValues.Add(routeValue.Key, routeValue.Value);
-                    }
+                    routeValues = new RouteValueDictionary(_routeValues);
                 }
 
                 if (Area != null)
                 {
                     if (routeValues == null)
                     {
-                        routeValues = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+                        routeValues = new RouteValueDictionary();
                     }
 
                     // Unconditionally replace any value from asp-route-area. 

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/project.json
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/project.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "Microsoft.AspNetCore.Mvc.Razor": "1.1.0-*",
     "Microsoft.Extensions.Caching.Memory": "1.1.0-*",
-    "Microsoft.AspNetCore.Routing": "1.1.0-*",
+    "Microsoft.AspNetCore.Routing.Abstractions": "1.1.0-*",
     "Microsoft.Extensions.FileSystemGlobbing": "1.1.0-*",
     "Microsoft.Extensions.Logging.Abstractions": {
       "version": "1.1.0-*",

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/project.json
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/project.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "Microsoft.AspNetCore.Mvc.Razor": "1.1.0-*",
     "Microsoft.Extensions.Caching.Memory": "1.1.0-*",
+    "Microsoft.AspNetCore.Routing": "1.1.0-*",
     "Microsoft.Extensions.FileSystemGlobbing": "1.1.0-*",
     "Microsoft.Extensions.Logging.Abstractions": {
       "version": "1.1.0-*",


### PR DESCRIPTION
Fixes #4624 
This fix has dependency on the Routing PR https://github.com/aspnet/Routing/pull/335 

Scenario https://github.com/aspnet/MusicStore  app . 
loadtest -k -n 1000 --rps 20  http://localhost:5000 

Before
![image](https://cloud.githubusercontent.com/assets/8011073/16499376/108ad82e-3eb5-11e6-8896-4cf929eb8ed1.png)

After

![image](https://cloud.githubusercontent.com/assets/8011073/16499423/48919212-3eb5-11e6-9c1c-8885bea8229b.png)


Total savings is 1.3% in total bytes