### PR TITLE
Add NonViewComponentAttribute

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/NonViewComponentAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/NonViewComponentAttribute.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Mvc
+{
+    /// <summary>
+    /// Indicates that the type and any derived types that this attribute is applied to
+    /// is not considered a view component by the default view component discovery mechanism.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public class NonViewComponentAttribute : Attribute
+    {
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/ViewComponentConventions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/ViewComponentConventions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Reflection;
+using Microsoft.AspNetCore.Mvc.Core;
 
 namespace Microsoft.AspNetCore.Mvc.ViewComponents
 {
@@ -82,7 +83,8 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
             if (!typeInfo.IsClass ||
                 !typeInfo.IsPublic ||
                 typeInfo.IsAbstract ||
-                typeInfo.ContainsGenericParameters)
+                typeInfo.ContainsGenericParameters ||
+                typeInfo.IsDefined(typeof(NonViewComponentAttribute)))
             {
                 return false;
             }

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponents/ViewComponentConventionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponents/ViewComponentConventionsTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Reflection;
+using Microsoft.AspNetCore.Mvc.Core;
 using Microsoft.AspNetCore.Mvc.ViewComponentConventionsTestClasses;
 using Xunit;
 
@@ -41,6 +42,10 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
 
         // Value types cannot be view components
         [InlineData(typeof(int), false)]
+
+        // If it has NonViewComponent it's not a view component
+        [InlineData(typeof(NonViewComponentAttributeViewComponent), false)]
+        [InlineData(typeof(ChildOfNonViewComponent), false)]
         public void IsComponent(Type type, bool expected)
         {
             // Arrange & Act
@@ -124,6 +129,13 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponentConventionsTestClasses
     public class Nada
     {
     }
+
+    [NonViewComponent]
+    public class NonViewComponentAttributeViewComponent
+    { }
+
+    public class ChildOfNonViewComponent : NonViewComponentAttributeViewComponent
+    { }
 
     public class NamingConventionViewComponent
     {


### PR DESCRIPTION
Fixes #5226. Add `NonViewComponentAttribute` and teach ViewComponentConventions to obey it.