### PR TITLE
Show message about preserveCompilationContext when a Roslyn diagnostic error says a reference cannot be found.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Properties/Resources.Designer.cs
@@ -447,7 +447,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         }
 
         /// <summary>
-        /// The Razor page '{0}' failed to compile. Ensure that your application's {1} sets the '{2}' compilation property.
+        /// One or more compilation references are missing. Possible causes include a missing '{0}' property under '{1}' in the application's {2}.
         /// </summary>
         internal static string Compilation_DependencyContextIsNotSpecified
         {
@@ -455,7 +455,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         }
 
         /// <summary>
-        /// The Razor page '{0}' failed to compile. Ensure that your application's {1} sets the '{2}' compilation property.
+        /// One or more compilation references are missing. Possible causes include a missing '{0}' property under '{1}' in the application's {2}.
         /// </summary>
         internal static string FormatCompilation_DependencyContextIsNotSpecified(object p0, object p1, object p2)
         {

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Resources.resx
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Resources.resx
@@ -201,7 +201,7 @@
     <value>A circular layout reference was detected when rendering '{0}'. The layout page '{1}' has already been rendered.</value>
   </data>
   <data name="Compilation_DependencyContextIsNotSpecified" xml:space="preserve">
-    <value>The Razor page '{0}' failed to compile. Ensure that your application's {1} sets the '{2}' compilation property.</value>
+    <value>One or more compilation references are missing. Possible causes include a missing '{0}' property under '{1}' in the application's {2}.</value>
   </data>
   <data name="ViewLocationFormatsIsRequired" xml:space="preserve">
     <value>'{0}' cannot be empty. These locations are required to locate a view for rendering.</value>

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/DefaultRoslynCompilationServiceTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/DefaultRoslynCompilationServiceTest.cs
@@ -249,27 +249,6 @@ public class MyNonCustomDefinedClass {}
         }
 
         [Fact]
-        public void Compile_ThrowsIfNoMetadataReferencesAreDiscoveredAndApplicationFailsToCompile()
-        {
-            // Arrange
-            var content = "public class MyTestType  {}";
-            var applicationPartManager = new ApplicationPartManager();
-            var compilationService = GetRoslynCompilationService(applicationPartManager);
-
-            var relativeFileInfo = new RelativeFileInfo(
-                new TestFileInfo { PhysicalPath = "SomePath" },
-                "some-relative-path.cshtml");
-
-            var expected = "The Razor page 'some-relative-path.cshtml' failed to compile. Ensure that your "
-                 + "application's project.json sets the 'preserveCompilationContext' compilation property.";
-
-            // Act and Assert
-            var ex = Assert.Throws<InvalidOperationException>(() =>
-                compilationService.Compile(relativeFileInfo, content));
-            Assert.Equal(expected, ex.Message);
-        }
-
-        [Fact]
         public void Compile_DoesNotThrowIfReferencesWereClearedInCallback()
         {
             // Arrange


### PR DESCRIPTION
Fixes #4911