### PR TITLE
Fix column attribute for <textarea> is incorrect

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/DefaultHtmlGenerator.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/DefaultHtmlGenerator.cs
@@ -658,7 +658,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 
             if (columns > 0)
             {
-                tagBuilder.MergeAttribute("columns", columns.ToString(CultureInfo.InvariantCulture), true);
+                tagBuilder.MergeAttribute("cols", columns.ToString(CultureInfo.InvariantCulture), true);
             }
 
             tagBuilder.MergeAttribute("name", fullName, true);

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperTextAreaExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperTextAreaExtensionsTest.cs
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Mvc.Core
 
             // Assert
             Assert.Equal(
-                "<textarea attr=\"HtmlEncode[[value]]\" columns=\"HtmlEncode[[2]]\" id=\"HtmlEncode[[Property1]]\" " +
+                "<textarea attr=\"HtmlEncode[[value]]\" cols=\"HtmlEncode[[2]]\" id=\"HtmlEncode[[Property1]]\" " +
                 "name=\"HtmlEncode[[Property1]]\" rows=\"HtmlEncode[[1]]\">" + Environment.NewLine +
                 "HtmlEncode[[myvalue]]</textarea>",
                 HtmlContentUtilities.HtmlContentToString(textAreaResult));
@@ -140,7 +140,7 @@ namespace Microsoft.AspNetCore.Mvc.Core
 
             // Assert
             Assert.Equal(
-                "<textarea attr=\"HtmlEncode[[value]]\" columns=\"HtmlEncode[[2]]\" id=\"HtmlEncode[[Property1]]\" " +
+                "<textarea attr=\"HtmlEncode[[value]]\" cols=\"HtmlEncode[[2]]\" id=\"HtmlEncode[[Property1]]\" " +
                 "name=\"HtmlEncode[[Property1]]\" rows=\"HtmlEncode[[1]]\">" + Environment.NewLine +
                 "</textarea>",
                 HtmlContentUtilities.HtmlContentToString(textAreaForResult));


### PR DESCRIPTION
- changed the call to tagBuilder.MergeAttribute using key "cols" instead of "columns"
- changed also unit test, to test "cols" key

#5039 