### PR TITLE
Small code cleanup

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/BindingSource.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/BindingSource.cs
@@ -203,7 +203,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         {
             if (object.ReferenceEquals(s1, null))
             {
-                return object.ReferenceEquals(s2, null); ;
+                return object.ReferenceEquals(s2, null);
             }
 
             return s1.Equals(s2);

--- a/src/Microsoft.AspNetCore.Mvc.Core/DependencyInjection/MvcCoreMvcBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/DependencyInjection/MvcCoreMvcBuilderExtensions.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.PartManager.PopulateFeature(feature);
 
             foreach (var controller in feature.Controllers.Select(c => c.AsType()))
-        {
+            {
                 builder.Services.TryAddTransient(controller, controller);
             }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/RedirectResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/RedirectResultExecutor.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         {
             var urlHelper = result.UrlHelper ?? _urlHelperFactory.GetUrlHelper(context);
 
-            // IsLocalUrl is called to handle  Urls starting with '~/'.
+            // IsLocalUrl is called to handle URLs starting with '~/'.
             var destinationUrl = result.Url;
             if (urlHelper.IsLocalUrl(destinationUrl))
             {

--- a/src/Microsoft.AspNetCore.Mvc.Core/LocalRedirectResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/LocalRedirectResult.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.AspNetCore.Mvc.Core;
 using Microsoft.AspNetCore.Mvc.Internal;
-using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Mvc
@@ -83,18 +82,6 @@ namespace Microsoft.AspNetCore.Mvc
 
             var executor = context.HttpContext.RequestServices.GetRequiredService<LocalRedirectResultExecutor>();
             executor.Execute(context, this);
-        }
-
-        private IUrlHelper GetUrlHelper(ActionContext context)
-        {
-            var urlHelper = UrlHelper;
-            if (urlHelper == null)
-            {
-                var services = context.HttpContext.RequestServices;
-                urlHelper = services.GetRequiredService<IUrlHelperFactory>().GetUrlHelper(context);
-            }
-
-            return urlHelper;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ObjectResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ObjectResult.cs
@@ -34,8 +34,8 @@ namespace Microsoft.AspNetCore.Mvc
         public override Task ExecuteResultAsync(ActionContext context)
         {
             var executor = context.HttpContext.RequestServices.GetRequiredService<ObjectResultExecutor>();
-            var result =  executor.ExecuteAsync(context, this);
-            
+            var result = executor.ExecuteAsync(context, this);
+
             return result;
         }
 


### PR DESCRIPTION
Summary of the changes:
- Removed unused private method `GetUrlHelper` in `LocalRedirectResult`.
- Removed extra `;` in `BindingSource`.
- Fixed opening `{` indentation in `MvcCoreMvcBuilderExtensions`.
- Improved comment in `RedirectResultExecutor`.
- Removed extra white-space in `ObjectResult`.
