### PR TITLE
Get rid of some duplicate test data

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/CollectionModelBinderProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/CollectionModelBinderProviderTest.cs
@@ -43,9 +43,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         [InlineData(typeof(IList<int>))]
         [InlineData(typeof(List<int>))]
         [InlineData(typeof(Collection<int>))]
-        [InlineData(typeof(IEnumerable<int>))]
-        [InlineData(typeof(IReadOnlyCollection<int>))]
-        [InlineData(typeof(IReadOnlyList<int>))]
         public void Create_ForSupportedTypes_ReturnsBinder(Type modelType)
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Routing/UrlHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Routing/UrlHelperTest.cs
@@ -941,10 +941,8 @@ namespace Microsoft.AspNetCore.Mvc.Routing
 
         [Theory]
         [InlineData(null, null, null, "/", null, "/")]
-        [InlineData(null, null, null, "/", null, "/")]
         [InlineData(null, null, null, "/Hello", null, "/Hello" )]
         [InlineData(null, null, null, "Hello", null, "/Hello")]
-        [InlineData(null, null, null, "/Hello", null, "/Hello")]
         [InlineData("/", null, null, "", null, "/")]
         [InlineData("/hello/", null, null, "/world", null, "/hello/world")]
         [InlineData("/hello/", "https", "myhost", "/world", "fragment-value", "https://myhost/hello/world#fragment-value")]


### PR DESCRIPTION
- remove a few warnings from output when testing in VS