### PR TITLE
[Fixes #5150] parsing issue on asp.net when request quality factor is specified

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Formatters/MediaType.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Formatters/MediaType.cs
@@ -308,7 +308,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
             // We check if the parsed media type has value at this stage when we have iterated
             // over all the parameters and we know if the parsing was sucessful.
-            if (!parser.ParsingFailed)
+            if (!parser.ParsingFailed && parser.CurrentOffset >= start)
             {
                 return new MediaTypeSegmentWithQuality(
                     new StringSegment(mediaType, start, parser.CurrentOffset - start),

--- a/src/Microsoft.AspNetCore.Mvc.Core/Formatters/MediaType.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Formatters/MediaType.cs
@@ -292,6 +292,12 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         public static MediaTypeSegmentWithQuality CreateMediaTypeSegmentWithQuality(string mediaType, int start)
         {
             var parsedMediaType = new MediaType(mediaType, start, length: null);
+            if (parsedMediaType.Type.Equals(default(StringSegment)) ||
+                parsedMediaType.SubType.Equals(default(StringSegment)))
+            {
+                return default(MediaTypeSegmentWithQuality);
+            }
+
             var parser = parsedMediaType._parameterParser;
 
             double quality = 1.0d;
@@ -306,9 +312,9 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 }
             }
 
-            // We check if the parsed media type has value at this stage when we have iterated
+            // We check if the parsed media type has a value at this stage when we have iterated
             // over all the parameters and we know if the parsing was sucessful.
-            if (!parser.ParsingFailed && parser.CurrentOffset >= start)
+            if (!parser.ParsingFailed)
             {
                 return new MediaTypeSegmentWithQuality(
                     new StringSegment(mediaType, start, parser.CurrentOffset - start),
@@ -395,6 +401,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             {
                 if (_mediaTypeBuffer == null)
                 {
+                    ParsingFailed = true;
                     result = default(MediaTypeParameter);
                     return false;
                 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/AcceptHeaderParser.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/AcceptHeaderParser.cs
@@ -72,40 +72,35 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
                 return true;
             }
 
-            // We deliverately want to ignore media types that we are not capable of parsing.
+            // We deliberately want to ignore media types that we are not capable of parsing.
             // This is due to the fact that some browsers will send invalid media types like 
             // ; q=0.9 or */;q=0.2, etc.
             // In this scenario, our recovery action consists of advancing the pointer to the
             // next separator and moving on.
             // In case we don't find the next separator, we simply advance the cursor to the
             // end of the string to signal that we are done parsing.
-            MediaTypeSegmentWithQuality result = default(MediaTypeSegmentWithQuality);
-            int length = 0;
+            var result = default(MediaTypeSegmentWithQuality);
+            var length = 0;
             try
             {
                 length = GetMediaTypeWithQualityLength(value, currentIndex, out result);
-
-                if (length == 0)
-                {
-                    // The parsing failed here without throwing any exception.
-                    currentIndex = value.IndexOf(',', currentIndex);
-                    if (currentIndex == -1)
-                    {
-                        index = value.Length;
-                        return false;
-                    }
-                    index = currentIndex;
-                    return false;
-                }
             }
             catch
             {
+                length = 0;
+            }
+
+            if (length == 0)
+            {
+                // The parsing failed.
                 currentIndex = value.IndexOf(',', currentIndex);
                 if (currentIndex == -1)
                 {
                     index = value.Length;
                     return false;
                 }
+                index = currentIndex;
+                return false;
             }
 
             currentIndex = currentIndex + length;
@@ -159,8 +154,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
             int start,
             out MediaTypeSegmentWithQuality result)
         {
-            result = default(MediaTypeSegmentWithQuality);
-
             result = MediaType.CreateMediaTypeSegmentWithQuality(input, start);
             if (result.MediaType.HasValue)
             {

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
                 () => { AcceptHeaderParser.ParseAcceptHeader(new List<string> { header }); });
 
             // Assert
-            Assert.Equal(ex.Message, expectedException);
+            Assert.Equal(expectedException, ex.Message);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Primitives;
 using Xunit;
@@ -46,6 +47,17 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
             {
                 Assert.Same(header, mediaType.MediaType.Buffer);
             }
+        }
+
+        [Fact]
+        public void ParseAcceptHeader_ParsesSimpleHeaderWithMultipleValues_InvalidFormat()
+        {
+            // Arrange
+            var header = "application/json, application/xml,;q=0.8";
+
+            // Act, Assert
+            Assert.Throws<FormatException>(
+                () => { AcceptHeaderParser.ParseAcceptHeader(new List<string> { header }); });
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
@@ -54,10 +54,14 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
         {
             // Arrange
             var header = "application/json, application/xml,;q=0.8";
+            var expectedException = "\"Invalid values ';q=0.8'.\"";
 
-            // Act, Assert
-            Assert.Throws<FormatException>(
+            // Act
+            var ex = Assert.Throws<FormatException>(
                 () => { AcceptHeaderParser.ParseAcceptHeader(new List<string> { header }); });
+
+            // Assert
+            Assert.Equal(ex.Message, expectedException);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
@@ -55,7 +55,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
         {
             // Arrange
             var header = "application/json, application/xml,;q=0.8";
-            var expectedMediaTypes = new List<MediaTypeSegmentWithQuality> {
+            var expectedMediaTypes = new List<MediaTypeSegmentWithQuality>
+            {
                 new MediaTypeSegmentWithQuality(new StringSegment("application/json"),1.0),
                 new MediaTypeSegmentWithQuality(new StringSegment("application/xml"),1.0),
             };
@@ -85,7 +86,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
                 { new [] { "img/png,/*;q=0.9,text/html" }, new string[] { "img/png", "text/html" } },
                 { new [] { "img/png, /;q=0.9" }, new string[] { "img/png", } },
                 { new [] { "img/png, */;q=0.9" }, new string[] { "img/png", } },
-                { new [] { "img/png, /*;q=0.9" }, new string[] { "img/png", } },
+                { new [] { "img/png;q=1.0, /*;q=0.9" }, new string[] { "img/png;q=1.0", } },
             };
 
         [Theory]
@@ -95,7 +96,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
             string[] expected)
         {
             // Arrange
-            var expectedMediaTypes = expected.Select(e => new MediaTypeSegmentWithQuality(new StringSegment(e), 1.0));
+            var expectedMediaTypes = expected.Select(e => new MediaTypeSegmentWithQuality(new StringSegment(e), 1.0)).ToList();
 
             // Act
             var parsed = AcceptHeaderParser.ParseAcceptHeader(acceptHeader);
@@ -110,8 +111,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
             // Arrange
             var expected = new List<MediaTypeSegmentWithQuality>
             {
-                new MediaTypeSegmentWithQuality(new StringSegment("application/json"),1.0),
-                new MediaTypeSegmentWithQuality(new StringSegment("application/xml;q=0.8"),0.8)
+                new MediaTypeSegmentWithQuality(new StringSegment("application/json"), 1.0),
+                new MediaTypeSegmentWithQuality(new StringSegment("application/xml;q=0.8"), 0.8)
             };
 
             // Act

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Primitives;
 using Xunit;
 
@@ -54,14 +55,53 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
         {
             // Arrange
             var header = "application/json, application/xml,;q=0.8";
-            var expectedException = "\"Invalid values ';q=0.8'.\"";
+            var expectedMediaTypes = new List<MediaTypeSegmentWithQuality> {
+                new MediaTypeSegmentWithQuality(new StringSegment("application/json"),1.0),
+                new MediaTypeSegmentWithQuality(new StringSegment("application/xml"),1.0),
+            };
 
             // Act
-            var ex = Assert.Throws<FormatException>(
-                () => { AcceptHeaderParser.ParseAcceptHeader(new List<string> { header }); });
+            var mediaTypes = AcceptHeaderParser.ParseAcceptHeader(new List<string> { header });
 
             // Assert
-            Assert.Equal(expectedException, ex.Message);
+            Assert.Equal(expectedMediaTypes, mediaTypes);
+        }
+
+        public static TheoryData<string[], string[]> ParseAcceptHeaderWithInvalidMediaTypesData =>
+            new TheoryData<string[], string[]>
+            {
+                { new [] { ";q=0.9" }, new string[] { } },
+                { new [] { "/" }, new string[] { } },
+                { new [] { "*/" }, new string[] { } },
+                { new [] { "/*" }, new string[] { } },
+                { new [] { "/;q=0.9" }, new string[] { } },
+                { new [] { "*/;q=0.9" }, new string[] { } },
+                { new [] { "/*;q=0.9" }, new string[] { } },
+                { new [] { "/;q=0.9,text/html" }, new string[] { "text/html" } },
+                { new [] { "*/;q=0.9,text/html" }, new string[] { "text/html" } },
+                { new [] { "/*;q=0.9,text/html" }, new string[] { "text/html" } },
+                { new [] { "img/png,/;q=0.9,text/html" }, new string[] { "img/png", "text/html" } },
+                { new [] { "img/png,*/;q=0.9,text/html" }, new string[] { "img/png", "text/html" } },
+                { new [] { "img/png,/*;q=0.9,text/html" }, new string[] { "img/png", "text/html" } },
+                { new [] { "img/png, /;q=0.9" }, new string[] { "img/png", } },
+                { new [] { "img/png, */;q=0.9" }, new string[] { "img/png", } },
+                { new [] { "img/png, /*;q=0.9" }, new string[] { "img/png", } },
+            };
+
+        [Theory]
+        [MemberData(nameof(ParseAcceptHeaderWithInvalidMediaTypesData))]
+        public void ParseAcceptHeader_GracefullyRecoversFromInvalidMediaTypeValues_AndReturnsValidMediaTypes(
+            string[] acceptHeader,
+            string[] expected)
+        {
+            // Arrange
+            var expectedMediaTypes = expected.Select(e => new MediaTypeSegmentWithQuality(new StringSegment(e), 1.0));
+
+            // Act
+            var parsed = AcceptHeaderParser.ParseAcceptHeader(acceptHeader);
+
+            // Assert
+            Assert.Equal(expectedMediaTypes, parsed);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ContentNegotiationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ContentNegotiationTest.cs
@@ -85,6 +85,25 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal(expectedContentType, response.Content.Headers.ContentType);
         }
 
+        [Theory]
+        [InlineData("/;q=0.9")]
+        [InlineData("/;q=0.9, invalid;q=0.5;application/json;q=0.1")]
+        [InlineData("/invalid;q=0.9, application/json;q=0.1,invalid;q=0.5")]
+        [InlineData("text/html, application/json, image/jpeg, *; q=.2, */*; q=.2")]
+        public async Task ContentNegotiationWithPartiallyValidAcceptHeader_SkipsInvalidEntries(string acceptHeader)
+        {
+            // Arrange
+            var expectedContentType = MediaTypeHeaderValue.Parse("application/json;charset=utf-8");
+            var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/ContentNegotiation/UserInfo_ProducesWithTypeOnly");
+            request.Headers.TryAddWithoutValidation("Accept", acceptHeader);
+
+            // Act
+            var response = await Client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(expectedContentType, response.Content.Headers.ContentType);
+        }
+
         [Fact]
         public async Task ProducesAttributeWithTypeOnly_RunsRegularContentNegotiation()
         {


### PR DESCRIPTION
* Fix an error on the parser when an invalid accept header is presented.
* Change the implementation to return 400 instead of 500.