### PR TITLE
Reduce `HtmlContentBuilder` allocations

### DIFF
--- a/Mvc.NoFun.sln
+++ b/Mvc.NoFun.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{DAAE4C74-D06F-4874-A166-33305D2643CE}"
 EndProject

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/FormTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/FormTagHelper.cs
@@ -226,7 +226,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 if (tagBuilder != null)
                 {
                     output.MergeAttributes(tagBuilder);
-                    output.PostContent.AppendHtml(tagBuilder.InnerHtml);
+                    if (tagBuilder.HasInnerHtml)
+                    {
+                        output.PostContent.AppendHtml(tagBuilder.InnerHtml);
+                    }
                 }
 
                 if (string.Equals(Method, "get", StringComparison.OrdinalIgnoreCase))

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/InputTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/InputTagHelper.cs
@@ -218,10 +218,14 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
             if (tagBuilder != null)
             {
-                // This TagBuilder contains the one <input/> element of interest. Since this is not the "checkbox"
-                // special-case, output is a self-closing element no longer guaranteed.
+                // This TagBuilder contains the one <input/> element of interest.
                 output.MergeAttributes(tagBuilder);
-                output.Content.AppendHtml(tagBuilder.InnerHtml);
+                if (tagBuilder.HasInnerHtml)
+                {
+                    // Since this is not the "checkbox" special-case, no guarantee that output is a self-closing
+                    // element. A later tag helper targeting this element may change output.TagMode.
+                    output.Content.AppendHtml(tagBuilder.InnerHtml);
+                }
             }
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/LabelTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/LabelTagHelper.cs
@@ -72,17 +72,20 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             {
                 output.MergeAttributes(tagBuilder);
 
-                // We check for whitespace to detect scenarios such as:
-                // <label for="Name">
-                // </label>
+                // Do not update the content if another tag helper targeting this element has already done so.
                 if (!output.IsContentModified)
                 {
+                    // We check for whitespace to detect scenarios such as:
+                    // <label for="Name">
+                    // </label>
                     var childContent = await output.GetChildContentAsync();
-
                     if (childContent.IsEmptyOrWhiteSpace)
                     {
-                        // Provide default label text since there was nothing useful in the Razor source.
-                        output.Content.SetHtmlContent(tagBuilder.InnerHtml);
+                        // Provide default label text (if any) since there was nothing useful in the Razor source.
+                        if (tagBuilder.HasInnerHtml)
+                        {
+                            output.Content.SetHtmlContent(tagBuilder.InnerHtml);
+                        }
                     }
                     else
                     {

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/SelectTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/SelectTagHelper.cs
@@ -147,7 +147,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             if (tagBuilder != null)
             {
                 output.MergeAttributes(tagBuilder);
-                output.PostContent.AppendHtml(tagBuilder.InnerHtml);
+                if (tagBuilder.HasInnerHtml)
+                {
+                    output.PostContent.AppendHtml(tagBuilder.InnerHtml);
+                }
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/TextAreaTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/TextAreaTagHelper.cs
@@ -70,10 +70,12 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
             if (tagBuilder != null)
             {
-                // Overwrite current Content to ensure expression result round-trips correctly.
-                output.Content.SetHtmlContent(tagBuilder.InnerHtml);
-
                 output.MergeAttributes(tagBuilder);
+                if (tagBuilder.HasInnerHtml)
+                {
+                    // Overwrite current Content to ensure expression result round-trips correctly.
+                    output.Content.SetHtmlContent(tagBuilder.InnerHtml);
+                }
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/ValidationMessageTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/ValidationMessageTagHelper.cs
@@ -76,17 +76,20 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 {
                     output.MergeAttributes(tagBuilder);
 
-                    // We check for whitespace to detect scenarios such as:
-                    // <span validation-for="Name">
-                    // </span>
+                    // Do not update the content if another tag helper targeting this element has already done so.
                     if (!output.IsContentModified)
                     {
+                        // We check for whitespace to detect scenarios such as:
+                        // <span validation-for="Name">
+                        // </span>
                         var childContent = await output.GetChildContentAsync();
-
                         if (childContent.IsEmptyOrWhiteSpace)
                         {
-                            // Provide default label text since there was nothing useful in the Razor source.
-                            output.Content.SetHtmlContent(tagBuilder.InnerHtml);
+                            // Provide default message text (if any) since there was nothing useful in the Razor source.
+                            if (tagBuilder.HasInnerHtml)
+                            {
+                                output.Content.SetHtmlContent(tagBuilder.InnerHtml);
+                            }
                         }
                         else
                         {

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/ValidationSummaryTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/ValidationSummaryTagHelper.cs
@@ -112,7 +112,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             }
 
             output.MergeAttributes(tagBuilder);
-            output.PostContent.AppendHtml(tagBuilder.InnerHtml);
+            if (tagBuilder.HasInnerHtml)
+            {
+                output.PostContent.AppendHtml(tagBuilder.InnerHtml);
+            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/DefaultDisplayTemplates.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/DefaultDisplayTemplates.cs
@@ -93,8 +93,8 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
                 return HtmlString.Empty;
             }
 
-            var collection = model as IEnumerable;
-            if (collection == null)
+            var enumerable = model as IEnumerable;
+            if (enumerable == null)
             {
                 // Only way we could reach here is if user passed templateName: "Collection" to a Display() overload.
                 throw new InvalidOperationException(Resources.FormatTemplates_TypeMustImplementIEnumerable(
@@ -119,12 +119,13 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             {
                 htmlHelper.ViewData.TemplateInfo.HtmlFieldPrefix = string.Empty;
 
-                var result = new HtmlContentBuilder();
+                var collection = model as ICollection;
+                var result = collection == null ? new HtmlContentBuilder() : new HtmlContentBuilder(collection.Count);
                 var viewEngine = serviceProvider.GetRequiredService<ICompositeViewEngine>();
                 var viewBufferScope = serviceProvider.GetRequiredService<IViewBufferScope>();
 
                 var index = 0;
-                foreach (var item in collection)
+                foreach (var item in enumerable)
                 {
                     var itemMetadata = elementMetadata;
                     if (item != null && !typeInCollectionIsNullableValueType)
@@ -224,7 +225,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             var viewEngine = serviceProvider.GetRequiredService<ICompositeViewEngine>();
             var viewBufferScope = serviceProvider.GetRequiredService<IViewBufferScope>();
 
-            var content = new HtmlContentBuilder();
+            var content = new HtmlContentBuilder(modelExplorer.Metadata.Properties.Count);
             foreach (var propertyExplorer in modelExplorer.Properties)
             {
                 var propertyMetadata = propertyExplorer.Metadata;

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/TagBuilder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/TagBuilder.cs
@@ -21,6 +21,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
     public class TagBuilder : IHtmlContent
     {
         private AttributeDictionary _attributes;
+        private IHtmlContentBuilder _innerHtml;
 
         /// <summary>
         /// Creates a new HTML tag that has the specified tag name.
@@ -34,7 +35,6 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             }
 
             TagName = tagName;
-            InnerHtml = new HtmlContentBuilder();
         }
 
         /// <summary>
@@ -57,7 +57,23 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <summary>
         /// Gets the inner HTML content of the element.
         /// </summary>
-        public IHtmlContentBuilder InnerHtml { get; }
+        public IHtmlContentBuilder InnerHtml
+        {
+            get
+            {
+                if (_innerHtml == null)
+                {
+                    _innerHtml = new HtmlContentBuilder();
+                }
+
+                return _innerHtml;
+            }
+        }
+
+        /// <summary>
+        /// Gets an indication <see cref="InnerHtml"/> has been access and is likely not empty.
+        /// </summary>
+        public bool HasInnerHtml => _innerHtml != null;
 
         /// <summary>
         /// Gets the tag name for this tag.
@@ -291,7 +307,11 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
                     writer.Write(TagName);
                     AppendAttributes(writer, encoder);
                     writer.Write(">");
-                    InnerHtml.WriteTo(writer, encoder);
+                    if (_innerHtml != null)
+                    {
+                        _innerHtml.WriteTo(writer, encoder);
+                    }
+
                     writer.Write("</");
                     writer.Write(TagName);
                     writer.Write(">");

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/TagBuilder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/TagBuilder.cs
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Gets an indication <see cref="InnerHtml"/> has been access and is likely not empty.
+        /// Gets an indication <see cref="InnerHtml"/> has been accessed and is likely not empty.
         /// </summary>
         public bool HasInnerHtml => _innerHtml != null;
 

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/TagBuilder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/TagBuilder.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
     public class TagBuilder : IHtmlContent
     {
         private AttributeDictionary _attributes;
-        private IHtmlContentBuilder _innerHtml;
+        private HtmlContentBuilder _innerHtml;
 
         /// <summary>
         /// Creates a new HTML tag that has the specified tag name.
@@ -71,9 +71,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Gets an indication <see cref="InnerHtml"/> has been accessed and is likely not empty.
+        /// Gets an indication <see cref="InnerHtml"/> is not empty.
         /// </summary>
-        public bool HasInnerHtml => _innerHtml != null;
+        public bool HasInnerHtml => _innerHtml?.Count > 0;
 
         /// <summary>
         /// Gets the tag name for this tag.

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/HtmlHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/HtmlHelper.cs
@@ -769,24 +769,21 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 isChecked,
                 htmlAttributes);
 
-            var hiddenForCheckboxTag = _htmlGenerator.GenerateHiddenForCheckbox(ViewContext, modelExplorer, expression);
-            if (checkbox == null || hiddenForCheckboxTag == null)
+            var hiddenForCheckbox = _htmlGenerator.GenerateHiddenForCheckbox(ViewContext, modelExplorer, expression);
+            if (checkbox == null || hiddenForCheckbox == null)
             {
                 return HtmlString.Empty;
             }
 
-            var checkboxContent = new HtmlContentBuilder().AppendHtml(checkbox);
-
             if (ViewContext.FormContext.CanRenderAtEndOfForm)
             {
-                ViewContext.FormContext.EndOfFormContent.Add(hiddenForCheckboxTag);
-            }
-            else
-            {
-                checkboxContent.AppendHtml(hiddenForCheckboxTag);
+                ViewContext.FormContext.EndOfFormContent.Add(hiddenForCheckbox);
+                return checkbox;
             }
 
-            return checkboxContent;
+            return new HtmlContentBuilder(capacity: 2)
+                .AppendHtml(checkbox)
+                .AppendHtml(hiddenForCheckbox);
         }
 
         protected virtual string GenerateDisplayName(ModelExplorer modelExplorer, string expression)

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/TagBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/TagBuilderTest.cs
@@ -117,7 +117,10 @@ namespace Microsoft.AspNetCore.Mvc.Core.Rendering
         [InlineData("attribute", "value", "<p attribute=\"HtmlEncode[[value]]\"></p>")]
         [InlineData("attribute", null, "<p attribute=\"\"></p>")]
         [InlineData("attribute", "", "<p attribute=\"\"></p>")]
-        public void WriteTo_WriteEmptyAttribute_WhenValueIsNullOrEmpty(string attributeKey, string attributeValue, string expectedOutput)
+        public void WriteTo_WriteEmptyAttribute_WhenValueIsNullOrEmpty(
+            string attributeKey,
+            string attributeValue,
+            string expectedOutput)
         {
             // Arrange
             var tagBuilder = new TagBuilder("p");
@@ -149,6 +152,22 @@ namespace Microsoft.AspNetCore.Mvc.Core.Rendering
                 // Assert
                 Assert.Equal("<p><span>Hello</span>HtmlEncode[[, World!]]</p>", writer.ToString());
             }
+
+            Assert.True(tagBuilder.HasInnerHtml);
+        }
+
+        [Fact]
+        public void ReadingInnerHtml_LeavesHasInnerHtmlFalse()
+        {
+            // Arrange
+            var tagBuilder = new TagBuilder("p");
+
+            // Act
+            var innerHtml = tagBuilder.InnerHtml;
+
+            // Assert
+            Assert.False(tagBuilder.HasInnerHtml);
+            Assert.NotNull(innerHtml);
         }
     }
 }


### PR DESCRIPTION
- #3918
- lazy-load `TagBuilder.InnerHtml`; add `HasInnerHtml` property for conservative use
- don't use a `HtmlContentBuilder` at all in `DefaultHtmlGenerator.GenerateValidationSummary()`
- avoid instantiating `HtmlContentBuilder` when short-circuits make it unnecessary
- provide correct `HtmlContentBuilder` capacity where known