### PR TITLE
EnumGroupAndName localize properly

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/EnumGroupAndName.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/EnumGroupAndName.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding
 {
@@ -10,8 +11,10 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
     /// </summary>
     public struct EnumGroupAndName
     {
+        private Func<string> _nameFunc;
+
         /// <summary>
-        /// Initializes a new instance of the EnumGroupAndName structure.
+        /// Initializes a new instance of the EnumGroupAndName structure. Should not be used if localization is in use.
         /// </summary>
         /// <param name="group">The group name.</param>
         /// <param name="name">The name.</param>
@@ -28,7 +31,28 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             }
 
             Group = group;
-            Name = name;
+            _nameFunc = () => name;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the EnumGroupAndName structure.
+        /// </summary>
+        /// <param name="group">The group name.</param>
+        /// <param name="name">A function which returns the name. (Necessary for proper localization.)</param>
+        public EnumGroupAndName(string group, Func<string> name)
+        {
+            if (group == null)
+            {
+                throw new ArgumentNullException(nameof(group));
+            }
+
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            Group = group;
+            _nameFunc = name;
         }
 
         /// <summary>
@@ -39,6 +63,35 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         /// <summary>
         /// Gets the name.
         /// </summary>
-        public string Name { get; }
+        public string Name
+        {
+            get
+            {
+                return _nameFunc();
+            }
+        }
+
+        // Equals and GetHashCode must be overloaded to accomidate the _nameFunc
+        public override bool Equals(object obj)
+        {
+            if (!(obj is EnumGroupAndName))
+            {
+                return false;
+            }
+
+            var second = (EnumGroupAndName)obj;
+
+            return string.Equals(Group, second.Group) && string.Equals(Name, second.Name);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashcode = HashCodeCombiner.Start();
+
+            hashcode.Add(Group);
+            hashcode.Add(Name);
+
+            return hashcode;
+        }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/DataAnnotationsMetadataProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/DataAnnotationsMetadataProviderTest.cs
@@ -4,10 +4,13 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.Linq;
+using Microsoft.AspNetCore.Mvc.DataAnnotations.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Localization;
 using Moq;
 using Xunit;
@@ -353,13 +356,13 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
             var stringLocalizer = new Mock<IStringLocalizer>(MockBehavior.Strict);
             stringLocalizer
                 .Setup(s => s["Model_Name"])
-                .Returns(new LocalizedString("Model_Name", "name from localizer"));
+                .Returns(() => new LocalizedString("Model_Name", "name from localizer " + CultureInfo.CurrentCulture));
             stringLocalizer
                 .Setup(s => s["Model_Description"])
-                .Returns(new LocalizedString("Model_Description", "description from localizer"));
+                .Returns(() => new LocalizedString("Model_Description", "description from localizer " + CultureInfo.CurrentCulture));
             stringLocalizer
                 .Setup(s => s["Model_Prompt"])
-                .Returns(new LocalizedString("Model_Prompt", "prompt from localizer"));
+                .Returns(() => new LocalizedString("Model_Prompt", "prompt from localizer " + CultureInfo.CurrentCulture));
 
             var stringLocalizerFactory = new Mock<IStringLocalizerFactory>(MockBehavior.Strict);
             stringLocalizerFactory
@@ -383,9 +386,18 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
             provider.CreateDisplayMetadata(context);
 
             // Assert
-            Assert.Equal("name from localizer", context.DisplayMetadata.DisplayName());
-            Assert.Equal("description from localizer", context.DisplayMetadata.Description());
-            Assert.Equal("prompt from localizer", context.DisplayMetadata.Placeholder());
+            using (new CultureReplacer("en-US", "en-US"))
+            {
+                Assert.Equal("name from localizer en-US", context.DisplayMetadata.DisplayName());
+                Assert.Equal("description from localizer en-US", context.DisplayMetadata.Description());
+                Assert.Equal("prompt from localizer en-US", context.DisplayMetadata.Placeholder());
+            }
+            using (new CultureReplacer("fr-FR", "fr-FR"))
+            {
+                Assert.Equal("name from localizer fr-FR", context.DisplayMetadata.DisplayName());
+                Assert.Equal("description from localizer fr-FR", context.DisplayMetadata.Description());
+                Assert.Equal("prompt from localizer fr-FR", context.DisplayMetadata.Placeholder());
+            }
         }
 
         [Theory]
@@ -589,6 +601,49 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
             Assert.Equal(expectedDictionary, context.DisplayMetadata.EnumNamesAndValues);
         }
 
+        [Fact]
+        public void CreateDisplayMetadata_DisplayName_Localized()
+        {
+            // Arrange
+            var type = typeof(EnumWithDisplayNames);
+            var attributes = new object[0];
+
+            var key = ModelMetadataIdentity.ForType(type);
+            var context = new DisplayMetadataProviderContext(key, new ModelAttributes(attributes));
+
+            var stringLocalizer = new Mock<IStringLocalizer>(MockBehavior.Strict);
+            stringLocalizer
+                .Setup(s => s[It.IsAny<string>()])
+                .Returns<string>((index) => new LocalizedString(index, index + " value"));
+
+            var stringLocalizerFactory = new Mock<IStringLocalizerFactory>(MockBehavior.Strict);
+            stringLocalizerFactory
+                .Setup(f => f.Create(It.IsAny<Type>()))
+                .Returns(stringLocalizer.Object);
+
+            var provider = new DataAnnotationsMetadataProvider(stringLocalizerFactory.Object);
+
+            // Act
+            provider.CreateDisplayMetadata(context);
+
+            // Assert
+            var expectedKeyValuePairs = new List<KeyValuePair<EnumGroupAndName, string>>
+            {
+                new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName("Zero", string.Empty), "0"),
+                new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, nameof(EnumWithDisplayNames.One)), "1"),
+                new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, "dos value"), "2"),
+                new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, "tres value"), "3"),
+                new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName(string.Empty, "name from resources"), "-2"),
+                new KeyValuePair<EnumGroupAndName, string>(new EnumGroupAndName("Negatives", "menos uno value"), "-1"),
+            };
+
+            Assert.Equal(
+                expectedKeyValuePairs?.OrderBy(item => item.Key.Group, StringComparer.Ordinal)
+                .ThenBy(item => item.Key.Name, StringComparer.Ordinal),
+                context.DisplayMetadata.EnumGroupedDisplayNamesAndValues?.OrderBy(item => item.Key.Group, StringComparer.Ordinal)
+                .ThenBy(item => item.Key.Name, StringComparer.Ordinal));
+        }
+
         // Type -> expected EnumDisplayNamesAndValues
         public static TheoryData<Type, IEnumerable<KeyValuePair<EnumGroupAndName, string>>> EnumDisplayNamesData
         {
@@ -725,6 +780,118 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
                 .ThenBy(item => item.Key.Name, StringComparer.Ordinal),
                 context.DisplayMetadata.EnumGroupedDisplayNamesAndValues?.OrderBy(item => item.Key.Group, StringComparer.Ordinal)
                 .ThenBy(item => item.Key.Name, StringComparer.Ordinal));
+        }
+
+        private DataAnnotationsMetadataProvider CreateLocalizingProvider()
+        {
+            var stringLocalizer = new Mock<IStringLocalizer>(MockBehavior.Strict);
+            stringLocalizer
+                .Setup(loc => loc[It.IsAny<string>()])
+                .Returns<string>((k =>
+                {
+                    if (k.Contains("Loc_Two"))
+                    {
+                        return new LocalizedString(k, $"{k} {CultureInfo.CurrentCulture}");
+                    }
+                    else
+                    {
+                        return new LocalizedString(k, k, resourceNotFound: true);
+                    }
+                }));
+
+            var stringLocalizerFactory = new Mock<IStringLocalizerFactory>(MockBehavior.Strict);
+            stringLocalizerFactory
+                .Setup(factory => factory.Create(typeof(EnumWithLocalizedDisplayNames)))
+                .Returns(stringLocalizer.Object);
+
+            return new DataAnnotationsMetadataProvider(stringLocalizerFactory: stringLocalizerFactory.Object);
+        }
+
+        [Fact]
+        public void CreateDisplayMetadata_EnumGroupedDisplayNamesAndValues_IStringLocalizer()
+        {
+            // Arrange
+            var provider = CreateLocalizingProvider();
+
+            var key = ModelMetadataIdentity.ForType(typeof(EnumWithLocalizedDisplayNames));
+            var attributes = new object[0];
+
+            // Act
+            var context = new DisplayMetadataProviderContext(key, new ModelAttributes(attributes));
+            provider.CreateDisplayMetadata(context);
+
+            string frenchEnumDisplay;
+            using (new CultureReplacer("fr-FR", "fr-FR"))
+            {
+                frenchEnumDisplay = context.DisplayMetadata.EnumGroupedDisplayNamesAndValues
+                    .Where(kvp => kvp.Value == "2")
+                    .First().Key.Name;
+            }
+
+            string englishEnumDisplay;
+            using (new CultureReplacer("en-US", "en-US"))
+            {
+                englishEnumDisplay = context.DisplayMetadata.EnumGroupedDisplayNamesAndValues
+                    .Where(kvp => kvp.Value == "2")
+                    .First().Key.Name;
+            }
+
+            // Assert
+            Assert.NotEqual(frenchEnumDisplay, englishEnumDisplay);
+            Assert.Equal("LOC_Two fr-FR", frenchEnumDisplay);
+            Assert.Equal("LOC_Two en-US", englishEnumDisplay);
+        }
+
+        [Fact]
+        public void CreateDisplayMetadata_EnumGroupedDisplayNamesAndValues_NameLocalizes()
+        {
+            // Arrange
+            var provider = CreateLocalizingProvider();
+
+            var key = ModelMetadataIdentity.ForType(typeof(EnumWithLocalizedDisplayNames));
+            var attributes = new object[0];
+
+            // Act
+            var context = new DisplayMetadataProviderContext(key, new ModelAttributes(attributes));
+            provider.CreateDisplayMetadata(context);
+
+            var enumNameAndGroup = context.DisplayMetadata.EnumGroupedDisplayNamesAndValues;
+
+            var groupOne = enumNameAndGroup.Where(e => e.Value == "1").First();
+            var groupTwo = enumNameAndGroup.Where(e => e.Value == "2").First();
+            var groupThree = enumNameAndGroup.Where(e => e.Value == "3").First();
+
+            string enNameOne;
+            string enNameTwo;
+            string enNameThree;
+            using (new CultureReplacer("en-US", "en-US"))
+            {
+                enNameOne = groupOne.Key.Name;
+                enNameTwo = groupTwo.Key.Name;
+                enNameThree = groupThree.Key.Name;
+            }
+
+            string frNameOne;
+            string frNameTwo;
+            string frNameThree;
+            using (new CultureReplacer("fr-FR", "fr-FR"))
+            {
+                frNameOne = groupOne.Key.Name;
+                frNameTwo = groupTwo.Key.Name;
+                frNameThree = groupThree.Key.Name;
+            }
+
+            // Display only
+            Assert.Equal("Attr_One_Name", enNameOne);
+            Assert.Equal("Attr_One_Name", frNameOne);
+
+            // IStringLocalizer
+            Assert.Equal("Loc_Two_Name en-US", enNameTwo);
+            Assert.Equal("Loc_Two_Name fr-FR", frNameTwo);
+
+            //ResourceType
+            Assert.Equal("type three name en-US", enNameThree);
+            Assert.Equal("type three name fr-FR", frNameThree);
         }
 
         [Fact]
@@ -876,6 +1043,20 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
 
         private enum EmptyEnum
         {
+        }
+
+        private enum EnumWithLocalizedDisplayNames
+        {
+            [Display(Name = "Attr_One_Name", Description = "Attr_One_Description", Prompt = "Attr_One_Prompt")]
+            One = 1,
+            [Display(Name = "Loc_Two_Name", Description = "Loc_Two_Description", Prompt = "Loc_Two_Prompt")]
+            Two = 2,
+            [Display(
+                Name = "Type_Three_Name",
+                Description = "Type_Three_Description",
+                Prompt = "Type_Three_Prompt",
+                ResourceType = typeof(TestResources))]
+            Three = 3
         }
 
         private enum EnumWithDisplayNames

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/ModelMetadataProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/ModelMetadataProviderTest.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Runtime.Serialization;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/ModelMetadataProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/ModelMetadataProviderTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Runtime.Serialization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/TestResources.cs
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/TestResources.cs
@@ -10,11 +10,15 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
     // internal properties.
     public static class TestResources
     {
-        public static string DisplayAttribute_Description { get; } = Resources.DisplayAttribute_Description;
+        public static string Type_Three_Name => "type three name " + CultureInfo.CurrentCulture;
+        public static string Type_Three_Description => "type three description " + CultureInfo.CurrentCulture;
+        public static string Type_Three_Prompt => "type three prompt " + CultureInfo.CurrentCulture;
 
-        public static string DisplayAttribute_Name { get; } = Resources.DisplayAttribute_Name;
+        public static string DisplayAttribute_Description => Resources.DisplayAttribute_Description;
 
-        public static string DisplayAttribute_Prompt { get; } = Resources.DisplayAttribute_Prompt;
+        public static string DisplayAttribute_Name => Resources.DisplayAttribute_Name;
+
+        public static string DisplayAttribute_Prompt => Resources.DisplayAttribute_Prompt;
 
         public static string DisplayAttribute_CultureSensitiveName =>
             Resources.DisplayAttribute_Name + CultureInfo.CurrentUICulture;

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/project.json
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-*",
     "Microsoft.AspNetCore.Mvc": "1.1.0-*",
-    "Microsoft.AspNetCore.Mvc.DataAnnotations": "1.1.0-alpha1-21905",
+    "Microsoft.AspNetCore.Mvc.DataAnnotations": "1.1.0-*",
     "Microsoft.AspNetCore.Mvc.Formatters.Xml": "1.1.0-*",
     "Microsoft.AspNetCore.Mvc.TestCommon": {
       "version": "1.1.0-*",

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/project.json
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/project.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-*",
     "Microsoft.AspNetCore.Mvc": "1.1.0-*",
+    "Microsoft.AspNetCore.Mvc.DataAnnotations": "1.1.0-alpha1-21905",
     "Microsoft.AspNetCore.Mvc.Formatters.Xml": "1.1.0-*",
     "Microsoft.AspNetCore.Mvc.TestCommon": {
       "version": "1.1.0-*",

--- a/test/Microsoft.AspNetCore.Mvc.TestCommon/TestModelMetadataProvider.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TestCommon/TestModelMetadataProvider.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using Microsoft.AspNetCore.Mvc.DataAnnotations.Internal;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using Microsoft.Extensions.Localization;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding
@@ -14,13 +15,13 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
     internal class TestModelMetadataProvider : DefaultModelMetadataProvider
     {
         // Creates a provider with all the defaults - includes data annotations
-        public static IModelMetadataProvider CreateDefaultProvider()
+        public static IModelMetadataProvider CreateDefaultProvider(IStringLocalizerFactory stringLocalizerFactory = null)
         {
             var detailsProviders = new IMetadataDetailsProvider[]
             {
                 new DefaultBindingMetadataProvider(),
                 new DefaultValidationMetadataProvider(),
-                new DataAnnotationsMetadataProvider(stringLocalizerFactory: null),
+                new DataAnnotationsMetadataProvider(stringLocalizerFactory),
                 new DataMemberRequiredBindingMetadataProvider(),
             };
 

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/DefaultTemplatesUtilities.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/DefaultTemplatesUtilities.cs
@@ -22,6 +22,7 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Mvc.ViewFeatures.Internal;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.WebEncoders.Testing;
 using Moq;
@@ -161,9 +162,14 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
 
         public static HtmlHelper<TModel> GetHtmlHelper<TModel>(
             TModel model,
-            ICompositeViewEngine viewEngine)
+            ICompositeViewEngine viewEngine,
+            IStringLocalizerFactory stringLocalizerFactory = null)
         {
-            return GetHtmlHelper(model, CreateUrlHelper(), viewEngine, TestModelMetadataProvider.CreateDefaultProvider());
+            return GetHtmlHelper(
+                model,
+                CreateUrlHelper(),
+                viewEngine,
+                TestModelMetadataProvider.CreateDefaultProvider(stringLocalizerFactory));
         }
 
         public static HtmlHelper<TModel> GetHtmlHelper<TModel>(


### PR DESCRIPTION
Fixes #5198 by adding a func to underlie `EnumGroupAndName.Name` and #5197 by teaching GetDisplayName to use an `IStringLocalizer`.

Turns out these two bugs were intertwined enough that it made the most sense to just do them as one PR.