### PR TITLE
[Design] Use `StringValuesTutu` to reduce `string` allocations

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/StringValuesTutu.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/StringValuesTutu.cs
@@ -1,0 +1,745 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.Extensions.Internal;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.AspNetCore.Mvc
+{
+    /// <summary>
+    /// Represents zero/null, one, or many strings in an efficient way.
+    /// </summary>
+    /// <remarks>
+    /// A variant of <see cref="StringValues"/> that converts back to a <see cref="string"/> without additional commas
+    /// between values. In addition, this <c>struct</c> lacks an implicit conversion to <see cref="string"/> and the
+    /// explicit and implicit conversions it has never return <c>null</c>.
+    /// </remarks>
+    public struct StringValuesTutu
+        : IList<string>, IReadOnlyList<string>, IEquatable<StringValuesTutu>, IEquatable<string>, IEquatable<string[]>
+    {
+        private static readonly string[] EmptyArray = new string[0];
+        public static readonly StringValuesTutu Empty = new StringValuesTutu(EmptyArray);
+
+        private readonly string _value;
+        private readonly string[] _values;
+
+        ////private string _concatenatedValue;
+
+        public StringValuesTutu(string value)
+        {
+            _value = value;
+            _values = null;
+
+            ////_concatenatedValue = null;
+        }
+
+        public StringValuesTutu(string[] values)
+        {
+            _value = null;
+            _values = values;
+
+            ////_concatenatedValue = null;
+        }
+
+        public static implicit operator StringValuesTutu(string value)
+        {
+            return new StringValuesTutu(value);
+        }
+
+        public static implicit operator StringValuesTutu(string[] values)
+        {
+            return new StringValuesTutu(values);
+        }
+
+        public int Count => _value != null ? 1 : (_values?.Length ?? 0);
+
+        bool ICollection<string>.IsReadOnly => true;
+
+        string IList<string>.this[int index]
+        {
+            get { return this[index]; }
+            set { throw new NotSupportedException(); }
+        }
+
+        public string this[int index]
+        {
+            get
+            {
+                if (_values != null)
+                {
+                    return _values[index]; // may throw
+                }
+
+                if (index == 0 && _value != null)
+                {
+                    return _value;
+                }
+
+                return EmptyArray[index]; // throws
+            }
+        }
+
+        public override string ToString()
+        {
+            return GetStringValue() ?? string.Empty;
+        }
+
+        private string GetStringValue()
+        {
+            if (_values == null)
+            {
+                return _value;
+            }
+
+            switch (_values.Length)
+            {
+                case 0:
+                    return null;
+                case 1:
+                    return _values[0];
+                default:
+                    ////if (_concatenatedValue == null)
+                    ////{
+                    ////    _concatenatedValue = string.Concat(_values);
+                    ////}
+
+                    return string.Concat(_values);
+            }
+        }
+
+        public string[] ToArray()
+        {
+            return GetArrayValue() ?? EmptyArray;
+        }
+
+        private string[] GetArrayValue()
+        {
+            if (_value != null)
+            {
+                return new[] { _value };
+            }
+
+            return _values;
+        }
+
+        int IList<string>.IndexOf(string item)
+        {
+            return IndexOf(item, startIndex: 0);
+        }
+
+        public int IndexOf(string item, int startIndex)
+        {
+            if (item == null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
+
+            if (startIndex < 0 || startIndex > Count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(startIndex), "ArgumentOutOfRange_Index");
+            }
+
+            if (_values != null)
+            {
+                var values = _values;
+                for (int i = startIndex; i < values.Length; i++)
+                {
+                    if (string.Equals(values[i], item, StringComparison.Ordinal))
+                    {
+                        return i;
+                    }
+                }
+
+                return -1;
+            }
+
+            if (_value != null && startIndex == 0)
+            {
+                return string.Equals(_value, item, StringComparison.Ordinal) ? 0 : -1;
+            }
+
+            return -1;
+        }
+
+        bool ICollection<string>.Contains(string item)
+        {
+            return IndexOf(item, startIndex: 0) >= 0;
+        }
+
+        void ICollection<string>.CopyTo(string[] array, int arrayIndex)
+        {
+            CopyTo(array, arrayIndex);
+        }
+
+        private void CopyTo(string[] array, int arrayIndex)
+        {
+            if (_values != null)
+            {
+                Array.Copy(_values, 0, array, arrayIndex, _values.Length);
+                return;
+            }
+
+            if (_value != null)
+            {
+                if (array == null)
+                {
+                    throw new ArgumentNullException(nameof(array));
+                }
+
+                if (arrayIndex < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+                }
+
+                if (array.Length - arrayIndex < 1)
+                {
+                    throw new ArgumentException(
+                        $"'{nameof(array)}' is not long enough to copy all the items in the collection. Check '{nameof(arrayIndex)}' and '{nameof(array)}' length.");
+                }
+
+                array[arrayIndex] = _value;
+            }
+        }
+
+        void ICollection<string>.Add(string item)
+        {
+            throw new NotSupportedException();
+        }
+
+        void IList<string>.Insert(int index, string item)
+        {
+            throw new NotSupportedException();
+        }
+
+        bool ICollection<string>.Remove(string item)
+        {
+            throw new NotSupportedException();
+        }
+
+        void IList<string>.RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        void ICollection<string>.Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(ref this);
+        }
+
+        IEnumerator<string> IEnumerable<string>.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public static bool IsNullOrEmpty(StringValuesTutu value)
+        {
+            if (value._values == null)
+            {
+                return string.IsNullOrEmpty(value._value);
+            }
+
+            switch (value._values.Length)
+            {
+                case 0: return true;
+                case 1: return string.IsNullOrEmpty(value._values[0]);
+                default: return false;
+            }
+        }
+
+        public static StringValuesTutu Concat(string value1, StringValuesTutu values)
+        {
+            if (string.IsNullOrEmpty(value1))
+            {
+                return values;
+            }
+
+            var count = values.Count;
+            if (count == 0)
+            {
+                return new StringValuesTutu(value1);
+            }
+
+            var combined = new string[1 + count];
+            combined[0] = value1;
+            values.CopyTo(combined, arrayIndex: 1);
+
+            return new StringValuesTutu(combined);
+        }
+
+        public static StringValuesTutu Concat(string value1, string value2, StringValuesTutu values)
+        {
+            if (string.IsNullOrEmpty(value1))
+            {
+                return Concat(value2, values);
+            }
+
+            var count = values.Count;
+            if (count == 0)
+            {
+                return new StringValuesTutu(new[] { value1, value2 });
+            }
+
+            var combined = new string[2 + count];
+            combined[0] = value1;
+            combined[1] = value2;
+            values.CopyTo(combined, arrayIndex: 2);
+
+            return new StringValuesTutu(combined);
+        }
+
+        public static StringValuesTutu Concat(string value1, string value2, string value3, StringValuesTutu values)
+        {
+            if (string.IsNullOrEmpty(value1))
+            {
+                return Concat(value2, value3, values);
+            }
+
+            var count = values.Count;
+            if (count == 0)
+            {
+                return new StringValuesTutu(new[] { value1, value2, value3 });
+            }
+
+            var combined = new string[3 + count];
+            combined[0] = value1;
+            combined[1] = value2;
+            combined[2] = value3;
+            values.CopyTo(combined, arrayIndex: 3);
+
+            return new StringValuesTutu(combined);
+        }
+
+        public static StringValuesTutu Concat(StringValuesTutu values, string value1)
+        {
+            if (string.IsNullOrEmpty(value1))
+            {
+                return values;
+            }
+
+            var count = values.Count;
+            if (count == 0)
+            {
+                return new StringValuesTutu(value1);
+            }
+
+            var combined = new string[count + 1];
+            combined[0] = value1;
+            values.CopyTo(combined, arrayIndex: 1);
+
+            return new StringValuesTutu(combined);
+        }
+
+        public static StringValuesTutu Concat(StringValuesTutu values, string value1, string value2)
+        {
+            if (string.IsNullOrEmpty(value1))
+            {
+                return Concat(values, value2);
+            }
+
+            var count = values.Count;
+            if (count == 0)
+            {
+                return new StringValuesTutu(new[] { value1, value2 });
+            }
+
+            var combined = new string[count + 2];
+            combined[0] = value1;
+            combined[1] = value2;
+            values.CopyTo(combined, arrayIndex: 2);
+
+            return new StringValuesTutu(combined);
+        }
+
+        public static StringValuesTutu Concat(StringValuesTutu values, string value1, string value2, string value3)
+        {
+            if (string.IsNullOrEmpty(value1))
+            {
+                return Concat(values, value2, value3);
+            }
+
+            var count = values.Count;
+            if (count == 0)
+            {
+                return new StringValuesTutu(new[] { value1, value2, value3 });
+            }
+
+            var combined = new string[count + 3];
+            combined[0] = value1;
+            combined[1] = value2;
+            combined[2] = value3;
+            values.CopyTo(combined, arrayIndex: 3);
+
+            return new StringValuesTutu(combined);
+        }
+
+        public static StringValuesTutu Concat(StringValuesTutu values, params string[] paramValues)
+        {
+            return Concat(values, new StringValuesTutu(paramValues));
+        }
+
+        public static StringValuesTutu Concat(StringValuesTutu values1, StringValuesTutu values2)
+        {
+            var count1 = values1.Count;
+            if (count1 == 0)
+            {
+                return values2;
+            }
+
+            var count2 = values2.Count;
+            if (count2 == 0)
+            {
+                return values1;
+            }
+
+            var combined = new string[count1 + count2];
+            values1.CopyTo(combined, 0);
+            values2.CopyTo(combined, count1);
+
+            return new StringValuesTutu(combined);
+        }
+
+        public static StringValuesTutu Concat(StringValuesTutu values1, string value1, StringValuesTutu values2)
+        {
+            if (string.IsNullOrEmpty(value1))
+            {
+                return Concat(values1, values2);
+            }
+
+            var count1 = values1.Count;
+            if (count1 == 0)
+            {
+                return Concat(value1, values2);
+            }
+
+            var count2 = values2.Count;
+            if (count2 == 0)
+            {
+                return Concat(values1, value1);
+            }
+
+            var combined = new string[count1 + 1 + count2];
+            values1.CopyTo(combined, 0);
+            combined[count1] = value1;
+            values2.CopyTo(combined, count1 + 1);
+
+            return new StringValuesTutu(combined);
+        }
+
+        public StringValuesTutu Substring(int startIndex)
+        {
+            return Substring(startIndex, Count - startIndex);
+        }
+
+        public StringValuesTutu Substring(int startIndex, int length)
+        {
+            if (startIndex < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(startIndex), "ArgumentOutOfRange_StartIndex");
+            }
+
+            if (startIndex > Count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(startIndex), "ArgumentOutOfRange_StartIndexLargerThanLength");
+            }
+
+            if (length < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(length), "ArgumentOutOfRange_NegativeLength");
+            }
+
+            if (startIndex > Count - length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(length), "ArgumentOutOfRange_IndexLength");
+            }
+
+            if (length == 0)
+            {
+                return Empty;
+            }
+
+            if (startIndex == 0 && length == Count)
+            {
+                return this;
+            }
+
+            Debug.Assert(_values != null, $"Attempt to Substring an uninitialized {typeof(StringValuesTutu)}.");
+
+            var substring = new string[length];
+            var i = 0;
+            for (var j = startIndex; length > 0; i++, j++, length--)
+            {
+                substring[i] = _values[j];
+            }
+
+            return new StringValuesTutu(substring);
+        }
+
+        public static bool Equals(StringValuesTutu left, StringValuesTutu right)
+        {
+            return Equals(left, right, StringComparison.Ordinal);
+        }
+
+        // Ignore value boundaries to determine equality.
+        public static bool Equals(StringValuesTutu left, StringValuesTutu right, StringComparison comparisonType)
+        {
+            var leftIndex = 0;
+            var rightIndex = 0;
+            var leftOffset = 0;
+            var rightOffset = 0;
+            while (leftIndex < left.Count && rightIndex < right.Count)
+            {
+                var leftString = left[leftIndex];
+                var rightString = right[rightIndex];
+                var length = Math.Min(leftString.Length - leftOffset, rightString.Length - rightOffset);
+                if (string.Compare(leftString, leftOffset, rightString, rightOffset, length, comparisonType) != 0)
+                {
+                    return false;
+                }
+
+                if (leftOffset + length == leftString.Length)
+                {
+                    leftIndex++;
+                    leftOffset = 0;
+                }
+                else
+                {
+                    leftOffset += length;
+                }
+
+                if (rightOffset + length == rightString.Length)
+                {
+                    rightIndex++;
+                    rightOffset = 0;
+                }
+                else
+                {
+                    rightOffset += length;
+                }
+            }
+
+            if (leftIndex != left.Count || leftOffset != 0)
+            {
+                // Something left in left.
+                return false;
+            }
+
+            if (rightIndex != right.Count || rightOffset != 0)
+            {
+                // Something left in right.
+                return false;
+            }
+
+            return true;
+        }
+
+        public static bool operator ==(StringValuesTutu left, StringValuesTutu right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(StringValuesTutu left, StringValuesTutu right)
+        {
+            return !Equals(left, right);
+        }
+
+        public bool Equals(StringValuesTutu other)
+        {
+            return Equals(this, other);
+        }
+
+        public static bool Equals(string left, StringValuesTutu right)
+        {
+            return Equals(new StringValuesTutu(left), right);
+        }
+
+        public static bool Equals(StringValuesTutu left, string right)
+        {
+            return Equals(left, new StringValuesTutu(right));
+        }
+
+        public bool Equals(string other)
+        {
+            return Equals(this, new StringValuesTutu(other));
+        }
+
+        public static bool Equals(string[] left, StringValuesTutu right)
+        {
+            return Equals(new StringValuesTutu(left), right);
+        }
+
+        public static bool Equals(StringValuesTutu left, string[] right)
+        {
+            return Equals(left, new StringValuesTutu(right));
+        }
+
+        public bool Equals(string[] other)
+        {
+            return Equals(this, new StringValuesTutu(other));
+        }
+
+        public static bool operator ==(StringValuesTutu left, string right)
+        {
+            return Equals(left, new StringValuesTutu(right));
+        }
+
+        public static bool operator !=(StringValuesTutu left, string right)
+        {
+            return !Equals(left, new StringValuesTutu(right));
+        }
+
+        public static bool operator ==(string left, StringValuesTutu right)
+        {
+            return Equals(new StringValuesTutu(left), right);
+        }
+
+        public static bool operator !=(string left, StringValuesTutu right)
+        {
+            return !Equals(new StringValuesTutu(left), right);
+        }
+
+        public static bool operator ==(StringValuesTutu left, string[] right)
+        {
+            return Equals(left, new StringValuesTutu(right));
+        }
+
+        public static bool operator !=(StringValuesTutu left, string[] right)
+        {
+            return !Equals(left, new StringValuesTutu(right));
+        }
+
+        public static bool operator ==(string[] left, StringValuesTutu right)
+        {
+            return Equals(new StringValuesTutu(left), right);
+        }
+
+        public static bool operator !=(string[] left, StringValuesTutu right)
+        {
+            return !Equals(new StringValuesTutu(left), right);
+        }
+
+        public static bool operator ==(StringValuesTutu left, object right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(StringValuesTutu left, object right)
+        {
+            return !left.Equals(right);
+        }
+        public static bool operator ==(object left, StringValuesTutu right)
+        {
+            return right.Equals(left);
+        }
+
+        public static bool operator !=(object left, StringValuesTutu right)
+        {
+            return !right.Equals(left);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+            {
+                return Equals(this, StringValuesTutu.Empty);
+            }
+
+            if (obj is string)
+            {
+                return Equals(this, (string)obj);
+            }
+
+            if (obj is string[])
+            {
+                return Equals(this, (string[])obj);
+            }
+
+            if (obj is StringValuesTutu)
+            {
+                return Equals(this, (StringValuesTutu)obj);
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            if (_values == null)
+            {
+                return _value == null ? 0 : _value.GetHashCode();
+            }
+
+            var hashCodeCombiner = HashCodeCombiner.Start();
+            for (var i = 0; i < _values.Length; i++)
+            {
+                hashCodeCombiner.Add(_values[i]);
+            }
+
+            return hashCodeCombiner.CombinedHash;
+        }
+
+        public struct Enumerator : IEnumerator<string>
+        {
+            private readonly string[] _values;
+            private string _current;
+            private int _index;
+
+            public Enumerator(ref StringValuesTutu values)
+            {
+                _values = values._values;
+                _current = values._value;
+                _index = 0;
+            }
+
+            public bool MoveNext()
+            {
+                if (_index < 0)
+                {
+                    return false;
+                }
+
+                if (_values != null)
+                {
+                    if (_index < _values.Length)
+                    {
+                        _current = _values[_index];
+                        _index++;
+                        return true;
+                    }
+
+                    _index = -1;
+                    return false;
+                }
+
+                _index = -1; // sentinel value
+                return _current != null;
+            }
+
+            public string Current => _current;
+
+            object IEnumerator.Current => _current;
+
+            void IEnumerator.Reset()
+            {
+                throw new NotSupportedException();
+            }
+
+            void IDisposable.Dispose()
+            {
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/Formatters/FormatterMappings.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Formatters/FormatterMappings.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc.Core;
-using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Mvc.Formatters

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/FormCollectionModelBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/FormCollectionModelBinder.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/InputTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/InputTagHelper.cs
@@ -69,6 +69,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         public InputTagHelper(IHtmlGenerator generator)
         {
             Generator = generator;
+            GeneratorTutu = HtmlGeneratorAdapter.GetTuTu(generator);
         }
 
         /// <inheritdoc />
@@ -81,6 +82,8 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         }
 
         protected IHtmlGenerator Generator { get; }
+
+        protected IHtmlGeneratorTutu GeneratorTutu { get; }
 
         [HtmlAttributeNotBound]
         [ViewContext]
@@ -199,10 +202,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                     return;
 
                 case "password":
-                    tagBuilder = Generator.GeneratePassword(
+                    tagBuilder = GeneratorTutu.GeneratePassword(
                         ViewContext,
                         modelExplorer,
-                        For.Name,
+                        For.NameValues,
                         value: null,
                         htmlAttributes: null);
                     break;
@@ -276,10 +279,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 }
             }
 
-            var checkBoxTag = Generator.GenerateCheckBox(
+            var checkBoxTag = GeneratorTutu.GenerateCheckBox(
                 ViewContext,
                 modelExplorer,
-                For.Name,
+                For.NameValues,
                 isChecked: null,
                 htmlAttributes: htmlAttributes);
             if (checkBoxTag != null)
@@ -294,7 +297,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 checkBoxTag.TagRenderMode = renderingMode;
                 output.Content.AppendHtml(checkBoxTag);
 
-                var hiddenForCheckboxTag = Generator.GenerateHiddenForCheckbox(ViewContext, modelExplorer, For.Name);
+                var hiddenForCheckboxTag = GeneratorTutu.GenerateHiddenForCheckbox(
+                    ViewContext,
+                    modelExplorer,
+                    For.NameValues);
                 if (hiddenForCheckboxTag != null)
                 {
                     hiddenForCheckboxTag.TagRenderMode = renderingMode;
@@ -323,10 +329,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                     "radio"));
             }
 
-            return Generator.GenerateRadioButton(
+            return GeneratorTutu.GenerateRadioButton(
                 ViewContext,
                 modelExplorer,
-                For.Name,
+                For.NameValues,
                 Value,
                 isChecked: null,
                 htmlAttributes: null);
@@ -350,10 +356,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 htmlAttributes["multiple"] = "multiple";
             }
 
-            return Generator.GenerateTextBox(
+            return GeneratorTutu.GenerateTextBox(
                 ViewContext,
                 modelExplorer,
-                For.Name,
+                For.NameValues,
                 value: modelExplorer.Model,
                 format: format,
                 htmlAttributes: htmlAttributes);
@@ -378,10 +384,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 { "type", "hidden" }
             };
 
-            return Generator.GenerateTextBox(
+            return GeneratorTutu.GenerateTextBox(
                 ViewContext,
                 modelExplorer,
-                For.Name,
+                For.NameValues,
                 value: value,
                 format: Format,
                 htmlAttributes: htmlAttributes);

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/LabelTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/LabelTagHelper.cs
@@ -24,6 +24,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         public LabelTagHelper(IHtmlGenerator generator)
         {
             Generator = generator;
+            GeneratorTutu = HtmlGeneratorAdapter.GetTuTu(generator);
         }
 
         /// <inheritdoc />
@@ -40,6 +41,8 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         public ViewContext ViewContext { get; set; }
 
         protected IHtmlGenerator Generator { get; }
+
+        protected IHtmlGeneratorTutu GeneratorTutu { get; }
 
         /// <summary>
         /// An expression to be evaluated against the current model.
@@ -61,10 +64,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 throw new ArgumentNullException(nameof(output));
             }
 
-            var tagBuilder = Generator.GenerateLabel(
+            var tagBuilder = GeneratorTutu.GenerateLabel(
                 ViewContext,
                 For.ModelExplorer,
-                For.Name,
+                For.NameValues,
                 labelText: null,
                 htmlAttributes: null);
 

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/SelectTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/SelectTagHelper.cs
@@ -36,6 +36,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         public SelectTagHelper(IHtmlGenerator generator)
         {
             Generator = generator;
+            GeneratorTutu = HtmlGeneratorAdapter.GetTuTu(generator);
         }
 
         /// <inheritdoc />
@@ -48,6 +49,8 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         }
 
         protected IHtmlGenerator Generator { get; }
+
+        protected IHtmlGeneratorTutu GeneratorTutu { get; }
 
         [HtmlAttributeNotBound]
         [ViewContext]
@@ -98,10 +101,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             var realModelType = For.ModelExplorer.ModelType;
             _allowMultiple = typeof(string) != realModelType &&
                 typeof(IEnumerable).IsAssignableFrom(realModelType);
-            _currentValues = Generator.GetCurrentValues(
+            _currentValues = GeneratorTutu.GetCurrentValues(
                 ViewContext,
                 For.ModelExplorer,
-                expression: For.Name,
+                expression: For.NameValues,
                 allowMultiple: _allowMultiple);
 
             // Whether or not (not being highly unlikely) we generate anything, could update contained <option/>
@@ -129,16 +132,16 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
             if (For == null)
             {
-                var options = Generator.GenerateGroupsAndOptions(optionLabel: null, selectList: items);
+                var options = GeneratorTutu.GenerateGroupsAndOptions(optionLabel: null, selectList: items);
                 output.PostContent.AppendHtml(options);
                 return;
             }
 
-            var tagBuilder = Generator.GenerateSelect(
+            var tagBuilder = GeneratorTutu.GenerateSelect(
                 ViewContext,
                 For.ModelExplorer,
                 optionLabel: null,
-                expression: For.Name,
+                expression: For.NameValues,
                 selectList: items,
                 currentValues: _currentValues,
                 allowMultiple: _allowMultiple,

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/TextAreaTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/TextAreaTagHelper.cs
@@ -23,6 +23,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         public TextAreaTagHelper(IHtmlGenerator generator)
         {
             Generator = generator;
+            GeneratorTutu = HtmlGeneratorAdapter.GetTuTu(generator);
         }
 
         /// <inheritdoc />
@@ -35,6 +36,8 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         }
 
         protected IHtmlGenerator Generator { get; }
+
+        protected IHtmlGeneratorTutu GeneratorTutu { get; }
 
         [HtmlAttributeNotBound]
         [ViewContext]
@@ -60,10 +63,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 throw new ArgumentNullException(nameof(output));
             }
 
-            var tagBuilder = Generator.GenerateTextArea(
+            var tagBuilder = GeneratorTutu.GenerateTextArea(
                 ViewContext,
                 For.ModelExplorer,
-                For.Name,
+                For.NameValues,
                 rows: 0,
                 columns: 0,
                 htmlAttributes: null);

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/ValidationMessageTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/ValidationMessageTagHelper.cs
@@ -25,6 +25,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         public ValidationMessageTagHelper(IHtmlGenerator generator)
         {
             Generator = generator;
+            GeneratorTutu = HtmlGeneratorAdapter.GetTuTu(generator);
         }
 
         /// <inheritdoc />
@@ -41,6 +42,8 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         public ViewContext ViewContext { get; set; }
 
         protected IHtmlGenerator Generator { get; }
+
+        protected IHtmlGeneratorTutu GeneratorTutu { get; }
 
         /// <summary>
         /// Name to be validated on the current model.
@@ -64,10 +67,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
             if (For != null)
             {
-                var tagBuilder = Generator.GenerateValidationMessage(
+                var tagBuilder = GeneratorTutu.GenerateValidationMessage(
                     ViewContext,
                     For.ModelExplorer,
-                    For.Name,
+                    For.NameValues,
                     message: null,
                     tag: null,
                     htmlAttributes: null);

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ExpressionTextCache.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ExpressionTextCache.cs
@@ -15,8 +15,8 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
     public class ExpressionTextCache
     {
         /// <inheritdoc />
-        public ConcurrentDictionary<LambdaExpression, string> Entries { get; } = 
-            new ConcurrentDictionary<LambdaExpression, string>(LambdaExpressionComparer.Instance);
+        public ConcurrentDictionary<LambdaExpression, StringValuesTutu> Entries { get; } =
+            new ConcurrentDictionary<LambdaExpression, StringValuesTutu>(LambdaExpressionComparer.Instance);
 
         // This comparer is tightly coupled with the logic of ExpressionHelper.GetExpressionText.
         // It is not designed to accurately compare any two arbitrary LambdaExpressions.
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
                 {
                     return true;
                 }
-                // We will cache only pure member access expressions. Hence we compare two expressions 
+                // We will cache only pure member access expressions. Hence we compare two expressions
                 // to be equal only if they are identical member access expressions.
                 var expression1 = lambdaExpression1.Body;
                 var expression2 = lambdaExpression2.Body;
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
                             return false;
                         }
                     }
-                    else 
+                    else
                     {
                         return true;
                     }

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ModelStateDictionaryExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ModelStateDictionaryExtensions.cs
@@ -154,18 +154,23 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         {
             // We check if expression is wrapped with conversion to object expression
             // and unwrap it if necessary, because Expression<Func<TModel, object>>
-            // automatically creates a convert to object expression for expresions
+            // automatically creates a convert to object expression for expressions
             // returning value types
             var unaryExpression = expression.Body as UnaryExpression;
 
+            StringValuesTutu expressionValues;
             if (IsConversionToObject(unaryExpression))
             {
-                return ExpressionHelper.GetExpressionText(Expression.Lambda(
+                expressionValues = ExpressionHelper.GetExpressionText(Expression.Lambda(
                     unaryExpression.Operand,
                     expression.Parameters[0]));
             }
+            else
+            {
+                expressionValues = ExpressionHelper.GetExpressionText(expression);
+            }
 
-            return ExpressionHelper.GetExpressionText(expression);
+            return expressionValues.ToString();
         }
 
         private static bool IsConversionToObject(UnaryExpression expression)

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/AttributeValuesDictionary.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/AttributeValuesDictionary.cs
@@ -1,0 +1,668 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Microsoft.AspNetCore.Mvc.ViewFeatures
+{
+    /// <summary>
+    /// A dictionary for HTML attributes.
+    /// </summary>
+    public class AttributeValuesDictionary
+        : IDictionary<string, StringValuesTutu>, IReadOnlyDictionary<string, StringValuesTutu>
+    {
+        private List<KeyValuePair<string, StringValuesTutu>> _items;
+
+        /// <inheritdoc />
+        public StringValuesTutu this[string key]
+        {
+            get
+            {
+                if (key == null)
+                {
+                    throw new ArgumentNullException(nameof(key));
+                }
+
+                var index = Find(key);
+                if (index < 0)
+                {
+                    throw new KeyNotFoundException();
+                }
+                else
+                {
+                    return Get(index).Value;
+                }
+            }
+
+            set
+            {
+                if (key == null)
+                {
+                    throw new ArgumentNullException(nameof(key));
+                }
+
+                var item = new KeyValuePair<string, StringValuesTutu>(key, value);
+                var index = Find(key);
+                if (index < 0)
+                {
+                    Insert(~index, item);
+                }
+                else
+                {
+                    Set(index, item);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public int Count => _items == null ? 0 : _items.Count;
+
+        /// <inheritdoc />
+        public bool IsReadOnly
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        /// <inheritdoc />
+        public ICollection<string> Keys
+        {
+            get
+            {
+                return new KeyCollection(this);
+            }
+        }
+
+        /// <inheritdoc />
+        public ICollection<StringValuesTutu> Values
+        {
+            get
+            {
+                return new ValueCollection(this);
+            }
+        }
+
+        /// <inheritdoc />
+        IEnumerable<string> IReadOnlyDictionary<string, StringValuesTutu>.Keys
+        {
+            get
+            {
+                return new KeyCollection(this);
+            }
+        }
+
+        /// <inheritdoc />
+        IEnumerable<StringValuesTutu> IReadOnlyDictionary<string, StringValuesTutu>.Values
+        {
+            get
+            {
+                return new ValueCollection(this);
+            }
+        }
+
+        private KeyValuePair<string, StringValuesTutu> Get(int index)
+        {
+            Debug.Assert(index >= 0 && index < Count);
+            return _items[index];
+        }
+
+        private void Set(int index, KeyValuePair<string, StringValuesTutu> value)
+        {
+            Debug.Assert(index >= 0 && index <= Count);
+            Debug.Assert(value.Key != null);
+
+            if (_items == null)
+            {
+                _items = new List<KeyValuePair<string, StringValuesTutu>>();
+            }
+
+            _items[index] = value;
+        }
+
+        private void Insert(int index, KeyValuePair<string, StringValuesTutu> value)
+        {
+            Debug.Assert(index >= 0 && index <= Count);
+            Debug.Assert(value.Key != null);
+
+            if (_items == null)
+            {
+                _items = new List<KeyValuePair<string, StringValuesTutu>>();
+            }
+
+            _items.Insert(index, value);
+        }
+
+        private void Remove(int index)
+        {
+            Debug.Assert(index >= 0 && index < Count);
+
+            _items.RemoveAt(index);
+        }
+
+        // This API is a lot like List<T>.BinarySearch https://msdn.microsoft.com/en-us/library/3f90y839(v=vs.110).aspx
+        // If an item is not found, we return the compliment of where it belongs. Then we don't need to search again
+        // to do something with it.
+        private int Find(string key)
+        {
+            Debug.Assert(key != null);
+
+            if (Count == 0)
+            {
+                return ~0;
+            }
+
+            var start = 0;
+            var end = Count - 1;
+
+            while (start <= end)
+            {
+                var pivot = start + (end - start >> 1);
+
+                var compare = StringComparer.OrdinalIgnoreCase.Compare(Get(pivot).Key, key);
+                if (compare == 0)
+                {
+                    return pivot;
+                }
+                if (compare < 0)
+                {
+                    start = pivot + 1;
+                }
+                else
+                {
+                    end = pivot - 1;
+                }
+            }
+
+            return ~start;
+        }
+
+        /// <inheritdoc />
+        public void Clear()
+        {
+            if (_items != null)
+            {
+                _items.Clear();
+            }
+        }
+
+        /// <inheritdoc />
+        public void Add(KeyValuePair<string, StringValuesTutu> item)
+        {
+            if (item.Key == null)
+            {
+                throw new ArgumentException(
+                    Resources.FormatPropertyOfTypeCannotBeNull(
+                        nameof(KeyValuePair<string, StringValuesTutu>.Key),
+                        nameof(KeyValuePair<string, StringValuesTutu>)),
+                    nameof(item));
+            }
+
+            var index = Find(item.Key);
+            if (index < 0)
+            {
+                Insert(~index, item);
+            }
+            else
+            {
+                throw new InvalidOperationException(Resources.FormatDictionary_DuplicateKey(item.Key));
+            }
+        }
+
+        /// <inheritdoc />
+        public void Add(string key, StringValuesTutu value)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            Add(new KeyValuePair<string, StringValuesTutu>(key, value));
+        }
+
+        /// <inheritdoc />
+        public bool Contains(KeyValuePair<string, StringValuesTutu> item)
+        {
+            if (item.Key == null)
+            {
+                throw new ArgumentException(
+                    Resources.FormatPropertyOfTypeCannotBeNull(
+                        nameof(KeyValuePair<string, StringValuesTutu>.Key),
+                        nameof(KeyValuePair<string, StringValuesTutu>)),
+                    nameof(item));
+            }
+
+            var index = Find(item.Key);
+            if (index < 0)
+            {
+                return false;
+            }
+            else
+            {
+                return StringValuesTutu.Equals(item.Value, Get(index).Value, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        /// <inheritdoc />
+        public bool ContainsKey(string key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            if (Count == 0)
+            {
+                return false;
+            }
+
+            return Find(key) >= 0;
+        }
+
+        /// <inheritdoc />
+        public void CopyTo(KeyValuePair<string, StringValuesTutu>[] array, int arrayIndex)
+        {
+            if (array == null)
+            {
+                throw new ArgumentNullException(nameof(array));
+            }
+
+            if (arrayIndex < 0 || arrayIndex >= array.Length)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            for (var i = 0; i < Count; i++)
+            {
+                array[arrayIndex + i] = Get(i);
+            }
+        }
+
+        /// <inheritdoc />
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        /// <inheritdoc />
+        public bool Remove(KeyValuePair<string, StringValuesTutu> item)
+        {
+            if (item.Key == null)
+            {
+                throw new ArgumentException(
+                    Resources.FormatPropertyOfTypeCannotBeNull(
+                        nameof(KeyValuePair<string, StringValuesTutu>.Key),
+                        nameof(KeyValuePair<string, StringValuesTutu>)),
+                    nameof(item));
+            }
+
+            var index = Find(item.Key);
+            if (index < 0)
+            {
+                return false;
+            }
+            else if (StringValuesTutu.Equals(item.Value, Get(index).Value, StringComparison.OrdinalIgnoreCase))
+            {
+                Remove(index);
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <inheritdoc />
+        public bool Remove(string key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            var index = Find(key);
+            if (index < 0)
+            {
+                return false;
+            }
+            else
+            {
+                Remove(index);
+                return true;
+            }
+        }
+
+        /// <inheritdoc />
+        public bool TryGetValue(string key, out StringValuesTutu value)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            var index = Find(key);
+            if (index < 0)
+            {
+                value = StringValuesTutu.Empty;
+                return false;
+            }
+            else
+            {
+                value = Get(index).Value;
+                return true;
+            }
+        }
+
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        /// <inheritdoc />
+        IEnumerator<KeyValuePair<string, StringValuesTutu>> IEnumerable<KeyValuePair<string, StringValuesTutu>>.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        /// <summary>
+        /// An enumerator for <see cref="AttributeValuesDictionary"/>.
+        /// </summary>
+        public struct Enumerator : IEnumerator<KeyValuePair<string, StringValuesTutu>>
+        {
+            private AttributeValuesDictionary _attributes;
+            private int _index;
+
+            /// <summary>
+            /// Creates a new <see cref="Enumerator"/>.
+            /// </summary>
+            /// <param name="attributes">The <see cref="AttributeValuesDictionary"/>.</param>
+            public Enumerator(AttributeValuesDictionary attributes)
+            {
+                _attributes = attributes;
+                _index = -1;
+            }
+
+            /// <inheritdoc />
+            public KeyValuePair<string, StringValuesTutu> Current
+            {
+                get
+                {
+                    return _attributes.Get(_index);
+                }
+            }
+
+            /// <inheritdoc />
+            object IEnumerator.Current
+            {
+                get
+                {
+                    return Current;
+                }
+            }
+
+            /// <inheritdoc />
+            public void Dispose()
+            {
+            }
+
+            /// <inheritdoc />
+            public bool MoveNext()
+            {
+                _index++;
+                return _index < _attributes.Count;
+            }
+
+            /// <inheritdoc />
+            public void Reset()
+            {
+                _index = -1;
+            }
+        }
+
+        private class KeyCollection : ICollection<string>
+        {
+            private readonly AttributeValuesDictionary _attributes;
+
+            public KeyCollection(AttributeValuesDictionary attributes)
+            {
+                _attributes = attributes;
+            }
+
+            public int Count => _attributes.Count;
+
+            public bool IsReadOnly => true;
+
+            public void Add(string item)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void Clear()
+            {
+                throw new NotSupportedException();
+            }
+
+            public bool Contains(string item)
+            {
+                if (item == null)
+                {
+                    throw new ArgumentNullException(nameof(item));
+                }
+
+                for (var i = 0; i < _attributes.Count; i++)
+                {
+                    if (string.Equals(item, _attributes.Get(i).Key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            public void CopyTo(string[] array, int arrayIndex)
+            {
+                if (array == null)
+                {
+                    throw new ArgumentNullException(nameof(array));
+                }
+
+                if (arrayIndex < 0 || arrayIndex >= array.Length)
+                {
+                    throw new IndexOutOfRangeException();
+                }
+
+                for (var i = 0; i < _attributes.Count; i++)
+                {
+                    array[arrayIndex + i] = _attributes.Get(i).Key;
+                }
+            }
+
+            public Enumerator GetEnumerator()
+            {
+                return new Enumerator(this._attributes);
+            }
+
+            public bool Remove(string item)
+            {
+                throw new NotSupportedException();
+            }
+
+            IEnumerator<string> IEnumerable<string>.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            public struct Enumerator : IEnumerator<string>
+            {
+                private AttributeValuesDictionary _attributes;
+                private int _index;
+
+                public Enumerator(AttributeValuesDictionary attributes)
+                {
+                    _attributes = attributes;
+                    _index = -1;
+                }
+
+                public string Current
+                {
+                    get
+                    {
+                        return _attributes.Get(_index).Key;
+                    }
+                }
+
+                object IEnumerator.Current
+                {
+                    get
+                    {
+                        return Current;
+                    }
+                }
+
+                public void Dispose()
+                {
+                }
+
+                public bool MoveNext()
+                {
+                    _index++;
+                    return _index < _attributes.Count;
+                }
+
+                public void Reset()
+                {
+                    _index = -1;
+                }
+            }
+        }
+
+        private class ValueCollection : ICollection<StringValuesTutu>
+        {
+            private readonly AttributeValuesDictionary _attributes;
+
+            public ValueCollection(AttributeValuesDictionary attributes)
+            {
+                _attributes = attributes;
+            }
+
+            public int Count => _attributes.Count;
+
+            public bool IsReadOnly => true;
+
+            public void Add(StringValuesTutu item)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void Clear()
+            {
+                throw new NotSupportedException();
+            }
+
+            public bool Contains(StringValuesTutu item)
+            {
+                for (var i = 0; i < _attributes.Count; i++)
+                {
+                    if (StringValuesTutu.Equals(item, _attributes.Get(i).Value, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            public void CopyTo(StringValuesTutu[] array, int arrayIndex)
+            {
+                if (array == null)
+                {
+                    throw new ArgumentNullException(nameof(array));
+                }
+
+                if (arrayIndex < 0 || arrayIndex >= array.Length)
+                {
+                    throw new IndexOutOfRangeException();
+                }
+
+                for (var i = 0; i < _attributes.Count; i++)
+                {
+                    array[arrayIndex + i] = _attributes.Get(i).Value;
+                }
+            }
+
+            public Enumerator GetEnumerator()
+            {
+                return new Enumerator(this._attributes);
+            }
+
+            public bool Remove(StringValuesTutu item)
+            {
+                throw new NotSupportedException();
+            }
+
+            IEnumerator<StringValuesTutu> IEnumerable<StringValuesTutu>.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            public struct Enumerator : IEnumerator<StringValuesTutu>
+            {
+                private AttributeValuesDictionary _attributes;
+                private int _index;
+
+                public Enumerator(AttributeValuesDictionary attributes)
+                {
+                    _attributes = attributes;
+                    _index = -1;
+                }
+
+                public StringValuesTutu Current
+                {
+                    get
+                    {
+                        return _attributes.Get(_index).Value;
+                    }
+                }
+
+                object IEnumerator.Current
+                {
+                    get
+                    {
+                        return Current;
+                    }
+                }
+
+                public void Dispose()
+                {
+                }
+
+                public bool MoveNext()
+                {
+                    _index++;
+                    return _index < _attributes.Count;
+                }
+
+                public void Reset()
+                {
+                    _index = -1;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/DefaultHtmlGenerator.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/DefaultHtmlGenerator.cs
@@ -22,7 +22,7 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 {
-    public class DefaultHtmlGenerator : IHtmlGenerator
+    public class DefaultHtmlGenerator : IHtmlGeneratorTutu
     {
         private const string HiddenListItem = @"<li style=""display:none""></li>";
         private static readonly MethodInfo ConvertEnumFromStringMethod =
@@ -181,6 +181,22 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             bool? isChecked,
             object htmlAttributes)
         {
+            return GenerateCheckBox(
+                viewContext,
+                modelExplorer,
+                new StringValuesTutu(expression),
+                isChecked,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public virtual TagBuilder GenerateCheckBox(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression,
+            bool? isChecked,
+            object htmlAttributes)
+        {
             if (viewContext == null)
             {
                 throw new ArgumentNullException(nameof(viewContext));
@@ -228,6 +244,15 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             ViewContext viewContext,
             ModelExplorer modelExplorer,
             string expression)
+        {
+            return GenerateHiddenForCheckbox(viewContext, modelExplorer, new StringValuesTutu(expression));
+        }
+
+        /// <inheritdoc />
+        public virtual TagBuilder GenerateHiddenForCheckbox(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression)
         {
             if (viewContext == null)
             {
@@ -315,6 +340,24 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             bool useViewData,
             object htmlAttributes)
         {
+            return GenerateHidden(
+                viewContext,
+                modelExplorer,
+                new StringValuesTutu(expression),
+                value,
+                useViewData,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public virtual TagBuilder GenerateHidden(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression,
+            object value,
+            bool useViewData,
+            object htmlAttributes)
+        {
             if (viewContext == null)
             {
                 throw new ArgumentNullException(nameof(viewContext));
@@ -350,6 +393,22 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             string labelText,
             object htmlAttributes)
         {
+            return GenerateLabel(
+                viewContext,
+                modelExplorer,
+                new StringValuesTutu(expression),
+                labelText,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public virtual TagBuilder GenerateLabel(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression,
+            string labelText,
+            object htmlAttributes)
+        {
             if (viewContext == null)
             {
                 throw new ArgumentNullException(nameof(viewContext));
@@ -363,23 +422,62 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             var resolvedLabelText = labelText ??
                 modelExplorer.Metadata.DisplayName ??
                 modelExplorer.Metadata.PropertyName;
+            StringValuesTutuContent content = null;
             if (resolvedLabelText == null)
             {
-                resolvedLabelText =
-                    string.IsNullOrEmpty(expression) ? string.Empty : expression.Split('.').Last();
+                if (StringValuesTutu.IsNullOrEmpty(expression))
+                {
+                    resolvedLabelText = string.Empty;
+                }
+                else
+                {
+                    for (var i = expression.Count - 1; i >= 0; i--)
+                    {
+                        var stringValue = expression[i];
+                        if (string.Equals(".", stringValue, StringComparison.Ordinal))
+                        {
+                            content = new StringValuesTutuContent(expression.Substring(i + 1));
+                            break;
+                        }
+
+                        var j = stringValue.LastIndexOf('.');
+                        if (j != -1)
+                        {
+                            var stringValues = StringValuesTutu.Concat(
+                                stringValue.Substring(j + 1),
+                                expression.Substring(i + 1));
+                            content = new StringValuesTutuContent(stringValues);
+                            break;
+                        }
+                    }
+
+                    if (content == null)
+                    {
+                        // Expression does not contain a dot separator.
+                        content = new StringValuesTutuContent(expression);
+                    }
+                }
             }
 
-            if (string.IsNullOrEmpty(resolvedLabelText))
+            if (content == null && string.IsNullOrEmpty(resolvedLabelText))
             {
                 return null;
             }
 
             var tagBuilder = new TagBuilder("label");
-            var idString =
-                TagBuilder.CreateSanitizedId(GetFullHtmlFieldName(viewContext, expression), IdAttributeDotReplacement);
-            tagBuilder.Attributes.Add("for", idString);
-            tagBuilder.InnerHtml.SetContent(resolvedLabelText);
+            var idString = TagBuilder.CreateSanitizedId(
+                GetFullHtmlFieldName(viewContext, expression),
+                IdAttributeDotReplacement);
+            tagBuilder.AttributeValues.Add("for", idString);
             tagBuilder.MergeAttributes(GetHtmlAttributeDictionaryOrNull(htmlAttributes), replaceExisting: true);
+            if (content == null)
+            {
+                tagBuilder.InnerHtml.SetContent(resolvedLabelText);
+            }
+            else
+            {
+                tagBuilder.InnerHtml.SetHtmlContent(content);
+            }
 
             return tagBuilder;
         }
@@ -389,6 +487,22 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             ViewContext viewContext,
             ModelExplorer modelExplorer,
             string expression,
+            object value,
+            object htmlAttributes)
+        {
+            return GeneratePassword(
+                viewContext,
+                modelExplorer,
+                new StringValuesTutu(expression),
+                value,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public virtual TagBuilder GeneratePassword(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression,
             object value,
             object htmlAttributes)
         {
@@ -421,6 +535,24 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             bool? isChecked,
             object htmlAttributes)
         {
+            return GenerateRadioButton(
+                viewContext,
+                modelExplorer,
+                new StringValuesTutu(expression),
+                value,
+                isChecked,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public virtual TagBuilder GenerateRadioButton(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression,
+            object value,
+            bool? isChecked,
+            object htmlAttributes)
+        {
             if (viewContext == null)
             {
                 throw new ArgumentNullException(nameof(viewContext));
@@ -442,7 +574,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                     // isChecked not provided nor found in the given attributes; fall back to view data.
                     var valueString = Convert.ToString(value, CultureInfo.CurrentCulture);
                     isChecked = string.Equals(
-                        EvalString(viewContext, expression),
+                        EvalString(viewContext, expression.ToString()),
                         valueString,
                         StringComparison.OrdinalIgnoreCase);
                 }
@@ -517,6 +649,26 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             bool allowMultiple,
             object htmlAttributes)
         {
+            return GenerateSelect(
+                viewContext,
+                modelExplorer,
+                optionLabel,
+                new StringValuesTutu(expression),
+                selectList,
+                allowMultiple,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateSelect(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            string optionLabel,
+            StringValuesTutu expression,
+            IEnumerable<SelectListItem> selectList,
+            bool allowMultiple,
+            object htmlAttributes)
+        {
             if (viewContext == null)
             {
                 throw new ArgumentNullException(nameof(viewContext));
@@ -545,13 +697,35 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             bool allowMultiple,
             object htmlAttributes)
         {
+            return GenerateSelect(
+                viewContext,
+                modelExplorer,
+                optionLabel,
+                new StringValuesTutu(expression),
+                selectList,
+                currentValues,
+                allowMultiple,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public virtual TagBuilder GenerateSelect(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            string optionLabel,
+            StringValuesTutu expression,
+            IEnumerable<SelectListItem> selectList,
+            ICollection<string> currentValues,
+            bool allowMultiple,
+            object htmlAttributes)
+        {
             if (viewContext == null)
             {
                 throw new ArgumentNullException(nameof(viewContext));
             }
 
             var fullName = GetFullHtmlFieldName(viewContext, expression);
-            if (string.IsNullOrEmpty(fullName))
+            if (StringValuesTutu.IsNullOrEmpty(fullName))
             {
                 throw new ArgumentException(
                     Resources.FormatHtmlGenerator_FieldNameCannotBeNullOrEmpty(
@@ -569,8 +743,10 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 selectList = GetSelectListItems(viewContext, expression);
             }
 
-            modelExplorer = modelExplorer ??
-                ExpressionMetadataProvider.FromStringExpression(expression, viewContext.ViewData, _metadataProvider);
+            modelExplorer = modelExplorer ?? ExpressionMetadataProvider.FromStringExpression(
+                expression.ToString(),
+                viewContext.ViewData,
+                _metadataProvider);
 
             // Convert each ListItem to an <option> tag and wrap them with <optgroup> if requested.
             var listItemBuilder = GenerateGroupsAndOptions(optionLabel, selectList, currentValues);
@@ -609,6 +785,24 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             int columns,
             object htmlAttributes)
         {
+            return GenerateTextArea(
+                viewContext,
+                modelExplorer,
+                new StringValuesTutu(expression),
+                rows,
+                columns,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public virtual TagBuilder GenerateTextArea(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression,
+            int rows,
+            int columns,
+            object htmlAttributes)
+        {
             if (viewContext == null)
             {
                 throw new ArgumentNullException(nameof(viewContext));
@@ -627,7 +821,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             }
 
             var fullName = GetFullHtmlFieldName(viewContext, expression);
-            if (string.IsNullOrEmpty(fullName))
+            if (StringValuesTutu.IsNullOrEmpty(fullName))
             {
                 throw new ArgumentException(
                     Resources.FormatHtmlGenerator_FieldNameCannotBeNullOrEmpty(
@@ -693,6 +887,24 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             string format,
             object htmlAttributes)
         {
+            return GenerateTextBox(
+                viewContext,
+                modelExplorer,
+                new StringValuesTutu(expression),
+                value,
+                format,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public virtual TagBuilder GenerateTextBox(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression,
+            object value,
+            string format,
+            object htmlAttributes)
+        {
             if (viewContext == null)
             {
                 throw new ArgumentNullException(nameof(viewContext));
@@ -722,13 +934,31 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             string tag,
             object htmlAttributes)
         {
+            return GenerateValidationMessage(
+                viewContext,
+                modelExplorer,
+                new StringValuesTutu(expression),
+                message,
+                tag,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public virtual TagBuilder GenerateValidationMessage(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression,
+            string message,
+            string tag,
+            object htmlAttributes)
+        {
             if (viewContext == null)
             {
                 throw new ArgumentNullException(nameof(viewContext));
             }
 
             var fullName = GetFullHtmlFieldName(viewContext, expression);
-            if (string.IsNullOrEmpty(fullName))
+            if (StringValuesTutu.IsNullOrEmpty(fullName))
             {
                 throw new ArgumentException(
                     Resources.FormatHtmlGenerator_FieldNameCannotBeNullOrEmpty(
@@ -784,7 +1014,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             else if (modelError != null)
             {
                 modelExplorer = modelExplorer ?? ExpressionMetadataProvider.FromStringExpression(
-                    expression,
+                    expression.ToString(),
                     viewContext.ViewData,
                     _metadataProvider);
                 tagBuilder.InnerHtml.SetContent(
@@ -816,7 +1046,8 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 throw new ArgumentNullException(nameof(viewContext));
             }
 
-            if (viewContext.ViewData.ModelState.IsValid && (!viewContext.ClientValidationEnabled || excludePropertyErrors))
+            if (viewContext.ViewData.ModelState.IsValid &&
+                (!viewContext.ClientValidationEnabled || excludePropertyErrors))
             {
                 // No client side validation/updates
                 return null;
@@ -899,13 +1130,23 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             string expression,
             bool allowMultiple)
         {
+            return GetCurrentValues(viewContext, modelExplorer, new StringValuesTutu(expression), allowMultiple);
+        }
+
+        /// <inheritdoc />
+        public virtual ICollection<string> GetCurrentValues(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression,
+            bool allowMultiple)
+        {
             if (viewContext == null)
             {
                 throw new ArgumentNullException(nameof(viewContext));
             }
 
             var fullName = GetFullHtmlFieldName(viewContext, expression);
-            if (string.IsNullOrEmpty(fullName))
+            if (StringValuesTutu.IsNullOrEmpty(fullName))
             {
                 throw new ArgumentException(
                     Resources.FormatHtmlGenerator_FieldNameCannotBeNullOrEmpty(
@@ -926,7 +1167,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 if (modelExplorer == null)
                 {
                     // Html.DropDownList() and Html.ListBox() helper case.
-                    rawValue = viewContext.ViewData.Eval(expression);
+                    rawValue = viewContext.ViewData.Eval(expression.ToString());
                     if (rawValue is IEnumerable<SelectListItem>)
                     {
                         // This ViewData item contains the fallback selectList collection for GenerateSelect().
@@ -962,8 +1203,11 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 rawValues = new[] { rawValue };
             }
 
-            modelExplorer = modelExplorer ??
-                ExpressionMetadataProvider.FromStringExpression(expression, viewContext.ViewData, _metadataProvider);
+            modelExplorer = modelExplorer ?? ExpressionMetadataProvider.FromStringExpression(
+                expression.ToString(),
+                viewContext.ViewData,
+                _metadataProvider);
+
             var metadata = modelExplorer.Metadata;
             if (allowMultiple && metadata.IsEnumerableType)
             {
@@ -1056,29 +1300,29 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 
             if (item.Value != null)
             {
-                tagBuilder.Attributes["value"] = item.Value;
+                tagBuilder.AttributeValues["value"] = item.Value;
             }
 
             if (selected)
             {
-                tagBuilder.Attributes["selected"] = "selected";
+                tagBuilder.AttributeValues["selected"] = "selected";
             }
 
             if (item.Disabled)
             {
-                tagBuilder.Attributes["disabled"] = "disabled";
+                tagBuilder.AttributeValues["disabled"] = "disabled";
             }
 
             return tagBuilder;
         }
 
-        internal static string GetFullHtmlFieldName(ViewContext viewContext, string expression)
+        internal static StringValuesTutu GetFullHtmlFieldName(ViewContext viewContext, StringValuesTutu expression)
         {
             var fullName = viewContext.ViewData.TemplateInfo.GetFullHtmlFieldName(expression);
             return fullName;
         }
 
-        internal static object GetModelStateValue(ViewContext viewContext, string key, Type destinationType)
+        internal static object GetModelStateValue(ViewContext viewContext, StringValuesTutu key, Type destinationType)
         {
             ModelStateEntry entry;
             if (viewContext.ViewData.ModelState.TryGetValue(key, out entry) && entry.RawValue != null)
@@ -1145,6 +1389,33 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             string format,
             IDictionary<string, object> htmlAttributes)
         {
+            return GenerateInput(
+                viewContext,
+                inputType,
+                modelExplorer,
+                new StringValuesTutu(expression),
+                value,
+                useViewData,
+                isChecked,
+                setId,
+                isExplicitValue,
+                format,
+                htmlAttributes);
+        }
+
+        protected virtual TagBuilder GenerateInput(
+            ViewContext viewContext,
+            InputType inputType,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression,
+            object value,
+            bool useViewData,
+            bool isChecked,
+            bool setId,
+            bool isExplicitValue,
+            string format,
+            IDictionary<string, object> htmlAttributes)
+        {
             if (viewContext == null)
             {
                 throw new ArgumentNullException(nameof(viewContext));
@@ -1154,7 +1425,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             // elements. But we support the *ForModel() methods in any lower-level template, once HtmlFieldPrefix is
             // non-empty.
             var fullName = GetFullHtmlFieldName(viewContext, expression);
-            if (string.IsNullOrEmpty(fullName))
+            if (StringValuesTutu.IsNullOrEmpty(fullName))
             {
                 throw new ArgumentException(
                     Resources.FormatHtmlGenerator_FieldNameCannotBeNullOrEmpty(
@@ -1173,7 +1444,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             tagBuilder.MergeAttribute("type", inputTypeString);
             tagBuilder.MergeAttribute("name", fullName, replaceExisting: true);
 
-            var suppliedTypeString = tagBuilder.Attributes["type"];
+            var suppliedTypeString = tagBuilder.AttributeValues["type"][0];
             if (_placeholderInputTypes.Contains(suppliedTypeString))
             {
                 AddPlaceholderAttribute(viewContext.ViewData, tagBuilder, modelExplorer, expression);
@@ -1206,7 +1477,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 
                     if (!usedModelState && useViewData)
                     {
-                        isChecked = EvalBoolean(viewContext, expression);
+                        isChecked = EvalBoolean(viewContext, expression.ToString());
                     }
 
                     if (isChecked)
@@ -1230,7 +1501,9 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                     var attributeValue = (string)GetModelStateValue(viewContext, fullName, typeof(string));
                     if (attributeValue == null)
                     {
-                        attributeValue = useViewData ? EvalString(viewContext, expression, format) : valueParameter;
+                        attributeValue = useViewData ?
+                            EvalString(viewContext, expression.ToString(), format) :
+                            valueParameter;
                     }
 
                     var addValue = true;
@@ -1302,7 +1575,20 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             ModelExplorer modelExplorer,
             string expression)
         {
-            modelExplorer = modelExplorer ?? ExpressionMetadataProvider.FromStringExpression(expression, viewData, _metadataProvider);
+            AddPlaceholderAttribute(viewData, tagBuilder, modelExplorer, new StringValuesTutu(expression));
+        }
+
+        protected virtual void AddPlaceholderAttribute(
+            ViewDataDictionary viewData,
+            TagBuilder tagBuilder,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression)
+        {
+            modelExplorer = modelExplorer ?? ExpressionMetadataProvider.FromStringExpression(
+                expression.ToString(),
+                viewData,
+                _metadataProvider);
+
             var placeholder = modelExplorer.Metadata.Placeholder;
             if (!string.IsNullOrEmpty(placeholder))
             {
@@ -1324,6 +1610,15 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             ModelExplorer modelExplorer,
             string expression)
         {
+            AddValidationAttributes(viewContext, tagBuilder, modelExplorer, new StringValuesTutu(expression));
+        }
+
+        protected virtual void AddValidationAttributes(
+            ViewContext viewContext,
+            TagBuilder tagBuilder,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression)
+        {
             // Only render attributes if client-side validation is enabled, and then only if we've
             // never rendered validation for a field with this name in this form.
             var formContext = viewContext.ClientValidationEnabled ? viewContext.FormContext : null;
@@ -1340,11 +1635,14 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 
             formContext.RenderedField(fullName, true);
 
-            modelExplorer = modelExplorer ??
-                ExpressionMetadataProvider.FromStringExpression(expression, viewContext.ViewData, _metadataProvider);
+            modelExplorer = modelExplorer ?? ExpressionMetadataProvider.FromStringExpression(
+                expression.ToString(),
+                viewContext.ViewData,
+                _metadataProvider);
 
-
-            var validators = _clientValidatorCache.GetValidators(modelExplorer.Metadata, _clientModelValidatorProvider);
+            var validators = _clientValidatorCache.GetValidators(
+                modelExplorer.Metadata,
+                _clientModelValidatorProvider);
             if (validators.Count > 0)
             {
                 var validationContext = new ClientModelValidationContext(
@@ -1434,7 +1732,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 
         private static IEnumerable<SelectListItem> GetSelectListItems(
             ViewContext viewContext,
-            string expression)
+            StringValuesTutu expression)
         {
             if (viewContext == null)
             {
@@ -1444,7 +1742,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             // Method is called only if user did not pass a select list in. They must provide select list items in the
             // ViewData dictionary and definitely not as the Model. (Even if the Model datatype were correct, a
             // <select> element generated for a collection of SelectListItems would be useless.)
-            var value = viewContext.ViewData.Eval(expression);
+            var value = viewContext.ViewData.Eval(expression.ToString());
 
             // First check whether above evaluation was successful and did not match ViewData.Model.
             if (value == null || value == viewContext.ViewData.Model)

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/FormContext.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/FormContext.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
     /// </remarks>
     public class FormContext
     {
-        private Dictionary<string, bool> _renderedFields;
+        private Dictionary<StringValuesTutu, bool> _renderedFields;
         private Dictionary<string, object> _formData;
         private IList<IHtmlContent> _endOfFormContent;
 
@@ -96,13 +96,13 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         /// Gets a dictionary mapping full HTML field names to indications that the named field has been rendered in
         /// this &lt;form&gt;.
         /// </summary>
-        private Dictionary<string, bool> RenderedFields
+        private Dictionary<StringValuesTutu, bool> RenderedFields
         {
             get
             {
                 if (_renderedFields == null)
                 {
-                    _renderedFields = new Dictionary<string, bool>(StringComparer.Ordinal);
+                    _renderedFields = new Dictionary<StringValuesTutu, bool>();
                 }
 
                 return _renderedFields;
@@ -131,6 +131,22 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         }
 
         /// <summary>
+        /// Returns an indication based on <see cref="RenderedFields"/> that the given <paramref name="fieldName"/> has
+        /// been rendered in this &lt;form&gt;.
+        /// </summary>
+        /// <param name="fieldName">The full HTML name of a field that may have been rendered.</param>
+        /// <returns>
+        /// <c>true</c> if the given <paramref name="fieldName"/> has been rendered; <c>false</c> otherwise.
+        /// </returns>
+        public bool RenderedField(StringValuesTutu fieldName)
+        {
+            bool result;
+            RenderedFields.TryGetValue(fieldName, out result);
+
+            return result;
+        }
+
+        /// <summary>
         /// Updates <see cref="RenderedFields"/> to indicate <paramref name="fieldName"/> has been rendered in this
         /// &lt;form&gt;.
         /// </summary>
@@ -143,6 +159,17 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 throw new ArgumentNullException(nameof(fieldName));
             }
 
+            RenderedFields[fieldName] = value;
+        }
+
+        /// <summary>
+        /// Updates <see cref="RenderedFields"/> to indicate <paramref name="fieldName"/> has been rendered in this
+        /// &lt;form&gt;.
+        /// </summary>
+        /// <param name="fieldName">The full HTML name of a field that may have been rendered.</param>
+        /// <param name="value">If <c>true</c>, the given <paramref name="fieldName"/> has been rendered.</param>
+        public void RenderedField(StringValuesTutu fieldName, bool value)
+        {
             RenderedFields[fieldName] = value;
         }
     }

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/HtmlGeneratorAdapter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/HtmlGeneratorAdapter.cs
@@ -1,0 +1,553 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace Microsoft.AspNetCore.Mvc.ViewFeatures
+{
+    /// <summary>
+    /// Adapts an <see cref="IHtmlGenerator"/> implementation to provide all of the <see cref="IHtmlGeneratorTutu"/>
+    /// interface.
+    /// </summary>
+    public class HtmlGeneratorAdapter : IHtmlGeneratorTutu
+    {
+        private readonly IHtmlGenerator _innerGenerator;
+
+        private HtmlGeneratorAdapter(IHtmlGenerator innerGenerator)
+        {
+            _innerGenerator = innerGenerator;
+        }
+
+        /// <inheritdoc />
+        public string IdAttributeDotReplacement => _innerGenerator.IdAttributeDotReplacement;
+
+        /// <summary>
+        /// Return a full <see cref="IHtmlGeneratorTutu"/> implementation based on the given
+        /// <paramref name="generator"/>.
+        /// </summary>
+        /// <param name="generator">The <see cref="IHtmlGenerator"/> implementation to cast or wrap.</param>
+        /// <returns>The <see cref="IHtmlGeneratorTutu"/> implementation.</returns>
+        public static IHtmlGeneratorTutu GetTuTu(IHtmlGenerator generator)
+        {
+            if (generator == null)
+            {
+                throw new ArgumentNullException(nameof(generator));
+            }
+
+            var generatorTuTu = generator as IHtmlGeneratorTutu;
+            if (generatorTuTu != null)
+            {
+                return generatorTuTu;
+            }
+
+            return new HtmlGeneratorAdapter(generator);
+        }
+
+        /// <inheritdoc />
+        public string Encode(object value)
+        {
+            return _innerGenerator.Encode(value);
+        }
+
+        /// <inheritdoc />
+        public string Encode(string value)
+        {
+            return _innerGenerator.Encode(value);
+        }
+
+        /// <inheritdoc />
+        public string FormatValue(object value, string format)
+        {
+            return _innerGenerator.FormatValue(value, format);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateActionLink(
+            ViewContext viewContext,
+            string linkText,
+            string actionName,
+            string controllerName,
+            string protocol,
+            string hostname,
+            string fragment,
+            object routeValues,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GenerateActionLink(
+                viewContext,
+                linkText,
+                actionName,
+                controllerName,
+                protocol,
+                hostname,
+                fragment,
+                routeValues,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public IHtmlContent GenerateAntiforgery(ViewContext viewContext)
+        {
+            return _innerGenerator.GenerateAntiforgery(viewContext);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateCheckBox(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            string expression,
+            bool? isChecked,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GenerateCheckBox(viewContext, modelExplorer, expression, isChecked, htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateCheckBox(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression,
+            bool? isChecked,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GenerateCheckBox(
+                viewContext,
+                modelExplorer,
+                expression.ToString(),
+                isChecked,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateForm(
+            ViewContext viewContext,
+            string actionName,
+            string controllerName,
+            object routeValues,
+            string method,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GenerateForm(
+                viewContext,
+                actionName,
+                controllerName,
+                routeValues,
+                method,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public IHtmlContent GenerateGroupsAndOptions(string optionLabel, IEnumerable<SelectListItem> selectList)
+        {
+            return _innerGenerator.GenerateGroupsAndOptions(optionLabel, selectList);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateHidden(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            string expression,
+            object value,
+            bool useViewData,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GenerateHidden(
+                viewContext,
+                modelExplorer,
+                expression,
+                value,
+                useViewData,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateHidden(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression,
+            object value,
+            bool useViewData,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GenerateHidden(
+                viewContext,
+                modelExplorer,
+                expression.ToString(),
+                value,
+                useViewData,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateHiddenForCheckbox(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            string expression)
+        {
+            return _innerGenerator.GenerateHiddenForCheckbox(viewContext, modelExplorer, expression);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateHiddenForCheckbox(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression)
+        {
+            return _innerGenerator.GenerateHiddenForCheckbox(viewContext, modelExplorer, expression.ToString());
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateLabel(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            string expression,
+            string labelText,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GenerateLabel(viewContext, modelExplorer, expression, labelText, htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateLabel(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression,
+            string labelText,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GenerateLabel(
+                viewContext,
+                modelExplorer,
+                expression.ToString(),
+                labelText,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GeneratePassword(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            string expression,
+            object value,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GeneratePassword(viewContext, modelExplorer, expression, value, htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GeneratePassword(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression,
+            object value,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GeneratePassword(
+                viewContext,
+                modelExplorer,
+                expression.ToString(),
+                value,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateRadioButton(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            string expression,
+            object value,
+            bool? isChecked,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GenerateRadioButton(
+                viewContext,
+                modelExplorer,
+                expression,
+                value,
+                isChecked,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateRadioButton(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression,
+            object value,
+            bool? isChecked,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GenerateRadioButton(
+                viewContext,
+                modelExplorer,
+                expression.ToString(),
+                value,
+                isChecked,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateRouteForm(
+            ViewContext viewContext,
+            string routeName,
+            object routeValues,
+            string method,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GenerateRouteForm(viewContext, routeName, routeValues, method, htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateRouteLink(
+            ViewContext viewContext,
+            string linkText,
+            string routeName,
+            string protocol,
+            string hostName,
+            string fragment,
+            object routeValues,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GenerateRouteLink(
+                viewContext,
+                linkText,
+                routeName,
+                protocol,
+                hostName,
+                fragment,
+                routeValues,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateSelect(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            string optionLabel,
+            string expression,
+            IEnumerable<SelectListItem> selectList,
+            bool allowMultiple,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GenerateSelect(
+                viewContext,
+                modelExplorer,
+                optionLabel,
+                expression,
+                selectList,
+                allowMultiple,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateSelect(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            string optionLabel,
+            StringValuesTutu expression,
+            IEnumerable<SelectListItem> selectList,
+            bool allowMultiple,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GenerateSelect(
+                viewContext,
+                modelExplorer,
+                optionLabel,
+                expression.ToString(),
+                selectList,
+                allowMultiple,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateSelect(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            string optionLabel,
+            string expression,
+            IEnumerable<SelectListItem> selectList,
+            ICollection<string> currentValues,
+            bool allowMultiple,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GenerateSelect(
+                viewContext,
+                modelExplorer,
+                optionLabel,
+                expression,
+                selectList,
+                currentValues,
+                allowMultiple,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateSelect(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            string optionLabel,
+            StringValuesTutu expression,
+            IEnumerable<SelectListItem> selectList,
+            ICollection<string> currentValues,
+            bool allowMultiple,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GenerateSelect(
+                viewContext,
+                modelExplorer,
+                optionLabel,
+                expression.ToString(),
+                selectList,
+                currentValues,
+                allowMultiple,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateTextArea(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            string expression,
+            int rows,
+            int columns,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GenerateTextArea(
+                viewContext,
+                modelExplorer,
+                expression,
+                rows,
+                columns,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateTextArea(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression,
+            int rows,
+            int columns,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GenerateTextArea(
+                viewContext,
+                modelExplorer,
+                expression.ToString(),
+                rows,
+                columns,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateTextBox(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            string expression,
+            object value,
+            string format,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GenerateTextBox(
+                viewContext,
+                modelExplorer,
+                expression,
+                value,
+                format,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateTextBox(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression,
+            object value,
+            string format,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GenerateTextBox(
+                viewContext,
+                modelExplorer,
+                expression.ToString(),
+                value,
+                format,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateValidationMessage(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            string expression,
+            string message,
+            string tag,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GenerateValidationMessage(
+                viewContext,
+                modelExplorer,
+                expression,
+                message,
+                tag,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateValidationMessage(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression,
+            string message,
+            string tag,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GenerateValidationMessage(
+                viewContext,
+                modelExplorer,
+                expression.ToString(),
+                message,
+                tag,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public TagBuilder GenerateValidationSummary(
+            ViewContext viewContext,
+            bool excludePropertyErrors,
+            string message,
+            string headerTag,
+            object htmlAttributes)
+        {
+            return _innerGenerator.GenerateValidationSummary(
+                viewContext,
+                excludePropertyErrors,
+                message,
+                headerTag,
+                htmlAttributes);
+        }
+
+        /// <inheritdoc />
+        public ICollection<string> GetCurrentValues(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            string expression,
+            bool allowMultiple)
+        {
+            return _innerGenerator.GetCurrentValues(viewContext, modelExplorer, expression, allowMultiple);
+        }
+
+        /// <inheritdoc />
+        public ICollection<string> GetCurrentValues(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression,
+            bool allowMultiple)
+        {
+            return _innerGenerator.GetCurrentValues(viewContext, modelExplorer, expression.ToString(), allowMultiple);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/HtmlHelperOfT.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/HtmlHelperOfT.cs
@@ -128,9 +128,18 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             }
 
             var modelExplorer = GetModelExplorer(expression);
+            if (htmlFieldName != null)
+            {
+                return GenerateDisplay(
+                    modelExplorer,
+                    htmlFieldName,
+                    templateName,
+                    additionalViewData);
+            }
+
             return GenerateDisplay(
                 modelExplorer,
-                htmlFieldName ?? GetExpressionName(expression),
+                GetExpressionName(expression),
                 templateName,
                 additionalViewData);
         }
@@ -272,7 +281,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             }
 
             var expressionName = GetExpressionName(expression);
-            return Name(expressionName);
+            return GenerateName(expressionName);
         }
 
         /// <inheritdoc />
@@ -354,7 +363,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 htmlAttributes);
         }
 
-        protected string GetExpressionName<TResult>(Expression<Func<TModel, TResult>> expression)
+        protected StringValuesTutu GetExpressionName<TResult>(Expression<Func<TModel, TResult>> expression)
         {
             if (expression == null)
             {

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/IHtmlGeneratorTutu.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/IHtmlGeneratorTutu.cs
@@ -1,69 +1,13 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 {
-    /// <summary>
-    /// Contract for a service supporting <see cref="IHtmlHelper"/> and <c>ITagHelper</c> implementations.
-    /// </summary>
-    public interface IHtmlGenerator
+    public interface IHtmlGeneratorTutu : IHtmlGenerator
     {
-        string IdAttributeDotReplacement { get; }
-
-        string Encode(string value);
-
-        string Encode(object value);
-
-        string FormatValue(object value, string format);
-
-        /// <summary>
-        /// Generate a &lt;a&gt; element for a link to an action.
-        /// </summary>
-        /// <param name="viewContext">The <see cref="ViewContext"/> instance for the current scope.</param>
-        /// <param name="linkText">The text to insert inside the element.</param>
-        /// <param name="actionName">The name of the action method.</param>
-        /// <param name="controllerName">The name of the controller.</param>
-        /// <param name="protocol">The protocol (scheme) for the generated link.</param>
-        /// <param name="hostname">The hostname for the generated link.</param>
-        /// <param name="fragment">The fragment for the genrated link.</param>
-        /// <param name="routeValues">
-        /// An <see cref="object"/> that contains the parameters for a route. The parameters are retrieved through
-        /// reflection by examining the properties of the <see cref="object"/>. This <see cref="object"/> is typically
-        /// created using <see cref="object"/> initializer syntax. Alternatively, an
-        /// <see cref="IDictionary{String, Object}"/> instance containing the route parameters.
-        /// </param>
-        /// <param name="htmlAttributes">
-        /// An <see cref="object"/> that contains the HTML attributes for the element. Alternatively, an
-        /// <see cref="IDictionary{String, Object}"/> instance containing the HTML attributes.
-        /// </param>
-        /// <returns>
-        /// A <see cref="TagBuilder"/> instance for the &lt;a&gt; element.
-        /// </returns>
-        TagBuilder GenerateActionLink(
-            ViewContext viewContext,
-            string linkText,
-            string actionName,
-            string controllerName,
-            string protocol,
-            string hostname,
-            string fragment,
-            object routeValues,
-            object htmlAttributes);
-
-        /// <summary>
-        /// Generate an &lt;input type="hidden".../&gt; element containing an antiforgery token.
-        /// </summary>
-        /// <param name="viewContext">The <see cref="ViewContext"/> instance for the current scope.</param>
-        /// <returns>
-        /// An <see cref="IHtmlContent"/> instance for the &lt;input type="hidden".../&gt; element. Intended to be used
-        /// inside a &lt;form&gt; element.
-        /// </returns>
-        IHtmlContent GenerateAntiforgery(ViewContext viewContext);
-
         /// <summary>
         /// Generate a &lt;input type="checkbox".../&gt; element.
         /// </summary>
@@ -81,8 +25,16 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         TagBuilder GenerateCheckBox(
             ViewContext viewContext,
             ModelExplorer modelExplorer,
-            string expression,
+            StringValuesTutu expression,
             bool? isChecked,
+            object htmlAttributes);
+
+        TagBuilder GenerateHidden(
+            ViewContext viewContext,
+            ModelExplorer modelExplorer,
+            StringValuesTutu expression,
+            object value,
+            bool useViewData,
             object htmlAttributes);
 
         /// <summary>
@@ -93,124 +45,28 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         TagBuilder GenerateHiddenForCheckbox(
             ViewContext viewContext,
             ModelExplorer modelExplorer,
-            string expression);
-
-        /// <summary>
-        /// Generate a &lt;form&gt; element. When the user submits the form, the action with name
-        /// <paramref name="actionName"/> will process the request.
-        /// </summary>
-        /// <param name="viewContext">A <see cref="ViewContext"/> instance for the current scope.</param>
-        /// <param name="actionName">The name of the action method.</param>
-        /// <param name="controllerName">The name of the controller.</param>
-        /// <param name="routeValues">
-        /// An <see cref="object"/> that contains the parameters for a route. The parameters are retrieved through
-        /// reflection by examining the properties of the <see cref="object"/>. This <see cref="object"/> is typically
-        /// created using <see cref="object"/> initializer syntax. Alternatively, an
-        /// <see cref="IDictionary{String, Object}"/> instance containing the route parameters.
-        /// </param>
-        /// <param name="method">The HTTP method for processing the form, either GET or POST.</param>
-        /// <param name="htmlAttributes">
-        /// An <see cref="object"/> that contains the HTML attributes for the element. Alternatively, an
-        /// <see cref="IDictionary{String, Object}"/> instance containing the HTML attributes.
-        /// </param>
-        /// <returns>
-        /// A <see cref="TagBuilder"/> instance for the &lt;/form&gt; element.
-        /// </returns>
-        TagBuilder GenerateForm(
-            ViewContext viewContext,
-            string actionName,
-            string controllerName,
-            object routeValues,
-            string method,
-            object htmlAttributes);
-
-        /// <summary>
-        /// Generate a &lt;form&gt; element. The route with name <paramref name="routeName"/> generates the
-        /// &lt;form&gt;'s <c>action</c> attribute value.
-        /// </summary>
-        /// <param name="viewContext">A <see cref="ViewContext"/> instance for the current scope.</param>
-        /// <param name="routeName">The name of the route.</param>
-        /// <param name="routeValues">
-        /// An <see cref="object"/> that contains the parameters for a route. The parameters are retrieved through
-        /// reflection by examining the properties of the <see cref="object"/>. This <see cref="object"/> is typically
-        /// created using <see cref="object"/> initializer syntax. Alternatively, an
-        /// <see cref="IDictionary{String, Object}"/> instance containing the route parameters.
-        /// </param>
-        /// <param name="method">The HTTP method for processing the form, either GET or POST.</param>
-        /// <param name="htmlAttributes">
-        /// An <see cref="object"/> that contains the HTML attributes for the element. Alternatively, an
-        /// <see cref="IDictionary{String, Object}"/> instance containing the HTML attributes.
-        /// </param>
-        /// <returns>
-        /// A <see cref="TagBuilder"/> instance for the &lt;/form&gt; element.
-        /// </returns>
-        TagBuilder GenerateRouteForm(
-            ViewContext viewContext,
-            string routeName,
-            object routeValues,
-            string method,
-            object htmlAttributes);
-
-        TagBuilder GenerateHidden(
-            ViewContext viewContext,
-            ModelExplorer modelExplorer,
-            string expression,
-            object value,
-            bool useViewData,
-            object htmlAttributes);
+            StringValuesTutu expression);
 
         TagBuilder GenerateLabel(
             ViewContext viewContext,
             ModelExplorer modelExplorer,
-            string expression,
+            StringValuesTutu expression,
             string labelText,
             object htmlAttributes);
 
         TagBuilder GeneratePassword(
             ViewContext viewContext,
             ModelExplorer modelExplorer,
-            string expression,
+            StringValuesTutu expression,
             object value,
             object htmlAttributes);
 
         TagBuilder GenerateRadioButton(
             ViewContext viewContext,
             ModelExplorer modelExplorer,
-            string expression,
+            StringValuesTutu expression,
             object value,
             bool? isChecked,
-            object htmlAttributes);
-
-        /// <summary>
-        /// Generate a &lt;a&gt; element for a link to an action.
-        /// </summary>
-        /// <param name="viewContext">The <see cref="ViewContext"/> instance for the current scope.</param>
-        /// <param name="linkText">The text to insert inside the element.</param>
-        /// <param name="routeName">The name of the route to use for link generation.</param>
-        /// <param name="protocol">The protocol (scheme) for the generated link.</param>
-        /// <param name="hostName">The hostname for the generated link.</param>
-        /// <param name="fragment">The fragment for the genrated link.</param>
-        /// <param name="routeValues">
-        /// An <see cref="object"/> that contains the parameters for a route. The parameters are retrieved through
-        /// reflection by examining the properties of the <see cref="object"/>. This <see cref="object"/> is typically
-        /// created using <see cref="object"/> initializer syntax. Alternatively, an
-        /// <see cref="IDictionary{String, Object}"/> instance containing the route parameters.
-        /// </param>
-        /// <param name="htmlAttributes">
-        /// An <see cref="object"/> that contains the HTML attributes for the element. Alternatively, an
-        /// <see cref="IDictionary{String, Object}"/> instance containing the HTML attributes.
-        /// </param>
-        /// <returns>
-        /// A <see cref="TagBuilder"/> instance for the &lt;a&gt; element.
-        /// </returns>
-        TagBuilder GenerateRouteLink(
-            ViewContext viewContext,
-            string linkText,
-            string routeName,
-            string protocol,
-            string hostName,
-            string fragment,
-            object routeValues,
             object htmlAttributes);
 
         /// <summary>
@@ -251,7 +107,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             ViewContext viewContext,
             ModelExplorer modelExplorer,
             string optionLabel,
-            string expression,
+            StringValuesTutu expression,
             IEnumerable<SelectListItem> selectList,
             bool allowMultiple,
             object htmlAttributes);
@@ -300,29 +156,16 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             ViewContext viewContext,
             ModelExplorer modelExplorer,
             string optionLabel,
-            string expression,
+            StringValuesTutu expression,
             IEnumerable<SelectListItem> selectList,
             ICollection<string> currentValues,
             bool allowMultiple,
             object htmlAttributes);
 
-        /// <summary>
-        /// Generates &lt;optgroup&gt; and &lt;option&gt; elements.
-        /// </summary>
-        /// <param name="optionLabel">Optional text for a default empty &lt;option&gt; element.</param>
-        /// <param name="selectList">
-        /// A collection of <see cref="SelectListItem"/> objects used to generate &lt;optgroup&gt; and &lt;option&gt;
-        /// elements.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IHtmlContent"/> instance for &lt;optgroup&gt; and &lt;option&gt; elements.
-        /// </returns>
-        IHtmlContent GenerateGroupsAndOptions(string optionLabel, IEnumerable<SelectListItem> selectList);
-
         TagBuilder GenerateTextArea(
             ViewContext viewContext,
             ModelExplorer modelExplorer,
-            string expression,
+            StringValuesTutu expression,
             int rows,
             int columns,
             object htmlAttributes);
@@ -330,7 +173,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         TagBuilder GenerateTextBox(
             ViewContext viewContext,
             ModelExplorer modelExplorer,
-            string expression,
+            StringValuesTutu expression,
             object value,
             string format,
             object htmlAttributes);
@@ -365,16 +208,9 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         TagBuilder GenerateValidationMessage(
             ViewContext viewContext,
             ModelExplorer modelExplorer,
-            string expression,
+            StringValuesTutu expression,
             string message,
             string tag,
-            object htmlAttributes);
-
-        TagBuilder GenerateValidationSummary(
-            ViewContext viewContext,
-            bool excludePropertyErrors,
-            string message,
-            string headerTag,
             object htmlAttributes);
 
         /// <summary>
@@ -414,7 +250,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         ICollection<string> GetCurrentValues(
             ViewContext viewContext,
             ModelExplorer modelExplorer,
-            string expression,
+            StringValuesTutu expression,
             bool allowMultiple);
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ModelExpression.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ModelExpression.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
 namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 {
@@ -33,14 +32,27 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 throw new ArgumentNullException(nameof(modelExplorer));
             }
 
-            Name = name;
+            NameValues = new StringValuesTutu(name);
+            ModelExplorer = modelExplorer;
+        }
+
+        public ModelExpression(StringValuesTutu nameValues, ModelExplorer modelExplorer)
+        {
+            if (modelExplorer == null)
+            {
+                throw new ArgumentNullException(nameof(modelExplorer));
+            }
+
+            NameValues = nameValues;
             ModelExplorer = modelExplorer;
         }
 
         /// <summary>
         /// String representation of the <see cref="System.Linq.Expressions.Expression"/> of interest.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name => NameValues.ToString();
+
+        public StringValuesTutu NameValues { get; }
 
         /// <summary>
         /// Metadata about the <see cref="System.Linq.Expressions.Expression"/> of interest.

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/StringValuesTutuContent.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/StringValuesTutuContent.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Microsoft.AspNetCore.Mvc.ViewFeatures
+{
+    [DebuggerDisplay("{DebuggerToString()}")]
+    public class StringValuesTutuContent : IHtmlContent
+    {
+        private readonly StringValuesTutu _stringValues;
+
+        public StringValuesTutuContent(StringValuesTutu stringValues)
+        {
+            _stringValues = stringValues;
+        }
+
+        public virtual void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            foreach (var value in _stringValues)
+            {
+                encoder.Encode(writer, value);
+            }
+        }
+
+        private string DebuggerToString()
+        {
+            return _stringValues.ToString();
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/TemplateBuilder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/TemplateBuilder.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
         private readonly ModelExplorer _modelExplorer;
         private object _model;
         private readonly ModelMetadata _metadata;
-        private readonly string _htmlFieldName;
+        private readonly StringValuesTutu _htmlFieldName;
         private readonly string _templateName;
         private readonly bool _readOnly;
         private readonly object _additionalViewData;
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             ViewContext viewContext,
             ViewDataDictionary viewData,
             ModelExplorer modelExplorer,
-            string htmlFieldName,
+            StringValuesTutu htmlFieldName,
             string templateName,
             bool readOnly,
             object additionalViewData)
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             viewData.ModelExplorer = _modelExplorer.GetExplorerForModel(_model);
 
             viewData.TemplateInfo.FormattedModelValue = formattedModelValue;
-            viewData.TemplateInfo.HtmlFieldPrefix = _viewData.TemplateInfo.GetFullHtmlFieldName(_htmlFieldName);
+            viewData.TemplateInfo.HtmlFieldPrefixValues = _viewData.TemplateInfo.GetFullHtmlFieldName(_htmlFieldName);
 
             if (_additionalViewData != null)
             {

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/MediaTypeTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/MediaTypeTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Linq;
 using Microsoft.Extensions.Primitives;
 using Xunit;
 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/StreamOutputFormatterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/StreamOutputFormatterTest.cs
@@ -3,10 +3,7 @@
 
 using System;
 using System.IO;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Primitives;
 using Xunit;
 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/MediaTypeCollectionTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/MediaTypeCollectionTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using Xunit;
 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/CompositeValueProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/CompositeValueProviderTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Primitives;
 using Moq;
 using Xunit;

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/EnumerableValueProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/EnumerableValueProviderTest.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Primitives;
 using Xunit;
 

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.EditWarehouse.Encoded.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.EditWarehouse.Encoded.html
@@ -7,34 +7,34 @@
         </div>
         <div>
             <label>HtmlEncode[[Address]]</label>
-            <textarea id="HtmlEncode[[Employee_Address]]" name="HtmlEncode[[Employee.Address]]">
+            <textarea id="HtmlEncode[[Employee]]HtmlEncode[[_]]HtmlEncode[[Address]]" name="HtmlEncode[[Employee]]HtmlEncode[[.]]HtmlEncode[[Address]]">
 HtmlEncode[[Address_1]]</textarea>;
         </div>
         <div>
-            <label for="HtmlEncode[[Employee_Password]]">HtmlEncode[[Password]]</label>
-            <input data-val="HtmlEncode[[true]]" data-val-required="HtmlEncode[[The Password field is required.]]" id="HtmlEncode[[Employee_Password]]" name="HtmlEncode[[Employee.Password]]" type="HtmlEncode[[password]]" />
+            <label for="HtmlEncode[[Employee]]HtmlEncode[[_]]HtmlEncode[[Password]]">HtmlEncode[[Password]]</label>
+            <input data-val="HtmlEncode[[true]]" data-val-required="HtmlEncode[[The Password field is required.]]" id="HtmlEncode[[Employee]]HtmlEncode[[_]]HtmlEncode[[Password]]" name="HtmlEncode[[Employee]]HtmlEncode[[.]]HtmlEncode[[Password]]" type="HtmlEncode[[password]]" />
         </div>
         <div>
             <label>HtmlEncode[[PhoneNumber]]</label>
-            <input id="HtmlEncode[[Employee_PhoneNumber]]" name="HtmlEncode[[Employee.PhoneNumber]]" type="HtmlEncode[[text]]" value="HtmlEncode[[PhoneNumber_1]]" />
+            <input id="HtmlEncode[[Employee]]HtmlEncode[[_]]HtmlEncode[[PhoneNumber]]" name="HtmlEncode[[Employee]]HtmlEncode[[.]]HtmlEncode[[PhoneNumber]]" type="HtmlEncode[[text]]" value="HtmlEncode[[PhoneNumber_1]]" />
         </div>
         <div>
             <label for="HtmlEncode[[Employee_Name]]">HtmlEncode[[Employee.Name]]</label>
-            <input type="HtmlEncode[[text]]" id="HtmlEncode[[Employee_Name]]" name="HtmlEncode[[Employee.Name]]" value="HtmlEncode[[EmployeeName_1]]" />
-            <span class="HtmlEncode[[field-validation-valid]]" data-valmsg-for="HtmlEncode[[Employee.Name]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
+            <input type="HtmlEncode[[text]]" id="HtmlEncode[[Employee]]HtmlEncode[[_]]HtmlEncode[[Name]]" name="HtmlEncode[[Employee]]HtmlEncode[[.]]HtmlEncode[[Name]]" value="HtmlEncode[[EmployeeName_1]]" />
+            <span class="HtmlEncode[[field-validation-valid]]" data-valmsg-for="HtmlEncode[[Employee]]HtmlEncode[[.]]HtmlEncode[[Name]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
         </div>
         <div>
-            <label for="HtmlEncode[[Employee_Gender]]">HtmlEncode[[Gender]]</label>
-            <input checked="HtmlEncode[[checked]]" data-val="HtmlEncode[[true]]" data-val-required="HtmlEncode[[The Gender field is required.]]" id="HtmlEncode[[Employee_Gender]]" name="HtmlEncode[[Employee.Gender]]" type="HtmlEncode[[radio]]" value="HtmlEncode[[Female]]" /> Female
-            <input id="HtmlEncode[[Employee_Gender]]" name="HtmlEncode[[Employee.Gender]]" type="HtmlEncode[[radio]]" value="HtmlEncode[[Male]]" /> Male
+            <label for="HtmlEncode[[Employee]]HtmlEncode[[_]]HtmlEncode[[Gender]]">HtmlEncode[[Gender]]</label>
+            <input checked="HtmlEncode[[checked]]" data-val="HtmlEncode[[true]]" data-val-required="HtmlEncode[[The Gender field is required.]]" id="HtmlEncode[[Employee]]HtmlEncode[[_]]HtmlEncode[[Gender]]" name="HtmlEncode[[Employee]]HtmlEncode[[.]]HtmlEncode[[Gender]]" type="HtmlEncode[[radio]]" value="HtmlEncode[[Female]]" /> Female
+            <input id="HtmlEncode[[Employee]]HtmlEncode[[_]]HtmlEncode[[Gender]]" name="HtmlEncode[[Employee]]HtmlEncode[[.]]HtmlEncode[[Gender]]" type="HtmlEncode[[radio]]" value="HtmlEncode[[Male]]" /> Male
         </div>
         <div>
-            <label for="HtmlEncode[[Employee_OfficeNumber]]">HtmlEncode[[OfficeNumber]]</label>
-            <select id="HtmlEncode[[Employee_OfficeNumber]]" name="HtmlEncode[[Employee.OfficeNumber]]"><option>HtmlEncode[[1001]]</option>
+            <label for="HtmlEncode[[Employee]]HtmlEncode[[_]]HtmlEncode[[OfficeNumber]]">HtmlEncode[[OfficeNumber]]</label>
+            <select id="HtmlEncode[[Employee]]HtmlEncode[[_]]HtmlEncode[[OfficeNumber]]" name="HtmlEncode[[Employee]]HtmlEncode[[.]]HtmlEncode[[OfficeNumber]]"><option>HtmlEncode[[1001]]</option>
 <option>HtmlEncode[[1002]]</option>
 </select>
         </div>
-        <input data-val="HtmlEncode[[true]]" data-val-range="HtmlEncode[[The field Number must be between 1 and 100.]]" data-val-range-max="HtmlEncode[[100]]" data-val-range-min="HtmlEncode[[1]]" data-val-required="HtmlEncode[[The Number field is required.]]" id="HtmlEncode[[Employee_Number]]" name="HtmlEncode[[Employee.Number]]" type="HtmlEncode[[hidden]]" value="HtmlEncode[[1]]" />
+        <input data-val="HtmlEncode[[true]]" data-val-range="HtmlEncode[[The field Number must be between 1 and 100.]]" data-val-range-max="HtmlEncode[[100]]" data-val-range-min="HtmlEncode[[1]]" data-val-required="HtmlEncode[[The Number field is required.]]" id="HtmlEncode[[Employee]]HtmlEncode[[_]]HtmlEncode[[Number]]" name="HtmlEncode[[Employee]]HtmlEncode[[.]]HtmlEncode[[Number]]" type="HtmlEncode[[hidden]]" value="HtmlEncode[[1]]" />
         <div class="HtmlEncode[[validation-summary-valid]]" data-valmsg-summary="HtmlEncode[[true]]"><ul><li style="display:none"></li>
 </ul></div>
         <input type="submit" />

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Order.Encoded.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Order.Encoded.html
@@ -46,37 +46,37 @@
             </select>
         </div>
         <div>
-            <label class="order" for="HtmlEncode[[Customer_Number]]">HtmlEncode[[Number]]</label>
-            <input type="HtmlEncode[[number]]" class="form-control" data-val="HtmlEncode[[true]]" data-val-range="HtmlEncode[[The field Number must be between 1 and 100.]]" data-val-range-max="HtmlEncode[[100]]" data-val-range-min="HtmlEncode[[1]]" data-val-required="HtmlEncode[[The Number field is required.]]" id="HtmlEncode[[Customer_Number]]" name="HtmlEncode[[Customer.Number]]" value="HtmlEncode[[1]]" />
-            <span class="HtmlEncode[[field-validation-valid]]" data-valmsg-for="HtmlEncode[[Customer.Number]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
+            <label class="order" for="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Number]]">HtmlEncode[[Number]]</label>
+            <input type="HtmlEncode[[number]]" class="form-control" data-val="HtmlEncode[[true]]" data-val-range="HtmlEncode[[The field Number must be between 1 and 100.]]" data-val-range-max="HtmlEncode[[100]]" data-val-range-min="HtmlEncode[[1]]" data-val-required="HtmlEncode[[The Number field is required.]]" id="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Number]]" name="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[Number]]" value="HtmlEncode[[1]]" />
+            <span class="HtmlEncode[[field-validation-valid]]" data-valmsg-for="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[Number]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
         </div>
         <div>
-            <label class="order" for="HtmlEncode[[Customer_Name]]">HtmlEncode[[Name]]</label>
-            <input type="HtmlEncode[[text]]" id="HtmlEncode[[Customer_Name]]" name="HtmlEncode[[Customer.Name]]" value="HtmlEncode[[NameStringValue]]" />
+            <label class="order" for="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Name]]">HtmlEncode[[Name]]</label>
+            <input type="HtmlEncode[[text]]" id="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Name]]" name="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[Name]]" value="HtmlEncode[[NameStringValue]]" />
         </div>
         <div>
-            <label class="order" for="HtmlEncode[[Customer_Email]]">HtmlEncode[[Email]]</label>
-            <input type="HtmlEncode[[email]]" id="HtmlEncode[[Customer_Email]]" name="HtmlEncode[[Customer.Email]]" value="" />
-            <span class="HtmlEncode[[field-validation-valid]]" data-valmsg-for="HtmlEncode[[Customer.Email]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
+            <label class="order" for="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Email]]">HtmlEncode[[Email]]</label>
+            <input type="HtmlEncode[[email]]" id="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Email]]" name="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[Email]]" value="" />
+            <span class="HtmlEncode[[field-validation-valid]]" data-valmsg-for="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[Email]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
         </div>
         <div>
-            <label class="order" for="HtmlEncode[[Customer_PhoneNumber]]">HtmlEncode[[PhoneNumber]]</label>
-            <input type="HtmlEncode[[tel]]" id="HtmlEncode[[Customer_PhoneNumber]]" name="HtmlEncode[[Customer.PhoneNumber]]" value="" />
+            <label class="order" for="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[PhoneNumber]]">HtmlEncode[[PhoneNumber]]</label>
+            <input type="HtmlEncode[[tel]]" id="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[PhoneNumber]]" name="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[PhoneNumber]]" value="" />
         </div>
         <div>
-            <label class="order" for="HtmlEncode[[Customer_Password]]">HtmlEncode[[Password]]</label>
-            <input type="HtmlEncode[[password]]" class="form-control" data-val="HtmlEncode[[true]]" data-val-required="HtmlEncode[[The Password field is required.]]" id="HtmlEncode[[Customer_Password]]" name="HtmlEncode[[Customer.Password]]" />
-            <span class="HtmlEncode[[field-validation-valid]]" data-valmsg-for="HtmlEncode[[Customer.Password]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
+            <label class="order" for="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Password]]">HtmlEncode[[Password]]</label>
+            <input type="HtmlEncode[[password]]" class="form-control" data-val="HtmlEncode[[true]]" data-val-required="HtmlEncode[[The Password field is required.]]" id="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Password]]" name="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[Password]]" />
+            <span class="HtmlEncode[[field-validation-valid]]" data-valmsg-for="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[Password]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
         </div>
         <div>
-            <label class="order" for="HtmlEncode[[Customer_Gender]]">HtmlEncode[[Gender]]</label>
-            <input type="HtmlEncode[[radio]]" value="HtmlEncode[[Male]]" data-val="HtmlEncode[[true]]" data-val-required="HtmlEncode[[The Gender field is required.]]" id="HtmlEncode[[Customer_Gender]]" name="HtmlEncode[[Customer.Gender]]" /> Male
-<input type="HtmlEncode[[radio]]" value="HtmlEncode[[Female]]" checked="HtmlEncode[[checked]]" id="HtmlEncode[[Customer_Gender]]" name="HtmlEncode[[Customer.Gender]]" /> Female
-            <span class="HtmlEncode[[field-validation-valid]]" data-valmsg-for="HtmlEncode[[Customer.Gender]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
+            <label class="order" for="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Gender]]">HtmlEncode[[Gender]]</label>
+            <input type="HtmlEncode[[radio]]" value="HtmlEncode[[Male]]" data-val="HtmlEncode[[true]]" data-val-required="HtmlEncode[[The Gender field is required.]]" id="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Gender]]" name="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[Gender]]" /> Male
+<input type="HtmlEncode[[radio]]" value="HtmlEncode[[Female]]" checked="HtmlEncode[[checked]]" id="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Gender]]" name="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[Gender]]" /> Female
+            <span class="HtmlEncode[[field-validation-valid]]" data-valmsg-for="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[Gender]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
         </div>
-        <div class="HtmlEncode[[order validation-summary-valid]]" data-valmsg-summary="HtmlEncode[[true]]"><ul><li style="display:none"></li>
+        <div class="order HtmlEncode[[validation-summary-valid]]" data-valmsg-summary="HtmlEncode[[true]]"><ul><li style="display:none"></li>
 </ul></div>
-        <input type="HtmlEncode[[hidden]]" id="HtmlEncode[[Customer_Key]]" name="HtmlEncode[[Customer.Key]]" value="HtmlEncode[[KeyA]]" />
+        <input type="HtmlEncode[[hidden]]" id="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Key]]" name="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[Key]]" value="HtmlEncode[[KeyA]]" />
         <input type="submit" />
     <input name="HtmlEncode[[__RequestVerificationToken]]" type="hidden" value="{0}" /><input name="HtmlEncode[[NeedSpecialHandle]]" type="HtmlEncode[[hidden]]" value="HtmlEncode[[false]]" /></form>
 </body>

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.OrderUsingHtmlHelpers.Encoded.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.OrderUsingHtmlHelpers.Encoded.html
@@ -45,37 +45,37 @@
             </select>
         </div>
         <div>
-            <label class="HtmlEncode[[order]]" for="HtmlEncode[[Customer_Number]]">HtmlEncode[[Number]]</label>
-            <input class="HtmlEncode[[form-control]]" data-val="HtmlEncode[[true]]" data-val-range="HtmlEncode[[The field Number must be between 1 and 100.]]" data-val-range-max="HtmlEncode[[100]]" data-val-range-min="HtmlEncode[[1]]" data-val-required="HtmlEncode[[The Number field is required.]]" id="HtmlEncode[[Customer_Number]]" name="HtmlEncode[[Customer.Number]]" type="HtmlEncode[[number]]" value="HtmlEncode[[1]]" />
-            <span class="HtmlEncode[[field-validation-valid]]" data-valmsg-for="HtmlEncode[[Customer.Number]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
+            <label class="HtmlEncode[[order]]" for="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Number]]">HtmlEncode[[Number]]</label>
+            <input class="HtmlEncode[[form-control]]" data-val="HtmlEncode[[true]]" data-val-range="HtmlEncode[[The field Number must be between 1 and 100.]]" data-val-range-max="HtmlEncode[[100]]" data-val-range-min="HtmlEncode[[1]]" data-val-required="HtmlEncode[[The Number field is required.]]" id="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Number]]" name="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[Number]]" type="HtmlEncode[[number]]" value="HtmlEncode[[1]]" />
+            <span class="HtmlEncode[[field-validation-valid]]" data-valmsg-for="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[Number]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
         </div>
         <div>
-            <label class="HtmlEncode[[order]]" for="HtmlEncode[[Customer_Name]]">HtmlEncode[[Name]]</label>
-            <input id="HtmlEncode[[Customer_Name]]" name="HtmlEncode[[Customer.Name]]" type="HtmlEncode[[text]]" value="HtmlEncode[[NameStringValue]]" />
+            <label class="HtmlEncode[[order]]" for="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Name]]">HtmlEncode[[Name]]</label>
+            <input id="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Name]]" name="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[Name]]" type="HtmlEncode[[text]]" value="HtmlEncode[[NameStringValue]]" />
         </div>
         <div>
-            <label class="HtmlEncode[[order]]" for="HtmlEncode[[Customer_Email]]">HtmlEncode[[Email]]</label>
-            <input id="HtmlEncode[[Customer_Email]]" name="HtmlEncode[[Customer.Email]]" type="HtmlEncode[[email]]" value="" />
-            <span class="HtmlEncode[[field-validation-valid]]" data-valmsg-for="HtmlEncode[[Customer.Email]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
+            <label class="HtmlEncode[[order]]" for="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Email]]">HtmlEncode[[Email]]</label>
+            <input id="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Email]]" name="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[Email]]" type="HtmlEncode[[email]]" value="" />
+            <span class="HtmlEncode[[field-validation-valid]]" data-valmsg-for="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[Email]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
         </div>
         <div>
-            <label class="HtmlEncode[[order]]" for="HtmlEncode[[Customer_PhoneNumber]]">HtmlEncode[[PhoneNumber]]</label>
-            <input id="HtmlEncode[[Customer_PhoneNumber]]" name="HtmlEncode[[Customer.PhoneNumber]]" type="HtmlEncode[[tel]]" value="" />
+            <label class="HtmlEncode[[order]]" for="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[PhoneNumber]]">HtmlEncode[[PhoneNumber]]</label>
+            <input id="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[PhoneNumber]]" name="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[PhoneNumber]]" type="HtmlEncode[[tel]]" value="" />
         </div>
         <div>
-            <label class="HtmlEncode[[order]]" for="HtmlEncode[[Customer_Password]]">HtmlEncode[[Password]]</label>
-            <input class="HtmlEncode[[form-control]]" data-val="HtmlEncode[[true]]" data-val-required="HtmlEncode[[The Password field is required.]]" id="HtmlEncode[[Customer_Password]]" name="HtmlEncode[[Customer.Password]]" type="HtmlEncode[[password]]" />
-            <span class="HtmlEncode[[field-validation-valid]]" data-valmsg-for="HtmlEncode[[Customer.Password]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
+            <label class="HtmlEncode[[order]]" for="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Password]]">HtmlEncode[[Password]]</label>
+            <input class="HtmlEncode[[form-control]]" data-val="HtmlEncode[[true]]" data-val-required="HtmlEncode[[The Password field is required.]]" id="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Password]]" name="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[Password]]" type="HtmlEncode[[password]]" />
+            <span class="HtmlEncode[[field-validation-valid]]" data-valmsg-for="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[Password]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
         </div>
         <div>
-            <label class="HtmlEncode[[order]]" for="HtmlEncode[[Customer_Gender]]">HtmlEncode[[Gender]]</label>
-            <input data-val="HtmlEncode[[true]]" data-val-required="HtmlEncode[[The Gender field is required.]]" id="HtmlEncode[[Customer_Gender]]" name="HtmlEncode[[Customer.Gender]]" type="HtmlEncode[[radio]]" value="HtmlEncode[[Male]]" /> Male
-<input checked="HtmlEncode[[checked]]" id="HtmlEncode[[Customer_Gender]]" name="HtmlEncode[[Customer.Gender]]" type="HtmlEncode[[radio]]" value="HtmlEncode[[Female]]" /> Female
-            <span class="HtmlEncode[[field-validation-valid]]" data-valmsg-for="HtmlEncode[[Customer.Gender]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
+            <label class="HtmlEncode[[order]]" for="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Gender]]">HtmlEncode[[Gender]]</label>
+            <input data-val="HtmlEncode[[true]]" data-val-required="HtmlEncode[[The Gender field is required.]]" id="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Gender]]" name="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[Gender]]" type="HtmlEncode[[radio]]" value="HtmlEncode[[Male]]" /> Male
+<input checked="HtmlEncode[[checked]]" id="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Gender]]" name="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[Gender]]" type="HtmlEncode[[radio]]" value="HtmlEncode[[Female]]" /> Female
+            <span class="HtmlEncode[[field-validation-valid]]" data-valmsg-for="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[Gender]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
         </div>
-        <div class="HtmlEncode[[validation-summary-valid order]]" data-valmsg-summary="HtmlEncode[[true]]"><ul><li style="display:none"></li>
+        <div class="HtmlEncode[[validation-summary-valid]]HtmlEncode[[ ]]HtmlEncode[[order]]" data-valmsg-summary="HtmlEncode[[true]]"><ul><li style="display:none"></li>
 </ul></div>
-        <input id="HtmlEncode[[Customer_Key]]" name="HtmlEncode[[Customer.Key]]" type="HtmlEncode[[hidden]]" value="HtmlEncode[[KeyA]]" />
+        <input id="HtmlEncode[[Customer]]HtmlEncode[[_]]HtmlEncode[[Key]]" name="HtmlEncode[[Customer]]HtmlEncode[[.]]HtmlEncode[[Key]]" type="HtmlEncode[[hidden]]" value="HtmlEncode[[KeyA]]" />
         <input type="submit"/>
     <input name="HtmlEncode[[__RequestVerificationToken]]" type="hidden" value="{0}" /><input name="HtmlEncode[[NeedSpecialHandle]]" type="HtmlEncode[[hidden]]" value="HtmlEncode[[false]]" /></form>
 </body>

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/AnchorTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/AnchorTagHelperTest.cs
@@ -6,9 +6,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.TestCommon;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Moq;
@@ -83,7 +85,9 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             var attribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("id"));
             Assert.Equal("myanchor", attribute.Value);
             attribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("href"));
-            Assert.Equal("home/index", attribute.Value);
+            Assert.Equal(
+                "home/index",
+                HtmlContentUtilities.HtmlContentToString((IHtmlContent)(attribute.Value), NullHtmlEncoder.Default));
             Assert.Equal("Something", output.Content.GetContent());
             Assert.Equal(expectedTagName, output.TagName);
         }
@@ -108,7 +112,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 });
             output.Content.SetContent(string.Empty);
 
-            var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var generator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             generator
                 .Setup(mock => mock.GenerateRouteLink(
                     It.IsAny<ViewContext>(),
@@ -134,7 +138,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             generator.Verify();
             Assert.Equal("a", output.TagName);
             Assert.Empty(output.Attributes);
-            Assert.True(output.Content.GetContent().Length == 0);
+            Assert.Empty(output.Content.GetContent());
         }
 
         [Fact]
@@ -157,7 +161,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 });
             output.Content.SetContent(string.Empty);
 
-            var generator = new Mock<IHtmlGenerator>();
+            var generator = new Mock<IHtmlGeneratorTutu>();
             generator
                 .Setup(mock => mock.GenerateActionLink(
                     It.IsAny<ViewContext>(),
@@ -185,7 +189,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             generator.Verify();
             Assert.Equal("a", output.TagName);
             Assert.Empty(output.Attributes);
-            Assert.True(output.Content.GetContent().Length == 0);
+            Assert.Empty(output.Content.GetContent());
         }
 
         [Fact]
@@ -208,7 +212,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 });
             output.Content.SetContent(string.Empty);
 
-            var generator = new Mock<IHtmlGenerator>();
+            var generator = new Mock<IHtmlGeneratorTutu>();
             var expectedRouteValues = new Dictionary<string, object> { { "area", "Admin" } };
 
             generator
@@ -242,7 +246,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
             Assert.Equal("a", output.TagName);
             Assert.Empty(output.Attributes);
-            Assert.True(output.Content.GetContent().Length == 0);
+            Assert.Empty(output.Content.GetContent());
         }
 
         [Fact]
@@ -265,7 +269,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 });
             output.Content.SetContent(string.Empty);
 
-            var generator = new Mock<IHtmlGenerator>();
+            var generator = new Mock<IHtmlGeneratorTutu>();
             var expectedRouteValues = new Dictionary<string, object> { { "area", "Admin" } };
 
             generator
@@ -300,7 +304,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
             Assert.Equal("a", output.TagName);
             Assert.Empty(output.Attributes);
-            Assert.True(output.Content.GetContent().Length == 0);
+            Assert.Empty(output.Content.GetContent());
         }
 
         [Fact]
@@ -323,7 +327,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 });
             output.Content.SetContent(string.Empty);
 
-            var generator = new Mock<IHtmlGenerator>();
+            var generator = new Mock<IHtmlGeneratorTutu>();
             var expectedRouteValues = new Dictionary<string, object> { { "area", string.Empty } };
 
             generator
@@ -357,7 +361,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
             Assert.Equal("a", output.TagName);
             Assert.Empty(output.Attributes);
-            Assert.True(output.Content.GetContent().Length == 0);
+            Assert.Empty(output.Content.GetContent());
         }
 
         [Theory]

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/FormTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/FormTagHelperTest.cs
@@ -90,9 +90,13 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             var attribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("id"));
             Assert.Equal("myform", attribute.Value);
             attribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("method"));
-            Assert.Equal("post", attribute.Value);
+            Assert.Equal(
+                "post",
+                HtmlContentUtilities.HtmlContentToString((IHtmlContent)(attribute.Value), NullHtmlEncoder.Default));
             attribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("action"));
-            Assert.Equal("home/index", attribute.Value);
+            Assert.Equal(
+                "home/index",
+                HtmlContentUtilities.HtmlContentToString((IHtmlContent)(attribute.Value), NullHtmlEncoder.Default));
             Assert.Empty(output.PreContent.GetContent());
             Assert.True(output.Content.GetContent().Length == 0);
             Assert.Equal(expectedPostContent, output.PostContent.GetContent());
@@ -127,7 +131,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-            var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var generator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             generator
                 .Setup(mock => mock.GenerateForm(
                     It.IsAny<ViewContext>(),
@@ -183,7 +187,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 });
             output.Attributes.Add(expectedAttribute);
 
-            var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var generator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             generator
                 .Setup(mock => mock.GenerateForm(
                     It.IsAny<ViewContext>(),
@@ -252,7 +256,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-            var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var generator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             generator
                 .Setup(mock => mock.GenerateForm(
                     viewContext,
@@ -305,7 +309,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 });
 
             var expectedRouteValues = new Dictionary<string, object> { { "area", "Admin" } };
-            var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var generator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             generator
                 .Setup(mock => mock.GenerateForm(
                     viewContext,
@@ -361,7 +365,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 });
 
             var expectedRouteValues = new Dictionary<string, object> { { "area", string.Empty } };
-            var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var generator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             generator
                 .Setup(mock => mock.GenerateForm(
                     viewContext,
@@ -417,7 +421,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 });
 
             var expectedRouteValues = new Dictionary<string, object> { { "area", "Admin" } };
-            var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var generator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             generator
                 .Setup(mock => mock.GenerateForm(
                     viewContext,
@@ -472,7 +476,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                     tagHelperContent.SetContent("Something");
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
-            var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var generator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             generator
                 .Setup(mock => mock.GenerateRouteForm(
                     viewContext,
@@ -517,7 +521,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         {
             // Arrange
             var viewContext = CreateViewContext();
-            var generator = new Mock<IHtmlGenerator>();
+            var generator = new Mock<IHtmlGeneratorTutu>();
 
             generator.Setup(mock => mock.GenerateAntiforgery(It.IsAny<ViewContext>()))
                      .Returns(new HtmlString("<input />"));

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/InputTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/InputTagHelperTest.cs
@@ -238,7 +238,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             await tagHelper.ProcessAsync(context, output);
 
             // Assert
-            Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedAttributes, output.Attributes, TagHelperAttributeStringComparer.Instance);
             Assert.Equal(expectedPreContent, output.PreContent.GetContent());
             Assert.Equal(expectedContent, output.Content.GetContent());
             Assert.Equal(expectedPostContent, output.PostContent.GetContent());
@@ -307,7 +307,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             tagHelper.Process(context, output);
 
             // Assert
-            Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedAttributes, output.Attributes, TagHelperAttributeStringComparer.Instance);
             Assert.Empty(output.PreContent.GetContent());
             Assert.Empty(output.Content.GetContent());
             Assert.Empty(output.PostContent.GetContent());
@@ -350,7 +350,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             output.Content.AppendHtml(originalContent);
             output.PostContent.AppendHtml(expectedPostContent);
 
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var tagHelper = GetTagHelper(htmlGenerator.Object, model: false, propertyName: nameof(Model.IsACar));
             tagHelper.Format = "somewhat-less-null"; // ignored
 
@@ -455,7 +455,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             var metadataProvider = new TestModelMetadataProvider();
             metadataProvider.ForProperty<Model>("Text").DisplayDetails(dd => dd.DataTypeName = dataTypeName);
 
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var tagHelper = GetTagHelper(
                 htmlGenerator.Object,
                 model,
@@ -489,7 +489,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             htmlGenerator.Verify();
 
             Assert.Equal(TagMode.StartTagOnly, output.TagMode);
-            Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedAttributes, output.Attributes, TagHelperAttributeStringComparer.Instance);
             Assert.Equal(expectedPreContent, output.PreContent.GetContent());
             Assert.Equal(expectedContent, output.Content.GetContent());
             Assert.Equal(expectedPostContent, output.PostContent.GetContent());
@@ -557,7 +557,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             var metadataProvider = new TestModelMetadataProvider();
             metadataProvider.ForProperty<Model>("Text").DisplayDetails(dd => dd.DataTypeName = dataTypeName);
 
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var tagHelper = GetTagHelper(
                 htmlGenerator.Object,
                 model,
@@ -590,7 +590,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             htmlGenerator.Verify();
 
             Assert.Equal(TagMode.StartTagOnly, output.TagMode);
-            Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedAttributes, output.Attributes, TagHelperAttributeStringComparer.Instance);
             Assert.Equal(expectedPreContent, output.PreContent.GetContent());
             Assert.Equal(expectedContent, output.Content.GetContent());
             Assert.Equal(expectedPostContent, output.PostContent.GetContent());
@@ -653,7 +653,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             output.Content.SetContent(expectedContent);
             output.PostContent.SetContent(expectedPostContent);
 
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var tagHelper = GetTagHelper(htmlGenerator.Object, model, nameof(Model.Text));
             tagHelper.Format = "somewhat-less-null"; // ignored
             tagHelper.InputTypeName = inputTypeName;
@@ -684,7 +684,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             htmlGenerator.Verify();
 
             Assert.Equal(TagMode.StartTagOnly, output.TagMode);
-            Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedAttributes, output.Attributes, TagHelperAttributeStringComparer.Instance);
             Assert.Equal(expectedPreContent, output.PreContent.GetContent());
             Assert.Equal(expectedContent, output.Content.GetContent());
             Assert.Equal(expectedPostContent, output.PostContent.GetContent());
@@ -767,7 +767,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             var metadataProvider = new TestModelMetadataProvider();
             metadataProvider.ForProperty<Model>("Text").DisplayDetails(dd => dd.DataTypeName = dataTypeName);
 
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var tagHelper = GetTagHelper(
                 htmlGenerator.Object,
                 model,
@@ -801,7 +801,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             htmlGenerator.Verify();
 
             Assert.Equal(TagMode.StartTagOnly, output.TagMode);
-            Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedAttributes, output.Attributes, TagHelperAttributeStringComparer.Instance);
             Assert.Equal(expectedPreContent, output.PreContent.GetContent());
             Assert.Equal(expectedContent, output.Content.GetContent());
             Assert.Equal(expectedPostContent, output.PostContent.GetContent());
@@ -878,7 +878,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             var metadataProvider = new TestModelMetadataProvider();
             metadataProvider.ForProperty<Model>("Text").DisplayDetails(dd => dd.DataTypeName = dataTypeName);
 
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var tagHelper = GetTagHelper(
                 htmlGenerator.Object,
                 model: null,
@@ -913,7 +913,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             htmlGenerator.Verify();
 
             Assert.Equal(TagMode.SelfClosing, output.TagMode);
-            Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedAttributes, output.Attributes, TagHelperAttributeStringComparer.Instance);
             Assert.Empty(output.PreContent.GetContent());
             Assert.Equal(string.Empty, output.Content.GetContent());
             Assert.Empty(output.PostContent.GetContent());
@@ -967,7 +967,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 { "type", expectedType }
             };
             var metadataProvider = TestModelMetadataProvider.CreateDefaultProvider();
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var tagHelper = GetTagHelper(
                 htmlGenerator.Object,
                 model: null,
@@ -994,7 +994,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             htmlGenerator.Verify();
 
             Assert.Equal(TagMode.SelfClosing, output.TagMode);
-            Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedAttributes, output.Attributes, TagHelperAttributeStringComparer.Instance);
             Assert.Empty(output.PreContent.GetContent());
             Assert.Equal(string.Empty, output.Content.GetContent());
             Assert.Empty(output.PostContent.GetContent());

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/LabelTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/LabelTagHelperTest.cs
@@ -223,7 +223,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             await tagHelper.ProcessAsync(tagHelperContext, output);
 
             // Assert
-            Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedAttributes, output.Attributes, TagHelperAttributeStringComparer.Instance);
             Assert.Equal(expectedPreContent, output.PreContent.GetContent());
             Assert.Equal(
                 tagHelperOutputContent.ExpectedContent,

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/SelectTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/SelectTagHelperTest.cs
@@ -241,7 +241,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
             // Assert
             Assert.Equal(TagMode.SelfClosing, output.TagMode);
-            Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedAttributes, output.Attributes, TagHelperAttributeStringComparer.Instance);
             Assert.Equal(expectedPreContent, output.PreContent.GetContent());
             Assert.Equal(expectedContent, output.Content.GetContent());
             Assert.Equal(expectedPostContent, output.PostContent.GetContent());
@@ -339,7 +339,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
             // Assert
             Assert.Equal(TagMode.SelfClosing, output.TagMode);
-            Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedAttributes, output.Attributes, TagHelperAttributeStringComparer.Instance);
             Assert.Equal(expectedPreContent, output.PreContent.GetContent());
             Assert.Equal(expectedContent, output.Content.GetContent());
             Assert.Equal(expectedPostContent, HtmlContentUtilities.HtmlContentToString(output.PostContent));
@@ -517,7 +517,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
             // Assert
             Assert.Equal(TagMode.SelfClosing, output.TagMode);
-            Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedAttributes, output.Attributes, TagHelperAttributeStringComparer.Instance);
             Assert.Equal(expectedPreContent, output.PreContent.GetContent());
             Assert.Equal(expectedContent, output.Content.GetContent());
             Assert.Equal(expectedPostContent, HtmlContentUtilities.HtmlContentToString(output.PostContent));
@@ -573,7 +573,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             string model = null;
             var modelExplorer = metadataProvider.GetModelExplorerForType(typeof(string), model);
 
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var viewContext = TestableHtmlGenerator.GetViewContext(model, htmlGenerator.Object, metadataProvider);
 
             // Simulate a (model => model) scenario. E.g. the calling helper may appear in a low-level template.
@@ -654,7 +654,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             var modelExplorer = metadataProvider.GetModelExplorerForType(modelType, model);
             var modelExpression = new ModelExpression(propertyName, modelExplorer);
 
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var viewContext = TestableHtmlGenerator.GetViewContext(model, htmlGenerator.Object, metadataProvider);
             var currentValues = new string[0];
             htmlGenerator

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/TagHelperAttributeStringComparer.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/TagHelperAttributeStringComparer.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.TestCommon;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Microsoft.AspNetCore.Mvc.TagHelpers
+{
+    public class TagHelperAttributeStringComparer : IEqualityComparer<TagHelperAttribute>
+    {
+        private TagHelperAttributeStringComparer()
+        {
+        }
+
+        public static TagHelperAttributeStringComparer Instance { get; } = new TagHelperAttributeStringComparer();
+
+        public bool Equals(TagHelperAttribute x, TagHelperAttribute y)
+        {
+            if (x == null ^ y == null)
+            {
+                return false;
+            }
+
+            if (x == null)
+            {
+                return true;
+            }
+
+            if (!string.Equals(x.Name, y.Name, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (x.ValueStyle != y.ValueStyle)
+            {
+                return false;
+            }
+
+            if (x.ValueStyle == HtmlAttributeValueStyle.Minimized)
+            {
+                return true;
+            }
+
+            var xString = GetValueString(x.Value);
+            var yString = GetValueString(y.Value);
+            return string.Equals(xString, yString, StringComparison.Ordinal);
+        }
+
+        private string GetValueString(object value)
+        {
+            if (value == null)
+            {
+                return string.Empty;
+            }
+
+            var stringValue = value as string;
+            if (stringValue != null)
+            {
+                return stringValue;
+            }
+
+            var htmlContent = value as IHtmlContent;
+            if (htmlContent != null)
+            {
+                // Use NullHtmlEncoder for consistency w/ `string` handling. `string`s will be encoded later.
+                return HtmlContentUtilities.HtmlContentToString(htmlContent, NullHtmlEncoder.Default);
+            }
+
+            return value.ToString();
+        }
+
+        public int GetHashCode(TagHelperAttribute obj)
+        {
+            return obj.GetHashCode();
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/TagHelperOutputExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/TagHelperOutputExtensionsTest.cs
@@ -676,7 +676,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                         },
                         new TagHelperAttributeList
                         {
-                            { "class", "btn2 btn" }
+                            { "clASS", "btn2 btn" }
                         }
                     },
                     {
@@ -691,7 +691,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                         },
                         new TagHelperAttributeList
                         {
-                            { "class", "btn2 btn" }
+                            { "clASS", "btn2 btn" }
                         }
                     },
                     {
@@ -706,7 +706,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                         },
                         new TagHelperAttributeList
                         {
-                            { "class", "btn2 btn" }
+                            { "clASS", "btn2 btn" }
                         }
                     },
                     {
@@ -725,7 +725,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                         new TagHelperAttributeList
                         {
                             { "before", "before value" },
-                            { "class", "btn2 btn" },
+                            { "clASS", "btn2 btn" },
                             { "mid", "mid value" },
                             { "after", "after value" },
                         }
@@ -748,7 +748,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                         new TagHelperAttributeList
                         {
                             { "before", "before value" },
-                            { "class", "btn2 btn" },
+                            { "clASS", "btn2 btn" },
                             { "mid", "mid value" },
                             { "after", "after value" },
                             { "A", "A Value" },
@@ -783,10 +783,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             tagHelperOutput.MergeAttributes(tagBuilder);
 
             // Assert
-            Assert.Equal(
-                expectedAttributes,
-                tagHelperOutput.Attributes,
-                CaseSensitiveTagHelperAttributeComparer.Default);
+            Assert.Equal(expectedAttributes, tagHelperOutput.Attributes, TagHelperAttributeStringComparer.Instance);
         }
 
         [Fact]
@@ -833,7 +830,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
             // Assert
             var attribute = Assert.Single(tagHelperOutput.Attributes);
-            Assert.Equal(expectedAttribute, attribute);
+            Assert.Equal(expectedAttribute, attribute, TagHelperAttributeStringComparer.Instance);
         }
 
         [Theory]
@@ -859,7 +856,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
             // Assert
             var attribute = Assert.Single(tagHelperOutput.Attributes);
-            Assert.Equal(new TagHelperAttribute(originalName, "Hello btn"), attribute);
+            Assert.Equal(
+                new TagHelperAttribute(originalName, "Hello btn"),
+                attribute,
+                TagHelperAttributeStringComparer.Instance);
         }
 
         [Fact]
@@ -881,7 +881,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
             // Assert
             var attribute = Assert.Single(tagHelperOutput.Attributes);
-            Assert.Equal(expectedAttribute, attribute);
+            Assert.Equal(expectedAttribute, attribute, TagHelperAttributeStringComparer.Instance);
         }
 
         [Fact]
@@ -906,9 +906,9 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             // Assert
             Assert.Equal(2, tagHelperOutput.Attributes.Count);
             var attribute = Assert.Single(tagHelperOutput.Attributes, attr => attr.Name.Equals("class"));
-            Assert.Equal(expectedAttribute1.Value, attribute.Value);
+            Assert.Equal(expectedAttribute1, attribute, TagHelperAttributeStringComparer.Instance);
             attribute = Assert.Single(tagHelperOutput.Attributes, attr => attr.Name.Equals("class2"));
-            Assert.Equal(expectedAttribute2.Value, attribute.Value);
+            Assert.Equal(expectedAttribute2, attribute, TagHelperAttributeStringComparer.Instance);
         }
 
         [Fact]
@@ -955,9 +955,9 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             // Assert
             Assert.Equal(tagHelperOutput.Attributes.Count, 2);
             var attribute = Assert.Single(tagHelperOutput.Attributes, attr => attr.Name.Equals("class"));
-            Assert.Equal(expectedOutputAttribute.Value, attribute.Value);
+            Assert.Equal(expectedOutputAttribute, attribute, TagHelperAttributeStringComparer.Instance);
             attribute = Assert.Single(tagHelperOutput.Attributes, attr => attr.Name.Equals("for"));
-            Assert.Equal(expectedBuilderAttribute.Value, attribute.Value);
+            Assert.Equal(expectedBuilderAttribute, attribute, TagHelperAttributeStringComparer.Instance);
         }
 
         private class CaseSensitiveTagHelperAttributeComparer : IEqualityComparer<TagHelperAttribute>

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/TestableHtmlGenerator.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/TestableHtmlGenerator.cs
@@ -114,7 +114,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             ViewContext viewContext,
             TagBuilder tagBuilder,
             ModelExplorer modelExplorer,
-            string expression)
+            StringValuesTutu expression)
         {
             tagBuilder.MergeAttributes(ValidationAttributes);
         }

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/TextAreaTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/TextAreaTagHelperTest.cs
@@ -154,7 +154,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
             // Assert
             Assert.Equal(TagMode.SelfClosing, output.TagMode);
-            Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.Equal(expectedAttributes, output.Attributes, TagHelperAttributeStringComparer.Instance);
             Assert.Equal(expectedContent, HtmlContentUtilities.HtmlContentToString(output.Content));
             Assert.Equal(expectedTagName, output.TagName);
         }

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/ValidationMessageTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/ValidationMessageTagHelperTest.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.TestCommon;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
@@ -77,11 +78,17 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             var attribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("id"));
             Assert.Equal("myvalidationmessage", attribute.Value);
             attribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("class"));
-            Assert.Equal("field-validation-valid", attribute.Value);
+            Assert.Equal(
+                "field-validation-valid",
+                HtmlContentUtilities.HtmlContentToString((IHtmlContent)(attribute.Value), NullHtmlEncoder.Default));
             attribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("data-valmsg-for"));
-            Assert.Equal("Name", attribute.Value);
+            Assert.Equal(
+                "Name",
+                HtmlContentUtilities.HtmlContentToString((IHtmlContent)(attribute.Value), NullHtmlEncoder.Default));
             attribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("data-valmsg-replace"));
-            Assert.Equal("true", attribute.Value);
+            Assert.Equal(
+                "true",
+                HtmlContentUtilities.HtmlContentToString((IHtmlContent)(attribute.Value), NullHtmlEncoder.Default));
             Assert.Equal(expectedPreContent, output.PreContent.GetContent());
             Assert.Equal(expectedContent, output.Content.GetContent());
             Assert.Equal(expectedPostContent, output.PostContent.GetContent());
@@ -94,7 +101,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             // Arrange
             var expectedViewContext = CreateViewContext();
             var modelExpression = CreateModelExpression("Hello");
-            var generator = new Mock<IHtmlGenerator>();
+            var generator = new Mock<IHtmlGeneratorTutu>();
             generator
                 .Setup(mock => mock.GenerateValidationMessage(
                     expectedViewContext,
@@ -149,7 +156,9 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         [InlineData("\r\n  \r\n", "\r\n Something Else \r\n", "\r\n Something Else \r\n")]
         [InlineData("\r\n  \r\n", "Some Content", "Some Content")]
         public async Task ProcessAsync_DoesNotOverrideOutputContent(
-            string childContent, string outputContent, string expectedOutputContent)
+            string childContent,
+            string outputContent,
+            string expectedOutputContent)
         {
             // Arrange
             var tagBuilder = new TagBuilder("span2");
@@ -157,12 +166,12 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             tagBuilder.Attributes.Add("data-foo", "bar");
             tagBuilder.Attributes.Add("data-hello", "world");
 
-            var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var generator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var setup = generator
                 .Setup(mock => mock.GenerateValidationMessage(
                     It.IsAny<ViewContext>(),
                     It.IsAny<ModelExplorer>(),
-                    It.IsAny<string>(),
+                    It.IsAny<StringValuesTutu>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<object>()))
@@ -199,9 +208,13 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             Assert.Equal("span", output.TagName);
             Assert.Equal(2, output.Attributes.Count);
             var attribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("data-foo"));
-            Assert.Equal("bar", attribute.Value);
+            Assert.Equal(
+                "bar",
+                HtmlContentUtilities.HtmlContentToString((IHtmlContent)(attribute.Value), NullHtmlEncoder.Default));
             attribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("data-hello"));
-            Assert.Equal("world", attribute.Value);
+            Assert.Equal(
+                "world",
+                HtmlContentUtilities.HtmlContentToString((IHtmlContent)(attribute.Value), NullHtmlEncoder.Default));
             Assert.Equal(expectedOutputContent, output.Content.GetContent());
         }
 
@@ -209,7 +222,8 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         [InlineData("Content of validation message", "Content of validation message")]
         [InlineData("\r\n  \r\n", "New HTML")]
         public async Task ProcessAsync_MergesTagBuilderFromGenerateValidationMessage(
-            string childContent, string expectedOutputContent)
+            string childContent,
+            string expectedOutputContent)
         {
             // Arrange
             var tagBuilder = new TagBuilder("span2");
@@ -217,12 +231,12 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             tagBuilder.Attributes.Add("data-foo", "bar");
             tagBuilder.Attributes.Add("data-hello", "world");
 
-            var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var generator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var setup = generator
                 .Setup(mock => mock.GenerateValidationMessage(
                     It.IsAny<ViewContext>(),
                     It.IsAny<ModelExplorer>(),
-                    It.IsAny<string>(),
+                    It.IsAny<StringValuesTutu>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<object>()))
@@ -258,9 +272,13 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             Assert.Equal("span", output.TagName);
             Assert.Equal(2, output.Attributes.Count);
             var attribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("data-foo"));
-            Assert.Equal("bar", attribute.Value);
+            Assert.Equal(
+                "bar",
+                HtmlContentUtilities.HtmlContentToString((IHtmlContent)(attribute.Value), NullHtmlEncoder.Default));
             attribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("data-hello"));
-            Assert.Equal("world", attribute.Value);
+            Assert.Equal(
+                "world",
+                HtmlContentUtilities.HtmlContentToString((IHtmlContent)(attribute.Value), NullHtmlEncoder.Default));
             Assert.Equal(expectedOutputContent, output.Content.GetContent());
         }
 
@@ -268,7 +286,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         public async Task ProcessAsync_DoesNothingIfNullFor()
         {
             // Arrange
-            var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var generator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var validationMessageTagHelper = new ValidationMessageTagHelper(generator.Object);
             var expectedPreContent = "original pre-content";
             var expectedContent = "original content";

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/ValidationSummaryTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/ValidationSummaryTagHelperTest.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.TestCommon;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
@@ -87,9 +88,13 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             // Assert
             Assert.Equal(2, output.Attributes.Count);
             var attribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("class"));
-            Assert.Equal("form-control validation-summary-valid", attribute.Value);
+            Assert.Equal(
+                "form-control validation-summary-valid",
+                HtmlContentUtilities.HtmlContentToString((IHtmlContent)(attribute.Value), NullHtmlEncoder.Default));
             attribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("data-valmsg-summary"));
-            Assert.Equal("true", attribute.Value);
+            Assert.Equal(
+                "true",
+                HtmlContentUtilities.HtmlContentToString((IHtmlContent)(attribute.Value), NullHtmlEncoder.Default));
             Assert.Equal(expectedPreContent, output.PreContent.GetContent());
             Assert.Equal(expectedContent, output.Content.GetContent());
             Assert.Equal(
@@ -151,7 +156,9 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             // Assert
             Assert.InRange(output.Attributes.Count, low: 1, high: 2);
             var attribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("class"));
-            Assert.Equal("form-control validation-summary-errors", attribute.Value);
+            Assert.Equal(
+                "form-control validation-summary-errors",
+                HtmlContentUtilities.HtmlContentToString((IHtmlContent)(attribute.Value), NullHtmlEncoder.Default));
             Assert.Equal(expectedPreContent, output.PreContent.GetContent());
             Assert.Equal(expectedContent, output.Content.GetContent());
             Assert.Equal(
@@ -213,9 +220,13 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             // Assert
             Assert.Equal(2, output.Attributes.Count);
             var attribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("class"));
-            Assert.Equal("form-control validation-summary-errors", attribute.Value);
+            Assert.Equal(
+                "form-control validation-summary-errors",
+                HtmlContentUtilities.HtmlContentToString((IHtmlContent)(attribute.Value), NullHtmlEncoder.Default));
             attribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("data-valmsg-summary"));
-            Assert.Equal("true", attribute.Value);
+            Assert.Equal(
+                "true",
+                HtmlContentUtilities.HtmlContentToString((IHtmlContent)(attribute.Value), NullHtmlEncoder.Default));
             Assert.Equal(expectedPreContent, output.PreContent.GetContent());
             Assert.Equal(expectedContent, output.Content.GetContent());
             Assert.Equal(
@@ -235,7 +246,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             // Arrange
             var expectedViewContext = CreateViewContext();
 
-            var generator = new Mock<IHtmlGenerator>();
+            var generator = new Mock<IHtmlGeneratorTutu>();
             generator
                 .Setup(mock => mock.GenerateValidationSummary(
                     expectedViewContext,
@@ -292,7 +303,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             tagBuilder.Attributes.Add("data-hello", "world");
             tagBuilder.Attributes.Add("anything", "something");
 
-            var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var generator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             generator
                 .Setup(mock => mock.GenerateValidationSummary(
                     It.IsAny<ViewContext>(),
@@ -334,11 +345,17 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             Assert.Equal("div", output.TagName);
             Assert.Equal(3, output.Attributes.Count);
             var attribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("data-foo"));
-            Assert.Equal("bar", attribute.Value);
+            Assert.Equal(
+                "bar",
+                HtmlContentUtilities.HtmlContentToString((IHtmlContent)(attribute.Value), NullHtmlEncoder.Default));
             attribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("data-hello"));
-            Assert.Equal("world", attribute.Value);
+            Assert.Equal(
+                "world",
+                HtmlContentUtilities.HtmlContentToString((IHtmlContent)(attribute.Value), NullHtmlEncoder.Default));
             attribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("anything"));
-            Assert.Equal("something", attribute.Value);
+            Assert.Equal(
+                "something",
+                HtmlContentUtilities.HtmlContentToString((IHtmlContent)(attribute.Value), NullHtmlEncoder.Default));
             Assert.Equal(expectedPreContent, output.PreContent.GetContent());
             Assert.Equal(expectedContent, output.Content.GetContent());
             Assert.Equal("Content of validation summaryNew HTML", output.PostContent.GetContent());
@@ -348,7 +365,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         public async Task ProcessAsync_DoesNothingIfValidationSummaryNone()
         {
             // Arrange
-            var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var generator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
 
             var validationSummaryTagHelper = new ValidationSummaryTagHelper(generator.Object)
             {
@@ -396,7 +413,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             var tagBuilder = new TagBuilder("span2");
             tagBuilder.InnerHtml.SetHtmlContent("New HTML");
 
-            var generator = new Mock<IHtmlGenerator>();
+            var generator = new Mock<IHtmlGeneratorTutu>();
             generator
                 .Setup(mock => mock.GenerateValidationSummary(
                     It.IsAny<ViewContext>(),

--- a/test/Microsoft.AspNetCore.Mvc.TestCommon/MediaTypeAssert.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TestCommon/MediaTypeAssert.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using Xunit.Sdk;

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Internal/ExpressionHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Internal/ExpressionHelperTest.cs
@@ -157,8 +157,8 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
                         (Expression<Func<TestModel, string>>)(m => value)
                     },
                     {
-                        // These two expressions are not actually equivalent. However ExpressionHelper returns 
-                        // string.Empty for these two expressions and hence they are considered as equivalent by the 
+                        // These two expressions are not actually equivalent. However ExpressionHelper returns
+                        // string.Empty for these two expressions and hence they are considered as equivalent by the
                         // cache.
                         (Expression<Func<TestModel, string>>)(m => Model),
                         (Expression<Func<TestModel, TestModel>>)(m => m)
@@ -207,10 +207,6 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
                         (Expression<Func<TestModel, Category>>)(model => model.SelectedCategory)
                     },
                     {
-                        (Expression<Func<IList<TestModel>, Category>>)(model => model[2].SelectedCategory),
-                        (Expression<Func<IList<TestModel>, Category>>)(model => model[2].SelectedCategory)
-                    },
-                    {
                         (Expression<Func<TestModel, string>>)(m => Model),
                         (Expression<Func<TestModel, string>>)(m => m.Model)
                     },
@@ -226,10 +222,6 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
                         (Expression<Func<TestModel, string>>)(m => key),
                         (Expression<Func<TestModel, string>>)(m => value)
                     },
-                    {
-                        (Expression<Func<IDictionary<string, TestModel>, string>>)(model => model[key].SelectedCategory.CategoryName.MainCategory),
-                        (Expression<Func<IDictionary<string, TestModel>, string>>)(model => model[key].SelectedCategory.CategoryName.MainCategory)
-                    },
                 };
             }
         }
@@ -242,7 +234,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             var text = ExpressionHelper.GetExpressionText(expression, _expressionTextCache);
 
             // Assert
-            Assert.Equal(expressionText, text);
+            Assert.Equal(expressionText, text.ToString(), StringComparer.Ordinal);
         }
 
         [Theory]
@@ -256,12 +248,12 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             var text2 = ExpressionHelper.GetExpressionText(expression, _expressionTextCache);
 
             // Assert
-            Assert.Same(text1, text2); // Cached
+            Assert.Equal(text1, text2); // Cached
         }
 
         [Theory]
         [MemberData(nameof(IndexerExpressions))]
-        public void GetExpressionText_DoesNotCacheIndexerExpression(LambdaExpression expression)
+        public void GetExpressionText_RecalculatesIndexerExpressionsConsistently(LambdaExpression expression)
         {
             // Act - 1
             var text1 = ExpressionHelper.GetExpressionText(expression, _expressionTextCache);
@@ -270,7 +262,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             var text2 = ExpressionHelper.GetExpressionText(expression, _expressionTextCache);
 
             // Assert
-            Assert.NotSame(text1, text2); // not cached
+            Assert.Equal(text1, text2); // not cached
         }
 
         [Theory]
@@ -284,7 +276,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             var text2 = ExpressionHelper.GetExpressionText(expression2, _expressionTextCache);
 
             // Assert
-            Assert.Same(text1, text2);
+            Assert.Equal(text1, text2);
         }
 
         [Theory]
@@ -298,7 +290,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             var text2 = ExpressionHelper.GetExpressionText(expression2, _expressionTextCache);
 
             // Assert
-            Assert.NotSame(text1, text2);
+            Assert.NotEqual(text1, text2);
         }
 
         private class TestModel

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/DefaultTemplatesUtilities.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/DefaultTemplatesUtilities.cs
@@ -74,6 +74,11 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
                 provider: TestModelMetadataProvider.CreateDefaultProvider());
         }
 
+        public static HtmlHelper<ObjectTemplateModel> GetHtmlHelper(IHtmlGeneratorTutu htmlGenerator)
+        {
+            return GetHtmlHelper((IHtmlGenerator)htmlGenerator);
+        }
+
         public static HtmlHelper<ObjectTemplateModel> GetHtmlHelper(IHtmlGenerator htmlGenerator)
         {
             var metadataProvider = TestModelMetadataProvider.CreateDefaultProvider();

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperCheckboxTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperCheckboxTest.cs
@@ -62,8 +62,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void CheckBoxExplicitParametersOverrideDictionary_ForNullModel()
         {
             // Arrange
-            var expected = @"<input checked=""HtmlEncode[[checked]]"" id=""HtmlEncode[[foo]]"" name=""HtmlEncode[[foo]]"" type=""HtmlEncode[[checkbox]]"" value=""HtmlEncode[[false]]"" />" +
-                           @"<input name=""HtmlEncode[[foo]]"" type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[false]]"" />";
+            var expected = @"<input checked=""HtmlEncode[[checked]]"" id=""HtmlEncode[[foo]]"" name=""HtmlEncode[[foo]]"" " +
+                @"type=""HtmlEncode[[checkbox]]"" value=""HtmlEncode[[false]]"" />" +
+                @"<input name=""HtmlEncode[[foo]]"" type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[false]]"" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper();
 
             // Act
@@ -190,9 +191,11 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var expected =
-                @"<input checked=""HtmlEncode[[checked]]"" id=""HtmlEncode[[Prefix_Property1]]"" " +
-                @"name=""HtmlEncode[[Prefix.Property1]]"" type=""HtmlEncode[[checkbox]]"" value=""HtmlEncode[[true]]"" />" +
-                @"<input name=""HtmlEncode[[Prefix.Property1]]"" type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[false]]"" />";
+                @"<input checked=""HtmlEncode[[checked]]"" id=""HtmlEncode[[Prefix]]HtmlEncode[[_]]HtmlEncode[[Property1]]"" " +
+                @"name=""HtmlEncode[[Prefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" type=""HtmlEncode[[checkbox]]"" " +
+                @"value=""HtmlEncode[[true]]"" />" +
+                @"<input name=""HtmlEncode[[Prefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" " +
+                @"value=""HtmlEncode[[false]]"" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetTestModelViewData());
             helper.ViewContext.ClientValidationEnabled = false;
             helper.ViewData.Remove(nameof(TestModel.Property1));
@@ -233,9 +236,11 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var expected =
-                @"<input checked=""HtmlEncode[[checked]]"" id=""HtmlEncode[[Prefix_Property1]]"" " +
-                @"name=""HtmlEncode[[Prefix.Property1]]"" type=""HtmlEncode[[checkbox]]"" value=""HtmlEncode[[true]]"" />" +
-                @"<input name=""HtmlEncode[[Prefix.Property1]]"" type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[false]]"" />";
+                @"<input checked=""HtmlEncode[[checked]]"" id=""HtmlEncode[[Prefix]]HtmlEncode[[_]]HtmlEncode[[Property1]]"" " +
+                @"name=""HtmlEncode[[Prefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" type=""HtmlEncode[[checkbox]]"" " +
+                @"value=""HtmlEncode[[true]]"" />" +
+                @"<input name=""HtmlEncode[[Prefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" " +
+                @"value=""HtmlEncode[[false]]"" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetTestModelViewData());
             helper.ViewContext.ClientValidationEnabled = false;
             helper.ViewData.Remove(nameof(TestModel.Property1));
@@ -275,9 +280,11 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var expected =
-                @"<input checked=""HtmlEncode[[checked]]"" id=""HtmlEncode[[Prefix_Property1]]"" " +
-                @"name=""HtmlEncode[[Prefix.Property1]]"" type=""HtmlEncode[[checkbox]]"" value=""HtmlEncode[[true]]"" />" +
-                @"<input name=""HtmlEncode[[Prefix.Property1]]"" type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[false]]"" />";
+                @"<input checked=""HtmlEncode[[checked]]"" id=""HtmlEncode[[Prefix]]HtmlEncode[[_]]HtmlEncode[[Property1]]"" " +
+                @"name=""HtmlEncode[[Prefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" type=""HtmlEncode[[checkbox]]"" " +
+                @"value=""HtmlEncode[[true]]"" />" +
+                @"<input name=""HtmlEncode[[Prefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" " +
+                @"value=""HtmlEncode[[false]]"" />";
             var metadataProvider = new EmptyModelMetadataProvider();
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(new ViewDataDictionary<TestModel>(metadataProvider));
             helper.ViewContext.ClientValidationEnabled = false;
@@ -315,9 +322,11 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var expected =
-                @"<input id=""HtmlEncode[[Prefix_Property1]]"" " +
-                @"name=""HtmlEncode[[Prefix.Property1]]"" type=""HtmlEncode[[checkbox]]"" value=""HtmlEncode[[true]]"" />" +
-                @"<input name=""HtmlEncode[[Prefix.Property1]]"" type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[false]]"" />";
+                @"<input id=""HtmlEncode[[Prefix]]HtmlEncode[[_]]HtmlEncode[[Property1]]"" " +
+                @"name=""HtmlEncode[[Prefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" type=""HtmlEncode[[checkbox]]"" " +
+                @"value=""HtmlEncode[[true]]"" />" +
+                @"<input name=""HtmlEncode[[Prefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" " +
+                @"value=""HtmlEncode[[false]]"" />";
             var metadataProvider = new EmptyModelMetadataProvider();
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(new ViewDataDictionary<TestModel>(metadataProvider));
             helper.ViewContext.ClientValidationEnabled = false;
@@ -372,9 +381,11 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void CheckBoxInTemplate_ReplaceDotsInIdByDefaultWithUnderscores()
         {
             // Arrange
-            var expected = @"<input id=""HtmlEncode[[MyPrefix_Property1]]"" name=""HtmlEncode[[MyPrefix.Property1]]"" " +
-                           @"Property3=""HtmlEncode[[Property3Value]]"" type=""HtmlEncode[[checkbox]]"" value=""HtmlEncode[[true]]"" /><input " +
-                           @"name=""HtmlEncode[[MyPrefix.Property1]]"" type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[false]]"" />";
+            var expected = @"<input id=""HtmlEncode[[MyPrefix]]HtmlEncode[[_]]HtmlEncode[[Property1]]"" " +
+                @"name=""HtmlEncode[[MyPrefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" " +
+                @"Property3=""HtmlEncode[[Property3Value]]"" type=""HtmlEncode[[checkbox]]"" value=""HtmlEncode[[true]]"" />" +
+                @"<input name=""HtmlEncode[[MyPrefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" " +
+                @"value=""HtmlEncode[[false]]"" />";
             var dictionary = new RouteValueDictionary(new { Property3 = "Property3Value" });
             var helper = DefaultTemplatesUtilities.GetHtmlHelper();
             helper.ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix = "MyPrefix";
@@ -390,9 +401,11 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void CheckBoxInTemplate_ReplacesDotsInIdWithIdDotReplacement()
         {
             // Arrange
-            var expected = @"<input id=""HtmlEncode[[MyPrefix!!!Property1]]"" name=""HtmlEncode[[MyPrefix.Property1]]"" " +
-                           @"Property3=""HtmlEncode[[Property3Value]]"" type=""HtmlEncode[[checkbox]]"" value=""HtmlEncode[[true]]"" /><input " +
-                           @"name=""HtmlEncode[[MyPrefix.Property1]]"" type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[false]]"" />";
+            var expected = @"<input id=""HtmlEncode[[MyPrefix]]HtmlEncode[[!!!]]HtmlEncode[[Property1]]"" " +
+                @"name=""HtmlEncode[[MyPrefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" " +
+                @"Property3=""HtmlEncode[[Property3Value]]"" type=""HtmlEncode[[checkbox]]"" value=""HtmlEncode[[true]]"" />" +
+                @"<input name=""HtmlEncode[[MyPrefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" " +
+                @"value=""HtmlEncode[[false]]"" />";
             var dictionary = new Dictionary<string, object> { { "Property3", "Property3Value" } };
             var helper = DefaultTemplatesUtilities.GetHtmlHelper<DefaultTemplatesUtilities.ObjectTemplateModel>(
                 model: null,
@@ -608,8 +621,10 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             var requiredMessage = ValidationAttributeUtil.GetRequiredErrorMessage("Property1");
             var expected =
                 $@"<input data-val=""HtmlEncode[[true]]"" data-val-required=""HtmlEncode[[{requiredMessage}]]"" " +
-                @"id=""HtmlEncode[[MyPrefix_Property1]]"" name=""HtmlEncode[[MyPrefix.Property1]]"" Property3=""HtmlEncode[[PropValue]]"" " +
-                @"type=""HtmlEncode[[checkbox]]"" value=""HtmlEncode[[true]]"" /><input name=""HtmlEncode[[MyPrefix.Property1]]"" type=""HtmlEncode[[hidden]]"" " +
+                @"id=""HtmlEncode[[MyPrefix]]HtmlEncode[[_]]HtmlEncode[[Property1]]"" " +
+                @"name=""HtmlEncode[[MyPrefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" Property3=""HtmlEncode[[PropValue]]"" " +
+                @"type=""HtmlEncode[[checkbox]]"" value=""HtmlEncode[[true]]"" />" +
+                @"<input name=""HtmlEncode[[MyPrefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" " +
                 @"value=""HtmlEncode[[false]]"" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetTestModelViewData());
             helper.ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix = "MyPrefix";
@@ -629,8 +644,10 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             var requiredMessage = ValidationAttributeUtil.GetRequiredErrorMessage("Property1");
             var expected =
                 $@"<input data-val=""HtmlEncode[[true]]"" data-val-required=""HtmlEncode[[{requiredMessage}]]"" " +
-                @"id=""HtmlEncode[[ComplexProperty_Property1]]"" name=""HtmlEncode[[ComplexProperty." +
-                @"Property1]]"" type=""HtmlEncode[[checkbox]]"" value=""HtmlEncode[[true]]"" /><input name=""HtmlEncode[[ComplexProperty.Property1]]"" " +
+                @"id=""HtmlEncode[[ComplexProperty]]HtmlEncode[[_]]HtmlEncode[[Property1]]"" " +
+                @"name=""HtmlEncode[[ComplexProperty]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" " +
+                @"type=""HtmlEncode[[checkbox]]"" value=""HtmlEncode[[true]]"" />" +
+                @"<input name=""HtmlEncode[[ComplexProperty]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" " +
                 @"type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[false]]"" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetModelWithValidationViewData());
 

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperDropDownListExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperDropDownListExtensionsTest.cs
@@ -198,7 +198,8 @@ namespace Microsoft.AspNetCore.Mvc.Core
         public void DropDownListFor_UsesSpecifiedExpressionAndSelectListAndHtmlAttributes()
         {
             // Arrange
-            var expectedHtml = "<select id=\"HtmlEncode[[Property3_2_]]\" Key=\"HtmlEncode[[Value]]\" name=\"HtmlEncode[[Property3[2]]]\">" +
+            var expectedHtml = "<select id=\"HtmlEncode[[Property3]]HtmlEncode[[_]]HtmlEncode[[2]]HtmlEncode[[_]]\" " +
+                "Key=\"HtmlEncode[[Value]]\" name=\"HtmlEncode[[Property3]]HtmlEncode[[[]]HtmlEncode[[2]]HtmlEncode[[]]]\">" +
                 "<option selected=\"HtmlEncode[[selected]]\" value=\"HtmlEncode[[4]]\">HtmlEncode[[Four]]</option>" + Environment.NewLine +
                 "<option value=\"HtmlEncode[[5]]\">HtmlEncode[[Five]]</option>" + Environment.NewLine +
                 "</select>";

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperFormExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperFormExtensionsTest.cs
@@ -278,7 +278,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateForm(
@@ -315,7 +315,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateForm(
@@ -352,7 +352,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateForm(
@@ -386,7 +386,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateForm(
@@ -430,7 +430,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateForm(
@@ -474,7 +474,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateForm(
@@ -514,7 +514,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateForm(
@@ -548,7 +548,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateForm(
@@ -588,7 +588,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateForm(
@@ -629,7 +629,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateForm(
@@ -670,7 +670,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateForm(
@@ -716,7 +716,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateForm(
@@ -762,7 +762,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateForm(
@@ -808,7 +808,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateForm(
@@ -856,7 +856,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateForm(
@@ -896,7 +896,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateRouteForm(
@@ -934,7 +934,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateRouteForm(
@@ -972,7 +972,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateRouteForm(
@@ -1005,7 +1005,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateRouteForm(
@@ -1043,7 +1043,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateRouteForm(
@@ -1081,7 +1081,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateRouteForm(
@@ -1116,7 +1116,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateRouteForm(
@@ -1155,7 +1155,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateRouteForm(
@@ -1199,7 +1199,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateRouteForm(
@@ -1243,7 +1243,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateRouteForm(
@@ -1287,7 +1287,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateRouteForm(
@@ -1332,7 +1332,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var tagBuilder = new TagBuilder(tagName: "form");
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             var htmlHelper = DefaultTemplatesUtilities.GetHtmlHelper(htmlGenerator.Object);
             htmlGenerator
                 .Setup(g => g.GenerateRouteForm(

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperFormTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperFormTest.cs
@@ -369,7 +369,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void BeginForm_EndForm_RendersAntiforgeryToken()
         {
             // Arrange
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             htmlGenerator
                 .Setup(g => g.GenerateForm(
                     It.IsAny<ViewContext>(),
@@ -407,7 +407,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void BeginForm_EndForm_RendersAntiforgeryTokenWhenMethodIsPost()
         {
             // Arrange
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             htmlGenerator
                 .Setup(g => g.GenerateForm(
                     It.IsAny<ViewContext>(),
@@ -446,7 +446,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void BeginForm_EndForm_SuppressAntiforgeryToken()
         {
             // Arrange
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             htmlGenerator
                 .Setup(g => g.GenerateForm(
                     It.IsAny<ViewContext>(),
@@ -484,7 +484,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void BeginForm_EndForm_SuppressAntiforgeryTokenWhenMethodIsGet()
         {
             // Arrange
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             htmlGenerator
                 .Setup(g => g.GenerateForm(
                     It.IsAny<ViewContext>(),
@@ -524,7 +524,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void BeginForm_EndForm_DoesNotSuppressAntiforgeryTokenWhenAntiforgeryIsTrue(FormMethod method)
         {
             // Arrange
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             htmlGenerator
                 .Setup(g => g.GenerateForm(
                     It.IsAny<ViewContext>(),
@@ -563,7 +563,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void BeginForm_EndForm_SuppressAntiforgeryToken_WithExplicitCallToAntiforgery()
         {
             // Arrange
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             htmlGenerator
                 .Setup(g => g.GenerateForm(
                     It.IsAny<ViewContext>(),
@@ -604,7 +604,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void BeginRouteForm_EndForm_RendersAntiforgeryToken()
         {
             // Arrange
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             htmlGenerator
                 .Setup(g => g.GenerateRouteForm(
                     It.IsAny<ViewContext>(),
@@ -641,7 +641,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void BeginRouteForm_EndForm_RendersAntiforgeryTokenWhenMethodIsPost()
         {
             // Arrange
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             htmlGenerator
                 .Setup(g => g.GenerateRouteForm(
                     It.IsAny<ViewContext>(),
@@ -684,7 +684,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void BeginRouteForm_EndForm_SuppressAntiforgeryToken()
         {
             // Arrange
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             htmlGenerator
                 .Setup(g => g.GenerateRouteForm(
                     It.IsAny<ViewContext>(),
@@ -726,7 +726,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void BeginRouteForm_EndForm_SuppressAntiforgeryTokenWhenMethodIsGet()
         {
             // Arrange
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             htmlGenerator
                 .Setup(g => g.GenerateRouteForm(
                     It.IsAny<ViewContext>(),
@@ -770,7 +770,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void BeginRouteForm_EndForm_DoesNotSuppressAntiforgeryTokenWhenAntiforgeryIsTrue(FormMethod method)
         {
             // Arrange
-            var htmlGenerator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var htmlGenerator = new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict);
             htmlGenerator
                 .Setup(g => g.GenerateRouteForm(
                     It.IsAny<ViewContext>(),

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperHiddenTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperHiddenTest.cs
@@ -20,12 +20,12 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             get
             {
                 var expected1 = @"<input baz=""HtmlEncode[[BazValue]]"" id=""HtmlEncode[[Property1]]"" name=""HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" " +
-                                @"value=""HtmlEncode[[ModelStateValue]]"" />";
+                    @"value=""HtmlEncode[[ModelStateValue]]"" />";
                 yield return new object[] { new Dictionary<string, object> { { "baz", "BazValue" } }, expected1 };
                 yield return new object[] { new { baz = "BazValue" }, expected1 };
 
                 var expected2 = @"<input foo-baz=""HtmlEncode[[BazValue]]"" id=""HtmlEncode[[Property1]]"" name=""HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" " +
-                                @"value=""HtmlEncode[[ModelStateValue]]"" />";
+                    @"value=""HtmlEncode[[ModelStateValue]]"" />";
                 yield return new object[] { new Dictionary<string, object> { { "foo-baz", "BazValue" } }, expected2 };
                 yield return new object[] { new { foo_baz = "BazValue" }, expected2 };
             }
@@ -81,7 +81,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void HiddenInTemplate_GetsValueFromPropertyOfViewDataEntry()
         {
             // Arrange
-            var expected = @"<input id=""HtmlEncode[[Prefix_Property1]]"" name=""HtmlEncode[[Prefix.Property1]]"" " +
+            var expected = @"<input id=""HtmlEncode[[Prefix]]HtmlEncode[[_]]HtmlEncode[[Property1]]"" " +
+                @"name=""HtmlEncode[[Prefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" " +
                 @"type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[contained-view-data-value]]"" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetViewDataWithNonNullModel());
             helper.ViewData.TemplateInfo.HtmlFieldPrefix = "Prefix";
@@ -116,7 +117,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void HiddenInTemplate_GetsValueFromViewDataEntry_EvenIfNull()
         {
             // Arrange
-            var expected = @"<input id=""HtmlEncode[[Prefix_Property1]]"" name=""HtmlEncode[[Prefix.Property1]]"" " +
+            var expected = @"<input id=""HtmlEncode[[Prefix]]HtmlEncode[[_]]HtmlEncode[[Property1]]"" " +
+                @"name=""HtmlEncode[[Prefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" " +
                 @"type=""HtmlEncode[[hidden]]"" value="""" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetViewDataWithNonNullModel());
             helper.ViewData.TemplateInfo.HtmlFieldPrefix = "Prefix";
@@ -151,7 +153,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var expected = @"<input id=""HtmlEncode[[Property1]]"" key=""HtmlEncode[[value]]"" name=""HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" " +
-                           @"value=""HtmlEncode[[test]]"" />";
+                @"value=""HtmlEncode[[test]]"" />";
             var attributes = new { key = "value" };
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetViewDataWithNullModelAndNonNullViewData());
 
@@ -167,7 +169,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var expected = @"<input data-key=""HtmlEncode[[value]]"" id=""HtmlEncode[[Property1]]"" name=""HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" " +
-                           @"value=""HtmlEncode[[test]]"" />";
+                @"value=""HtmlEncode[[test]]"" />";
             var attributes = new Dictionary<string, object> { { "data-key", "value" } };
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetViewDataWithNullModelAndNonNullViewData());
 
@@ -244,7 +246,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void HiddenInTemplate_GetsModelValue_IfModelStateAndViewDataEmpty()
         {
             // Arrange
-            var expected = @"<input id=""HtmlEncode[[Prefix_Property1]]"" name=""HtmlEncode[[Prefix.Property1]]"" " +
+            var expected = @"<input id=""HtmlEncode[[Prefix]]HtmlEncode[[_]]HtmlEncode[[Property1]]"" " +
+                @"name=""HtmlEncode[[Prefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" " +
                 @"type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[property-value]]"" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetViewDataWithNonNullModel());
             helper.ViewData.TemplateInfo.HtmlFieldPrefix = "Prefix";
@@ -275,7 +278,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void HiddenInTemplate_DoesNotUseAttributeValue()
         {
             // Arrange
-            var expected = @"<input id=""HtmlEncode[[Prefix_Property1]]"" name=""HtmlEncode[[Prefix.Property1]]"" " +
+            var expected = @"<input id=""HtmlEncode[[Prefix]]HtmlEncode[[_]]HtmlEncode[[Property1]]"" " +
+                @"name=""HtmlEncode[[Prefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" " +
                 @"type=""HtmlEncode[[hidden]]"" value="""" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetViewDataWithNonNullModel());
             helper.ViewData.TemplateInfo.HtmlFieldPrefix = "Prefix";
@@ -292,7 +296,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             // Arrange
             var expected = @"<input baz=""HtmlEncode[[BazValue]]"" id=""HtmlEncode[[keyNotFound]]"" name=""HtmlEncode[[keyNotFound]]"" type=""HtmlEncode[[hidden]]"" " +
-                           @"value="""" />";
+                @"value="""" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetViewDataWithModelStateAndModelAndViewDataValues());
             var attributes = new Dictionary<string, object> { { "baz", "BazValue" } };
 
@@ -307,7 +311,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void HiddenInTemplate_GetsEmptyValue_IfPropertyIsNotFound()
         {
             // Arrange
-            var expected = @"<input id=""HtmlEncode[[Prefix_keyNotFound]]"" name=""HtmlEncode[[Prefix.keyNotFound]]"" " +
+            var expected = @"<input id=""HtmlEncode[[Prefix]]HtmlEncode[[_]]HtmlEncode[[keyNotFound]]"" " +
+                @"name=""HtmlEncode[[Prefix]]HtmlEncode[[.]]HtmlEncode[[keyNotFound]]"" " +
                 @"type=""HtmlEncode[[hidden]]"" value="""" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetViewDataWithModelStateAndModelAndViewDataValues());
             helper.ViewData.TemplateInfo.HtmlFieldPrefix = "Prefix";
@@ -323,8 +328,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void HiddenInTemplate_WithExplicitValue_GeneratesExpectedValue()
         {
             // Arrange
-            var expected = @"<input id=""HtmlEncode[[MyPrefix_Property1]]"" name=""HtmlEncode[[MyPrefix.Property1]]"" type=""HtmlEncode[[hidden]]"" " +
-                           @"value=""HtmlEncode[[PropValue]]"" />";
+            var expected = @"<input id=""HtmlEncode[[MyPrefix]]HtmlEncode[[_]]HtmlEncode[[Property1]]"" " +
+                @"name=""HtmlEncode[[MyPrefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" " +
+                @"value=""HtmlEncode[[PropValue]]"" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetViewDataWithModelStateAndModelAndViewDataValues());
             helper.ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix = "MyPrefix";
 
@@ -354,8 +360,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void HiddenInTemplate_UsesPrefixName_ToLookupPropertyValueInModelState()
         {
             // Arrange
-            var expected = @"<input id=""HtmlEncode[[MyPrefix$Property1]]"" name=""HtmlEncode[[MyPrefix.Property1]]"" type=""HtmlEncode[[hidden]]"" " +
-                           @"value=""HtmlEncode[[modelstate-with-prefix]]"" />";
+            var expected = @"<input id=""HtmlEncode[[MyPrefix]]HtmlEncode[[$]]HtmlEncode[[Property1]]"" " +
+                @"name=""HtmlEncode[[MyPrefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" " +
+                @"value=""HtmlEncode[[modelstate-with-prefix]]"" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(
                 GetViewDataWithModelStateAndModelAndViewDataValues(),
                 idAttributeDotReplacement: "$");
@@ -385,8 +392,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void HiddenInTemplate_UsesPrefixNameToLookupPropertyValueInViewData()
         {
             // Arrange
-            var expected = @"<input id=""HtmlEncode[[MyPrefix$Property1]]"" name=""HtmlEncode[[MyPrefix.Property1]]"" type=""HtmlEncode[[hidden]]"" " +
-                           @"value=""HtmlEncode[[vdd-with-prefix]]"" />";
+            var expected = @"<input id=""HtmlEncode[[MyPrefix]]HtmlEncode[[$]]HtmlEncode[[Property1]]"" " +
+                @"name=""HtmlEncode[[MyPrefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" " +
+                @"value=""HtmlEncode[[vdd-with-prefix]]"" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(
                 GetViewDataWithModelStateAndModelAndViewDataValues(),
                 idAttributeDotReplacement: "$");
@@ -428,8 +436,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void HiddenWithViewDataErrors_GeneratesExpectedValue()
         {
             // Arrange
-            var expected = @"<input baz=""HtmlEncode[[BazValue]]"" class=""HtmlEncode[[input-validation-error some-class]]"" id=""HtmlEncode[[Property1]]""" +
-                           @" name=""HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[ModelStateValue]]"" />";
+            var expected = @"<input baz=""HtmlEncode[[BazValue]]"" " +
+                @"class=""HtmlEncode[[input-validation-error]]HtmlEncode[[ ]]HtmlEncode[[some-class]]"" id=""HtmlEncode[[Property1]]""" +
+                @" name=""HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[ModelStateValue]]"" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetViewDataWithErrors());
             var attributes = new Dictionary<string, object>
             {
@@ -643,8 +652,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void HiddenForInTemplate_GeneratesExpectedValue()
         {
             // Arrange
-            var expected = @"<input id=""HtmlEncode[[MyPrefix_Property1]]"" name=""HtmlEncode[[MyPrefix.Property1]]"" type=""HtmlEncode[[hidden]]"" " +
-                           @"value=""HtmlEncode[[propValue]]"" />";
+            var expected = @"<input id=""HtmlEncode[[MyPrefix]]HtmlEncode[[_]]HtmlEncode[[Property1]]"" " +
+                @"name=""HtmlEncode[[MyPrefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" " +
+                @"value=""HtmlEncode[[propValue]]"" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetViewDataWithModelStateAndModelAndViewDataValues());
             helper.ViewData.Model.Property1 = "propValue";
             helper.ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix = "MyPrefix";
@@ -660,8 +670,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void HiddenForInTemplate_UsesPrefixWhenLookingUpModelStateValues()
         {
             // Arrange
-            var expected = @"<input id=""HtmlEncode[[MyPrefix$Property1]]"" name=""HtmlEncode[[MyPrefix.Property1]]"" type=""HtmlEncode[[hidden]]"" " +
-                           @"value=""HtmlEncode[[modelstate-with-prefix]]"" />";
+            var expected = @"<input id=""HtmlEncode[[MyPrefix]]HtmlEncode[[$]]HtmlEncode[[Property1]]"" " +
+                @"name=""HtmlEncode[[MyPrefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" " +
+                @"value=""HtmlEncode[[modelstate-with-prefix]]"" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(
                 GetViewDataWithModelStateAndModelAndViewDataValues(),
                 "$");
@@ -692,8 +703,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void HiddenForWithViewDataErrors_GeneratesExpectedValue()
         {
             // Arrange
-            var expected = @"<input baz=""HtmlEncode[[BazValue]]"" class=""HtmlEncode[[input-validation-error some-class]]"" id=""HtmlEncode[[Property1]]"" " +
-                           @"name=""HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[ModelStateValue]]"" />";
+            var expected = @"<input baz=""HtmlEncode[[BazValue]]"" " +
+                @"class=""HtmlEncode[[input-validation-error]]HtmlEncode[[ ]]HtmlEncode[[some-class]]"" id=""HtmlEncode[[Property1]]"" " +
+                @"name=""HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[ModelStateValue]]"" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetViewDataWithErrors());
             var attributes = new Dictionary<string, object>
             {
@@ -735,23 +747,31 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
                 {
                     {
                         model => model.Property3["key"],
-                        @"<input data-val=""HtmlEncode[[true]]"" id=""HtmlEncode[[Property3_key_]]"" name=""HtmlEncode[[Property3[key]]]"" " +
+                        @"<input data-val=""HtmlEncode[[true]]"" " +
+                        @"id=""HtmlEncode[[Property3]]HtmlEncode[[_]]HtmlEncode[[key]]HtmlEncode[[_]]"" " +
+                        @"name=""HtmlEncode[[Property3]]HtmlEncode[[[]]HtmlEncode[[key]]HtmlEncode[[]]]"" " +
                         @"type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[ModelProp3Val]]"" />"
                     },
                     {
                         model => model.Property4.Property5,
-                        @"<input data-val=""HtmlEncode[[true]]"" id=""HtmlEncode[[Property4_Property5]]"" name=""HtmlEncode[[Property4.Property5]]"" " +
+                        @"<input data-val=""HtmlEncode[[true]]"" " +
+                        @"id=""HtmlEncode[[Property4]]HtmlEncode[[_]]HtmlEncode[[Property5]]"" " +
+                        @"name=""HtmlEncode[[Property4]]HtmlEncode[[.]]HtmlEncode[[Property5]]"" " +
                         @"type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[ModelProp5Val]]"" />"
                     },
                     {
                         model => model.Property4.Property6[0],
-                        @"<input data-val=""HtmlEncode[[true]]"" id=""HtmlEncode[[Property4_Property6_0_]]"" name=""HtmlEncode[[Property4.Property6[0]]]"" " +
+                        @"<input data-val=""HtmlEncode[[true]]"" " +
+                        @"id=""HtmlEncode[[Property4]]HtmlEncode[[_]]HtmlEncode[[Property6]]HtmlEncode[[_]]HtmlEncode[[0]]HtmlEncode[[_]]"" " +
+                        @"name=""HtmlEncode[[Property4]]HtmlEncode[[.]]HtmlEncode[[Property6]]HtmlEncode[[[]]HtmlEncode[[0]]HtmlEncode[[]]]"" " +
                         @"type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[ModelProp6Val]]"" />"
                     },
                     {
                         model => localModel.Property4.Property5,
-                        @"<input data-val=""HtmlEncode[[true]]"" id=""HtmlEncode[[localModel_Property4_Property5]]"" " +
-                        @"name=""HtmlEncode[[localModel.Property4.Property5]]"" type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[local-value]]"" />"
+                        @"<input data-val=""HtmlEncode[[true]]"" " +
+                        @"id=""HtmlEncode[[localModel]]HtmlEncode[[_]]HtmlEncode[[Property4]]HtmlEncode[[_]]HtmlEncode[[Property5]]"" " +
+                        @"name=""HtmlEncode[[localModel]]HtmlEncode[[.]]HtmlEncode[[Property4]]HtmlEncode[[.]]HtmlEncode[[Property5]]"" " +
+                        @"type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[local-value]]"" />"
                     }
                 };
             }
@@ -794,18 +814,24 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
                 {
                     {
                         model => model.Property3["key"],
-                        @"<input data-val=""HtmlEncode[[true]]"" id=""HtmlEncode[[pre_Property3_key_]]"" name=""HtmlEncode[[pre.Property3[key]]]"" " +
+                        @"<input data-val=""HtmlEncode[[true]]"" " +
+                        @"id=""HtmlEncode[[pre]]HtmlEncode[[_]]HtmlEncode[[Property3]]HtmlEncode[[_]]HtmlEncode[[key]]HtmlEncode[[_]]"" " +
+                        @"name=""HtmlEncode[[pre]]HtmlEncode[[.]]HtmlEncode[[Property3]]HtmlEncode[[[]]HtmlEncode[[key]]HtmlEncode[[]]]"" " +
                         @"type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[Prop3Val]]"" />"
                     },
                     {
                         model => model.Property4.Property5,
-                        @"<input data-val=""HtmlEncode[[true]]"" id=""HtmlEncode[[pre_Property4_Property5]]"" name=""HtmlEncode[[pre.Property4.Property5]]"" " +
+                        @"<input data-val=""HtmlEncode[[true]]"" " +
+                        @"id=""HtmlEncode[[pre]]HtmlEncode[[_]]HtmlEncode[[Property4]]HtmlEncode[[_]]HtmlEncode[[Property5]]"" " +
+                        @"name=""HtmlEncode[[pre]]HtmlEncode[[.]]HtmlEncode[[Property4]]HtmlEncode[[.]]HtmlEncode[[Property5]]"" " +
                         @"type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[Prop5Val]]"" />"
                     },
                     {
                         model => model.Property4.Property6[0],
-                        @"<input data-val=""HtmlEncode[[true]]"" id=""HtmlEncode[[pre_Property4_Property6_0_]]"" " +
-                        @"name=""HtmlEncode[[pre.Property4.Property6[0]]]"" type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[Prop6Val]]"" />"
+                        @"<input data-val=""HtmlEncode[[true]]"" " +
+                        @"id=""HtmlEncode[[pre]]HtmlEncode[[_]]HtmlEncode[[Property4]]HtmlEncode[[_]]HtmlEncode[[Property6]]HtmlEncode[[_]]HtmlEncode[[0]]HtmlEncode[[_]]"" " +
+                        @"name=""HtmlEncode[[pre]]HtmlEncode[[.]]HtmlEncode[[Property4]]HtmlEncode[[.]]HtmlEncode[[Property6]]HtmlEncode[[[]]HtmlEncode[[0]]HtmlEncode[[]]]"" " +
+                        @"type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[Prop6Val]]"" />"
                     }
                 };
             }

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperLabelExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperLabelExtensionsTest.cs
@@ -45,8 +45,12 @@ namespace Microsoft.AspNetCore.Mvc.Core
             var labelForResult = helper.LabelFor(m => m.Property1);
 
             // Assert
-            Assert.Equal("<label for=\"HtmlEncode[[Property1]]\">HtmlEncode[[Property1]]</label>", HtmlContentUtilities.HtmlContentToString(labelResult));
-            Assert.Equal("<label for=\"HtmlEncode[[Property1]]\">HtmlEncode[[Property1]]</label>", HtmlContentUtilities.HtmlContentToString(labelForResult));
+            Assert.Equal(
+                "<label for=\"HtmlEncode[[Property1]]\">HtmlEncode[[Property1]]</label>",
+                HtmlContentUtilities.HtmlContentToString(labelResult));
+            Assert.Equal(
+                "<label for=\"HtmlEncode[[Property1]]\">HtmlEncode[[Property1]]</label>",
+                HtmlContentUtilities.HtmlContentToString(labelForResult));
         }
 
         [Fact]
@@ -60,8 +64,12 @@ namespace Microsoft.AspNetCore.Mvc.Core
             var labelForResult = helper.LabelFor(m => m.Inner.Id);
 
             // Assert
-            Assert.Equal("<label for=\"HtmlEncode[[Inner_Id]]\">HtmlEncode[[Id]]</label>", HtmlContentUtilities.HtmlContentToString(labelResult));
-            Assert.Equal("<label for=\"HtmlEncode[[Inner_Id]]\">HtmlEncode[[Id]]</label>", HtmlContentUtilities.HtmlContentToString(labelForResult));
+            Assert.Equal(
+                "<label for=\"HtmlEncode[[Inner_Id]]\">HtmlEncode[[Id]]</label>",
+                HtmlContentUtilities.HtmlContentToString(labelResult));
+            Assert.Equal(
+                "<label for=\"HtmlEncode[[Inner]]HtmlEncode[[_]]HtmlEncode[[Id]]\">HtmlEncode[[Id]]</label>",
+                HtmlContentUtilities.HtmlContentToString(labelForResult));
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperPasswordTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperPasswordTest.cs
@@ -78,8 +78,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void PasswordWithPrefix_GeneratesExpectedValue()
         {
             // Arrange
-            var expected = @"<input id=""HtmlEncode[[MyPrefix_Property1]]"" name=""HtmlEncode[[MyPrefix.Property1]]"" type=""HtmlEncode[[password]]"" " +
-                           @"value=""HtmlEncode[[explicit-value]]"" />";
+            var expected = @"<input id=""HtmlEncode[[MyPrefix]]HtmlEncode[[_]]HtmlEncode[[Property1]]"" " +
+                @"name=""HtmlEncode[[MyPrefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" type=""HtmlEncode[[password]]"" " +
+                @"value=""HtmlEncode[[explicit-value]]"" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetViewDataWithModelStateAndModelAndViewDataValues());
             helper.ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix = "MyPrefix";
 
@@ -94,8 +95,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void PasswordWithPrefix_UsesIdDotReplacementToken()
         {
             // Arrange
-            var expected = @"<input id=""HtmlEncode[[MyPrefix$Property1]]"" name=""HtmlEncode[[MyPrefix.Property1]]"" type=""HtmlEncode[[password]]"" " +
-                           @"value=""HtmlEncode[[explicit-value]]"" />";
+            var expected = @"<input id=""HtmlEncode[[MyPrefix]]HtmlEncode[[$]]HtmlEncode[[Property1]]"" " +
+                @"name=""HtmlEncode[[MyPrefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" type=""HtmlEncode[[password]]"" " +
+                @"value=""HtmlEncode[[explicit-value]]"" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(
                 GetViewDataWithModelStateAndModelAndViewDataValues(),
                 idAttributeDotReplacement: "$");
@@ -146,8 +148,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void Password_UsesModelStateErrors_ButDoesNotUseModelOrViewDataOrModelStateForValueAttribute()
         {
             // Arrange
-            var expected = @"<input class=""HtmlEncode[[input-validation-error some-class]]"" id=""HtmlEncode[[Property1]]""" +
-                           @" name=""HtmlEncode[[Property1]]"" test-key=""HtmlEncode[[test-value]]"" type=""HtmlEncode[[password]]"" />";
+            var expected = @"<input class=""HtmlEncode[[input-validation-error]]HtmlEncode[[ ]]HtmlEncode[[some-class]]"" " +
+                @"id=""HtmlEncode[[Property1]]""" +
+                @" name=""HtmlEncode[[Property1]]"" test-key=""HtmlEncode[[test-value]]"" type=""HtmlEncode[[password]]"" />";
             var vdd = GetViewDataWithErrors();
             vdd.Model.Property1 = "property-value";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(vdd);
@@ -240,7 +243,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void PasswordForWithPrefix_GeneratesExpectedValue()
         {
             // Arrange
-            var expected = @"<input id=""HtmlEncode[[MyPrefix_Property1]]"" name=""HtmlEncode[[MyPrefix.Property1]]"" type=""HtmlEncode[[password]]"" />";
+            var expected = @"<input id=""HtmlEncode[[MyPrefix]]HtmlEncode[[_]]HtmlEncode[[Property1]]"" " +
+                @"name=""HtmlEncode[[MyPrefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]"" type=""HtmlEncode[[password]]"" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetViewDataWithModelStateAndModelAndViewDataValues());
             helper.ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix = "MyPrefix";
 
@@ -255,8 +259,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         public void PasswordFor_UsesModelStateErrors_ButDoesNotUseModelOrViewDataOrModelStateForValueAttribute()
         {
             // Arrange
-            var expected = @"<input baz=""HtmlEncode[[BazValue]]"" class=""HtmlEncode[[input-validation-error some-class]]"" id=""HtmlEncode[[Property1]]"" " +
-                           @"name=""HtmlEncode[[Property1]]"" type=""HtmlEncode[[password]]"" />";
+            var expected = @"<input baz=""HtmlEncode[[BazValue]]"" " +
+                @"class=""HtmlEncode[[input-validation-error]]HtmlEncode[[ ]]HtmlEncode[[some-class]]"" id=""HtmlEncode[[Property1]]"" " +
+                @"name=""HtmlEncode[[Property1]]"" type=""HtmlEncode[[password]]"" />";
             var vdd = GetViewDataWithErrors();
             vdd.Model.Property1 = "prop1-value";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(vdd);
@@ -298,18 +303,24 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
                 {
                     {
                         model => model.Property3["key"],
-                        @"<input data-val=""HtmlEncode[[true]]"" id=""HtmlEncode[[pre_Property3_key_]]"" name=""HtmlEncode[[pre.Property3[key]]]"" " +
+                        @"<input data-val=""HtmlEncode[[true]]"" " +
+                        @"id=""HtmlEncode[[pre]]HtmlEncode[[_]]HtmlEncode[[Property3]]HtmlEncode[[_]]HtmlEncode[[key]]HtmlEncode[[_]]"" " +
+                        @"name=""HtmlEncode[[pre]]HtmlEncode[[.]]HtmlEncode[[Property3]]HtmlEncode[[[]]HtmlEncode[[key]]HtmlEncode[[]]]"" " +
                         @"type=""HtmlEncode[[password]]"" value=""HtmlEncode[[attr-value]]"" />"
                     },
                     {
                         model => model.Property4.Property5,
-                        @"<input data-val=""HtmlEncode[[true]]"" id=""HtmlEncode[[pre_Property4_Property5]]"" name=""HtmlEncode[[pre.Property4.Property5]]"" " +
+                        @"<input data-val=""HtmlEncode[[true]]"" " +
+                        @"id=""HtmlEncode[[pre]]HtmlEncode[[_]]HtmlEncode[[Property4]]HtmlEncode[[_]]HtmlEncode[[Property5]]"" " +
+                        @"name=""HtmlEncode[[pre]]HtmlEncode[[.]]HtmlEncode[[Property4]]HtmlEncode[[.]]HtmlEncode[[Property5]]"" " +
                         @"type=""HtmlEncode[[password]]"" value=""HtmlEncode[[attr-value]]"" />"
                     },
                     {
                         model => model.Property4.Property6[0],
-                        @"<input data-val=""HtmlEncode[[true]]"" id=""HtmlEncode[[pre_Property4_Property6_0_]]"" " +
-                        @"name=""HtmlEncode[[pre.Property4.Property6[0]]]"" type=""HtmlEncode[[password]]"" value=""HtmlEncode[[attr-value]]"" />"
+                        @"<input data-val=""HtmlEncode[[true]]"" " +
+                        @"id=""HtmlEncode[[pre]]HtmlEncode[[_]]HtmlEncode[[Property4]]HtmlEncode[[_]]HtmlEncode[[Property6]]HtmlEncode[[_]]HtmlEncode[[0]]HtmlEncode[[_]]"" " +
+                        @"name=""HtmlEncode[[pre]]HtmlEncode[[.]]HtmlEncode[[Property4]]HtmlEncode[[.]]HtmlEncode[[Property6]]HtmlEncode[[[]]HtmlEncode[[0]]HtmlEncode[[]]]"" " +
+                        @"type=""HtmlEncode[[password]]"" value=""HtmlEncode[[attr-value]]"" />"
                     }
                 };
             }
@@ -446,18 +457,21 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
                 {
                     {
                         model => model.Property3["key"],
-                        @"<input id=""HtmlEncode[[pre_Property3_key_]]"" name=""HtmlEncode[[pre.Property3[key]]]"" " +
+                        @"<input id=""HtmlEncode[[pre]]HtmlEncode[[_]]HtmlEncode[[Property3]]HtmlEncode[[_]]HtmlEncode[[key]]HtmlEncode[[_]]"" " +
+                        @"name=""HtmlEncode[[pre]]HtmlEncode[[.]]HtmlEncode[[Property3]]HtmlEncode[[[]]HtmlEncode[[key]]HtmlEncode[[]]]"" " +
                         @"type=""HtmlEncode[[password]]"" />"
                     },
                     {
                         model => model.Property4.Property5,
-                        @"<input id=""HtmlEncode[[pre_Property4_Property5]]"" name=""HtmlEncode[[pre.Property4.Property5]]"" " +
+                        @"<input id=""HtmlEncode[[pre]]HtmlEncode[[_]]HtmlEncode[[Property4]]HtmlEncode[[_]]HtmlEncode[[Property5]]"" " +
+                        @"name=""HtmlEncode[[pre]]HtmlEncode[[.]]HtmlEncode[[Property4]]HtmlEncode[[.]]HtmlEncode[[Property5]]"" " +
                         @"type=""HtmlEncode[[password]]"" />"
                     },
                     {
                         model => model.Property4.Property6[0],
-                        @"<input id=""HtmlEncode[[pre_Property4_Property6_0_]]"" " +
-                        @"name=""HtmlEncode[[pre.Property4.Property6[0]]]"" type=""HtmlEncode[[password]]"" />"
+                        @"<input id=""HtmlEncode[[pre]]HtmlEncode[[_]]HtmlEncode[[Property4]]HtmlEncode[[_]]HtmlEncode[[Property6]]HtmlEncode[[_]]HtmlEncode[[0]]HtmlEncode[[_]]"" " +
+                        @"name=""HtmlEncode[[pre]]HtmlEncode[[.]]HtmlEncode[[Property4]]HtmlEncode[[.]]HtmlEncode[[Property6]]HtmlEncode[[[]]HtmlEncode[[0]]HtmlEncode[[]]]"" " +
+                        @"type=""HtmlEncode[[password]]"" />"
                     }
                 };
             }
@@ -469,7 +483,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             Expression<Func<PasswordModel, string>> expression,
             string expected)
         {
-            // Arrange            
+            // Arrange
             var model = new PasswordModel();
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
             helper.ViewData.TemplateInfo.HtmlFieldPrefix = "pre";
@@ -489,7 +503,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             // Act
             var result = helper.PasswordFor(expression);
 
-            // Assert 
+            // Assert
             Assert.Equal(expected, HtmlContentUtilities.HtmlContentToString(result));
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperSelectTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperSelectTest.cs
@@ -698,7 +698,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             var selectList = SomeDisabledOneSelectedSelectList;
             var savedSelected = selectList.Select(item => item.Selected).ToList();
             var expectedHtml =
-                "<select id=\"HtmlEncode[[Property1_2_]]\" name=\"HtmlEncode[[Property1[2]]]\"><option value=\"HtmlEncode[[0]]\">HtmlEncode[[Zero]]</option>" +
+                "<select id=\"HtmlEncode[[Property1]]HtmlEncode[[_]]HtmlEncode[[2]]HtmlEncode[[_]]\" " +
+                "name=\"HtmlEncode[[Property1]]HtmlEncode[[[]]HtmlEncode[[2]]HtmlEncode[[]]]\"><option value=\"HtmlEncode[[0]]\">HtmlEncode[[Zero]]</option>" +
                 Environment.NewLine +
                 "<option disabled=\"HtmlEncode[[disabled]]\" value=\"HtmlEncode[[1]]\">HtmlEncode[[One]]</option>" + Environment.NewLine +
                 "<option selected=\"HtmlEncode[[selected]]\" value=\"HtmlEncode[[2]]\">HtmlEncode[[Two]]</option>" + Environment.NewLine +
@@ -1526,8 +1527,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
 
         private static string GetExpectedSelectElementWithPrefix(SelectSources source, bool allowMultiple)
         {
-            return $"<select id=\"HtmlEncode[[Prefix_Property1]]\"{ GetMultiple(allowMultiple) } " +
-                "name=\"HtmlEncode[[Prefix.Property1]]\">" +
+            return $"<select id=\"HtmlEncode[[Prefix]]HtmlEncode[[_]]HtmlEncode[[Property1]]\"{ GetMultiple(allowMultiple) } " +
+                "name=\"HtmlEncode[[Prefix]]HtmlEncode[[.]]HtmlEncode[[Property1]]\">" +
                 $"{ GetOption(SelectSources.ModelStateEntry, source) }{ Environment.NewLine }" +
                 $"{ GetOption(SelectSources.ModelStateEntryWithPrefix, source) }{ Environment.NewLine }" +
                 $"{ GetOption(SelectSources.ViewDataEntry, source) }{ Environment.NewLine }" +
@@ -1576,7 +1577,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         {
             public TestHtmlHelper(IModelMetadataProvider metadataProvider)
                 : base(
-                      new Mock<IHtmlGenerator>(MockBehavior.Strict).Object,
+                      new Mock<IHtmlGeneratorTutu>(MockBehavior.Strict).Object,
                       new Mock<ICompositeViewEngine>(MockBehavior.Strict).Object,
                       metadataProvider,
                       new TestViewBufferScope(),

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperTextAreaTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperTextAreaTest.cs
@@ -15,14 +15,14 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         [Fact]
         public void TextAreaFor_GeneratesPlaceholderAttribute_WhenDisplayAttributePromptIsSetAndTypeIsValid()
         {
-            // Arrange            
+            // Arrange
             var model = new TextAreaModelWithAPlaceholder();
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
 
             // Act
             var textArea = helper.TextAreaFor(m => m.Property1);
 
-            // Assert 
+            // Assert
             var result = HtmlContentUtilities.HtmlContentToString(textArea);
             Assert.Contains(@"placeholder=""HtmlEncode[[placeholder]]""", result, StringComparison.Ordinal);
         }
@@ -30,14 +30,14 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         [Fact]
         public void TextAreaFor_DoesNotGeneratePlaceholderAttribute_WhenNoPlaceholderPresentInModel()
         {
-            // Arrange            
+            // Arrange
             var model = new TextAreaModelWithoutAPlaceholder();
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
 
             // Act
             var textArea = helper.TextAreaFor(m => m.Property1);
 
-            // Assert 
+            // Assert
             var result = HtmlContentUtilities.HtmlContentToString(textArea);
             Assert.DoesNotContain(@"placeholder=""HtmlEncode[[placeholder]]""", result, StringComparison.Ordinal);
         }
@@ -50,17 +50,20 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
                 {
                     {
                         model => model.Property3["key"],
-                        "<textarea id=\"HtmlEncode[[pre_Property3_key_]]\" name=\"HtmlEncode[[pre.Property3[key]]]\">" + Environment.NewLine +
+                        "<textarea id=\"HtmlEncode[[pre]]HtmlEncode[[_]]HtmlEncode[[Property3]]HtmlEncode[[_]]HtmlEncode[[key]]HtmlEncode[[_]]\" " +
+                        "name=\"HtmlEncode[[pre]]HtmlEncode[[.]]HtmlEncode[[Property3]]HtmlEncode[[[]]HtmlEncode[[key]]HtmlEncode[[]]]\">" + Environment.NewLine +
                         "HtmlEncode[[Prop3Val]]</textarea>"
                     },
                     {
                         model => model.Property4.Property5,
-                        "<textarea id=\"HtmlEncode[[pre_Property4_Property5]]\" name=\"HtmlEncode[[pre.Property4.Property5]]\">" + Environment.NewLine +
+                        "<textarea id=\"HtmlEncode[[pre]]HtmlEncode[[_]]HtmlEncode[[Property4]]HtmlEncode[[_]]HtmlEncode[[Property5]]\" " +
+                        "name=\"HtmlEncode[[pre]]HtmlEncode[[.]]HtmlEncode[[Property4]]HtmlEncode[[.]]HtmlEncode[[Property5]]\">" + Environment.NewLine +
                         "HtmlEncode[[Prop5Val]]</textarea>"
                     },
                     {
                         model => model.Property4.Property6[0],
-                        "<textarea id=\"HtmlEncode[[pre_Property4_Property6_0_]]\" name=\"HtmlEncode[[pre.Property4.Property6[0]]]\">" + Environment.NewLine +
+                        "<textarea id=\"HtmlEncode[[pre]]HtmlEncode[[_]]HtmlEncode[[Property4]]HtmlEncode[[_]]HtmlEncode[[Property6]]HtmlEncode[[_]]HtmlEncode[[0]]HtmlEncode[[_]]\" " +
+                        "name=\"HtmlEncode[[pre]]HtmlEncode[[.]]HtmlEncode[[Property4]]HtmlEncode[[.]]HtmlEncode[[Property6]]HtmlEncode[[[]]HtmlEncode[[0]]HtmlEncode[[]]]\">" + Environment.NewLine +
                         "HtmlEncode[[Prop6Val]]</textarea>"
                     }
                 };
@@ -97,17 +100,20 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
                 {
                     {
                         model => model.Property3["key"],
-                        "<textarea id=\"HtmlEncode[[pre_Property3_key_]]\" name=\"HtmlEncode[[pre.Property3[key]]]\">" + Environment.NewLine +
+                        "<textarea id=\"HtmlEncode[[pre]]HtmlEncode[[_]]HtmlEncode[[Property3]]HtmlEncode[[_]]HtmlEncode[[key]]HtmlEncode[[_]]\" " +
+                        "name=\"HtmlEncode[[pre]]HtmlEncode[[.]]HtmlEncode[[Property3]]HtmlEncode[[[]]HtmlEncode[[key]]HtmlEncode[[]]]\">" + Environment.NewLine +
                         "HtmlEncode[[MProp3Val]]</textarea>"
                     },
                     {
                         model => model.Property4.Property5,
-                        "<textarea id=\"HtmlEncode[[pre_Property4_Property5]]\" name=\"HtmlEncode[[pre.Property4.Property5]]\">" + Environment.NewLine +
+                        "<textarea id=\"HtmlEncode[[pre]]HtmlEncode[[_]]HtmlEncode[[Property4]]HtmlEncode[[_]]HtmlEncode[[Property5]]\" " +
+                        "name=\"HtmlEncode[[pre]]HtmlEncode[[.]]HtmlEncode[[Property4]]HtmlEncode[[.]]HtmlEncode[[Property5]]\">" + Environment.NewLine +
                         "HtmlEncode[[MProp5Val]]</textarea>"
                     },
                     {
                         model => model.Property4.Property6[0],
-                        "<textarea id=\"HtmlEncode[[pre_Property4_Property6_0_]]\" name=\"HtmlEncode[[pre.Property4.Property6[0]]]\">" + Environment.NewLine +
+                        "<textarea id=\"HtmlEncode[[pre]]HtmlEncode[[_]]HtmlEncode[[Property4]]HtmlEncode[[_]]HtmlEncode[[Property6]]HtmlEncode[[_]]HtmlEncode[[0]]HtmlEncode[[_]]\" " +
+                        "name=\"HtmlEncode[[pre]]HtmlEncode[[.]]HtmlEncode[[Property4]]HtmlEncode[[.]]HtmlEncode[[Property6]]HtmlEncode[[[]]HtmlEncode[[0]]HtmlEncode[[]]]\">" + Environment.NewLine +
                         "HtmlEncode[[MProp6Val]]</textarea>"
                     }
                 };

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperTextBoxTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperTextBoxTest.cs
@@ -21,14 +21,14 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         [InlineData("number")]
         public void TextBoxFor_GeneratesPlaceholderAttribute_WhenDisplayAttributePromptIsSetAndTypeIsValid(string type)
         {
-            // Arrange            
+            // Arrange
             var model = new TextBoxModel();
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
 
             // Act
             var textBox = helper.TextBoxFor(m => m.Property1, new { type });
 
-            // Assert 
+            // Assert
             var result = HtmlContentUtilities.HtmlContentToString(textBox);
             Assert.Contains(@"placeholder=""HtmlEncode[[placeholder]]""", result, StringComparison.Ordinal);
         }
@@ -48,14 +48,14 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         [InlineData("file")]
         public void TextBoxFor_DoesNotGeneratePlaceholderAttribute_WhenDisplayAttributePromptIsSetAndTypeIsInvalid(string type)
         {
-            // Arrange            
+            // Arrange
             var model = new TextBoxModel();
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
 
             // Act
             var textBox = helper.TextBoxFor(m => m.Property1, new { type });
 
-            // Assert 
+            // Assert
             var result = HtmlContentUtilities.HtmlContentToString(textBox);
             Assert.DoesNotContain(@"placeholder=""HtmlEncode[[placeholder]]""", result, StringComparison.Ordinal);
         }
@@ -68,18 +68,21 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
                 {
                     {
                         model => model.Property3["key"],
-                        @"<input id=""HtmlEncode[[pre_Property3_key_]]"" name=""HtmlEncode[[pre.Property3[key]]]"" " +
+                        @"<input id=""HtmlEncode[[pre]]HtmlEncode[[_]]HtmlEncode[[Property3]]HtmlEncode[[_]]HtmlEncode[[key]]HtmlEncode[[_]]"" " +
+                        @"name=""HtmlEncode[[pre]]HtmlEncode[[.]]HtmlEncode[[Property3]]HtmlEncode[[[]]HtmlEncode[[key]]HtmlEncode[[]]]"" " +
                         @"type=""HtmlEncode[[text]]"" value=""HtmlEncode[[Prop3Val]]"" />"
                     },
                     {
                         model => model.Property4.Property5,
-                        @"<input id=""HtmlEncode[[pre_Property4_Property5]]"" name=""HtmlEncode[[pre.Property4.Property5]]"" " +
+                        @"<input id=""HtmlEncode[[pre]]HtmlEncode[[_]]HtmlEncode[[Property4]]HtmlEncode[[_]]HtmlEncode[[Property5]]"" " +
+                        @"name=""HtmlEncode[[pre]]HtmlEncode[[.]]HtmlEncode[[Property4]]HtmlEncode[[.]]HtmlEncode[[Property5]]"" " +
                         @"type=""HtmlEncode[[text]]"" value=""HtmlEncode[[Prop5Val]]"" />"
                     },
                     {
                         model => model.Property4.Property6[0],
-                        @"<input id=""HtmlEncode[[pre_Property4_Property6_0_]]"" " +
-                        @"name=""HtmlEncode[[pre.Property4.Property6[0]]]"" type=""HtmlEncode[[text]]"" value=""HtmlEncode[[Prop6Val]]"" />"
+                        @"<input id=""HtmlEncode[[pre]]HtmlEncode[[_]]HtmlEncode[[Property4]]HtmlEncode[[_]]HtmlEncode[[Property6]]HtmlEncode[[_]]HtmlEncode[[0]]HtmlEncode[[_]]"" " +
+                        @"name=""HtmlEncode[[pre]]HtmlEncode[[.]]HtmlEncode[[Property4]]HtmlEncode[[.]]HtmlEncode[[Property6]]HtmlEncode[[[]]HtmlEncode[[0]]HtmlEncode[[]]]"" " +
+                        @"type=""HtmlEncode[[text]]"" value=""HtmlEncode[[Prop6Val]]"" />"
                     }
                 };
             }
@@ -115,18 +118,21 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
                 {
                     {
                         model => model.Property3["key"],
-                        @"<input id=""HtmlEncode[[pre_Property3_key_]]"" name=""HtmlEncode[[pre.Property3[key]]]"" " +
+                        @"<input id=""HtmlEncode[[pre]]HtmlEncode[[_]]HtmlEncode[[Property3]]HtmlEncode[[_]]HtmlEncode[[key]]HtmlEncode[[_]]"" " +
+                        @"name=""HtmlEncode[[pre]]HtmlEncode[[.]]HtmlEncode[[Property3]]HtmlEncode[[[]]HtmlEncode[[key]]HtmlEncode[[]]]"" " +
                         @"type=""HtmlEncode[[text]]"" value=""HtmlEncode[[MProp3Val]]"" />"
                     },
                     {
                         model => model.Property4.Property5,
-                        @"<input id=""HtmlEncode[[pre_Property4_Property5]]"" name=""HtmlEncode[[pre.Property4.Property5]]"" " +
+                        @"<input id=""HtmlEncode[[pre]]HtmlEncode[[_]]HtmlEncode[[Property4]]HtmlEncode[[_]]HtmlEncode[[Property5]]"" " +
+                        @"name=""HtmlEncode[[pre]]HtmlEncode[[.]]HtmlEncode[[Property4]]HtmlEncode[[.]]HtmlEncode[[Property5]]"" " +
                         @"type=""HtmlEncode[[text]]"" value=""HtmlEncode[[MProp5Val]]"" />"
                     },
                     {
                         model => model.Property4.Property6[0],
-                        @"<input id=""HtmlEncode[[pre_Property4_Property6_0_]]"" " +
-                        @"name=""HtmlEncode[[pre.Property4.Property6[0]]]"" type=""HtmlEncode[[text]]"" value=""HtmlEncode[[MProp6Val]]"" />"
+                        @"<input id=""HtmlEncode[[pre]]HtmlEncode[[_]]HtmlEncode[[Property4]]HtmlEncode[[_]]HtmlEncode[[Property6]]HtmlEncode[[_]]HtmlEncode[[0]]HtmlEncode[[_]]"" " +
+                        @"name=""HtmlEncode[[pre]]HtmlEncode[[.]]HtmlEncode[[Property4]]HtmlEncode[[.]]HtmlEncode[[Property6]]HtmlEncode[[[]]HtmlEncode[[0]]HtmlEncode[[]]]"" " +
+                        @"type=""HtmlEncode[[text]]"" value=""HtmlEncode[[MProp6Val]]"" />"
                     }
                 };
             }

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperValidationSummaryTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperValidationSummaryTest.cs
@@ -30,7 +30,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
                     "<ul><li style=\"display:none\"></li>" + Environment.NewLine +
                     "</ul></div>";
                 var divWithAttributes = "<div attribute-name=\"HtmlEncode[[attribute-value]]\" " +
-                    "class=\"HtmlEncode[[validation-summary-valid wood smoke]]\" data-valmsg-summary=\"HtmlEncode[[true]]\"><ul>" +
+                    "class=\"HtmlEncode[[validation-summary-valid]]HtmlEncode[[ ]]HtmlEncode[[wood smoke]]\" " +
+                    "data-valmsg-summary=\"HtmlEncode[[true]]\"><ul>" +
                     "<li style=\"display:none\"></li>" + Environment.NewLine +
                     "</ul></div>";
                 var divWithMessage = "<div class=\"HtmlEncode[[validation-summary-valid]]\" data-valmsg-summary=\"HtmlEncode[[true]]\">" +
@@ -42,12 +43,14 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
                     "<ul><li style=\"display:none\"></li>" + Environment.NewLine +
                     "</ul></div>";
                 var divWithMessageAndAttributes = "<div attribute-name=\"HtmlEncode[[attribute-value]]\" " +
-                    "class=\"HtmlEncode[[validation-summary-valid wood smoke]]\" data-valmsg-summary=\"HtmlEncode[[true]]\">" +
+                    "class=\"HtmlEncode[[validation-summary-valid]]HtmlEncode[[ ]]HtmlEncode[[wood smoke]]\" " +
+                    "data-valmsg-summary=\"HtmlEncode[[true]]\">" +
                     "<span>HtmlEncode[[This is my message]]</span>" + Environment.NewLine +
                     "<ul><li style=\"display:none\"></li>" + Environment.NewLine +
                     "</ul></div>";
                 var divWithH3MessageAndAttributes = "<div attribute-name=\"HtmlEncode[[attribute-value]]\" " +
-                    "class=\"HtmlEncode[[validation-summary-valid wood smoke]]\" data-valmsg-summary=\"HtmlEncode[[true]]\">" +
+                    "class=\"HtmlEncode[[validation-summary-valid]]HtmlEncode[[ ]]HtmlEncode[[wood smoke]]\" " +
+                    "data-valmsg-summary=\"HtmlEncode[[true]]\">" +
                     "<h3>HtmlEncode[[This is my message]]</h3>" + Environment.NewLine +
                     "<ul><li style=\"display:none\"></li>" + Environment.NewLine +
                     "</ul></div>";


### PR DESCRIPTION
- #3918
- focus on avoiding concatenations when generating HTML `name` and `id` attributes
- preserves `public` properties and methods; adds new ones for increased efficiency
- add `StringValuesTutu` that builds on `StringValues`: add more helper methods and remove commas between values
 - `IHtmlGeneratorTutu` that adds overloads using `StringValuesTutu`
   - `HtmlGeneratorAdapter` in support of `IHtmlGenerator` replacements in DI
 - `ModelStateDictionary` overloads of _lookup_ methods using `StringValuesTutu`
 - `ModelExpression.NameValues` of type `StringValuesTutu`
 - `TagBuilder.AttributeValues` and method overloads overload using `StringValuesTutu`
 - `TemplateInfo.HtmlFieldPrefixValues` and `TemplateInfo.GetFullHtmlFieldName()` overload using `StringValuesTutu`
- fix minor bug in `TagHelperOutputExtensions`: lost user's chosen casing of "class"

Have not checked (but can be done afterward)
- whether some `StringValuesTutu.ToString()` calls can be avoided
- which of { "[", index, "]" } and { "[index]" } when creating `StringValuesTutu` uses less memory overall
- whether `StringValuesTutu` should be a `class` that concatenates its `_values` at most once

Separately, haven't touched `ViewDataDictionary` lookups and that likely uses lots of memory
- might need some of the `ModelStateDictionary` approach in this class

nit: remove excess `using`s in classes I touched but ended up leaving unchanged