### PR TITLE
Remove test workarounds for and mentions of closed or Mono bugs

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/DefaultObjectValidatorTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/DefaultObjectValidatorTests.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using Microsoft.AspNetCore.Testing;
-using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
@@ -489,8 +488,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             Assert.Equal("Error3", error.ErrorMessage);
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public void Validate_ComplexType_IValidatableObject_CanUseRequestServices()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/SimpleTypeModelBinderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/SimpleTypeModelBinderTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Globalization;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Testing;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
@@ -15,7 +14,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         {
             get
             {
-                var data = new TheoryData<Type>
+                return new TheoryData<Type>
                 {
                     typeof(byte),
                     typeof(short),
@@ -24,15 +23,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                     typeof(Guid),
                     typeof(double),
                     typeof(DayOfWeek),
+                    typeof(DateTimeOffset),
                 };
-
-                // DateTimeOffset doesn't have a TypeConverter in Mono.
-                if (!TestPlatformHelper.IsMono)
-                {
-                    data.Add(typeof(DateTimeOffset));
-                }
-
-                return data;
             }
         }
 
@@ -215,7 +207,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             // Arrange
             var bindingContext = GetBindingContext(typeof(int));
             bindingContext.ValueProvider = new SimpleValueProvider
-            { 
+            {
                 { "theModelName", "42" }
             };
 

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/CompareAttributeAdapterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/CompareAttributeAdapterTest.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Testing;
-using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Localization;
 using Moq;
 using Xunit;
@@ -26,9 +25,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
             var attribute = new CompareAttribute("OtherProperty");
             var adapter = new CompareAttributeAdapter(attribute, stringLocalizer: null);
 
-            // Mono issue - https://github.com/aspnet/External/issues/19
-            var expectedMessage = PlatformNormalizer.NormalizeContent(
-                    "'MyPropertyDisplayName' and 'OtherPropertyDisplayName' do not match.");
+            var expectedMessage = "'MyPropertyDisplayName' and 'OtherPropertyDisplayName' do not match.";
 
             var actionContext = new ActionContext();
             var context = new ClientModelValidationContext(
@@ -106,8 +103,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
             var attribute = new CompareAttribute("OtherProperty");
             var adapter = new CompareAttributeAdapter(attribute, stringLocalizer: null);
 
-            // Mono issue - https://github.com/aspnet/External/issues/19
-            var expectedMessage = PlatformNormalizer.NormalizeContent("'MyProperty' and 'OtherProperty' do not match.");
+            var expectedMessage = "'MyProperty' and 'OtherProperty' do not match.";
 
             var actionContext = new ActionContext();
             var context = new ClientModelValidationContext(
@@ -168,9 +164,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
                 });
         }
 
-        [ConditionalFact]
-        // ValidationAttribute in Mono does not read non-public resx properties.
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public void ClientRulesWithCompareAttribute_ErrorMessageUsesResourceOverride()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Json.Test/JsonOutputFormatterTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Json.Test/JsonOutputFormatterTests.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Primitives;
@@ -303,28 +302,18 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         {
             get
             {
-                var data = new TheoryData<string, string, bool>
+                return new TheoryData<string, string, bool>
                 {
                     { "This is a test 激光這兩個字是甚麼意思 string written using utf-8", "utf-8", true },
                     { "This is a test 激光這兩個字是甚麼意思 string written using utf-16", "utf-16", true },
                     { "This is a test 激光這兩個字是甚麼意思 string written using utf-32", "utf-32", false },
 #if !NETCOREAPP1_0
-                    // CoreCLR does not like shift_jis as an encoding.
+                    // CoreCLR does not like shift_jis or iso-2022-kr as an encoding.
                     { "This is a test 激光這兩個字是甚麼意思 string written using shift_jis", "shift_jis", false },
+                    { "This is a test 레이저 단어 뜻 string written using iso-2022-kr", "iso-2022-kr", false },
 #endif
                     { "This is a test æøå string written using iso-8859-1", "iso-8859-1", false },
                 };
-
-#if !NETCOREAPP1_0
-                // CoreCLR does not like iso-2022-kr as an encoding.
-                if (!TestPlatformHelper.IsMono)
-                {
-                    // Mono issue - https://github.com/aspnet/External/issues/28
-                    data.Add("This is a test 레이저 단어 뜻 string written using iso-2022-kr", "iso-2022-kr", false);
-                }
-#endif
-
-                return data;
             }
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/Internal/SerializableErrorWrapperTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/Internal/SerializableErrorWrapperTests.cs
@@ -6,7 +6,6 @@ using System.Runtime.Serialization;
 using System.Text;
 using System.Xml;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.AspNetCore.Testing;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
@@ -91,13 +90,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
             var res = new StreamReader(outputStream, Encoding.UTF8).ReadToEnd();
 
             // Assert
-            var expectedContent =
-                TestPlatformHelper.IsMono ?
-                    "<?xml version=\"1.0\" encoding=\"utf-8\"?><Error xmlns:i=\"" +
-                    "http://www.w3.org/2001/XMLSchema-instance\"><key1>Test Error 1 Test Error 2</key1>" +
-                    "<key2>Test Error 3</key2></Error>" :
-                    "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
-                    "<Error><key1>Test Error 1 Test Error 2</key1><key2>Test Error 3</key2></Error>";
+            var expectedContent = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                "<Error><key1>Test Error 1 Test Error 2</key1><key2>Test Error 3</key2></Error>";
 
             Assert.Equal(expectedContent, res);
         }

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlAssertTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlAssertTest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Testing;
-using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 using Xunit.Sdk;
 
@@ -39,21 +37,13 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
         {
             get
             {
-                var data = new TheoryData<string, string>
+                return new TheoryData<string, string>
                 {
                     { "<A></A>", "<A></A>" },
                     { "<A><!-- comment1 --><B></B></A>", "<A><!-- comment1 --><B></B></A>" },
                     { "<A/>", "<A/>" },
+                    { "<A><![CDATA[<greeting></greeting>]]></A>", "<A><![CDATA[<greeting></greeting>]]></A>" },
                 };
-
-                // DeepEquals returns false even though the generated XML documents are equal.
-                // This is fixed in Mono 4.3.0
-                if (!TestPlatformHelper.IsMono)
-                {
-                    data.Add("<A><![CDATA[<greeting></greeting>]]></A>", "<A><![CDATA[<greeting></greeting>]]></A>");
-                }
-
-                return data;
             }
         }
 
@@ -74,10 +64,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             Assert.Throws<EqualException>(() => XmlAssert.Equal(input1, input2));
         }
 
-        [ConditionalFact]
-        // DeepEquals returns false even though the generated XML documents are equal.
-        // This is fixed in Mono 4.3.0
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public void ReturnsSuccessfully_WithMatchingXmlDeclaration_IgnoringCase()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlDataContractSerializerOutputFormatterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlDataContractSerializerOutputFormatterTest.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal;
-using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using Moq;
@@ -92,9 +91,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             }
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Theory]
         [MemberData(nameof(BasicTypeValues))]
         public async Task WriteAsync_CanWriteBasicTypes(object input, string expectedOutput)
         {
@@ -113,9 +110,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             XmlAssert.Equal(expectedOutput, content);
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public void XmlDataContractSerializer_CachesSerializerForType()
         {
             // Arrange
@@ -133,9 +128,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             Assert.Equal(1, formatter.createSerializerCalledCount);
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public void DefaultConstructor_ExpectedWriterSettings_Created()
         {
             // Arrange and Act
@@ -149,9 +142,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             Assert.False(writerSettings.CheckCharacters);
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task SuppliedWriterSettings_TakeAffect()
         {
             // Arrange
@@ -177,9 +168,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             XmlAssert.Equal(expectedOutput, content);
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task WriteAsync_WritesSimpleTypes()
         {
             // Arrange
@@ -202,9 +191,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             XmlAssert.Equal(expectedOutput, content);
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task WriteAsync_WritesComplexTypes()
         {
             // Arrange
@@ -237,9 +224,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             XmlAssert.Equal(expectedOutput, content);
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task WriteAsync_WritesOnModifiedWriterSettings()
         {
             // Arrange
@@ -268,9 +253,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             XmlAssert.Equal(expectedOutput, content);
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task WriteAsync_WritesUTF16Output()
         {
             // Arrange
@@ -298,9 +281,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             XmlAssert.Equal(expectedOutput, content);
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task WriteAsync_WritesIndentedOutput()
         {
             // Arrange
@@ -324,9 +305,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             XmlAssert.Equal(expectedOutput, content);
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task WriteAsync_VerifyBodyIsNotClosedAfterOutputIsWritten()
         {
             // Arrange
@@ -342,9 +321,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             Assert.True(body.CanRead);
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task WriteAsync_DoesntFlushOutputStream()
         {
             // Arrange
@@ -373,9 +350,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             }
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Theory]
         [MemberData(nameof(TypesForCanWriteResult))]
         public void CanWriteResult_ReturnsExpectedOutput(object input, Type declaredType, bool expectedOutput)
         {
@@ -401,9 +376,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             }
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Theory]
         [MemberData(nameof(TypesForGetSupportedContentTypes))]
         public void GetSupportedContentTypes_ReturnsSupportedTypes(Type type, object expectedOutput)
         {
@@ -427,9 +400,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
         }
 
 #if !NETCOREAPP1_0
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task WriteAsync_ThrowsWhenNotConfiguredWithKnownTypes()
         {
             // Arrange
@@ -465,9 +436,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
         }
 #endif
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task WriteAsync_ThrowsWhenNotConfiguredWithPreserveReferences()
         {
             // Arrange
@@ -483,9 +452,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
                 async () => await formatter.WriteAsync(outputFormatterContext));
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task WriteAsync_WritesWhenConfiguredWithRootName()
         {
             // Arrange
@@ -526,9 +493,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             XmlAssert.Equal(expectedOutput, content);
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task WriteAsync_WritesWhenConfiguredWithKnownTypes()
         {
             // Arrange
@@ -572,9 +537,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             XmlAssert.Equal(expectedOutput, content);
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task WriteAsync_WritesWhenConfiguredWithPreserveReferences()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlSerializerInputFormatterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlSerializerInputFormatterTest.cs
@@ -12,9 +12,7 @@ using System.Xml;
 using System.Xml.Serialization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.AspNetCore.Testing;
-using Microsoft.AspNetCore.Testing.xunit;
 using Moq;
 using Xunit;
 
@@ -228,9 +226,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             Assert.Equal(expectedInt, model.SampleInt);
         }
 
-        [ConditionalFact]
-        // ReaderQuotas are not honored on Mono
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task ReadAsync_ThrowsOnExceededMaxDepth()
         {
             // Arrange
@@ -249,9 +245,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             await Assert.ThrowsAsync(typeof(InvalidOperationException), () => formatter.ReadAsync(context));
         }
 
-        [ConditionalFact]
-        // ReaderQuotas are not honored on Mono
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task ReadAsync_ThrowsWhenReaderQuotasAreChanged()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ApiExplorerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ApiExplorerTest.cs
@@ -7,7 +7,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.AspNetCore.Testing.xunit;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -722,9 +721,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                 });
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task ApiExplorer_ResponseContentType_Unset()
         {
             // Arrange & Act
@@ -789,9 +786,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Empty(responseType.ResponseFormats);
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Theory]
         [InlineData("Controller", "text/xml", "Microsoft.AspNetCore.Mvc.Formatters.XmlDataContractSerializerOutputFormatter")]
         [InlineData("Action", "application/json", "Microsoft.AspNetCore.Mvc.Formatters.JsonOutputFormatter")]
         public async Task ApiExplorer_ResponseContentType_OverrideOnAction(

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ConsumesAttributeTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ConsumesAttributeTests.cs
@@ -6,8 +6,6 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using BasicWebSite.Models;
-using Microsoft.AspNetCore.Mvc.Infrastructure;
-using Microsoft.AspNetCore.Testing.xunit;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -99,9 +97,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal(expectedString, product.SampleString);
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task DerivedClassLevelAttribute_OveridesBaseClassLevel()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ContentNegotiationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ContentNegotiationTest.cs
@@ -8,7 +8,6 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Formatters.Xml;
-using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests
@@ -106,9 +105,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal(expectedOutput, actual);
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task ProducesAttribute_WithTypeAndContentType_UsesContentType()
         {
             // Arrange
@@ -298,9 +295,7 @@ END:VCARD
             Assert.Equal(expectedBody, body);
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task XmlFormatter_SupportedMediaType_DoesNotChangeAcrossRequests()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/FileResultTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/FileResultTests.cs
@@ -4,7 +4,6 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests
@@ -18,9 +17,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
         public HttpClient Client { get; }
 
-        [ConditionalFact]
-        // https://github.com/aspnet/Mvc/issues/2727
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task FileFromDisk_CanBeEnabled_WithMiddleware()
         {
             // Arrange & Act
@@ -37,9 +34,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal("This is a sample text file", body);
         }
 
-        [ConditionalFact]
-        // https://github.com/aspnet/Mvc/issues/2727
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task FileFromDisk_ReturnsFileWithFileName()
         {
             // Arrange & Act

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/FlushPointTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/FlushPointTest.cs
@@ -3,7 +3,6 @@
 
 using System.Net.Http;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/InputFormatterTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/InputFormatterTests.cs
@@ -3,11 +3,8 @@
 
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Testing.xunit;
-using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests
@@ -21,9 +18,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
         public HttpClient Client { get; }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task CheckIfXmlInputFormatterIsBeingCalled()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/InputObjectValidationTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/InputObjectValidationTests.cs
@@ -7,8 +7,6 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Testing;
-using Microsoft.AspNetCore.Testing.xunit;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -45,9 +43,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             }
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task CheckIfObjectIsDeserializedWithoutErrors()
         {
             // Arrange
@@ -90,13 +86,11 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            // Mono issue - https://github.com/aspnet/External/issues/29
-            Assert.Equal(PlatformNormalizer.NormalizeContent(
+            Assert.Equal(
                 "The field Id must be between 1 and 2000.," +
                 "The field Name must be a string or array type with a minimum length of '5'.," +
                 "The field Alias must be a string with a minimum length of 3 and a maximum length of 15.," +
-                "The field Designation must match the regular expression " +
-                (TestPlatformHelper.IsMono ? "[0-9a-zA-Z]*." : "'[0-9a-zA-Z]*'.")),
+                "The field Designation must match the regular expression '[0-9a-zA-Z]*'.",
                 await response.Content.ReadAsStringAsync());
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/JsonOutputFormatterTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/JsonOutputFormatterTests.cs
@@ -8,7 +8,6 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Formatters;
-using Microsoft.AspNetCore.Testing.xunit;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -48,9 +47,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal(expectedBody, actualBody);
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task SerializableErrorIsReturnedInExpectedFormat()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/LinkGenerationTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/LinkGenerationTests.cs
@@ -7,7 +7,6 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Testing;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests
@@ -53,10 +52,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
-            // Location.ToString() in mono returns file://url. (https://github.com/aspnet/External/issues/21)
-            Assert.Equal(
-                TestPlatformHelper.IsMono ? new Uri(expected) : new Uri(expected, UriKind.Relative),
-                response.Headers.Location);
+            Assert.Equal(new Uri(expected, UriKind.Relative), response.Headers.Location);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RemoteAttributeValidationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RemoteAttributeValidationTest.cs
@@ -45,11 +45,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(_resourcesAssembly, outputFile, expectedContent, responseContent);
 #else
-            // Mono issue - https://github.com/aspnet/External/issues/19
-            Assert.Equal(
-                PlatformNormalizer.NormalizeContent(expectedContent),
-                responseContent,
-                ignoreLineEndingDifferences: true);
+            Assert.Equal(expectedContent, responseContent, ignoreLineEndingDifferences: true);
 #endif
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RespectBrowserAcceptHeaderTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RespectBrowserAcceptHeaderTests.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Formatters.Xml;
-using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests
@@ -40,9 +39,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal("{\"id\":10,\"name\":\"John\"}", responseData);
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Theory]
         [InlineData("application/xml,*/*;q=0.2")]
         [InlineData("application/xml,*/*")]
         public async Task AllMediaRangeAcceptHeader_ProducesAttributeIsHonored(string acceptHeader)
@@ -68,9 +65,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             XmlAssert.Equal(expectedResponseData, responseData);
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Theory]
         [InlineData("application/xml,*/*;q=0.2")]
         [InlineData("application/xml,*/*")]
         public async Task AllMediaRangeAcceptHeader_WithContentTypeHeader_ContentTypeIsIgnored(string acceptHeader)
@@ -100,9 +95,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal(expectedResponseData, responseData);
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Theory]
         [InlineData("application/xml,application/json;q=0.2")]
         [InlineData("application/xml,application/json")]
         public async Task AllMediaRangeAcceptHeader_WithExactMatch_ReturnsExpectedContent(string acceptHeader)

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/SerializableErrorTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/SerializableErrorTests.cs
@@ -7,8 +7,6 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Formatters.Xml;
-using Microsoft.AspNetCore.Testing;
-using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests
@@ -22,22 +20,15 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
         public HttpClient Client { get; }
 
-        public static TheoryData AcceptHeadersData
+        public static TheoryData<string> AcceptHeadersData
         {
             get
             {
-                var data = new TheoryData<string>
+                return new TheoryData<string>
                 {
-                    "application/xml-xmlser"
+                    "application/xml-dcs",
+                    "application/xml-xmlser",
                 };
-
-                // Mono issue - https://github.com/aspnet/External/issues/18
-                if (!TestPlatformHelper.IsMono)
-                {
-                    data.Add("application/xml-dcs");
-                }
-
-                return data;
             }
         }
 
@@ -62,13 +53,8 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             XmlAssert.Equal(expectedXml, responseData);
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        // XmlSerializer test is disabled Mono.Xml2.XmlTextReader.ReadText is unable to read the XML.
-        // This is fixed in mono 4.3.0.
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
-        [InlineData("application/xml-xmlser")]
-        [InlineData("application/xml-dcs")]
+        [Theory]
+        [MemberData(nameof(AcceptHeadersData))]
         public async Task PostedSerializableError_IsBound(string acceptHeader)
         {
             // Arrange
@@ -89,13 +75,8 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             XmlAssert.Equal(expectedXml, responseData);
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        // XmlSerializer test is disabled Mono.Xml2.XmlTextReader.ReadText is unable to read the XML.
-        // This is fixed in mono 4.3.0.
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
-        [InlineData("application/xml-xmlser")]
-        [InlineData("application/xml-dcs")]
+        [Theory]
+        [MemberData(nameof(AcceptHeadersData))]
         public async Task IsReturnedInExpectedFormat(string acceptHeader)
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/TagHelpersTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/TagHelpersTest.cs
@@ -115,11 +115,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             ResourceFile.UpdateFile(_resourcesAssembly, outputFile, expectedContent, responseContent);
 #else
             expectedContent = string.Format(expectedContent, forgeryToken);
-            // Mono issue - https://github.com/aspnet/External/issues/19
-            Assert.Equal(
-                PlatformNormalizer.NormalizeContent(expectedContent.Trim()),
-                responseContent,
-                ignoreLineEndingDifferences: true);
+            Assert.Equal(expectedContent.Trim(), responseContent, ignoreLineEndingDifferences: true);
 #endif
         }
 
@@ -216,11 +212,7 @@ page:<root>root-content</root>"
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(_resourcesAssembly, outputFile, expectedContent, responseContent);
 #else
-            // Mono issue - https://github.com/aspnet/External/issues/19
-            Assert.Equal(
-                PlatformNormalizer.NormalizeContent(expectedContent),
-                responseContent,
-                ignoreLineEndingDifferences: true);
+            Assert.Equal(expectedContent, responseContent, ignoreLineEndingDifferences: true);
 #endif
         }
 
@@ -284,11 +276,7 @@ page:<root>root-content</root>"
 #if GENERATE_BASELINES
             ResourceFile.UpdateFile(_resourcesAssembly, outputFile, expectedContent, responseContent);
 #else
-            // Mono issue - https://github.com/aspnet/External/issues/19
-            Assert.Equal(
-                PlatformNormalizer.NormalizeContent(expectedContent),
-                responseContent,
-                ignoreLineEndingDifferences: true);
+            Assert.Equal(expectedContent, responseContent, ignoreLineEndingDifferences: true);
 #endif
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/TempDataTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/TempDataTest.cs
@@ -7,8 +7,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Net.Http.Headers;
 using Xunit;
 
@@ -73,9 +71,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal("Foo", body);
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/21
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task Redirect_RetainsTempData_EvenIfAccessed()
         {
             // Arrange
@@ -139,9 +135,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal("Foo", body);
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/21
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task TempData_ValidTypes_RoundTripProperly()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ViewEngineTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ViewEngineTests.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Localization;
-using Microsoft.AspNetCore.Testing;
 using Microsoft.Net.Http.Headers;
 using Xunit;
 
@@ -120,25 +119,23 @@ partial-contentcomponent-content";
             Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
 
-        public static IEnumerable<object[]> RazorViewEngine_UsesAllExpandedPathsToLookForViewsData
+        public static TheoryData<string, string> RazorViewEngine_UsesAllExpandedPathsToLookForViewsData
         {
             get
             {
                 var expected1 = @"expander-index
 gb-partial";
-                yield return new[] { "en-GB", expected1 };
-
                 var expected2 = @"fr-index
 fr-partial";
-                yield return new[] { "fr", expected2 };
-
-                if (!TestPlatformHelper.IsMono)
-                {
-                    // https://github.com/aspnet/Mvc/issues/2759
-                    var expected3 = @"expander-index
+                var expected3 = @"expander-index
 expander-partial";
-                    yield return new[] { "!-invalid-!", expected3 };
-                }
+
+                return new TheoryData<string, string>
+                {
+                    { "en-GB", expected1 },
+                    { "fr", expected2 },
+                    { "!-invalid-!", expected3 },
+                };
             }
         }
 
@@ -261,26 +258,23 @@ index-content";
             Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
 
-        public static IEnumerable<object[]> RazorViewEngine_UsesExpandersForLayoutsData
+        public static TheoryData<string, string> RazorViewEngine_UsesExpandersForLayoutsData
         {
             get
             {
                 var expected1 =
  @"<language-layout>View With Layout
 </language-layout>";
-
-                yield return new[] { "en-GB", expected1 };
-
-                if (!TestPlatformHelper.IsMono)
-                {
-                    // https://github.com/aspnet/Mvc/issues/2759
-                    yield return new[] { "!-invalid-!", expected1 };
-                }
-
                 var expected2 =
 @"<fr-language-layout>View With Layout
 </fr-language-layout>";
-                yield return new[] { "fr", expected2 };
+
+                return new TheoryData<string, string>
+                {
+                    { "en-GB", expected1 },
+                    { "!-invalid-!", expected1 },
+                    { "fr", expected2 },
+                };
             }
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/WebApiCompatShimBasicTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/WebApiCompatShimBasicTest.cs
@@ -10,8 +10,6 @@ using System.Net.Http.Formatting;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using System.Web.Http;
-using Microsoft.AspNetCore.Testing;
-using Microsoft.AspNetCore.Testing.xunit;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -169,9 +167,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal("The field ID must be between 0 and 100.", json["ID"]);
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/24
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task ApiController_RequestProperty()
         {
             // Arrange
@@ -189,9 +185,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal(expected, content);
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/24
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task ApiController_RequestParameter()
         {
             // Arrange
@@ -251,11 +245,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.NotNull(response.Content);
-            if (!TestPlatformHelper.IsMono)
-            {
-                // Mono issue - https://github.com/aspnet/External/issues/20
-                Assert.NotNull(response.Content.Headers.ContentLength);
-            }
+            Assert.NotNull(response.Content.Headers.ContentLength);
 
             Assert.Null(response.Headers.TransferEncodingChunked);
 

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/XmlDataContractSerializerFormattersWrappingTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/XmlDataContractSerializerFormattersWrappingTest.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Formatters.Xml;
-using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests
@@ -20,9 +19,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
         public HttpClient Client { get; }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Theory]
         [InlineData("http://localhost/IEnumerable/ValueTypes")]
         [InlineData("http://localhost/IQueryable/ValueTypes")]
         public async Task CanWrite_ValueTypes(string url)
@@ -44,9 +41,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                 result);
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Theory]
         [InlineData("http://localhost/IEnumerable/NonWrappedTypes")]
         [InlineData("http://localhost/IQueryable/NonWrappedTypes")]
         public async Task CanWrite_NonWrappedTypes(string url)
@@ -68,9 +63,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                 result);
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Theory]
         [InlineData("http://localhost/IEnumerable/NonWrappedTypes_Empty")]
         [InlineData("http://localhost/IQueryable/NonWrappedTypes_Empty")]
         public async Task CanWrite_NonWrappedTypes_Empty(string url)
@@ -91,9 +84,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                 result);
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Theory]
         [InlineData("http://localhost/IEnumerable/NonWrappedTypes_NullInstance")]
         [InlineData("http://localhost/IQueryable/NonWrappedTypes_NullInstance")]
         public async Task CanWrite_NonWrappedTypes_NullInstance(string url)
@@ -114,9 +105,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                 result);
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Theory]
         [InlineData("http://localhost/IEnumerable/WrappedTypes")]
         [InlineData("http://localhost/IQueryable/WrappedTypes")]
         public async Task CanWrite_WrappedTypes(string url)
@@ -139,9 +128,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                 result);
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Theory]
         [InlineData("http://localhost/IEnumerable/WrappedTypes_Empty")]
         [InlineData("http://localhost/IQueryable/WrappedTypes_Empty")]
         public async Task CanWrite_WrappedTypes_Empty(string url)
@@ -162,9 +149,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                 result);
         }
 
-        [ConditionalTheory]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Theory]
         [InlineData("http://localhost/IEnumerable/WrappedTypes_NullInstance")]
         [InlineData("http://localhost/IQueryable/WrappedTypes_NullInstance")]
         public async Task CanWrite_WrappedTypes_NullInstance(string url)
@@ -185,9 +170,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                 result);
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task CanWrite_IEnumerableOf_SerializableErrors()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/XmlOutputFormatterTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/XmlOutputFormatterTests.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Formatters.Xml;
-using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests
@@ -20,9 +19,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
         public HttpClient Client { get; }
 
-        [ConditionalFact]
-        // Mono.Xml2.XmlTextReader.ReadText is unable to read the XML. This is fixed in mono 4.3.0.
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task XmlDataContractSerializerOutputFormatterIsCalled()
         {
             // Arrange
@@ -63,9 +60,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                 await response.Content.ReadAsStringAsync());
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/18
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task XmlSerializerFailsAndDataContractSerializerIsCalled()
         {
             // Arrange
@@ -107,9 +102,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                 await response.Content.ReadAsStringAsync());
         }
 
-        [ConditionalFact]
-        // Mono.Xml2.XmlTextReader.ReadText is unable to read the XML. This is fixed in mono 4.3.0.
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task XmlDataContractSerializerOutputFormatter_WhenDerivedClassIsReturned()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/XmlSerializerInputFormatterTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/XmlSerializerInputFormatterTests.cs
@@ -5,7 +5,6 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests
@@ -37,9 +36,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal(sampleInputInt.ToString(), await response.Content.ReadAsStringAsync());
         }
 
-        [ConditionalFact]
-        // Mono.Xml2.XmlTextReader.ReadText is unable to read the XML. This is fixed in mono 4.3.0.
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task ThrowsOnInvalidInput_AndAddsToModelState()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/ImageTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/ImageTagHelperTest.cs
@@ -32,20 +32,19 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         [Theory]
         [InlineData(null, "test.jpg", "test.jpg")]
         [InlineData("abcd.jpg", "test.jpg", "test.jpg")]
-        [InlineData(null, "~/test.jpg", "virtualRoot/test.jpg")]
-        [InlineData("abcd.jpg", "~/test.jpg", "virtualRoot/test.jpg")]
+        [InlineData(null, "~/test.jpg", "/virtualRoot/test.jpg")]
+        [InlineData("abcd.jpg", "~/test.jpg", "/virtualRoot/test.jpg")]
         public void Process_SrcDefaultsToTagHelperOutputSrcAttributeAddedByOtherTagHelper(
             string src,
             string srcOutput,
             string expectedSrcPrefix)
         {
             // Arrange
-            var allAttributes = new TagHelperAttributeList(
-                new TagHelperAttributeList
-                {
-                    { "alt", new HtmlString("Testing") },
-                    { "asp-append-version", true },
-                });
+            var allAttributes = new TagHelperAttributeList
+            {
+                { "alt", new HtmlString("Testing") },
+                { "asp-append-version", true },
+            };
             var context = MakeTagHelperContext(allAttributes);
             var outputAttributes = new TagHelperAttributeList
                 {
@@ -61,11 +60,9 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             var viewContext = MakeViewContext();
             var urlHelper = new Mock<IUrlHelper>();
 
-            // Ensure expanded path does not look like an absolute path on Linux, avoiding
-            // https://github.com/aspnet/External/issues/21
             urlHelper
                 .Setup(urlhelper => urlhelper.Content(It.IsAny<string>()))
-                .Returns(new Func<string, string>(url => url.Replace("~/", "virtualRoot/")));
+                .Returns(new Func<string, string>(url => url.Replace("~/", "/virtualRoot/")));
             var urlHelperFactory = new Mock<IUrlHelperFactory>();
             urlHelperFactory
                 .Setup(f => f.GetUrlHelper(It.IsAny<ActionContext>()))

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/LinkTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/LinkTagHelperTest.cs
@@ -35,8 +35,8 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         [Theory]
         [InlineData(null, "test.css", "test.css")]
         [InlineData("abcd.css", "test.css", "test.css")]
-        [InlineData(null, "~/test.css", "virtualRoot/test.css")]
-        [InlineData("abcd.css", "~/test.css", "virtualRoot/test.css")]
+        [InlineData(null, "~/test.css", "/virtualRoot/test.css")]
+        [InlineData("abcd.css", "~/test.css", "/virtualRoot/test.css")]
         public void Process_HrefDefaultsToTagHelperOutputHrefAttributeAddedByOtherTagHelper(
             string href,
             string hrefOutput,
@@ -60,11 +60,9 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             var viewContext = MakeViewContext();
             var urlHelper = new Mock<IUrlHelper>();
 
-            // Ensure expanded path does not look like an absolute path on Linux, avoiding
-            // https://github.com/aspnet/External/issues/21
             urlHelper
                 .Setup(urlhelper => urlhelper.Content(It.IsAny<string>()))
-                .Returns(new Func<string, string>(url => url.Replace("~/", "virtualRoot/")));
+                .Returns(new Func<string, string>(url => url.Replace("~/", "/virtualRoot/")));
             var urlHelperFactory = new Mock<IUrlHelperFactory>();
             urlHelperFactory
                 .Setup(f => f.GetUrlHelper(It.IsAny<ActionContext>()))

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/ScriptTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/ScriptTagHelperTest.cs
@@ -36,8 +36,8 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         [Theory]
         [InlineData(null, "test.js", "test.js")]
         [InlineData("abcd.js", "test.js", "test.js")]
-        [InlineData(null, "~/test.js", "virtualRoot/test.js")]
-        [InlineData("abcd.js", "~/test.js", "virtualRoot/test.js")]
+        [InlineData(null, "~/test.js", "/virtualRoot/test.js")]
+        [InlineData("abcd.js", "~/test.js", "/virtualRoot/test.js")]
         public void Process_SrcDefaultsToTagHelperOutputSrcAttributeAddedByOtherTagHelper(
             string src,
             string srcOutput,
@@ -61,11 +61,9 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             var viewContext = MakeViewContext();
             var urlHelper = new Mock<IUrlHelper>();
 
-            // Ensure expanded path does not look like an absolute path on Linux, avoiding
-            // https://github.com/aspnet/External/issues/21
             urlHelper
                 .Setup(urlhelper => urlhelper.Content(It.IsAny<string>()))
-                .Returns(new Func<string, string>(url => url.Replace("~/", "virtualRoot/")));
+                .Returns(new Func<string, string>(url => url.Replace("~/", "/virtualRoot/")));
             var urlHelperFactory = new Mock<IUrlHelperFactory>();
             urlHelperFactory
                 .Setup(f => f.GetUrlHelper(It.IsAny<ActionContext>()))

--- a/test/Microsoft.AspNetCore.Mvc.TestCommon/PlatformNormalizer.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TestCommon/PlatformNormalizer.cs
@@ -2,48 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text.RegularExpressions;
-using Microsoft.AspNetCore.Testing;
 using Microsoft.AspNetCore.Razor;
 
 namespace Microsoft.AspNetCore.Mvc
 {
     public static class PlatformNormalizer
     {
-        // Mono issue - https://github.com/aspnet/External/issues/19
-        public static string NormalizeContent(string input)
-        {
-            if (TestPlatformHelper.IsMono)
-            {
-                var equivalents = new Dictionary<string, string> {
-                    {
-                        "The [0-9a-zA-Z ]+ field is required.", "RequiredAttribute_ValidationError"
-                    },
-                    {
-                        "'[0-9a-zA-Z ]+' and '[0-9a-zA-Z ]+' do not match.", "CompareAttribute_MustMatch"
-                    },
-                    {
-                        "The field [0-9a-zA-Z ]+ must be a string with a minimum length of [0-9]+ and a " +
-                            "maximum length of [0-9]+.",
-                        "StringLengthAttribute_ValidationErrorIncludingMinimum"
-                    },
-                };
-
-                var result = input;
-
-                foreach (var kvp in equivalents)
-                {
-                    result = Regex.Replace(result, kvp.Key, kvp.Value);
-                }
-
-                return result;
-            }
-
-            return input;
-        }
-
         // Each new line character is returned as "_".
         public static string GetNewLinesAsUnderscores(int numberOfNewLines)
         {
@@ -63,5 +28,5 @@ namespace Microsoft.AspNetCore.Mvc
             var differenceInLength = windowsNewLineLength - Environment.NewLine.Length;
             return new SourceLocation(absoluteIndex - (differenceInLength * lineIndex), lineIndex, characterIndex);
         }
-    }  
+    }
 }

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperCheckboxTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperCheckboxTest.cs
@@ -473,7 +473,6 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var requiredMessage = ValidationAttributeUtil.GetRequiredErrorMessage("Property1");
-            // Mono issue - https://github.com/aspnet/External/issues/19
             var expected =
                 $@"<input {{0}}data-val=""HtmlEncode[[true]]"" data-val-required=""HtmlEncode[[{requiredMessage}]]"" " +
                 @"id=""HtmlEncode[[Property1]]"" name=""HtmlEncode[[Property1]]"" type=""HtmlEncode[[checkbox]]"" value=""HtmlEncode[[true]]"" />" +

--- a/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/DefaultContentNegotiatorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/DefaultContentNegotiatorTest.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Net.Http.Formatting.Mocks;
 using System.Net.Http.Headers;
 using System.Text;
-using Microsoft.AspNetCore.Testing;
 using Microsoft.TestCommon;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -393,8 +392,7 @@ namespace System.Net.Http.Formatting
             _request.Headers.Add("x-requested-with", "XMLHttpRequest");
 
             // Act
-            // Mono issue - https://github.com/aspnet/External/issues/27
-            var type = TestPlatformHelper.IsMono ? typeof(string) : typeof(JToken);
+            var type = typeof(JToken);
             var result = _negotiator.Negotiate(type, _request, new MediaTypeFormatterCollection());
 
             Assert.Equal("application/json", result.MediaType.MediaType);

--- a/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/HttpErrorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/HttpErrorTest.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Http.Formatting;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.AspNetCore.Testing.xunit;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -146,9 +145,7 @@ namespace System.Web.Http.Dispatcher
             Assert.Contains("c", data);
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/25
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public void HttpError_Roundtrips_WithXmlFormatter()
         {
             HttpError error = new HttpError("error") { { "ErrorCode", 42 }, { "Data", new[] { "a", "b", "c" } } };

--- a/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/HttpRequestMessage/HttpRequestMessageFeatureTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/HttpRequestMessage/HttpRequestMessageFeatureTest.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.WebApiCompatShim
@@ -51,9 +50,7 @@ namespace Microsoft.AspNetCore.Mvc.WebApiCompatShim
             Assert.Equal(new HttpMethod("OPTIONS"), request.Method);
         }
 
-        [ConditionalFact]
-        // Mono issue - https://github.com/aspnet/External/issues/24
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public void HttpRequestMessage_CopiesHeader()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/HttpResponseMessageOutputFormatterTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/HttpResponseMessageOutputFormatterTests.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.WebApiCompatShim;
-using Microsoft.AspNetCore.Testing.xunit;
 using Moq;
 using Moq.Protected;
 using Xunit;
@@ -39,9 +38,7 @@ namespace Microsoft.AspNetCore.Mvc.WebApiCompatShimTest
             streamContent.Protected().Verify("Dispose", Times.Once(), true);
         }
 
-        [ConditionalFact]
-        // Issue - https://github.com/aspnet/External/issues/20
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task ExplicitlySet_ChunkedEncodingFlag_IsIgnored()
         {
             // Arrange
@@ -63,9 +60,7 @@ namespace Microsoft.AspNetCore.Mvc.WebApiCompatShimTest
             Assert.NotNull(httpContext.Response.ContentLength);
         }
 
-        [ConditionalFact]
-        // Issue - https://github.com/aspnet/External/issues/20
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task ExplicitlySet_ChunkedEncodingHeader_IsIgnored()
         {
             // Arrange
@@ -88,9 +83,7 @@ namespace Microsoft.AspNetCore.Mvc.WebApiCompatShimTest
             Assert.NotNull(httpContext.Response.ContentLength);
         }
 
-        [ConditionalFact]
-        // Issue - https://github.com/aspnet/External/issues/20
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task ExplicitlySet_MultipleEncodings_ChunkedNotIgnored()
         {
             // Arrange
@@ -115,9 +108,7 @@ namespace Microsoft.AspNetCore.Mvc.WebApiCompatShimTest
             Assert.NotNull(httpContext.Response.ContentLength);
         }
 
-        [ConditionalFact]
-        // Issue - https://github.com/aspnet/External/issues/20
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public async Task ExplicitlySet_MultipleEncodingsUsingChunkedFlag_ChunkedNotIgnored()
         {
             // Arrange


### PR DESCRIPTION
- only a few `[ConditionalTheory]` and `TestPlatformHelper` uses remain
- no `[ConditionalFact]`, `TestPlatformHelper.IsMono` or `FrameworkSkipCondition` uses remain
- but left aspnet/External#44 and aspnet/External#45 workarounds alone (in product code)