### PR TITLE
Correct test failures on Windows with `git config core.autocrlf false`

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/DirectivesTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/DirectivesTest.cs
@@ -55,7 +55,7 @@ Write says:WriteLiteral says:<strong>Write says:98052WriteLiteral says:</strong>
             var body = await Client.GetStringAsync("Directives/ViewReplacesTModelTokenFromInheritedBasePages");
 
             // Assert
-            Assert.Equal(expected, body.Trim());
+            Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/HtmlGenerationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/HtmlGenerationTest.cs
@@ -496,7 +496,7 @@ Products: Music Systems, Televisions (3)";
             var response = await Client.GetStringAsync("http://localhost/HtmlGeneration_Home/ItemUsingSharedEditorTemplate");
 
             // Assert
-            Assert.Equal(expected, response);
+            Assert.Equal(expected, response, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -510,7 +510,7 @@ Products: Music Systems, Televisions (3)";
             var response = await Client.GetStringAsync("http://localhost/HtmlGeneration_Home/ItemUsingModelSpecificEditorTemplate");
 
             // Assert
-            Assert.Equal(expected, response);
+            Assert.Equal(expected, response, ignoreLineEndingDifferences: true);
         }
 
         private static HttpRequestMessage RequestWithLocale(string url, string locale)


### PR DESCRIPTION
- line endings in checked-out files do not necessarily match `Environment.NewLine`