### PR TITLE
Correct examination of `IHtmlHelper.Label()` return value

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/project.json
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/project.json
@@ -12,6 +12,7 @@
     ]
   },
   "buildOptions": {
+    "allowUnsafe": true,
     "warningsAsErrors": true,
     "keyFile": "../../tools/Key.snk",
     "nowarn": [

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/DefaultTemplatesUtilities.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/DefaultTemplatesUtilities.cs
@@ -286,7 +286,6 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
                .AddSingleton(urlHelperFactory.Object)
                .AddSingleton(Mock.Of<IViewComponentHelper>())
                .AddSingleton(innerHelper)
-               .AddSingleton<HtmlEncoder, HtmlTestEncoder>()
                .AddSingleton<IViewBufferScope, TestViewBufferScope>()
                .BuildServiceProvider();
 

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/DefaultTemplatesUtilities.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/DefaultTemplatesUtilities.cs
@@ -286,6 +286,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
                .AddSingleton(urlHelperFactory.Object)
                .AddSingleton(Mock.Of<IViewComponentHelper>())
                .AddSingleton(innerHelper)
+               .AddSingleton<HtmlEncoder, HtmlTestEncoder>()
                .AddSingleton<IViewBufferScope, TestViewBufferScope>()
                .BuildServiceProvider();
 


### PR DESCRIPTION
- #5317
- worked only because `TagBuilder` cannot be empty and `HtmlString` overrides `ToString()`
 - `TagBuilder.ToString()` (now the type's `FullName`) is also never empty