### PR TITLE
Localize Enum Display names

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/EnumGroupAndName.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/EnumGroupAndName.cs
@@ -10,8 +10,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
     /// </summary>
     public struct EnumGroupAndName
     {
+        private Func<string> _name;
+
         /// <summary>
-        /// Initializes a new instance of the EnumGroupAndName structure.
+        /// Initializes a new instance of the <see cref="EnumGroupAndName"/> structure. This constructor should 
+        /// not be used in any site where localization is important.
         /// </summary>
         /// <param name="group">The group name.</param>
         /// <param name="name">The name.</param>
@@ -28,7 +31,30 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             }
 
             Group = group;
-            Name = name;
+            _name = () => name;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EnumGroupAndName"/> structure.
+        /// </summary>
+        /// <param name="group">The group name.</param>
+        /// <param name="name">A <see cref="Func{String}"/> which will return the name.</param>
+        public EnumGroupAndName(
+            string group,
+            Func<string> name)
+        {
+            if (group == null)
+            {
+                throw new ArgumentNullException(nameof(group));
+            }
+
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            Group = group;
+            _name = name;
         }
 
         /// <summary>
@@ -39,6 +65,12 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         /// <summary>
         /// Gets the name.
         /// </summary>
-        public string Name { get; }
+        public string Name
+        {
+            get
+            {
+                return _name();
+            }
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/HtmlHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/HtmlHelper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -522,6 +523,23 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             string templateName,
             object additionalViewData)
         {
+            var modelEnum = modelExplorer.Model as Enum;
+            if (modelExplorer.Metadata.IsEnum && modelEnum != null)
+            {
+                var value = modelEnum.ToString("d");
+                var enumGrouped = modelExplorer.Metadata.EnumGroupedDisplayNamesAndValues;
+                Debug.Assert(enumGrouped != null);
+                foreach (var kvp in enumGrouped)
+                {
+                    if (kvp.Value == value)
+                    {
+                        // Creates a ModelExplorer with the same Metadata except that the Model is a string instead of an Enum
+                        modelExplorer = modelExplorer.GetExplorerForModel(kvp.Key.Name);
+                        break;
+                    }
+                }
+            }
+
             var templateBuilder = new TemplateBuilder(
                 _viewEngine,
                 _bufferScope,

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/DataAnnotationsMetadataProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/DataAnnotationsMetadataProviderTest.cs
@@ -2,12 +2,17 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.Linq;
+using Microsoft.AspNetCore.Mvc.DataAnnotations.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Microsoft.AspNetCore.Testing;
+using Microsoft.DotNet.InternalAbstractions;
 using Microsoft.Extensions.Localization;
 using Moq;
 using Xunit;
@@ -353,13 +358,13 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
             var stringLocalizer = new Mock<IStringLocalizer>(MockBehavior.Strict);
             stringLocalizer
                 .Setup(s => s["Model_Name"])
-                .Returns(new LocalizedString("Model_Name", "name from localizer"));
+                .Returns(() => new LocalizedString("Model_Name", "name from localizer " + CultureInfo.CurrentCulture));
             stringLocalizer
                 .Setup(s => s["Model_Description"])
-                .Returns(new LocalizedString("Model_Description", "description from localizer"));
+                .Returns(() => new LocalizedString("Model_Description", "description from localizer " + CultureInfo.CurrentCulture));
             stringLocalizer
                 .Setup(s => s["Model_Prompt"])
-                .Returns(new LocalizedString("Model_Prompt", "prompt from localizer"));
+                .Returns(() => new LocalizedString("Model_Prompt", "prompt from localizer " + CultureInfo.CurrentCulture));
 
             var stringLocalizerFactory = new Mock<IStringLocalizerFactory>(MockBehavior.Strict);
             stringLocalizerFactory
@@ -383,9 +388,18 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
             provider.CreateDisplayMetadata(context);
 
             // Assert
-            Assert.Equal("name from localizer", context.DisplayMetadata.DisplayName());
-            Assert.Equal("description from localizer", context.DisplayMetadata.Description());
-            Assert.Equal("prompt from localizer", context.DisplayMetadata.Placeholder());
+            using (new CultureReplacer("en-US", "en-US"))
+            {
+                Assert.Equal("name from localizer en-US", context.DisplayMetadata.DisplayName());
+                Assert.Equal("description from localizer en-US", context.DisplayMetadata.Description());
+                Assert.Equal("prompt from localizer en-US", context.DisplayMetadata.Placeholder());
+            }
+            using (new CultureReplacer("fr-FR", "fr-FR"))
+            {
+                Assert.Equal("name from localizer fr-FR", context.DisplayMetadata.DisplayName());
+                Assert.Equal("description from localizer fr-FR", context.DisplayMetadata.Description());
+                Assert.Equal("prompt from localizer fr-FR", context.DisplayMetadata.Placeholder());
+            }
         }
 
         [Theory]
@@ -589,6 +603,48 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
             Assert.Equal(expectedDictionary, context.DisplayMetadata.EnumNamesAndValues);
         }
 
+        [Fact]
+        public void CreateDisplayMetadata_DisplayName_LocalizeWithStringLocalizer()
+        {
+            // Arrange
+            var expectedKeyValuePairs = new List<KeyValuePair<EnumGroupAndName, string>>
+            {
+                new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName("Zero", string.Empty), "0"),
+                new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithDisplayNames.One)), "1"),
+                new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, "dos value"), "2"),
+                new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, "tres value"), "3"),
+                new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, "name from resources"), "-2"),
+                new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName("Negatives", "menos uno value"), "-1"),
+            };
+
+            var type = typeof(EnumWithDisplayNames);
+            var attributes = new object[0];
+
+            var key = ModelMetadataIdentity.ForType(type);
+            var context = new DisplayMetadataProviderContext(key, new ModelAttributes(attributes));
+
+            var stringLocalizer = new Mock<IStringLocalizer>(MockBehavior.Strict);
+            stringLocalizer
+                .Setup(s => s[It.IsAny<string>()])
+                .Returns<string>((index) => new LocalizedString(index, index + " value"));
+
+            var stringLocalizerFactory = new Mock<IStringLocalizerFactory>(MockBehavior.Strict);
+            stringLocalizerFactory
+                .Setup(f => f.Create(It.IsAny<Type>()))
+                .Returns(stringLocalizer.Object);
+
+            var provider = new DataAnnotationsMetadataProvider(stringLocalizerFactory.Object);
+
+            // Act
+            provider.CreateDisplayMetadata(context);
+
+            // Assert
+            Assert.Equal(
+                expectedKeyValuePairs,
+                context.DisplayMetadata.EnumGroupedDisplayNamesAndValues,
+                KVPEnumGroupAndNameComparer.Instance);
+        }
+
         // Type -> expected EnumDisplayNamesAndValues
         public static TheoryData<Type, IEnumerable<KeyValuePair<EnumGroupAndName, string>>> EnumDisplayNamesData
         {
@@ -719,12 +775,90 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
             provider.CreateDisplayMetadata(context);
 
             // Assert
-            // OrderBy is used because the order of the results may very depending on the platform / client.
             Assert.Equal(
-                expectedKeyValuePairs?.OrderBy(item => item.Key.Group, StringComparer.Ordinal)
-                .ThenBy(item => item.Key.Name, StringComparer.Ordinal),
-                context.DisplayMetadata.EnumGroupedDisplayNamesAndValues?.OrderBy(item => item.Key.Group, StringComparer.Ordinal)
-                .ThenBy(item => item.Key.Name, StringComparer.Ordinal));
+                expectedKeyValuePairs,
+                context.DisplayMetadata.EnumGroupedDisplayNamesAndValues,
+                KVPEnumGroupAndNameComparer.Instance);
+        }
+
+        [Fact]
+        public void CreateDisplayMetadata_EnumGroupedDisplayNamesAndValues_NameWithNoIStringLocalizerAndNoResourceType()
+        {
+            // Arrange & Act
+            var enumNameAndGroup = GetLocalizedEnumGroupedDisplayNamesAndValues(useStringLocalizer: false);
+
+            // Assert
+            var groupTwo = Assert.Single(enumNameAndGroup, e => e.Value.Equals("2", StringComparison.Ordinal));
+
+            using (new CultureReplacer("en-US", "en-US"))
+            {
+                Assert.Equal("Loc_Two_Name", groupTwo.Key.Name);
+            }
+
+            using (new CultureReplacer("fr-FR", "fr-FR"))
+            {
+                Assert.Equal("Loc_Two_Name", groupTwo.Key.Name);
+            }
+        }
+
+        [Fact]
+        public void CreateDisplayMetadata_EnumGroupedDisplayNamesAndValues_NameWithIStringLocalizerAndNoResourceType()
+        {
+            // Arrange & Act
+            var enumNameAndGroup = GetLocalizedEnumGroupedDisplayNamesAndValues(useStringLocalizer: true);
+
+            // Assert
+            var groupTwo = Assert.Single(enumNameAndGroup, e => e.Value.Equals("2", StringComparison.Ordinal));
+
+            using (new CultureReplacer("en-US", "en-US"))
+            {
+                Assert.Equal("Loc_Two_Name en-US", groupTwo.Key.Name);
+            }
+
+            using (new CultureReplacer("fr-FR", "fr-FR"))
+            {
+                Assert.Equal("Loc_Two_Name fr-FR", groupTwo.Key.Name);
+            }
+        }
+
+        [Fact]
+        public void CreateDisplayMetadata_EnumGroupedDisplayNamesAndValues_NameWithNoIStringLocalizerAndResourceType()
+        {
+            // Arrange & Act
+            var enumNameAndGroup = GetLocalizedEnumGroupedDisplayNamesAndValues(useStringLocalizer: false);
+
+            // Assert
+            var groupThree = Assert.Single(enumNameAndGroup, e => e.Value.Equals("3", StringComparison.Ordinal));
+
+            using (new CultureReplacer("en-US", "en-US"))
+            {
+                Assert.Equal("type three name en-US", groupThree.Key.Name);
+            }
+
+            using (new CultureReplacer("fr-FR", "fr-FR"))
+            {
+                Assert.Equal("type three name fr-FR", groupThree.Key.Name);
+            }
+        }
+
+        [Fact]
+        public void CreateDisplayMetadata_EnumGroupedDisplayNamesAndValues_NameWithIStringLocalizerAndResourceType()
+        {
+            // Arrange & Act
+            var enumNameAndGroup = GetLocalizedEnumGroupedDisplayNamesAndValues(useStringLocalizer: true);
+
+            var groupThree = Assert.Single(enumNameAndGroup, e => e.Value.Equals("3", StringComparison.Ordinal));
+
+            // Assert
+            using (new CultureReplacer("en-US", "en-US"))
+            {
+                Assert.Equal("type three name en-US", groupThree.Key.Name);
+            }
+
+            using (new CultureReplacer("fr-FR", "fr-FR"))
+            {
+                Assert.Equal("type three name fr-FR", groupThree.Key.Name);
+            }
         }
 
         [Fact]
@@ -848,6 +982,70 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
             Assert.Same(attribute, validatorMetadata);
         }
 
+        private IEnumerable<KeyValuePair<EnumGroupAndName, string>> GetLocalizedEnumGroupedDisplayNamesAndValues(
+            bool useStringLocalizer)
+        {
+            var provider = CreateIStringLocalizerProvider(useStringLocalizer);
+
+            var key = ModelMetadataIdentity.ForType(typeof(EnumWithLocalizedDisplayNames));
+            var attributes = new object[0];
+
+            var context = new DisplayMetadataProviderContext(key, new ModelAttributes(attributes));
+            provider.CreateDisplayMetadata(context);
+
+            return context.DisplayMetadata.EnumGroupedDisplayNamesAndValues;
+        }
+
+        private DataAnnotationsMetadataProvider CreateIStringLocalizerProvider(bool useStringLocalizer)
+        {
+            var stringLocalizer = new Mock<IStringLocalizer>(MockBehavior.Strict);
+            stringLocalizer
+                .Setup(loc => loc[It.IsAny<string>()])
+                .Returns<string>((k =>
+                {
+                    return new LocalizedString(k, $"{k} {CultureInfo.CurrentCulture}");
+                }));
+
+            var stringLocalizerFactory = new Mock<IStringLocalizerFactory>(MockBehavior.Strict);
+            stringLocalizerFactory
+                .Setup(factory => factory.Create(typeof(EnumWithLocalizedDisplayNames)))
+                .Returns(stringLocalizer.Object);
+
+            return new DataAnnotationsMetadataProvider(
+                useStringLocalizer ? stringLocalizerFactory.Object : null);
+        }
+
+        private class KVPEnumGroupAndNameComparer : IEqualityComparer<KeyValuePair<EnumGroupAndName, string>>
+        {
+            public static readonly IEqualityComparer<KeyValuePair<EnumGroupAndName, string>> Instance = new KVPEnumGroupAndNameComparer();
+
+            private KVPEnumGroupAndNameComparer()
+            {
+            }
+
+            public bool Equals(KeyValuePair<EnumGroupAndName, string> x, KeyValuePair<EnumGroupAndName, string> y)
+            {
+                using (new CultureReplacer(string.Empty, string.Empty))
+                {
+                    return x.Key.Name.Equals(y.Key.Name, StringComparison.Ordinal)
+                        && x.Key.Group.Equals(y.Key.Group, StringComparison.Ordinal);
+                }
+            }
+
+            public int GetHashCode(KeyValuePair<EnumGroupAndName, string> obj)
+            {
+                using (new CultureReplacer(string.Empty, string.Empty))
+                {
+                    var hashcode = HashCodeCombiner.Start();
+
+                    hashcode.Add(obj.Key.Name);
+                    hashcode.Add(obj.Key.Group);
+
+                    return hashcode.CombinedHash;
+                }
+            }
+        }
+
         private class TestValidationAttribute : ValidationAttribute, IClientModelValidator
         {
             public void AddValidation(ClientModelValidationContext context)
@@ -872,6 +1070,14 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
             public int Id { get; set; }
 
             public string Name { get; set; }
+        }
+
+        private enum EnumWithLocalizedDisplayNames
+        {
+            [Display(Name = "Loc_Two_Name")]
+            Two = 2,
+            [Display(Name = nameof(TestResources.Type_Three_Name), ResourceType = typeof(TestResources))]
+            Three = 3
         }
 
         private enum EmptyEnum

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/TestResources.cs
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/TestResources.cs
@@ -10,11 +10,13 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
     // internal properties.
     public static class TestResources
     {
-        public static string DisplayAttribute_Description { get; } = Resources.DisplayAttribute_Description;
+        public static string Type_Three_Name => "type three name " + CultureInfo.CurrentCulture;
 
-        public static string DisplayAttribute_Name { get; } = Resources.DisplayAttribute_Name;
+        public static string DisplayAttribute_Description => Resources.DisplayAttribute_Description;
 
-        public static string DisplayAttribute_Prompt { get; } = Resources.DisplayAttribute_Prompt;
+        public static string DisplayAttribute_Name => Resources.DisplayAttribute_Name;
+
+        public static string DisplayAttribute_Prompt => Resources.DisplayAttribute_Prompt;
 
         public static string DisplayAttribute_CultureSensitiveName =>
             Resources.DisplayAttribute_Name + CultureInfo.CurrentUICulture;

--- a/test/Microsoft.AspNetCore.Mvc.TestCommon/TestModelMetadataProvider.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TestCommon/TestModelMetadataProvider.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using Microsoft.AspNetCore.Mvc.DataAnnotations.Internal;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using Microsoft.Extensions.Localization;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding
@@ -14,13 +15,13 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
     internal class TestModelMetadataProvider : DefaultModelMetadataProvider
     {
         // Creates a provider with all the defaults - includes data annotations
-        public static IModelMetadataProvider CreateDefaultProvider()
+        public static IModelMetadataProvider CreateDefaultProvider(IStringLocalizerFactory stringLocalizerFactory = null)
         {
             var detailsProviders = new IMetadataDetailsProvider[]
             {
                 new DefaultBindingMetadataProvider(),
                 new DefaultValidationMetadataProvider(),
-                new DataAnnotationsMetadataProvider(stringLocalizerFactory: null),
+                new DataAnnotationsMetadataProvider(stringLocalizerFactory),
                 new DataMemberRequiredBindingMetadataProvider(),
             };
 

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/DefaultTemplatesUtilities.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/DefaultTemplatesUtilities.cs
@@ -22,6 +22,7 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Mvc.ViewFeatures.Internal;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.WebEncoders.Testing;
 using Moq;
@@ -161,9 +162,14 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
 
         public static HtmlHelper<TModel> GetHtmlHelper<TModel>(
             TModel model,
-            ICompositeViewEngine viewEngine)
+            ICompositeViewEngine viewEngine,
+            IStringLocalizerFactory stringLocalizerFactory = null)
         {
-            return GetHtmlHelper(model, CreateUrlHelper(), viewEngine, TestModelMetadataProvider.CreateDefaultProvider());
+            return GetHtmlHelper(
+                model,
+                CreateUrlHelper(),
+                viewEngine,
+                TestModelMetadataProvider.CreateDefaultProvider(stringLocalizerFactory));
         }
 
         public static HtmlHelper<TModel> GetHtmlHelper<TModel>(


### PR DESCRIPTION
This PR addresses a bug and a couple missing features.

The bug (#5198) is that Enum display values  would previously store the first value that was used and always use that. By passing a function which returns a Name value to the constructor of EnumGroupAndName and executing that when we need the name we avoid this.

One missing feature is #5197, that `GetEnumSelectList` was checking the DisplayAttributes for values to display, but it wasn't localizing those values like other uses of DisplayAttributes do.

The other missing feature was #4215. It boils down to that `Html.DisplayFor` didn't pay attention to DisplayAttributes on enums, and consequently didn't localize them.