### PR TITLE
Localize DataAnnotations

### DIFF
--- a/Mvc.sln
+++ b/Mvc.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{DAAE4C74-D06F-4874-A166-33305D2643CE}"
 EndProject

--- a/src/Microsoft.AspNetCore.Mvc.DataAnnotations/Internal/MvcDataAnnotationsMvcOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.Mvc.DataAnnotations/Internal/MvcDataAnnotationsMvcOptionsSetup.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
             var stringLocalizerFactory = serviceProvider.GetService<IStringLocalizerFactory>();
             var validationAttributeAdapterProvider = serviceProvider.GetRequiredService<IValidationAttributeAdapterProvider>();
 
-            options.ModelMetadataDetailsProviders.Add(new DataAnnotationsMetadataProvider());
+            options.ModelMetadataDetailsProviders.Add(new DataAnnotationsMetadataProvider(stringLocalizerFactory));
 
             options.ModelValidatorProviders.Add(new DataAnnotationsModelValidatorProvider(
                 validationAttributeAdapterProvider,

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/ModelMetadataProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/ModelMetadataProviderTest.cs
@@ -1050,7 +1050,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
                       new DefaultCompositeMetadataDetailsProvider(new IMetadataDetailsProvider[]
                       {
                           new DefaultBindingMetadataProvider(),
-                          new DataAnnotationsMetadataProvider(),
+                          new DataAnnotationsMetadataProvider(stringLocalizerFactory: null),
                       }),
                       new TestOptionsManager<MvcOptions>())
             {

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/TestResources.cs
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/TestResources.cs
@@ -14,6 +14,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 
         public static string DisplayAttribute_Name { get; } = Resources.DisplayAttribute_Name;
 
+        public static string DisplayAttribute_Prompt { get; } = Resources.DisplayAttribute_Prompt;
+
         public static string DisplayAttribute_CultureSensitiveName =>
             Resources.DisplayAttribute_Name + CultureInfo.CurrentUICulture;
 

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Properties/Resources.Designer.cs
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Properties/Resources.Designer.cs
@@ -58,6 +58,22 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Test
             return GetString("DisplayAttribute_Name");
         }
 
+        /// <summary>
+        /// prompt from resources
+        /// </summary>
+        internal static string DisplayAttribute_Prompt
+        {
+            get { return GetString("DisplayAttribute_Prompt"); }
+        }
+
+        /// <summary>
+        /// prompt from resources
+        /// </summary>
+        internal static string FormatDisplayAttribute_Prompt()
+        {
+            return GetString("DisplayAttribute_Prompt");
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Resources.resx
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Resources.resx
@@ -126,4 +126,7 @@
   <data name="DisplayAttribute_Name" xml:space="preserve">
     <value>name from resources</value>
   </data>
+  <data name="DisplayAttribute_Prompt" xml:space="preserve">
+    <value>prompt from resources</value>
+  </data>
 </root>

--- a/test/Microsoft.AspNetCore.Mvc.TestCommon/TestModelMetadataProvider.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TestCommon/TestModelMetadataProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             {
                 new DefaultBindingMetadataProvider(),
                 new DefaultValidationMetadataProvider(),
-                new DataAnnotationsMetadataProvider(),
+                new DataAnnotationsMetadataProvider(stringLocalizerFactory: null),
                 new DataMemberRequiredBindingMetadataProvider(),
             };
 
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             {
                 new DefaultBindingMetadataProvider(),
                 new DefaultValidationMetadataProvider(),
-                new DataAnnotationsMetadataProvider(),
+                new DataAnnotationsMetadataProvider(stringLocalizerFactory: null),
                 new DataMemberRequiredBindingMetadataProvider(),
             };
 
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                   {
                       new DefaultBindingMetadataProvider(),
                       new DefaultValidationMetadataProvider(),
-                      new DataAnnotationsMetadataProvider(),
+                      new DataAnnotationsMetadataProvider(stringLocalizerFactory: null),
                       detailsProvider
                   }),
                   new TestOptionsManager<MvcOptions>())


### PR DESCRIPTION
This is a design PR for #3518, with the goal of localizing the remaining end-user visible DataAnnotations. The behavior we're going for here is basically what we already have to the validation attributes, the value for each property is used as a resource key and fallen back to if nothing is found.