### PR TITLE
Put `ModelBindingHelper` on a diet

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Internal/ModelBindingHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Internal/ModelBindingHelper.cs
@@ -44,42 +44,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Internal
             IObjectModelValidator objectModelValidator)
             where TModel : class
         {
-            if (model == null)
-            {
-                throw new ArgumentNullException(nameof(model));
-            }
-
-            if (prefix == null)
-            {
-                throw new ArgumentNullException(nameof(prefix));
-            }
-
-            if (actionContext == null)
-            {
-                throw new ArgumentNullException(nameof(actionContext));
-            }
-
-            if (metadataProvider == null)
-            {
-                throw new ArgumentNullException(nameof(metadataProvider));
-            }
-
-            if (modelBinderFactory == null)
-            {
-                throw new ArgumentNullException(nameof(modelBinderFactory));
-            }
-
-            if (valueProvider == null)
-            {
-                throw new ArgumentNullException(nameof(valueProvider));
-            }
-
-            if (objectModelValidator == null)
-            {
-                throw new ArgumentNullException(nameof(objectModelValidator));
-            }
-
-            // Includes everything by default.
             return TryUpdateModelAsync(
                 model,
                 prefix,
@@ -88,6 +52,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Internal
                 modelBinderFactory,
                 valueProvider,
                 objectModelValidator,
+                // Includes everything by default.
                 propertyFilter: (m) => true);
         }
 
@@ -120,41 +85,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Internal
             params Expression<Func<TModel, object>>[] includeExpressions)
            where TModel : class
         {
-            if (model == null)
-            {
-                throw new ArgumentNullException(nameof(model));
-            }
-
-            if (prefix == null)
-            {
-                throw new ArgumentNullException(nameof(prefix));
-            }
-
-            if (actionContext == null)
-            {
-                throw new ArgumentNullException(nameof(actionContext));
-            }
-
-            if (metadataProvider == null)
-            {
-                throw new ArgumentNullException(nameof(metadataProvider));
-            }
-
-            if (modelBinderFactory == null)
-            {
-                throw new ArgumentNullException(nameof(modelBinderFactory));
-            }
-
-            if (valueProvider == null)
-            {
-                throw new ArgumentNullException(nameof(valueProvider));
-            }
-
-            if (objectModelValidator == null)
-            {
-                throw new ArgumentNullException(nameof(objectModelValidator));
-            }
-
             if (includeExpressions == null)
             {
                 throw new ArgumentNullException(nameof(includeExpressions));
@@ -204,46 +134,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Internal
             Func<ModelMetadata, bool> propertyFilter)
             where TModel : class
         {
-            if (model == null)
-            {
-                throw new ArgumentNullException(nameof(model));
-            }
-
-            if (prefix == null)
-            {
-                throw new ArgumentNullException(nameof(prefix));
-            }
-
-            if (actionContext == null)
-            {
-                throw new ArgumentNullException(nameof(actionContext));
-            }
-
-            if (metadataProvider == null)
-            {
-                throw new ArgumentNullException(nameof(metadataProvider));
-            }
-
-            if (modelBinderFactory == null)
-            {
-                throw new ArgumentNullException(nameof(modelBinderFactory));
-            }
-
-            if (valueProvider == null)
-            {
-                throw new ArgumentNullException(nameof(valueProvider));
-            }
-
-            if (objectModelValidator == null)
-            {
-                throw new ArgumentNullException(nameof(objectModelValidator));
-            }
-
-            if (propertyFilter == null)
-            {
-                throw new ArgumentNullException(nameof(propertyFilter));
-            }
-
             return TryUpdateModelAsync(
                model,
                typeof(TModel),
@@ -282,47 +172,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Internal
             IValueProvider valueProvider,
             IObjectModelValidator objectModelValidator)
         {
-            if (model == null)
-            {
-                throw new ArgumentNullException(nameof(model));
-            }
-
-            if (modelType == null)
-            {
-                throw new ArgumentNullException(nameof(modelType));
-            }
-
-            if (prefix == null)
-            {
-                throw new ArgumentNullException(nameof(prefix));
-            }
-
-            if (actionContext == null)
-            {
-                throw new ArgumentNullException(nameof(actionContext));
-            }
-
-            if (metadataProvider == null)
-            {
-                throw new ArgumentNullException(nameof(metadataProvider));
-            }
-
-            if (modelBinderFactory == null)
-            {
-                throw new ArgumentNullException(nameof(modelBinderFactory));
-            }
-
-            if (valueProvider == null)
-            {
-                throw new ArgumentNullException(nameof(valueProvider));
-            }
-
-            if (objectModelValidator == null)
-            {
-                throw new ArgumentNullException(nameof(objectModelValidator));
-            }
-
-            // Includes everything by default.
             return TryUpdateModelAsync(
                 model,
                 modelType,
@@ -332,6 +181,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Internal
                 modelBinderFactory,
                 valueProvider,
                 objectModelValidator,
+                // Includes everything by default.
                 propertyFilter: (m) => true);
         }
 
@@ -787,20 +637,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Internal
         }
 
         /// <summary>
-        /// Converts the provided <paramref name="value"/> to a value of <see cref="Type"/> <typeparamref name="T"/>
-        /// using the <see cref="CultureInfo.InvariantCulture"/>.
-        /// </summary>
-        /// <typeparam name="T">The <see cref="Type"/> for conversion.</typeparam>
-        /// <param name="value">The value to convert."/></param>
-        /// <returns>
-        /// The converted value or the default value of <typeparamref name="T"/> if the value could not be converted.
-        /// </returns>
-        public static T ConvertTo<T>(object value)
-        {
-            return ConvertTo<T>(value, culture: null);
-        }
-
-        /// <summary>
         /// Converts the provided <paramref name="value"/> to a value of <see cref="Type"/> <typeparamref name="T"/>.
         /// </summary>
         /// <typeparam name="T">The <see cref="Type"/> for conversion.</typeparam>
@@ -813,25 +649,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Internal
         {
             var converted = ConvertTo(value, typeof(T), culture);
             return converted == null ? default(T) : (T)converted;
-        }
-
-        /// <summary>
-        /// Converts the provided <paramref name="value"/> to a value of <see cref="Type"/> <paramref name="type"/>
-        /// using the <see cref="CultureInfo.InvariantCulture"/>.
-        /// </summary>
-        /// <param name="value">The value to convert.</param>
-        /// <param name="type">The <see cref="Type"/> for conversion.</param>
-        /// <returns>
-        /// The converted value or <c>null</c> if the value could not be converted.
-        /// </returns>
-        public static object ConvertTo(object value, Type type)
-        {
-            if (type == null)
-            {
-                throw new ArgumentNullException(nameof(type));
-            }
-
-            return ConvertTo(value, type, culture: null);
         }
 
         /// <summary>

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ModelBindingHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ModelBindingHelperTest.cs
@@ -843,14 +843,14 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         [Fact]
         public void ConvertTo_ReturnsNullForReferenceTypes_WhenValueIsNull()
         {
-            var convertedValue = ModelBindingHelper.ConvertTo(null, typeof(string));
+            var convertedValue = ModelBindingHelper.ConvertTo(value: null, type: typeof(string), culture: null);
             Assert.Null(convertedValue);
         }
 
         [Fact]
         public void ConvertTo_ReturnsDefaultForValueTypes_WhenValueIsNull()
         {
-            var convertedValue = ModelBindingHelper.ConvertTo(null, typeof(int));
+            var convertedValue = ModelBindingHelper.ConvertTo(value: null, type: typeof(int), culture: null);
             Assert.Equal(0, convertedValue);
         }
 
@@ -861,7 +861,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             var value = new int[] { 1, 20, 42 };
 
             // Act
-            var converted = ModelBindingHelper.ConvertTo(value, typeof(string));
+            var converted = ModelBindingHelper.ConvertTo(value, typeof(string), culture: null);
 
             // Assert
             Assert.Equal("1", converted);
@@ -874,7 +874,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             var value = 42;
 
             // Act
-            var converted = ModelBindingHelper.ConvertTo<string[]>(value);
+            var converted = ModelBindingHelper.ConvertTo<string[]>(value, culture: null);
 
             // Assert
             Assert.NotNull(converted);
@@ -888,7 +888,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             // Arrange
 
             // Act
-            var converted = ModelBindingHelper.ConvertTo<string>(42);
+            var converted = ModelBindingHelper.ConvertTo<string>(42, culture: null);
 
             // Assert
             Assert.NotNull(converted);
@@ -901,10 +901,10 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             // Arrange
 
             // Act
-            var returned = ModelBindingHelper.ConvertTo<int?>(null);
+            var returned = ModelBindingHelper.ConvertTo<int?>(value: null, culture: null);
 
             // Assert
-            Assert.Equal(returned, null);
+            Assert.Null(returned);
         }
 
         [Fact]
@@ -914,10 +914,10 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             var original = " ";
 
             // Act
-            var returned = ModelBindingHelper.ConvertTo<int?>(original);
+            var returned = ModelBindingHelper.ConvertTo<int?>(original, culture: null);
 
             // Assert
-            Assert.Equal(returned, null);
+            Assert.Null(returned);
         }
 
         [Fact]
@@ -926,7 +926,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             // Arrange
 
             // Act
-            var outValue = ModelBindingHelper.ConvertTo(new string[] { null }, typeof(int));
+            var outValue = ModelBindingHelper.ConvertTo(new string[] { null }, typeof(int), culture: null);
 
             // Assert
             Assert.Null(outValue);
@@ -938,7 +938,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             // Arrange
 
             // Act
-            var outValue = ModelBindingHelper.ConvertTo(new int[0], typeof(int));
+            var outValue = ModelBindingHelper.ConvertTo(new int[0], typeof(int), culture: null);
 
             // Assert
             Assert.Null(outValue);
@@ -951,7 +951,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         {
             // Arrange
             // Act
-            var outValue = ModelBindingHelper.ConvertTo(value, typeof(int));
+            var outValue = ModelBindingHelper.ConvertTo(value, typeof(int), culture: null);
 
             // Assert
             Assert.Null(outValue);
@@ -963,7 +963,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             // Arrange
 
             // Act
-            var outValue = ModelBindingHelper.ConvertTo(null, typeof(int[]));
+            var outValue = ModelBindingHelper.ConvertTo(value: null, type: typeof(int[]), culture: null);
 
             // Assert
             Assert.Null(outValue);
@@ -975,10 +975,10 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             // Arrange
 
             // Act
-            var outValue = ModelBindingHelper.ConvertTo(new object[] { 1 }, typeof(IntEnum));
+            var outValue = ModelBindingHelper.ConvertTo(new object[] { 1 }, typeof(IntEnum), culture: null);
 
             // Assert
-            Assert.Equal(outValue, IntEnum.Value1);
+            Assert.Equal(IntEnum.Value1, outValue);
         }
 
         [Theory]
@@ -1008,7 +1008,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             // Arrange
 
             // Act
-            var outValue = ModelBindingHelper.ConvertTo(new object[] { input }, enumType);
+            var outValue = ModelBindingHelper.ConvertTo(new object[] { input }, enumType, culture: null);
 
             // Assert
             Assert.Equal(expected, outValue);
@@ -1020,10 +1020,10 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             // Arrange
 
             // Act
-            var outValue = ModelBindingHelper.ConvertTo(new object[] { "1" }, typeof(IntEnum));
+            var outValue = ModelBindingHelper.ConvertTo(new object[] { "1" }, typeof(IntEnum), culture: null);
 
             // Assert
-            Assert.Equal(outValue, IntEnum.Value1);
+            Assert.Equal(IntEnum.Value1, outValue);
         }
 
         [Fact]
@@ -1032,10 +1032,10 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             // Arrange
 
             // Act
-            var outValue = ModelBindingHelper.ConvertTo(new object[] { "Value1" }, typeof(IntEnum));
+            var outValue = ModelBindingHelper.ConvertTo(new object[] { "Value1" }, typeof(IntEnum), culture: null);
 
             // Assert
-            Assert.Equal(outValue, IntEnum.Value1);
+            Assert.Equal(IntEnum.Value1, outValue);
         }
 
         [Fact]
@@ -1044,7 +1044,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             // Arrange
 
             // Act
-            var outValue = ModelBindingHelper.ConvertTo("12", typeof(int?));
+            var outValue = ModelBindingHelper.ConvertTo("12", typeof(int?), culture: null);
 
             // Assert
             Assert.Equal(12, outValue);
@@ -1056,7 +1056,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             // Arrange
 
             // Act
-            var outValue = ModelBindingHelper.ConvertTo("12.5", typeof(double?));
+            var outValue = ModelBindingHelper.ConvertTo("12.5", typeof(double?), culture: null);
 
             // Assert
             Assert.Equal(12.5, outValue);
@@ -1068,7 +1068,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             // Arrange
 
             // Act
-            var outValue = ModelBindingHelper.ConvertTo(12M, typeof(int?));
+            var outValue = ModelBindingHelper.ConvertTo(12M, typeof(int?), culture: null);
 
             // Assert
             Assert.Equal(12, outValue);
@@ -1080,7 +1080,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             // Arrange
 
             // Act
-            var outValue = ModelBindingHelper.ConvertTo(12.5M, typeof(double?));
+            var outValue = ModelBindingHelper.ConvertTo(12.5M, typeof(double?), culture: null);
 
             // Assert
             Assert.Equal(12.5, outValue);
@@ -1092,7 +1092,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             // Arrange
 
             // Act
-            var outValue = ModelBindingHelper.ConvertTo(12M, typeof(int?));
+            var outValue = ModelBindingHelper.ConvertTo(12M, typeof(int?), culture: null);
 
             // Assert
             Assert.Equal(12, outValue);
@@ -1104,7 +1104,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             // Arrange
 
             // Act
-            var outValue = ModelBindingHelper.ConvertTo(12M, typeof(long?));
+            var outValue = ModelBindingHelper.ConvertTo(12M, typeof(long?), culture: null);
 
             // Assert
             Assert.Equal(12L, outValue);
@@ -1116,7 +1116,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             // Arrange
 
             // Act
-            var outValue = ModelBindingHelper.ConvertTo(new object[] { "some string" }, typeof(string));
+            var outValue = ModelBindingHelper.ConvertTo(new object[] { "some string" }, typeof(string), culture: null);
 
             // Assert
             Assert.Equal("some string", outValue);
@@ -1131,7 +1131,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             // Arrange
 
             // Act
-            var outValue = ModelBindingHelper.ConvertTo(value, typeof(IntEnum[]));
+            var outValue = ModelBindingHelper.ConvertTo(value, typeof(IntEnum[]), culture: null);
 
             // Assert
             var result = Assert.IsType<IntEnum[]>(outValue);
@@ -1149,7 +1149,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             // Arrange
 
             // Act
-            var outValue = ModelBindingHelper.ConvertTo(value, typeof(FlagsEnum[]));
+            var outValue = ModelBindingHelper.ConvertTo(value, typeof(FlagsEnum[]), culture: null);
 
             // Assert
             var result = Assert.IsType<FlagsEnum[]>(outValue);
@@ -1165,7 +1165,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             var original = new[] { "some string" };
 
             // Act
-            var outValue = ModelBindingHelper.ConvertTo(original, typeof(string[]));
+            var outValue = ModelBindingHelper.ConvertTo(original, typeof(string[]), culture: null);
 
             // Assert
             Assert.Same(original, outValue);
@@ -1181,7 +1181,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 
             // Act & Assert
             var ex = Assert.Throws<FormatException>(
-                () => ModelBindingHelper.ConvertTo("this-is-not-a-valid-value", destinationType));
+                () => ModelBindingHelper.ConvertTo("this-is-not-a-valid-value", destinationType, culture: null));
         }
 
         [Fact]
@@ -1205,7 +1205,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             // Arrange
 
             // Act & Assert
-            Assert.Equal(expectedValue, ModelBindingHelper.ConvertTo(initialValue, typeof(T)));
+            Assert.Equal(expectedValue, ModelBindingHelper.ConvertTo(initialValue, typeof(T), culture: null));
         }
 
         public static IEnumerable<object[]> IntrinsicConversionData
@@ -1248,7 +1248,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 
             // Act & Assert
             var ex = Assert.Throws<InvalidOperationException>(
-                () => ModelBindingHelper.ConvertTo(new MyClassWithoutConverter(), destinationType));
+                () => ModelBindingHelper.ConvertTo(new MyClassWithoutConverter(), destinationType, culture: null));
             Assert.Equal(expectedMessage, ex.Message);
         }
 
@@ -1264,7 +1264,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 
             // Act & Assert
             var ex = Assert.Throws<InvalidOperationException>(
-                () => ModelBindingHelper.ConvertTo(value, destinationType));
+                () => ModelBindingHelper.ConvertTo(value, destinationType, culture: null));
             Assert.Equal(expectedMessage, ex.Message);
         }
 
@@ -1278,7 +1278,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             var value = new MySubClassWithoutConverter();
 
             // Act
-            var result = ModelBindingHelper.ConvertTo(value, destinationType);
+            var result = ModelBindingHelper.ConvertTo(value, destinationType, culture: null);
 
             // Assert
             Assert.Same(value, result);
@@ -1298,7 +1298,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             };
 
             // Act
-            var result = ModelBindingHelper.ConvertTo(value, destinationType);
+            var result = ModelBindingHelper.ConvertTo(value, destinationType, culture: null);
 
             // Assert
             Assert.IsType(destinationType, result);
@@ -1323,7 +1323,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             // Arrange
 
             // Act
-            var outValue = ModelBindingHelper.ConvertTo<FlagsEnum>(value);
+            var outValue = ModelBindingHelper.ConvertTo<FlagsEnum>(value, culture: null);
 
             // Assert
             Assert.Equal(expected, outValue);


### PR DESCRIPTION
- remove extra argument checks
- remove two test-only `ConvertTo()` overloads
 - this relates to #4521