### PR TITLE
Remove ViewDataEvaluator.GetPropertyValue Closure

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ViewDataEvaluator.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ViewDataEvaluator.cs
@@ -203,7 +203,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 return null;
             }
 
-            return new ViewDataInfo(container, propertyInfo, () => propertyInfo.GetValue(container));
+            return new ViewDataInfo(container, propertyInfo);
         }
 
         private struct ExpressionPair


### PR DESCRIPTION
Adds extra field and .ctor to `ViewDataInfo`

MusicStoreViews 

**Before**

![before](https://aoa.blob.core.windows.net/aspnet/veiwdata-eval-1.png)

**After**

![after](https://aoa.blob.core.windows.net/aspnet/veiwdata-eval-2.png)

Increase 456 kB
Decrease 4,994 kB

**Overall decrease 4,538 kB**

/cc @dougbu @rynowak 