### PR TITLE
Make sure we don't try to add the same key multiple times

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcCoreRouteOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcCoreRouteOptionsSetup.cs
@@ -12,6 +12,8 @@ namespace Microsoft.AspNetCore.Mvc.Internal
     /// </summary>
     public class MvcCoreRouteOptionsSetup : ConfigureOptions<RouteOptions>
     {
+        private const string KnownRouteValueConstraintKey = "exists";
+
         public MvcCoreRouteOptionsSetup()
             : base(ConfigureRouting)
         {
@@ -23,7 +25,10 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         /// <param name="options">The <see cref="RouteOptions"/>.</param>
         public static void ConfigureRouting(RouteOptions options)
         {
-            options.ConstraintMap.Add("exists", typeof(KnownRouteValueConstraint));
+            if (!options.ConstraintMap.ContainsKey(KnownRouteValueConstraintKey))
+            {
+                options.ConstraintMap.Add(KnownRouteValueConstraintKey, typeof(KnownRouteValueConstraint));
+            }
         }
     }
 }


### PR DESCRIPTION
We hit an issue where multiple `MvcCoreRouteOptionsSetup` were being run because of several registrations in the service collection. See issues below.

Ideally, this shouldn't happen, but it did, because of another bug (or an ill-defined contract in MS.Ext.DI). This ensures that the configuration is idempotent :sparkles: 

https://github.com/structuremap/StructureMap.Microsoft.DependencyInjection/issues/11
https://github.com/structuremap/StructureMap.Microsoft.DependencyInjection/issues/12