### PR TITLE
Replace ConfigureOptions with IConfigureOptions

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcCoreRouteOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcCoreRouteOptionsSetup.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Options;
@@ -10,19 +11,19 @@ namespace Microsoft.AspNetCore.Mvc.Internal
     /// <summary>
     /// Sets up MVC default options for <see cref="RouteOptions"/>.
     /// </summary>
-    public class MvcCoreRouteOptionsSetup : ConfigureOptions<RouteOptions>
+    public class MvcCoreRouteOptionsSetup : IConfigureOptions<RouteOptions>
     {
-        public MvcCoreRouteOptionsSetup()
-            : base(ConfigureRouting)
-        {
-        }
-
         /// <summary>
         /// Configures the <see cref="RouteOptions"/>.
         /// </summary>
         /// <param name="options">The <see cref="RouteOptions"/>.</param>
-        public static void ConfigureRouting(RouteOptions options)
+        public void Configure(RouteOptions options)
         {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
             options.ConstraintMap.Add("exists", typeof(KnownRouteValueConstraint));
         }
     }

--- a/src/Microsoft.AspNetCore.Mvc.DataAnnotations/Internal/MvcDataAnnotationsLocalizationOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.Mvc.DataAnnotations/Internal/MvcDataAnnotationsLocalizationOptionsSetup.cs
@@ -9,14 +9,10 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
     /// <summary>
     /// Sets up default options for <see cref="MvcDataAnnotationsLocalizationOptions"/>.
     /// </summary>
-    public class MvcDataAnnotationsLocalizationOptionsSetup : ConfigureOptions<MvcDataAnnotationsLocalizationOptions>
+    public class MvcDataAnnotationsLocalizationOptionsSetup : IConfigureOptions<MvcDataAnnotationsLocalizationOptions>
     {
-        public MvcDataAnnotationsLocalizationOptionsSetup()
-            : base(ConfigureMvc)
-        {
-        }
-
-        public static void ConfigureMvc(MvcDataAnnotationsLocalizationOptions options)
+        /// <inheritdoc />
+        public void Configure(MvcDataAnnotationsLocalizationOptions options)
         {
             if (options == null)
             {

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/MvcXmlDataContractSerializerMvcOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/MvcXmlDataContractSerializerMvcOptionsSetup.cs
@@ -8,24 +8,16 @@ using Microsoft.Extensions.Options;
 namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
 {
     /// <summary>
-    /// A <see cref="ConfigureOptions{TOptions}"/> implementation which will add the
+    /// A <see cref="IConfigureOptions{TOptions}"/> implementation which will add the
     /// data contract serializer formatters to <see cref="MvcOptions"/>.
     /// </summary>
-    public class MvcXmlDataContractSerializerMvcOptionsSetup : ConfigureOptions<MvcOptions>
+    public class MvcXmlDataContractSerializerMvcOptionsSetup : IConfigureOptions<MvcOptions>
     {
-        /// <summary>
-        /// Creates a new instance of <see cref="MvcXmlDataContractSerializerMvcOptionsSetup"/>.
-        /// </summary>
-        public MvcXmlDataContractSerializerMvcOptionsSetup()
-            : base(ConfigureMvc)
-        {
-        }
-
         /// <summary>
         /// Adds the data contract serializer formatters to <see cref="MvcOptions"/>.
         /// </summary>
         /// <param name="options">The <see cref="MvcOptions"/>.</param>
-        public static void ConfigureMvc(MvcOptions options)
+        public void Configure(MvcOptions options)
         {
             options.ModelMetadataDetailsProviders.Add(new DataMemberRequiredBindingMetadataProvider());
 

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/MvcXmlSerializerMvcOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/MvcXmlSerializerMvcOptionsSetup.cs
@@ -6,24 +6,16 @@ using Microsoft.Extensions.Options;
 namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
 {
     /// <summary>
-    /// A <see cref="ConfigureOptions{TOptions}"/> implementation which will add the
+    /// A <see cref="IConfigureOptions{TOptions}"/> implementation which will add the
     /// XML serializer formatters to <see cref="MvcOptions"/>.
     /// </summary>
-    public class MvcXmlSerializerMvcOptionsSetup : ConfigureOptions<MvcOptions>
+    public class MvcXmlSerializerMvcOptionsSetup : IConfigureOptions<MvcOptions>
     {
-        /// <summary>
-        /// Creates a new <see cref="MvcXmlSerializerMvcOptionsSetup"/>.
-        /// </summary>
-        public MvcXmlSerializerMvcOptionsSetup()
-            : base(ConfigureMvc)
-        {
-        }
-
         /// <summary>
         /// Adds the XML serializer formatters to <see cref="MvcOptions"/>.
         /// </summary>
         /// <param name="options">The <see cref="MvcOptions"/>.</param>
-        public static void ConfigureMvc(MvcOptions options)
+        public void Configure(MvcOptions options)
         {
             options.OutputFormatters.Add(new XmlSerializerOutputFormatter());
             options.InputFormatters.Add(new XmlSerializerInputFormatter());

--- a/src/Microsoft.AspNetCore.Mvc.Razor/DependencyInjection/MvcRazorMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/DependencyInjection/MvcRazorMvcCoreBuilderExtensions.cs
@@ -142,8 +142,10 @@ namespace Microsoft.Extensions.DependencyInjection
 
             // DependencyContextRazorViewEngineOptionsSetup needs to run after RazorViewEngineOptionsSetup.
             // The ordering of the following two lines is important to ensure this behavior.
+#pragma warning disable 0618
             services.TryAddEnumerable(
                 ServiceDescriptor.Transient<IConfigureOptions<RazorViewEngineOptions>, RazorViewEngineOptionsSetup>());
+#pragma warning restore 0618
             services.TryAddEnumerable(
                 ServiceDescriptor.Transient<
                     IConfigureOptions<RazorViewEngineOptions>,

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/MvcRazorMvcViewOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/MvcRazorMvcViewOptionsSetup.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.Internal
@@ -10,37 +9,36 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
     /// <summary>
     /// Configures <see cref="MvcViewOptions"/> to use <see cref="RazorViewEngine"/>.
     /// </summary>
-    public class MvcRazorMvcViewOptionsSetup : ConfigureOptions<MvcViewOptions>
+    public class MvcRazorMvcViewOptionsSetup : IConfigureOptions<MvcViewOptions>
     {
+        private readonly IRazorViewEngine _razorViewEngine;
+
         /// <summary>
         /// Initializes a new instance of <see cref="MvcRazorMvcViewOptionsSetup"/>.
         /// </summary>
         /// <param name="razorViewEngine">The <see cref="IRazorViewEngine"/>.</param>
         public MvcRazorMvcViewOptionsSetup(IRazorViewEngine razorViewEngine)
-            : base(options => ConfigureMvc(razorViewEngine, options))
-        {
-        }
-
-        /// <summary>
-        /// Configures <paramref name="options"/> to use <see cref="RazorViewEngine"/>.
-        /// </summary>
-        /// <param name="razorViewEngine">The <see cref="IRazorViewEngine"/>.</param>
-        /// <param name="options">The <see cref="MvcViewOptions"/> to configure.</param>
-        public static void ConfigureMvc(
-            IRazorViewEngine razorViewEngine,
-            MvcViewOptions options)
         {
             if (razorViewEngine == null)
             {
                 throw new ArgumentNullException(nameof(razorViewEngine));
             }
 
+            _razorViewEngine = razorViewEngine;
+        }
+
+        /// <summary>
+        /// Configures <paramref name="options"/> to use <see cref="RazorViewEngine"/>.
+        /// </summary>
+        /// <param name="options">The <see cref="MvcViewOptions"/> to configure.</param>
+        public void Configure(MvcViewOptions options)
+        {
             if (options == null)
             {
                 throw new ArgumentNullException(nameof(options));
             }
 
-            options.ViewEngines.Add(razorViewEngine);
+            options.ViewEngines.Add(_razorViewEngine);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Razor/RazorViewEngineOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/RazorViewEngineOptionsSetup.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Razor;
@@ -12,6 +13,7 @@ namespace Microsoft.AspNetCore.Mvc
     /// <summary>
     /// Sets up default options for <see cref="RazorViewEngineOptions"/>.
     /// </summary>
+    [Obsolete("This type is for internal use and will be removed in a future version.")]
     public class RazorViewEngineOptionsSetup : ConfigureOptions<RazorViewEngineOptions>
     {
         /// <summary>

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/TempDataMvcOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/TempDataMvcOptionsSetup.cs
@@ -8,14 +8,9 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
     /// <summary>
     /// Sets up default options for <see cref="MvcOptions"/>.
     /// </summary>
-    public class TempDataMvcOptionsSetup : ConfigureOptions<MvcOptions>
+    public class TempDataMvcOptionsSetup : IConfigureOptions<MvcOptions>
     {
-        public TempDataMvcOptionsSetup()
-            : base(ConfigureMvc)
-        {
-        }
-
-        public static void ConfigureMvc(MvcOptions options)
+        public void Configure(MvcOptions options)
         {
             options.Filters.Add(new SaveTempDataAttribute());
         }

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/MvcDataAnnotationsMvcOptionsSetup.cs
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/MvcDataAnnotationsMvcOptionsSetup.cs
@@ -1,0 +1,37 @@
+﻿// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.DataAnnotations.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Test.Internal
+{
+    public class MvcDataAnnotationsMvcOptionsSetupTests
+    {
+        [Fact]
+        public void MvcDataAnnotationsMvcOptionsSetup_ServiceConstructorWithoutIStringLocalizer()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            services.AddSingleton<IHostingEnvironment>(Mock.Of<IHostingEnvironment>());
+            services.AddSingleton<IValidationAttributeAdapterProvider, ValidationAttributeAdapterProvider>();
+            services.AddSingleton<IOptions<MvcDataAnnotationsLocalizationOptions>>(
+                new TestOptionsManager<MvcDataAnnotationsLocalizationOptions>());
+            services.AddSingleton<IConfigureOptions<MvcOptions>, MvcDataAnnotationsMvcOptionsSetup>();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            // Act
+            var optionsSetup = serviceProvider.GetRequiredService<IConfigureOptions<MvcOptions>>();
+
+            // Assert
+            Assert.NotNull(optionsSetup);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/TestMvcOptions.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/TestMvcOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Buffers;
 using Microsoft.AspNetCore.Mvc.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.DataAnnotations.Internal;
@@ -10,9 +11,11 @@ using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.ObjectPool;
 using Microsoft.Extensions.Options;
+using Moq;
 
 namespace Microsoft.AspNetCore.Mvc.IntegrationTests
 {
@@ -24,23 +27,31 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             var optionsSetup = new MvcCoreMvcOptionsSetup(new TestHttpRequestStreamReaderFactory());
             optionsSetup.Configure(Value);
 
-            var collection = new ServiceCollection().AddOptions();
-            collection.AddSingleton<ICompositeMetadataDetailsProvider, DefaultCompositeMetadataDetailsProvider>();
-            collection.AddSingleton<IModelMetadataProvider, DefaultModelMetadataProvider>();
-            collection.AddSingleton<IValidationAttributeAdapterProvider, ValidationAttributeAdapterProvider>();
-            MvcDataAnnotationsMvcOptionsSetup.ConfigureMvc(
-                Value,
-                collection.BuildServiceProvider());
+            var validationAttributeAdapterProvider = new ValidationAttributeAdapterProvider();
+            var dataAnnotationLocalizationOptions = new TestOptionsManager<MvcDataAnnotationsLocalizationOptions>();
+            var stringLocalizer = new Mock<IStringLocalizer>();
+            var stringLocalizerFactory = new Mock<IStringLocalizerFactory>();
+            stringLocalizerFactory
+                .Setup(s => s.Create(It.IsAny<Type>()))
+                .Returns(stringLocalizer.Object);
+
+            var dataAnnotationOptionsSetup = new MvcDataAnnotationsMvcOptionsSetup(
+                validationAttributeAdapterProvider,
+                dataAnnotationLocalizationOptions,
+                stringLocalizerFactory.Object);
+            dataAnnotationOptionsSetup.Configure(Value);
 
             var loggerFactory = new LoggerFactory();
-            var serializerSettings = JsonSerializerSettingsProvider.CreateSerializerSettings();
+            var jsonOptions = new TestOptionsManager<MvcJsonOptions>();
+            var charPool = ArrayPool<char>.Shared;
+            var objectPoolProvider = new DefaultObjectPoolProvider();
 
-            MvcJsonMvcOptionsSetup.ConfigureMvc(
-                Value,
-                serializerSettings,
+            var mvcJsonMvcOptionsSetup = new MvcJsonMvcOptionsSetup(
                 loggerFactory,
-                ArrayPool<char>.Shared,
-                new DefaultObjectPoolProvider());
+                jsonOptions,
+                charPool,
+                objectPoolProvider);
+            mvcJsonMvcOptionsSetup.Configure(Value);
         }
 
         public MvcOptions Value { get; }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/DependencyContextRazorViewEngineOptionsSetupTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/DependencyContextRazorViewEngineOptionsSetupTest.cs
@@ -265,7 +265,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var hostingEnvironment = new Mock<IHostingEnvironment>();
             hostingEnvironment.SetupGet(e => e.EnvironmentName)
                 .Returns("Development");
+#pragma warning disable 0618
             var viewEngineSetup = new RazorViewEngineOptionsSetup(hostingEnvironment.Object);
+#pragma warning restore 0618
 
             // Act
             viewEngineSetup.Configure(options);

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorViewEngineOptionsSetupTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorViewEngineOptionsSetupTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Hosting;
@@ -23,7 +23,9 @@ namespace Microsoft.AspNetCore.Mvc
                 .Returns(expected);
             hostingEnv.SetupGet(e => e.EnvironmentName)
                 .Returns("Development");
+#pragma warning disable 0618
             var optionsSetup = new RazorViewEngineOptionsSetup(hostingEnv.Object);
+#pragma warning restore 0618
 
             // Act
             optionsSetup.Configure(options);
@@ -44,7 +46,9 @@ namespace Microsoft.AspNetCore.Mvc
             var hostingEnv = new Mock<IHostingEnvironment>();
             hostingEnv.SetupGet(e => e.EnvironmentName)
                   .Returns(environment);
+#pragma warning disable 0618
             var optionsSetup = new RazorViewEngineOptionsSetup(hostingEnv.Object);
+#pragma warning restore 0618
 
             // Act
             optionsSetup.Configure(options);
@@ -66,7 +70,9 @@ namespace Microsoft.AspNetCore.Mvc
             var hostingEnv = new Mock<IHostingEnvironment>();
             hostingEnv.SetupGet(e => e.EnvironmentName)
                   .Returns(environment);
+#pragma warning disable 0618
             var optionsSetup = new RazorViewEngineOptionsSetup(hostingEnv.Object);
+#pragma warning restore 0618
 
             // Act
             optionsSetup.Configure(options);

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazoreViewEngineTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazoreViewEngineTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -1564,7 +1564,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Test
             IEnumerable<string> viewLocationFormats = null,
             IEnumerable<string> areaViewLocationFormats = null)
         {
+#pragma warning disable 0618
             var optionsSetup = new RazorViewEngineOptionsSetup(Mock.Of<IHostingEnvironment>());
+#pragma warning restore 0618
 
             var options = new RazorViewEngineOptions();
             optionsSetup.Configure(options);

--- a/test/Microsoft.AspNetCore.Mvc.Test/MvcServiceCollectionExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Test/MvcServiceCollectionExtensionsTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -327,7 +327,9 @@ namespace Microsoft.AspNetCore.Mvc
                         typeof(IConfigureOptions<RazorViewEngineOptions>),
                         new[]
                         {
+#pragma warning disable 0618
                             typeof(RazorViewEngineOptionsSetup),
+#pragma warning restore 0618
                             typeof(DependencyContextRazorViewEngineOptionsSetup)
                         }
                     },


### PR DESCRIPTION
Fixes #4736. Replace `ConfigureOptions` with `IConfigureOptions` to avoid unnecessary delagates.