### PR TITLE
[Prototype] Async resource filter's short circuited result gets executed more than once

### DIFF
--- a/samples/MvcSandbox/Controllers/HomeController.cs
+++ b/samples/MvcSandbox/Controllers/HomeController.cs
@@ -1,15 +1,109 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace MvcSandbox.Controllers
 {
     public class HomeController : Controller
     {
-        public IActionResult Index()
+        [TestSyncResourceFilter(FilterAction = TestSyncResourceFilter.Action.PassThrough, Order = 1)]
+        [TestSyncResourceFilter(FilterAction = TestSyncResourceFilter.Action.PassThrough, Order = 2)]
+        [TestSyncResourceFilter(FilterAction = TestSyncResourceFilter.Action.Shortcircuit, Order = 2)]
+        public IActionResult Sync()
         {
-            return View();
+            return Content("Home.Sync");
+        }
+
+        [TestAsyncResourceFilter(FilterAction = TestAsyncResourceFilter.Action.PassThrough, Order = 1)]
+        [TestAsyncResourceFilter(FilterAction = TestAsyncResourceFilter.Action.Shortcircuit, Order = 2)]
+        public IActionResult Async()
+        {
+            return Content("Home.Async");
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+    public class TestSyncResourceFilter : Attribute, IResourceFilter, IOrderedFilter
+    {
+        public enum Action
+        {
+            PassThrough,
+            ThrowException,
+            Shortcircuit
+        }
+
+        public readonly string ExceptionMessage = $"Error!! in {nameof(TestSyncResourceFilter)}";
+
+        public readonly string ShortcircuitMessage = $"Shortcircuited by {nameof(TestSyncResourceFilter)}";
+
+        public Action FilterAction { get; set; }
+
+        public int Order { get; set; }
+
+        public void OnResourceExecuted(ResourceExecutedContext context)
+        {
+        }
+
+        public void OnResourceExecuting(ResourceExecutingContext context)
+        {
+            if (FilterAction == Action.PassThrough)
+            {
+                return;
+            }
+            else if (FilterAction == Action.ThrowException)
+            {
+                throw new InvalidOperationException(ExceptionMessage);
+            }
+            else
+            {
+                context.Result = new ContentResult()
+                {
+                    Content = ShortcircuitMessage
+                };
+            }
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+    public class TestAsyncResourceFilter : Attribute, IAsyncResourceFilter, IOrderedFilter
+    {
+        public enum Action
+        {
+            PassThrough,
+            ThrowException,
+            Shortcircuit
+        }
+
+        public readonly string ExceptionMessage = $"Error!! in {nameof(TestAsyncResourceFilter)}";
+
+        public readonly string ShortcircuitMessage = $"Shortcircuited by {nameof(TestAsyncResourceFilter)}";
+
+        public Action FilterAction { get; set; }
+
+        public int Order { get; set; }
+
+        public Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)
+        {
+            if (FilterAction == Action.PassThrough)
+            {
+                return next();
+            }
+            else if (FilterAction == Action.ThrowException)
+            {
+                throw new InvalidOperationException(ExceptionMessage);
+            }
+            else
+            {
+                context.Result = new ContentResult()
+                {
+                    Content = ShortcircuitMessage
+                };
+                return Task.FromResult(true);
+            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionInvoker.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionInvoker.cs
@@ -290,12 +290,9 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                             Canceled = true,
                             Result = _resourceExecutingContext.Result,
                         };
-                    }
 
-                    _diagnosticSource.AfterOnResourceExecution(_resourceExecutedContext, item.FilterAsync);
+                        _diagnosticSource.AfterOnResourceExecution(_resourceExecutedContext, item.FilterAsync);
 
-                    if (_resourceExecutingContext.Result != null)
-                    {
                         _logger.ResourceFilterShortCircuited(item.FilterAsync);
 
                         await InvokeResultAsync(_resourceExecutingContext.Result);


### PR DESCRIPTION
@rynowak Potential changes. I will file an issue now. (sync filters do not have this problem as the way the call stack is, its preventing from this issue to happen)
