### PR TITLE
Fix #4998 - Change lifetime of ViewComponentResultExecutor

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/DependencyInjection/MvcViewFeaturesMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/DependencyInjection/MvcViewFeaturesMvcCoreBuilderExtensions.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddSingleton<
                 IViewComponentDescriptorCollectionProvider,
                 DefaultViewComponentDescriptorCollectionProvider>();
-            services.TryAddSingleton<ViewComponentResultExecutor>();
+            services.TryAddTransient<ViewComponentResultExecutor>();
 
             services.TryAddSingleton<ViewComponentInvokerCache>();
             services.TryAddTransient<IViewComponentDescriptorProvider, DefaultViewComponentDescriptorProvider>();


### PR DESCRIPTION
This service has a scoped dependency so it should be scoped or transient.

This is a minimal fix for the 1.0.1 release. The actual fix will go into dev and will include adding functional test verification of our service lifetimes.