### PR TITLE
Fix proposal for Issue#5150

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Formatters/MediaType.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Formatters/MediaType.cs
@@ -308,7 +308,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
             // We check if the parsed media type has value at this stage when we have iterated
             // over all the parameters and we know if the parsing was sucessful.
-            if (!parser.ParsingFailed)
+            if (!parser.ParsingFailed && parser.CurrentOffset >= start)
             {
                 return new MediaTypeSegmentWithQuality(
                     new StringSegment(mediaType, start, parser.CurrentOffset - start),

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
                 () => { AcceptHeaderParser.ParseAcceptHeader(new List<string> { header }); });
 
             // Assert
-            Assert.Equal(ex.Message, expectedException);
+            Assert.Equal(expectedException, ex.Message);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Primitives;
 using Xunit;
@@ -46,6 +47,17 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
             {
                 Assert.Same(header, mediaType.MediaType.Buffer);
             }
+        }
+
+        [Fact]
+        public void ParseAcceptHeader_ParsesSimpleHeaderWithMultipleValues_InvalidFormat()
+        {
+            // Arrange
+            var header = "application/json, application/xml,;q=0.8";
+
+            // Act, Assert
+            Assert.Throws<FormatException>(
+                () => { AcceptHeaderParser.ParseAcceptHeader(new List<string> { header }); });
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
@@ -54,10 +54,14 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
         {
             // Arrange
             var header = "application/json, application/xml,;q=0.8";
+            var expectedException = "\"Invalid values ';q=0.8'.\"";
 
-            // Act, Assert
-            Assert.Throws<FormatException>(
+            // Act
+            var ex = Assert.Throws<FormatException>(
                 () => { AcceptHeaderParser.ParseAcceptHeader(new List<string> { header }); });
+
+            // Assert
+            Assert.Equal(ex.Message, expectedException);
         }
 
         [Fact]


### PR DESCRIPTION
Hi, I was looking at this issue and would like to contribute.

**_Problem:_**
When the Accept header contains _**accept-params**_ without **_media-range,_** MediaTypeSegmentWithQuality 
calls StringSegment with a negative length, which causes the System.ArgumentOutOfRangeException.

**_Proposed Solution:_**
Add a check to avoid passing negative length to _StringSegment,_ this will return the default of  _MediaTypeSegmentWithQuality_, leading to a FormatException, which gives more useful information about what went wrong.

Addresses #5150 

/CC: @dougbu @javiercn @danroth27