### PR TITLE
Renamed SslPort to TlsPort

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs
@@ -136,9 +136,9 @@ namespace Microsoft.AspNetCore.Mvc
         public IList<IValueProviderFactory> ValueProviderFactories { get; }
 
         /// <summary>
-        /// Gets or sets the SSL port that is used by this application when <see cref="RequireHttpsAttribute"/>
+        /// Gets or sets the TLS port that is used by this application when <see cref="RequireHttpsAttribute"/>
         /// is used. If not set the port won't be specified in the secured URL e.g. https://localhost/path.
         /// </summary>
-        public int? SslPort { get; set; }
+        public int? TlsPort { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/RequireHttpsAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RequireHttpsAttribute.cs
@@ -71,10 +71,10 @@ namespace Microsoft.AspNetCore.Mvc
                 var request = filterContext.HttpContext.Request;
 
                 var host = request.Host;
-                if (optionsAccessor.Value.SslPort.HasValue && optionsAccessor.Value.SslPort > 0)
+                if (optionsAccessor.Value.TlsPort.HasValue && optionsAccessor.Value.TlsPort > 0)
                 {
-                    // a specific SSL port is specified
-                    host = new HostString(host.Host, optionsAccessor.Value.SslPort.Value);
+                    // a specific TLS port is specified
+                    host = new HostString(host.Host, optionsAccessor.Value.TlsPort.Value);
                 }
                 else
                 {

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/RequireHttpsAttributeTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/RequireHttpsAttributeTests.cs
@@ -161,9 +161,9 @@ namespace Microsoft.AspNetCore.Mvc
         [InlineData("http://localhost:5000/path", 44380, "https://localhost:44380/path")]
         [InlineData("http://localhost:5000/path?foo=bar", 44380, "https://localhost:44380/path?foo=bar")]
         [InlineData("http://本地主機:5000", 44380, "https://xn--tiq21tzznx7c:44380/")]
-        public void OnAuthorization_RedirectsToHttpsEndpoint_ForCustomSslPort(
+        public void OnAuthorization_RedirectsToHttpsEndpoint_ForCustomTlsPort(
             string url,
-            int? sslPort,
+            int? tlsPort,
             string expectedUrl)
         {
             // Arrange
@@ -171,7 +171,7 @@ namespace Microsoft.AspNetCore.Mvc
             var uri = new Uri(url);
 
             var requestContext = new DefaultHttpContext();
-            requestContext.RequestServices = CreateServices(sslPort);
+            requestContext.RequestServices = CreateServices(tlsPort);
             requestContext.Request.Scheme = "http";
             requestContext.Request.Method = "GET";
             requestContext.Request.Host = HostString.FromUriComponent(uri);
@@ -226,10 +226,10 @@ namespace Microsoft.AspNetCore.Mvc
             return new AuthorizationFilterContext(actionContext, new IFilterMetadata[0]);
         }
 
-        private static IServiceProvider CreateServices(int? sslPort = null)
+        private static IServiceProvider CreateServices(int? tlsPort = null)
         {
             var options = new TestOptionsManager<MvcOptions>();
-            options.Value.SslPort = sslPort;
+            options.Value.TlsPort = tlsPort;
 
             var services = new ServiceCollection();
             services.AddSingleton<IOptions<MvcOptions>>(options);


### PR DESCRIPTION
The property `SslPort` in the class `MvcOptions` has a legacy name.

SSL is no longer used as it has been superseded by TLS. 

Fixes issue #5285 