### PR TITLE
Do not generate a validation summary when `excludePropertyErrors` unless specific model has an error

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/HtmlHelperOptionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/HtmlHelperOptionsTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             // Arrange
             var expected =
 @"<div class=""validation-summary-errors""><validationSummaryElement>MySummary</validationSummaryElement>
-<ul><li style=""display:none""></li>
+<ul><li>A model error occurred.</li>
 </ul></div>
 <validationMessageElement class=""field-validation-error"">An error occurred.</validationMessageElement>
 <input id=""Prefix!Property1"" name=""Prefix.Property1"" type=""text"" value="""" />
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 <div class=""editor-field""><input class=""text-box single-line"" id=""MyDate"" name=""MyDate"" type=""datetime"" value=""2000-01-02T03:04:05.060&#x2B;00:00"" /> </div>
 
 <div class=""validation-summary-errors""><validationSummaryElement>MySummary</validationSummaryElement>
-<ul><li style=""display:none""></li>
+<ul><li>A model error occurred.</li>
 </ul></div>
 <validationMessageElement class=""field-validation-error"">An error occurred.</validationMessageElement>
 <input id=""Prefix!Property1"" name=""Prefix.Property1"" type=""text"" value="""" />
@@ -54,7 +54,7 @@ False";
             // Arrange
             var expected =
 @"<div class=""validation-summary-errors""><ValidationSummaryInView>MySummary</ValidationSummaryInView>
-<ul><li style=""display:none""></li>
+<ul><li>A model error occurred.</li>
 </ul></div>
 <ValidationInView class=""field-validation-error"" data-valmsg-for=""Error"" data-valmsg-replace=""true"">An error occurred.</ValidationInView>
 <input id=""Prefix!Property1"" name=""Prefix.Property1"" type=""text"" value="""" />
@@ -63,7 +63,7 @@ False";
 
 True
 <div class=""validation-summary-errors""><ValidationSummaryInPartialView>MySummary</ValidationSummaryInPartialView>
-<ul><li style=""display:none""></li>
+<ul><li>A model error occurred.</li>
 </ul></div>
 <ValidationInPartialView class=""field-validation-error"" data-valmsg-for=""Error"" data-valmsg-replace=""true"">An error occurred.</ValidationInPartialView>
 <input id=""Prefix!Property1"" name=""Prefix.Property1"" type=""text"" value="""" />

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Customer.Index.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Customer.Index.html
@@ -33,8 +33,7 @@
         <div class="order validation-summary-errors" data-valmsg-summary="true"><ul><li>The value &#x27;&#x27; is invalid.</li>
 <li>The Password field is required.</li>
 </ul></div>
-        <div class="order validation-summary-errors"><ul><li style="display:none"></li>
-</ul></div>
+        <div class="order"></div>
         <input type="submit"/>
     <input name="__RequestVerificationToken" type="hidden" value="{0}" /></form>
 </body>

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperValidationSummaryTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperValidationSummaryTest.cs
@@ -75,9 +75,6 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             get
             {
-                var basicDiv = "<div class=\"HtmlEncode[[validation-summary-errors]]\"><ul>" +
-                    "<li style=\"display:none\"></li>" + Environment.NewLine +
-                    "</ul></div>";
                 var divWithError = "<div class=\"HtmlEncode[[validation-summary-errors]]\"><ul>" +
                     "<li>HtmlEncode[[This is my validation message]]</li>" + Environment.NewLine +
                     "</ul></div>";
@@ -89,8 +86,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
                 {
                     { false, false, divWithError, divWithError },
                     { false, true, divWithErrorAndSummary, divWithErrorAndSummary },
-                    { true, false, divWithError, basicDiv },
-                    { true, true, divWithError, basicDiv },
+                    { true, false, divWithError, string.Empty },
+                    { true, true, divWithError, string.Empty },
                 };
             }
         }
@@ -100,9 +97,6 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             get
             {
-                var basicDiv = "<div class=\"HtmlEncode[[validation-summary-errors]]\"><ul>" +
-                    "<li style=\"display:none\"></li>" + Environment.NewLine +
-                    "</ul></div>";
                 var divWithRootError = "<div class=\"HtmlEncode[[validation-summary-errors]]\"><ul>" +
                     "<li>HtmlEncode[[This is an error for the model root.]]</li>" + Environment.NewLine +
                     "<li>HtmlEncode[[This is another error for the model root.]]</li>" + Environment.NewLine +
@@ -129,7 +123,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
                     { false, "some.unrelated.prefix", divWithAllErrors },
                     { true, string.Empty, divWithRootError },
                     { true, "Property3", divWithProperty3Error },
-                    { true, "some.unrelated.prefix", basicDiv },
+                    { true, "some.unrelated.prefix", string.Empty },
                 };
             }
         }
@@ -526,11 +520,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             var validationSummaryResult = helper.ValidationSummary(excludePropertyErrors: true);
 
             // Assert
-            Assert.Equal(
-                "<div class=\"HtmlEncode[[validation-summary-errors]]\"><ul><li style=\"display:none\"></li>" +
-                Environment.NewLine +
-                "</ul></div>",
-                HtmlContentUtilities.HtmlContentToString(validationSummaryResult));
+            Assert.Equal(HtmlString.Empty, validationSummaryResult);
         }
 
         [Fact]
@@ -576,6 +566,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var helper = DefaultTemplatesUtilities.GetHtmlHelper();
+            helper.ViewData.ModelState.AddModelError(string.Empty, "Error for root");
             helper.ViewData.ModelState.AddModelError("Property1", "Error for Property1");
 
             // Act
@@ -585,7 +576,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             Assert.Equal(
                 "<div class=\"HtmlEncode[[validation-summary-errors]]\"><span>HtmlEncode[[Custom Message]]</span>" +
                 Environment.NewLine +
-                "<ul><li style=\"display:none\"></li>" + Environment.NewLine +
+                "<ul><li>HtmlEncode[[Error for root]]</li>" + Environment.NewLine +
                 "</ul></div>",
                 HtmlContentUtilities.HtmlContentToString(validationSummaryResult));
         }
@@ -633,6 +624,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var helper = DefaultTemplatesUtilities.GetHtmlHelper();
+            helper.ViewData.ModelState.AddModelError(string.Empty, "Error for root");
             helper.ViewData.ModelState.AddModelError("Property1", "Error for Property1");
 
             // Act
@@ -642,7 +634,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             Assert.Equal(
                 "<div class=\"HtmlEncode[[validation-summary-errors]]\"><div>HtmlEncode[[Custom Message]]</div>" +
                 Environment.NewLine +
-                "<ul><li style=\"display:none\"></li>" + Environment.NewLine +
+                "<ul><li>HtmlEncode[[Error for root]]</li>" + Environment.NewLine +
                 "</ul></div>",
                 HtmlContentUtilities.HtmlContentToString(validationSummaryResult));
         }
@@ -652,16 +644,20 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var helper = DefaultTemplatesUtilities.GetHtmlHelper();
+            helper.ViewData.ModelState.AddModelError(string.Empty, "Error for root");
             helper.ViewData.ModelState.AddModelError("Property1", "Error for Property1");
 
             // Act
-            var validationSummaryResult = helper.ValidationSummary(excludePropertyErrors: true, message: "Custom Message", htmlAttributes: new { attr = "value" });
+            var validationSummaryResult = helper.ValidationSummary(
+                excludePropertyErrors: true,
+                message: "Custom Message",
+                htmlAttributes: new { attr = "value" });
 
             // Assert
             Assert.Equal(
                 "<div attr=\"HtmlEncode[[value]]\" class=\"HtmlEncode[[validation-summary-errors]]\"><span>HtmlEncode[[Custom Message]]</span>" +
                 Environment.NewLine +
-                "<ul><li style=\"display:none\"></li>" + Environment.NewLine +
+                "<ul><li>HtmlEncode[[Error for root]]</li>" + Environment.NewLine +
                 "</ul></div>",
                 HtmlContentUtilities.HtmlContentToString(validationSummaryResult));
         }

--- a/test/WebSites/RazorWebSite/Controllers/HtmlHelperOptionsController.cs
+++ b/test/WebSites/RazorWebSite/Controllers/HtmlHelperOptionsController.cs
@@ -23,6 +23,7 @@ namespace RazorWebSite.Controllers
                 offset: TimeSpan.FromHours(0))
             };
 
+            ModelState.AddModelError(string.Empty, "A model error occurred.");
             ModelState.AddModelError("Error", "An error occurred.");
             return View(model);
         }
@@ -42,6 +43,7 @@ namespace RazorWebSite.Controllers
                 offset: TimeSpan.FromHours(0))
             };
 
+            ModelState.AddModelError(string.Empty, "A model error occurred.");
             ModelState.AddModelError("Error", "An error occurred.");
             return View(model);
         }


### PR DESCRIPTION
- #5209
- update affected `HtmlHelperValiationSummaryTest` and functional tests
- add `ValidationSummaryTagHelperTest` tests to cover related scenarios

##### Behaviour changes when no errors exist for the model:
###### Tag helper
``` html
<div asp-validation-summary="ModelOnly" class="order"><h3>Oopsie<h3></div>
```
previously generated
``` html
<div class="order validation-summary-errors"><h3>Oopsie</h3><ul><li style="display:none"></li>
</ul></div>
```
and now generates
``` html
<div class="order"><h3>Oopsie</h3></div>
```
###### HTML helper
``` c#
@Html.ValidationSummary(excludePropertyErrors: true, message: "Oopsie")
```
previously generated
``` html
<div class=\"validation-summary-errors\"><span>Oopsie</span>
<ul><li style=\"display:none\"></li>
</ul></div>
```
and now generates nothing (`@HtmlString.Empty`).