### PR TITLE
DefaultViewComponentFactory no longer allocates new lambda delegate

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/DefaultViewComponentFactory.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/DefaultViewComponentFactory.cs
@@ -59,11 +59,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
         {
             var propertiesToActivate = _injectActions.GetOrAdd(
                 viewComponent.GetType(),
-                type =>
-                PropertyActivator<ViewComponentContext>.GetPropertiesToActivate(
-                    type,
-                    typeof(ViewComponentContextAttribute),
-                    CreateActivateInfo));
+                _getPropertiesToActivate);
 
             for (var i = 0; i < propertiesToActivate.Length; i++)
             {


### PR DESCRIPTION
`DefaultViewComponentFactory` no longer allocates new lambda delegate on each call to `CreateViewComponent`.

The `_getPropertiesToActivate` delegate was already created and cached in the constructor of the class but not used anywhere else.

With this commit, the `DefaultViewComponentFactory` class has the same workflow as all the other similar classes - `ViewDataDictionaryControllerPropertyActivator`, `DefaultTagHelperFactory` and `DefaultControllerPropertyActivator`. All of these use the cached readonly field.