### PR TITLE
[Part1 of #4895] Modified FormCollectionModelBinderProvider to throw when binding for...

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/FormCollectionModelBinderProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/FormCollectionModelBinderProvider.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Reflection;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Core;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
 {
@@ -19,7 +21,18 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 throw new ArgumentNullException(nameof(context));
             }
 
-            if (context.Metadata.ModelType == typeof(IFormCollection))
+            var modelType = context.Metadata.ModelType;
+
+            if (typeof(FormCollection).GetTypeInfo().IsAssignableFrom(modelType))
+            {
+                throw new InvalidOperationException(
+                    Resources.FormatFormCollectionModelBinder_CannotBindToFormCollection(
+                        typeof(FormCollectionModelBinder).FullName,
+                        modelType.FullName,
+                        typeof(IFormCollection).FullName));
+            }
+
+            if (modelType == typeof(IFormCollection))
             {
                 return new FormCollectionModelBinder();
             }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Properties/Resources.Designer.cs
@@ -1322,6 +1322,22 @@ namespace Microsoft.AspNetCore.Mvc.Core
             return string.Format(CultureInfo.CurrentCulture, GetString("AuthorizeFilter_AuthorizationPolicyCannotBeCreated"), p0, p1);
         }
 
+        /// <summary>
+        /// The '{0}' cannot bind to a model of type '{1}'. Change the model type to '{2}' instead.
+        /// </summary>
+        internal static string FormCollectionModelBinder_CannotBindToFormCollection
+        {
+            get { return GetString("FormCollectionModelBinder_CannotBindToFormCollection"); }
+        }
+
+        /// <summary>
+        /// The '{0}' cannot bind to a model of type '{1}'. Change the model type to '{2}' instead.
+        /// </summary>
+        internal static string FormatFormCollectionModelBinder_CannotBindToFormCollection(object p0, object p1, object p2)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("FormCollectionModelBinder_CannotBindToFormCollection"), p0, p1, p2);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNetCore.Mvc.Core/Resources.resx
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -372,5 +372,8 @@
   </data>
   <data name="AuthorizeFilter_AuthorizationPolicyCannotBeCreated" xml:space="preserve">
     <value>An {0} cannot be created without a valid instance of {1}.</value>
+  </data>
+  <data name="FormCollectionModelBinder_CannotBindToFormCollection" xml:space="preserve">
+    <value>The '{0}' cannot bind to a model of type '{1}'. Change the model type to '{2}' instead.</value>
   </data>
 </root>

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/ComplexTypeModelBinderProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/ComplexTypeModelBinderProviderTest.cs
@@ -55,11 +55,107 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             Assert.IsType<ComplexTypeModelBinder>(result);
         }
 
+        [Theory]
+        [InlineData(typeof(PointStructWithExplicitConstructor))]
+        [InlineData(typeof(PointStructWithNoExplicitConstructor))]
+        public void Create_ForStructModel_ReturnsNull(Type modelType)
+        {
+            // Arrange
+            var provider = new ComplexTypeModelBinderProvider();
+            var context = new TestModelBinderProviderContext(modelType);
+
+            // Act
+            var result = provider.GetBinder(context);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData(typeof(ClassWithNoDefaultConstructor))]
+        [InlineData(typeof(ClassWithStaticConstructor))]
+        [InlineData(typeof(ClassWithInternalDefaultConstructor))]
+        public void Create_ForModelTypeWithNoDefaultPublicConstructor_ReturnsNull(Type modelType)
+        {
+            // Arrange
+            var provider = new ComplexTypeModelBinderProvider();
+            var context = new TestModelBinderProviderContext(modelType);
+
+            // Act
+            var result = provider.GetBinder(context);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Create_ForAbstractModelTypeWithDefaultPublicConstructor_ReturnsNull()
+        {
+            // Arrange
+            var provider = new ComplexTypeModelBinderProvider();
+            var context = new TestModelBinderProviderContext(typeof(AbstractClassWithDefaultConstructor));
+
+            // Act
+            var result = provider.GetBinder(context);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        private struct PointStructWithNoExplicitConstructor
+        {
+            public double X { get; set; }
+            public double Y { get; set; }
+        }
+
+        private struct PointStructWithExplicitConstructor
+        {
+            public PointStructWithExplicitConstructor(double x, double y)
+            {
+                X = x;
+                Y = y;
+            }
+            public double X { get; }
+            public double Y { get; }
+        }
+
         private class Person
         {
             public string Name { get; set; }
 
             public int Age { get; set; }
+        }
+
+        private class ClassWithNoDefaultConstructor
+        {
+            public ClassWithNoDefaultConstructor(int id) { }
+        }
+
+        private class ClassWithInternalDefaultConstructor
+        {
+            internal ClassWithInternalDefaultConstructor() { }
+        }
+
+        private class ClassWithStaticConstructor
+        {
+            static ClassWithStaticConstructor() { }
+
+            public ClassWithStaticConstructor(int id) { }
+        }
+
+        private abstract class AbstractClassWithDefaultConstructor
+        {
+            private readonly string _name;
+
+            public AbstractClassWithDefaultConstructor()
+                : this("James")
+            {
+            }
+
+            public AbstractClassWithDefaultConstructor(string name)
+            {
+                _name = name;
+            }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/FormCollectionModelBinderProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/FormCollectionModelBinderProviderTest.cs
@@ -12,6 +12,22 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
     {
         [Theory]
         [InlineData(typeof(FormCollection))]
+        [InlineData(typeof(DerviedFormCollection))]
+        public void Create_ThrowsException_ForFormCollectionModelType(Type modelType)
+        {
+            // Arrange
+            var provider = new FormCollectionModelBinderProvider();
+            var context = new TestModelBinderProviderContext(modelType);
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(() => provider.GetBinder(context));
+
+            Assert.Equal(
+                $"The '{typeof(FormCollectionModelBinder).FullName}' cannot bind to a model of type '{modelType.FullName}'. Change the model type to '{typeof(IFormCollection).FullName}' instead.",
+                exception.Message);
+        }
+
+        [Theory]
         [InlineData(typeof(TestClass))]
         [InlineData(typeof(IList<int>))]
         [InlineData(typeof(int[]))]
@@ -44,6 +60,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
 
         private class TestClass
         {
+        }
+
+        private class DerviedFormCollection : FormCollection
+        {
+            public DerviedFormCollection() : base(fields: null, files: null) { }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/ActionParametersIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/ActionParametersIntegrationTest.cs
@@ -383,6 +383,120 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.Empty(modelState.Keys);
         }
 
+        [Fact]
+        public async Task ActionParameter_ModelPropertyTypeWithNoDefaultConstructor_NoOps()
+        {
+            // Arrange
+            var parameterType = typeof(Class1);
+            var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
+            var parameter = new ParameterDescriptor()
+            {
+                Name = "p",
+                ParameterType = parameterType
+            };
+            var testContext = ModelBindingTestHelper.GetTestContext(request =>
+            {
+                request.QueryString = QueryString.Create("Name", "James").Add("Property1.City", "Seattle");
+            });
+            var modelState = testContext.ModelState;
+
+            // Act
+            var result = await argumentBinder.BindModelAsync(parameter, testContext);
+
+            // Assert
+            Assert.True(result.IsModelSet);
+            Assert.True(modelState.IsValid);
+            var model = Assert.IsType<Class1>(result.Model);
+            Assert.Null(model.Property1);
+            var keyValuePair = Assert.Single(modelState);
+            Assert.Equal("Name", keyValuePair.Key);
+            Assert.Equal("James", keyValuePair.Value.AttemptedValue);
+            Assert.Equal("James", keyValuePair.Value.RawValue);
+        }
+
+        [Fact]
+        public async Task ActionParameter_BindingToStructModel_Fails()
+        {
+            // Arrange
+            var parameterType = typeof(PointStruct);
+            var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
+            var parameter = new ParameterDescriptor()
+            {
+                ParameterType = parameterType
+            };
+            var testContext = ModelBindingTestHelper.GetTestContext();
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => argumentBinder.BindModelAsync(parameter, testContext));
+
+            Assert.Equal(
+                string.Format("Could not create a model binder for model object of type '{0}'.", parameterType.FullName),
+                exception.Message);
+        }
+
+        [Theory]
+        [InlineData(typeof(ClassWithNoDefaultConstructor))]
+        [InlineData(typeof(AbstractClassWithNoDefaultConstructor))]
+        public async Task ActionParameter_NoDefaultConstructor_Fails(Type parameterType)
+        {
+            // Arrange
+            var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
+            var parameter = new ParameterDescriptor()
+            {
+                ParameterType = parameterType
+            };
+            var testContext = ModelBindingTestHelper.GetTestContext();
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => argumentBinder.BindModelAsync(parameter, testContext));
+
+            Assert.Equal(
+                string.Format("Could not create a model binder for model object of type '{0}'.", parameterType.FullName),
+                exception.Message);
+        }
+
+        private struct PointStruct
+        {
+            public PointStruct(double x, double y)
+            {
+                X = x;
+                Y = y;
+            }
+            public double X { get; }
+            public double Y { get; }
+        }
+
+        private class Class1
+        {
+            public ClassWithNoDefaultConstructor Property1 { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class ClassWithNoDefaultConstructor
+        {
+            public ClassWithNoDefaultConstructor(int id) { }
+            public string City { get; set; }
+        }
+
+        private abstract class AbstractClassWithNoDefaultConstructor
+        {
+            private readonly string _name;
+
+            public AbstractClassWithNoDefaultConstructor()
+                : this("James")
+            {
+            }
+
+            public AbstractClassWithNoDefaultConstructor(string name)
+            {
+                _name = name;
+            }
+
+            public string Name { get; set; }
+        }
+
         private class CustomReadOnlyCollection<T> : ICollection<T>
         {
             private ICollection<T> _original;


### PR DESCRIPTION
…FormCollection model type.

Part 1 of [Fixes #4895] No parameterless Constructor defined
I will send the fix for ComplexTypeModelBinderProvider in a separate PR

@dougbu @rynowak 