### PR TITLE
Discussion: TagHelper addition for authentication/authorization

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/AuthorizedTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/AuthorizedTagHelper.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.TagHelpers
+{
+    using System;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Razor.TagHelpers;
+    using Microsoft.Extensions.Primitives;
+
+    /// <summary>
+    ///   Renders content based on authentication/authorization status/roles of user
+    /// </summary>
+    /// <example>
+    ///   &lt;authorized&gt;You are logged in!&lt;/authorized&gt;
+    /// </example>
+    /// <example>
+    ///   &lt;authorized is-inverted=&quot;true&quot;&gt;You are not logged in!&lt;/authorized&gt;
+    /// </example>
+    /// <example>
+    ///   &lt;authorized roles="Developer,Admin" &gt;You are a developer or admin!&lt;/authorized&gt;
+    /// </example>
+    /// <example>
+    ///   &lt;authorized roles="Developer,Admin" is-inverted=&quot;true&quot;&gt;You are not a developer nor an admin!&lt;/authorized&gt;
+    /// </example>
+    public class AuthorizedTagHelper : TagHelper
+    {
+        private static readonly char[] NameSeparator = { ',' };
+
+        private const string RolesAttributeName = "roles";
+        private const string IsInvertedAttributeName = "is-inverted";
+
+        /// <summary>
+        /// Creates a new <see cref="AuthorizedTagHelper"/>.
+        /// </summary>
+        /// <param name="httpContextAccessor">The <see cref="IHttpContextAccessor"/>.</param>
+        public AuthorizedTagHelper(IHttpContextAccessor httpContextAccessor)
+        {
+            this.HttpContextAccessor = httpContextAccessor;
+        }
+
+        /// <inheritdoc />
+        public override int Order => -1000;
+
+        /// <summary>
+        /// A comma separated list of roles for which the content should be rendered.
+        /// </summary>
+        /// <remarks>
+        /// The specified role names are compared case insensitively IPrincipal.Identity.IsInRole(). Leaving Roles blank will render content for authorized users only. Specify RoleCheck to the AuthorizedRoleCheck.NotInRole to show content when user is not in role. Leaving Roles blank and specifying RoleCheck to the AuthorizedRoleCheck.NotInRole will show content only for non-authenticated users.
+        /// </remarks>
+        [HtmlAttributeName(RolesAttributeName)]
+        public string Roles { get; set; }
+
+        /// <summary>
+        /// Boolean determining whether you must be in the role or not in the role.
+        /// </summary>
+        /// <remarks>
+        /// Setting this to true will show content for unauthenticated users only (if roles are left blank) or only those users not in any of the roles specified under roles.
+        /// </remarks>
+        [HtmlAttributeName(IsInvertedAttributeName)]
+        public bool IsInverted { get; set; }
+
+        protected IHttpContextAccessor HttpContextAccessor { get; }
+
+        /// <inheritdoc />
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (output == null)
+            {
+                throw new ArgumentNullException(nameof(output));
+            }
+
+            // Always strip the outer tag name as we never want <environment> to render
+            output.TagName = null;
+
+            var user = this.HttpContextAccessor.HttpContext.User;
+            var isAuthenticated = user?.Identity?.IsAuthenticated ?? false;
+            if (!isAuthenticated && !this.IsInverted)
+            {
+                // Not authenticated, suppress output
+                output.SuppressOutput();
+                return;
+            }
+
+            var roles = this.Roles ?? string.Empty;
+            var tokenizer = new StringTokenizer(roles, NameSeparator);
+            var hasMatch = false;
+            var hasAnyRole = false;
+            foreach (var item in tokenizer)
+            {
+                var roleSegment = item.Trim();
+                if (roleSegment.HasValue && roleSegment.Length > 0)
+                {
+                    hasAnyRole = true;
+                    var role = roleSegment.ToString();
+                    if (user != null && user.IsInRole(role))
+                    {
+                        hasMatch = true;
+                        break;
+                    }
+                }
+            }
+
+            var shouldSuppressOutput = this.IsInverted ? hasMatch || isAuthenticated && !hasAnyRole : !hasMatch && hasAnyRole;
+
+            if (shouldSuppressOutput)
+            {
+                // This instance had at least one non-empty environment specified but none of these
+                // environments matched the current environment. Suppress the output in this case.
+                output.SuppressOutput();
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/AuthorizedTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/AuthorizedTagHelperTest.cs
@@ -1,0 +1,211 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.TagHelpers.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Razor.TagHelpers;
+    using Moq;
+    using Xunit;
+
+    public class AuthorizedTagHelperTest
+    {
+        [Theory]
+        [InlineData("Admin", "Admin")]
+        [InlineData("admin", "Admin")]
+        [InlineData("Admin", "admin")]
+        [InlineData(" admin", "Admin")]
+        [InlineData("admin ", "Admin")]
+        [InlineData(" admin ", "Admin")]
+        [InlineData("admin,somethingelse", "Admin")]
+        [InlineData("admin ,somethingelse", "admin")]
+        [InlineData("admin\t,somethingelse", "admin")]
+        public void ShowsContentWhenAuthenticatedAndRoleMatchesForNonInvertedRoleCheck(string rolesAttribute, string userHasRoles)
+        {
+            ShouldShowContent(rolesAttribute, userHasRoles, isInverted: false, isAuthenticated: true);
+        }
+
+        [Theory]
+        [InlineData("", "Admin")]
+        [InlineData(null, "Admin")]
+        [InlineData("  ", "Admin")]
+        [InlineData(", ", "Admin")]
+        [InlineData("   , ", "Admin")]
+        [InlineData("\t,\t", "Admin")]
+        [InlineData(",", "Admin")]
+        [InlineData(",,", "Admin")]
+        [InlineData(",,,", "Admin")]
+        [InlineData(",,, ", "Admin")]
+        public void ShowsContentWhenAuthenticatedAndNoRoleIsSpecifiedForNonInvertedRoleCheck(string rolesAttribute, string userHasRoles)
+        {
+            ShouldShowContent(rolesAttribute, userHasRoles, isInverted: false, isAuthenticated: true);
+        }
+
+        [Theory]
+        [InlineData("Admin", null)]
+        public void DoesNotShowContentWhenNotAuthenticatedForNonInvertedRoleCheck(string rolesAttribute, string userHasRoles)
+        {
+            ShouldNotShowContent(rolesAttribute, userHasRoles, isInverted: false, isAuthenticated: false);
+        }
+
+        [Theory]
+        [InlineData("Admin", null)]
+        public void ShowsContentWhenNotAuthenticatedForInvertedRoleCheck(string rolesAttribute, string userHasRoles)
+        {
+            ShouldShowContent(rolesAttribute, userHasRoles, isInverted: true, isAuthenticated: false);
+        }
+
+        [Theory]
+        [InlineData(null, "Admin")]
+        public void DoesNotShowContentWhenAuthenticatedForInvertedRoleCheck(string rolesAttribute, string userHasRoles)
+        {
+            ShouldNotShowContent(rolesAttribute, userHasRoles, isInverted: true, isAuthenticated: true);
+        }
+
+
+        [Theory]
+        [InlineData("NotAdmin", "Admin")]
+        [InlineData(" NotAdmin", "Admin")]
+        [InlineData("NotAdmin ", "Admin")]
+        [InlineData(" NotAdmin ", "Admin")]
+        [InlineData("notadmin", "Admin")]
+        [InlineData(" notadmin", "Admin")]
+        [InlineData("notadmin ", "Admin")]
+        [InlineData("foo,notadmin", "Admin")]
+        [InlineData("foo, notadmin", "Admin")]
+        [InlineData("foo,\tnotadmin", "Admin")]
+        [InlineData("foo,notadmin\t", "Admin")]
+        [InlineData("foo,\tnotadmin\t", "Admin")]
+        public void ShowsContentWhenAuthenticatedAndNoRoleMatchesForInvertedRoleCheck(string rolesAttribute, string userHasRoles)
+        {
+            ShouldShowContent(rolesAttribute, userHasRoles, isInverted: true, isAuthenticated: true);
+        }
+
+        [Theory]
+        [InlineData("Admin", "Admin")]
+        [InlineData(" Admin", "Admin")]
+        [InlineData("Admin ", "Admin")]
+        [InlineData(" Admin ", "Admin")]
+        [InlineData("admin", "Admin")]
+        [InlineData(" admin", "Admin")]
+        [InlineData("admin ", "Admin")]
+        [InlineData("foo,admin", "Admin")]
+        [InlineData("foo, admin", "Admin")]
+        [InlineData("foo,\tadmin", "Admin")]
+        [InlineData("foo,admin\t", "Admin")]
+        [InlineData("foo,\tadmin\t", "Admin")]
+        public void DoesNotShowContentWhenAuthenticatedAndRoleMatchesForInvertedRoleCheck(string rolesAttribute, string userHasRoles)
+        {
+            ShouldNotShowContent(rolesAttribute, userHasRoles, isInverted: true, isAuthenticated: true);
+        }
+
+        [Theory]
+        [InlineData()]
+        public void ShouldNotFailForNullUser()
+        {
+            // Arrange
+            var content = "content";
+            var context = MakeTagHelperContext(
+                attributes: new TagHelperAttributeList { { "roles", string.Empty }, { "is-inverted", false } });
+            var output = MakeTagHelperOutput("authorized", childContent: content);
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.SetupGet(x => x.HttpContext.User).Returns((ClaimsPrincipal)null);
+
+            // Act
+            var helper = new AuthorizedTagHelper(httpContextAccessor.Object)
+            {
+                Roles = string.Empty,
+                IsInverted = false
+            };
+
+            helper.Process(context, output);
+
+            // Assert
+            // Not throwing is good enough
+        }
+
+        private void ShouldShowContent(string rolesAttribute, string userHasRoles, bool isInverted, bool isAuthenticated)
+        {
+            // Arrange
+            var content = "content";
+            var context = MakeTagHelperContext(
+                attributes: new TagHelperAttributeList { { "roles", rolesAttribute }, { "is-inverted", isInverted } });
+            var output = MakeTagHelperOutput("authorized", childContent: content);
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(h => h.HttpContext.User.IsInRole(It.IsAny<string>())).Returns<string>(role => userHasRoles?.Split(',').Any(userRole => string.Compare(role, userRole, StringComparison.OrdinalIgnoreCase) == 0) ?? false);
+            httpContextAccessor.SetupGet(h => h.HttpContext.User.Identity.IsAuthenticated).Returns(isAuthenticated);
+
+            // Act
+            var helper = new AuthorizedTagHelper(httpContextAccessor.Object)
+            {
+                Roles = rolesAttribute,
+                IsInverted = isInverted
+            };
+            helper.Process(context, output);
+
+            // Assert
+            Assert.Null(output.TagName);
+            Assert.False(output.IsContentModified);
+        }
+
+        private void ShouldNotShowContent(string rolesAttribute, string userHasRoles, bool isInverted, bool isAuthenticated)
+        {
+            // Arrange
+            var content = "content";
+            var context = MakeTagHelperContext(
+                attributes: new TagHelperAttributeList { { "roles", rolesAttribute }, { "is-inverted", isInverted } });
+            var output = MakeTagHelperOutput("authorized", childContent: content);
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(h => h.HttpContext.User.IsInRole(It.IsAny<string>())).Returns<string>(role => userHasRoles?.Split(',').Any(userRole => string.Compare(role, userRole, StringComparison.OrdinalIgnoreCase) == 0) ?? false);
+            httpContextAccessor.SetupGet(h => h.HttpContext.User.Identity.IsAuthenticated).Returns(isAuthenticated);
+
+            // Act
+            var helper = new AuthorizedTagHelper(httpContextAccessor.Object)
+            {
+                Roles = rolesAttribute,
+                IsInverted = isInverted
+            };
+            helper.Process(context, output);
+
+            // Assert
+            Assert.Null(output.TagName);
+            Assert.Empty(output.PreContent.GetContent());
+            Assert.True(output.Content.GetContent().Length == 0);
+            Assert.Empty(output.PostContent.GetContent());
+            Assert.True(output.IsContentModified);
+        }
+
+        private TagHelperContext MakeTagHelperContext(TagHelperAttributeList attributes = null)
+        {
+            attributes = attributes ?? new TagHelperAttributeList();
+
+            return new TagHelperContext(
+                attributes,
+                items: new Dictionary<object, object>(),
+                uniqueId: Guid.NewGuid().ToString("N"));
+        }
+
+        private TagHelperOutput MakeTagHelperOutput(
+            string tagName,
+            TagHelperAttributeList attributes = null,
+            string childContent = null)
+        {
+            attributes = attributes ?? new TagHelperAttributeList();
+
+            return new TagHelperOutput(
+                tagName,
+                attributes,
+                getChildContentAsync: (useCachedResult, encoder) =>
+                {
+                    var tagHelperContent = new DefaultTagHelperContent();
+                    tagHelperContent.SetContent(childContent);
+                    return Task.FromResult<TagHelperContent>(tagHelperContent);
+                });
+        }
+    }
+}


### PR DESCRIPTION
Thinking of contributing a taghelper to facilitate masking content by authentication/authorization state.

Best I could come up with so far is this:
```
<authorized>You are authenticated!</authorized>
<authorized is-inverted="true">You are not authenticated</authorized>
<authorized roles="Foo, Bar">You are either a Foo or a Bar!</authorized>
<authorized roles="Foo, Bar" is-inverted="true">You are neither a foo nor a bar!</authorized>
```

I am personally not in love with the is-inverted property, but could not think of any brighter naming. I was debating adding multiple tag helpers (e.g. `<authenticated /> <un-authenticated />`, and `<authorized />` and `<un-authorized />`), but that seemed (much) worse. I was also toying with the idea of naming the property something like role-check="InRole" or role-check="NotInRole"), but that didn't work well with the authenticated portion. 

Generally speaking where would the team like taghelpers contributed? Obviously anyone could just add third party packages, but items so core to the framework might be best co-located at least. Maybe add a futures contrib if this is the wrong place for it?

Ideas and feedback welcome.