### PR TITLE
Handle `!ConvertEmptyStringToNull` cases correctly in `SimpleTypeModelBinder`

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelMetadata.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelMetadata.cs
@@ -92,8 +92,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         public abstract BindingSource BindingSource { get; }
 
         /// <summary>
-        /// Gets a value indicating whether or not to convert an empty string value to <c>null</c> when
-        /// representing a model as text.
+        /// Gets a value indicating whether or not to convert an empty string value or one containing only whitespace
+        /// characters to <c>null</c> when representing a model as text.
         /// </summary>
         public abstract bool ConvertEmptyStringToNull { get; }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Metadata/DisplayMetadata.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Metadata/DisplayMetadata.cs
@@ -17,8 +17,9 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
         public IDictionary<object, object> AdditionalValues { get; } = new Dictionary<object, object>();
 
         /// <summary>
-        /// Gets or sets a value indicating whether or not empty strings should be treated as <c>null</c>.
-        /// See <see cref="ModelMetadata.ConvertEmptyStringToNull"/>
+        /// Gets or sets a value indicating whether or not to convert an empty string value or one containing only
+        /// whitespace characters to <c>null</c> when representing a model as text. See
+        /// <see cref="ModelMetadata.ConvertEmptyStringToNull"/>
         /// </summary>
         public bool ConvertEmptyStringToNull { get; set; } = true;
 


### PR DESCRIPTION
- #4988
- preserve whitespace as the setting demands
 - correct previous `string.IsNullOrEmpty()` call to match previous `ValueProviderResultExtensions.ConvertTo()` use
- short-circuit other `string`-to-`string` conversions (as `ValueProviderResultExtensions.ConvertTo()` does)
- correct documentation of `ConvertEmptyStringToNull` properties
- add more tests of these scenarios and remove duplicate `BindModel_ValidValueProviderResult_ConvertEmptyStringsToNull()` test