### PR TITLE
Move value source information from `<remarks>` to `<summary>`

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelMetadata.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelMetadata.cs
@@ -112,8 +112,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         public abstract string Description { get; }
 
         /// <summary>
-        /// Gets the composite format <see cref="string"/> (see
-        /// http://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to display the model.
+        /// Gets the format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to display the
+        /// model.
         /// </summary>
         public abstract string DisplayFormatString { get; }
 
@@ -123,8 +123,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         public abstract string DisplayName { get; }
 
         /// <summary>
-        /// Gets the composite format <see cref="string"/> (see
-        /// http://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to edit the model.
+        /// Gets the format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to edit the model.
         /// </summary>
         public abstract string EditFormatString { get; }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/ApiExplorer/IApiRequestMetadataProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ApiExplorer/IApiRequestMetadataProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Mvc.Formatters;
 namespace Microsoft.AspNetCore.Mvc.ApiExplorer
 {
     /// <summary>
-    /// Provides a a set of possible content types than can be consumed by the action.
+    /// Provides a set of possible content types than can be consumed by the action.
     /// </summary>
     public interface IApiRequestMetadataProvider : IFilterMetadata
     {

--- a/src/Microsoft.AspNetCore.Mvc.Razor/RazorPage.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/RazorPage.cs
@@ -763,8 +763,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         /// In layout pages, renders the content of the section named <paramref name="name"/>.
         /// </summary>
         /// <param name="name">The name of the section to render.</param>
-        /// <returns>An empty <see cref="IHtmlContent"/> to allow the <see cref="Write(object)"/> call to
-        /// succeed.</returns>
+        /// <returns>An empty <see cref="IHtmlContent"/>.</returns>
         /// <remarks>The method writes to the <see cref="Output"/> and the value returned is a token
         /// value that allows the Write (produced due to @RenderSection(..)) to succeed. However the
         /// value does not represent the rendered content.</remarks>
@@ -783,8 +782,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         /// </summary>
         /// <param name="name">The section to render.</param>
         /// <param name="required">Indicates if this section must be rendered.</param>
-        /// <returns>An empty <see cref="IHtmlContent"/> to allow the <see cref="Write(object)"/> call to
-        /// succeed.</returns>
+        /// <returns>An empty <see cref="IHtmlContent"/>.</returns>
         /// <remarks>The method writes to the <see cref="Output"/> and the value returned is a token
         /// value that allows the Write (produced due to @RenderSection(..)) to succeed. However the
         /// value does not represent the rendered content.</remarks>
@@ -805,8 +803,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         /// In layout pages, asynchronously renders the content of the section named <paramref name="name"/>.
         /// </summary>
         /// <param name="name">The section to render.</param>
-        /// <returns>A <see cref="Task{HtmlString}"/> that on completion returns an empty <see cref="IHtmlContent"/>
-        /// that allows the <see cref="Write(object)"/> call to succeed.</returns>
+        /// <returns>
+        /// A <see cref="Task{HtmlString}"/> that on completion returns an empty <see cref="IHtmlContent"/>.
+        /// </returns>
         /// <remarks>The method writes to the <see cref="Output"/> and the value returned is a token
         /// value that allows the Write (produced due to @RenderSection(..)) to succeed. However the
         /// value does not represent the rendered content.</remarks>
@@ -826,8 +825,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         /// <param name="name">The section to render.</param>
         /// <param name="required">Indicates the <paramref name="name"/> section must be registered
         /// (using <c>@section</c>) in the page.</param>
-        /// <returns>A <see cref="Task{HtmlString}"/> that on completion returns an empty <see cref="IHtmlContent"/>
-        /// that allows the <see cref="Write(object)"/> call to succeed.</returns>
+        /// <returns>
+        /// A <see cref="Task{HtmlString}"/> that on completion returns an empty <see cref="IHtmlContent"/>.
+        /// </returns>
         /// <remarks>The method writes to the <see cref="Output"/> and the value returned is a token
         /// value that allows the Write (produced due to @RenderSection(..)) to succeed. However the
         /// value does not represent the rendered content.</remarks>

--- a/src/Microsoft.AspNetCore.Mvc.Razor/RazorPage.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/RazorPage.cs
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.Razor.Internal;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.Routing;
@@ -764,7 +763,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         /// In layout pages, renders the content of the section named <paramref name="name"/>.
         /// </summary>
         /// <param name="name">The name of the section to render.</param>
-        /// <returns>Returns <see cref="HtmlString.Empty"/> to allow the <see cref="Write(object)"/> call to
+        /// <returns>An empty <see cref="IHtmlContent"/> to allow the <see cref="Write(object)"/> call to
         /// succeed.</returns>
         /// <remarks>The method writes to the <see cref="Output"/> and the value returned is a token
         /// value that allows the Write (produced due to @RenderSection(..)) to succeed. However the
@@ -784,7 +783,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         /// </summary>
         /// <param name="name">The section to render.</param>
         /// <param name="required">Indicates if this section must be rendered.</param>
-        /// <returns>Returns <see cref="HtmlString.Empty"/> to allow the <see cref="Write(object)"/> call to
+        /// <returns>An empty <see cref="IHtmlContent"/> to allow the <see cref="Write(object)"/> call to
         /// succeed.</returns>
         /// <remarks>The method writes to the <see cref="Output"/> and the value returned is a token
         /// value that allows the Write (produced due to @RenderSection(..)) to succeed. However the
@@ -806,8 +805,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         /// In layout pages, asynchronously renders the content of the section named <paramref name="name"/>.
         /// </summary>
         /// <param name="name">The section to render.</param>
-        /// <returns>A <see cref="Task{HtmlString}"/> that on completion returns <see cref="HtmlString.Empty"/> that
-        /// allows the <see cref="Write(object)"/> call to succeed.</returns>
+        /// <returns>A <see cref="Task{HtmlString}"/> that on completion returns an empty <see cref="IHtmlContent"/>
+        /// that allows the <see cref="Write(object)"/> call to succeed.</returns>
         /// <remarks>The method writes to the <see cref="Output"/> and the value returned is a token
         /// value that allows the Write (produced due to @RenderSection(..)) to succeed. However the
         /// value does not represent the rendered content.</remarks>
@@ -827,8 +826,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         /// <param name="name">The section to render.</param>
         /// <param name="required">Indicates the <paramref name="name"/> section must be registered
         /// (using <c>@section</c>) in the page.</param>
-        /// <returns>A <see cref="Task{HtmlString}"/> that on completion returns <see cref="HtmlString.Empty"/> that
-        /// allows the <see cref="Write(object)"/> call to succeed.</returns>
+        /// <returns>A <see cref="Task{HtmlString}"/> that on completion returns an empty <see cref="IHtmlContent"/>
+        /// that allows the <see cref="Write(object)"/> call to succeed.</returns>
         /// <remarks>The method writes to the <see cref="Output"/> and the value returned is a token
         /// value that allows the Write (produced due to @RenderSection(..)) to succeed. However the
         /// value does not represent the rendered content.</remarks>
@@ -912,7 +911,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         /// on the response stream, writing out any buffered content to the <see cref="HttpResponse.Body"/>.
         /// </summary>
         /// <returns>A <see cref="Task{HtmlString}"/> that represents the asynchronous flush operation and on
-        /// completion returns <see cref="HtmlString.Empty"/>.</returns>
+        /// completion returns an empty <see cref="IHtmlContent"/>.</returns>
         /// <remarks>The value returned is a token value that allows FlushAsync to work directly in an HTML
         /// section. However the value does not represent the rendered content.
         /// This method also writes out headers, so any modifications to headers must be done before
@@ -1015,7 +1014,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         /// <summary>
         /// Sets antiforgery cookie and X-Frame-Options header on the response.
         /// </summary>
-        /// <returns><see cref="HtmlString.Empty"/>.</returns>
+        /// <returns>An empty <see cref="IHtmlContent"/>.</returns>
         /// <remarks> Call this method to send antiforgery cookie token and X-Frame-Options header to client
         /// before <see cref="FlushAsync"/> flushes the headers. </remarks>
         public virtual HtmlString SetAntiforgeryCookieAndHeader()

--- a/src/Microsoft.AspNetCore.Mvc.Razor/RazorViewEngineOptions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/RazorViewEngineOptions.cs
@@ -42,8 +42,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         /// <remarks>
         /// <para>
         /// The locations of the views returned from controllers that do not belong to an area.
-        /// Locations are composite format strings (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx),
-        /// which may contain the following format items:
+        /// Locations are format strings (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) which may contain
+        /// the following format items:
         /// </para>
         /// <list type="bullet">
         /// <item>
@@ -68,8 +68,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         /// <remarks>
         /// <para>
         /// The locations of the views returned from controllers that belong to an area.
-        /// Locations are composite format strings (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx),
-        /// which may contain the following format items:
+        /// Locations are format strings (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) which may contain
+        /// the following format items:
         /// </para>
         /// <list type="bullet">
         /// <item>

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/InputTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/InputTagHelper.cs
@@ -93,9 +93,8 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         public ModelExpression For { get; set; }
 
         /// <summary>
-        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx) to
-        /// apply when converting the <see cref="For"/> result to a <see cref="string"/>. Sets the generated "value"
-        /// attribute to that formatted <see cref="string"/>.
+        /// The format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to format the
+        /// <see cref="For"/> result. Sets the generated "value" attribute to that formatted string.
         /// </summary>
         /// <remarks>
         /// Not used if the provided (see <see cref="InputTypeName"/>) or calculated "type" attribute value is

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/HtmlHelperInputExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/HtmlHelperInputExtensions.cs
@@ -14,39 +14,20 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
     {
         /// <summary>
         /// Returns an &lt;input&gt; element of type "checkbox" with value "true" and an &lt;input&gt; element of type
-        /// "hidden" with value "false".
+        /// "hidden" with value "false" for the specified <paramref name="expression"/>. Adds a "checked" attribute to
+        /// the "checkbox" element based on the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <see cref="IHtmlHelper.ViewData"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; elements.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// checkbox element's "name" attribute. Sanitizes <paramref name="expression"/> to set checkbox element's "id"
         /// attribute.
-        /// </para>
-        /// <para>Determines checkbox element's "checked" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="bool"/>.
-        /// </item>
-        /// <item>
-        /// <see cref="ViewFeatures.ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a 
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="bool"/>.
-        /// </item>
-        /// <item>
-        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
-        /// current model if result is non-<c>null</c> and can be converted to a <see cref="bool"/>. For example
-        /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
-        /// property.
-        /// </item>
-        /// <item>Otherwise, does not include a "checked" attribute.</item>
-        /// </list>
-        /// <para>
-        /// In all but the default case, includes a "checked" attribute with
-        /// value "checked" if the <see cref="bool"/> values is <c>true</c>; does not include the attribute otherwise.
-        /// </para>
         /// </remarks>
         public static IHtmlContent CheckBox(this IHtmlHelper htmlHelper, string expression)
         {
@@ -60,41 +41,22 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
 
         /// <summary>
         /// Returns an &lt;input&gt; element of type "checkbox" with value "true" and an &lt;input&gt; element of type
-        /// "hidden" with value "false".
+        /// "hidden" with value "false" for the specified <paramref name="expression"/>. Adds a "checked" attribute to
+        /// the "checkbox" element based on the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <paramref name="isChecked"/> parameter,
+        /// the <see cref="IHtmlHelper.ViewData"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="isChecked">If <c>true</c>, checkbox is initially checked.</param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; elements.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// checkbox element's "name" attribute. Sanitizes <paramref name="expression"/> to set checkbox element's "id"
         /// attribute.
-        /// </para>
-        /// <para>Determines checkbox element's "checked" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="bool"/>.
-        /// </item>
-        /// <item><paramref name="isChecked"/> if non-<c>null</c>.</item>
-        /// <item>
-        /// <see cref="ViewFeatures.ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a 
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="bool"/>.
-        /// </item>
-        /// <item>
-        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
-        /// current model if result is non-<c>null</c> and can be converted to a <see cref="bool"/>. For example
-        /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
-        /// property.
-        /// </item>
-        /// <item>Otherwise, does not include a "checked" attribute.</item>
-        /// </list>
-        /// <para>
-        /// In all but the default case, includes a "checked" attribute with
-        /// value "checked" if the <see cref="bool"/> values is <c>true</c>; does not include the attribute otherwise.
-        /// </para>
         /// </remarks>
         public static IHtmlContent CheckBox(
             this IHtmlHelper htmlHelper,
@@ -111,7 +73,13 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
 
         /// <summary>
         /// Returns an &lt;input&gt; element of type "checkbox" with value "true" and an &lt;input&gt; element of type
-        /// "hidden" with value "false".
+        /// "hidden" with value "false" for the specified <paramref name="expression"/>. Adds a "checked" attribute to
+        /// the "checkbox" element based on the first non-<c>null</c> value found in:
+        /// the <paramref name="htmlAttributes"/> dictionary entry with key "checked",
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <see cref="IHtmlHelper.ViewData"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
@@ -122,34 +90,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; elements.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// checkbox element's "name" attribute. Sanitizes <paramref name="expression"/> to set checkbox element's "id"
         /// attribute.
-        /// </para>
-        /// <para>Determines checkbox element's "checked" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="bool"/>.
-        /// </item>
-        /// <item>
-        /// <see cref="ViewFeatures.ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a 
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="bool"/>.
-        /// </item>
-        /// <item>
-        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
-        /// current model if result is non-<c>null</c> and can be converted to a <see cref="bool"/>. For example
-        /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
-        /// property.
-        /// </item>
-        /// <item>Existing "checked" entry in <paramref name="htmlAttributes"/> if any.</item>
-        /// <item>Otherwise, does not include a "checked" attribute.</item>
-        /// </list>
-        /// <para>
-        /// In all but the <paramref name="htmlAttributes"/> and default cases, includes a "checked" attribute with
-        /// value "checked" if the <see cref="bool"/> values is <c>true</c>; does not include the attribute otherwise.
-        /// </para>
         /// </remarks>
         public static IHtmlContent CheckBox(
             this IHtmlHelper htmlHelper,
@@ -166,33 +109,19 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
 
         /// <summary>
         /// Returns an &lt;input&gt; element of type "checkbox" with value "true" and an &lt;input&gt; element of type
-        /// "hidden" with value "false".
+        /// "hidden" with value "false" for the specified <paramref name="expression"/>. Adds a "checked" attribute to
+        /// the "checkbox" element based on the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper{TModel}.NameFor"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; elements.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and the string representation of the
         /// <paramref name="expression"/> to set checkbox element's "name" attribute. Sanitizes the string
         /// representation of the <paramref name="expression"/> to set checkbox element's "id" attribute.
-        /// </para>
-        /// <para>Determines checkbox element's "checked" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for the string representation of the
-        /// <paramref name="expression"/> if entry exists and can be converted to a <see cref="bool"/>.
-        /// </item>
-        /// <item>
-        /// <paramref name="expression"/> result if it is non-<c>null</c> and can be parsed as a
-        /// <see cref="bool"/>.
-        /// </item>
-        /// <item>Otherwise, does not include a "checked" attribute.</item>
-        /// </list>
-        /// <para>
-        /// In all but the default case, includes a "checked" attribute with
-        /// value "checked" if the <see cref="bool"/> values is <c>true</c>; does not include the attribute otherwise.
-        /// </para>
         /// </remarks>
         public static IHtmlContent CheckBoxFor<TModel>(
             this IHtmlHelper<TModel> htmlHelper,
@@ -212,35 +141,20 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "hidden" for the specified <paramref name="expression"/>.
+        /// Returns an &lt;input&gt; element of type "hidden" for the specified <paramref name="expression"/>. Adds a
+        /// "value" attribute to the element containing the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <see cref="IHtmlHelper.ViewData"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
-        /// </para>
-        /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// <see cref="ViewFeatures.ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a 
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
-        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
-        /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
-        /// property.
-        /// </item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         public static IHtmlContent Hidden(this IHtmlHelper htmlHelper, string expression)
         {
@@ -253,37 +167,22 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "hidden" for the specified <paramref name="expression"/>.
+        /// Returns an &lt;input&gt; element of type "hidden" for the specified <paramref name="expression"/>. Adds a
+        /// "value" attribute to the element containing the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <paramref name="value"/> parameter,
+        /// the <see cref="IHtmlHelper.ViewData"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
-        /// </para>
-        /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item><paramref name="value"/> if non-<c>null</c>.</item>
-        /// <item>
-        /// <see cref="ViewFeatures.ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a 
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
-        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
-        /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
-        /// property.
-        /// </item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         public static IHtmlContent Hidden(
             this IHtmlHelper htmlHelper,
@@ -299,7 +198,11 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "hidden" for the specified <paramref name="expression"/>.
+        /// Returns an &lt;input&gt; element of type "hidden" for the specified <paramref name="expression"/>. Adds a
+        /// "value" attribute to the element containing the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper{TModel}.NameFor"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
@@ -307,23 +210,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and the string representation of the
         /// <paramref name="expression"/> to set &lt;input&gt; element's "name" attribute. Sanitizes the string
         /// representation of the <paramref name="expression"/> to set element's "id" attribute.
-        /// </para>
-        /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for the string representation of the
-        /// <paramref name="expression"/> if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// <paramref name="expression"/> result if it is non-<c>null</c> and can be parsed as a
-        /// <see cref="string"/>.
-        /// </item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         public static IHtmlContent HiddenFor<TModel, TResult>(
             this IHtmlHelper<TModel> htmlHelper,
@@ -343,7 +232,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "password" for the specified <paramref name="expression"/>.
+        /// Returns an &lt;input&gt; element of type "password" for the specified <paramref name="expression"/>. Does
+        /// not add a "value" attribute.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
@@ -364,23 +254,17 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "password" for the specified <paramref name="expression"/>.
+        /// Returns an &lt;input&gt; element of type "password" for the specified <paramref name="expression"/>. Adds a
+        /// "value" attribute containing the <paramref name="value"/> parameter if that is non-<c>null</c>.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
-        /// </para>
-        /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item><paramref name="value"/> if non-<c>null</c>.</item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         public static IHtmlContent Password(
             this IHtmlHelper htmlHelper,
@@ -396,7 +280,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "password" for the specified <paramref name="expression"/>.
+        /// Returns an &lt;input&gt; element of type "password" for the specified <paramref name="expression"/>. Does
+        /// not add a "value" attribute.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
@@ -404,19 +289,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and the string representation of the
         /// <paramref name="expression"/> to set &lt;input&gt; element's "name" attribute. Sanitizes the string
         /// representation of the <paramref name="expression"/> to set element's "id" attribute.
-        /// </para>
-        /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <paramref name="expression"/> result if it is non-<c>null</c> and can be parsed as a
-        /// <see cref="string"/>.
-        /// </item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         public static IHtmlContent PasswordFor<TModel, TResult>(
             this IHtmlHelper<TModel> htmlHelper,
@@ -437,40 +312,23 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
 
         /// <summary>
         /// Returns an &lt;input&gt; element of type "radio" for the specified <paramref name="expression"/>.
+        /// Adds a "value" attribute to the element containing the <paramref name="value"/> parameter if that is
+        /// non-<c>null</c>.
+        /// Adds a "checked" attribute to the element if <paramref name="value"/> matches the first non-<c>null</c>
+        /// value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <see cref="IHtmlHelper.ViewData"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">Value to include in the element. Must not be <c>null</c>.</param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute. Sets &lt;input&gt; element's "value" attribute to <paramref name="value"/>.
-        /// </para>
-        /// <para>Determines &lt;input&gt; element's "checked" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// <see cref="ViewFeatures.ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a 
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
-        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
-        /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
-        /// property.
-        /// </item>
-        /// <item>Otherwise, does not include a "checked" attribute.</item>
-        /// </list>
-        /// <para>
-        /// In all but the default case, includes a "checked" attribute with
-        /// value "checked" if the <see cref="string"/> values is equal to a converted <see cref="string"/> for
-        /// <paramref name="value"/>; does not include the attribute otherwise.
-        /// </para>
         /// </remarks>
         public static IHtmlContent RadioButton(
             this IHtmlHelper htmlHelper,
@@ -487,6 +345,16 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
 
         /// <summary>
         /// Returns an &lt;input&gt; element of type "radio" for the specified <paramref name="expression"/>.
+        /// Adds a "value" attribute to the element containing the first non-<c>null</c> value found in:
+        /// the <paramref name="value"/> parameter, or
+        /// the <paramref name="htmlAttributes"/> dictionary entry with key "value".
+        /// Adds a "checked" attribute to the element if <paramref name="value"/> matches the first non-<c>null</c>
+        /// value found in:
+        /// the <paramref name="htmlAttributes"/> dictionary entry with key "checked",
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <see cref="IHtmlHelper.ViewData"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
@@ -501,41 +369,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
-        /// </para>
-        /// <para>Determines element's "value" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item><paramref name="value"/> if non-<c>null</c>.</item>
-        /// <item>Existing "value" entry in <paramref name="htmlAttributes"/> if any.</item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
-        /// <para>Determines &lt;input&gt; element's "checked" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>Existing "checked" entry in <paramref name="htmlAttributes"/> if any.</item>
-        /// <item>
-        /// <see cref="ViewFeatures.ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a 
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
-        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
-        /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
-        /// property.
-        /// </item>
-        /// <item>Otherwise, does not include a "checked" attribute.</item>
-        /// </list>
-        /// <para>
-        /// In all but the <paramref name="htmlAttributes"/> and default cases, includes a "checked" attribute with
-        /// value "checked" if the <see cref="string"/> values is equal to a converted <see cref="string"/> for
-        /// <paramref name="value"/>; does not include the attribute otherwise.
-        /// </para>
         /// </remarks>
         public static IHtmlContent RadioButton(
             this IHtmlHelper htmlHelper,
@@ -553,6 +389,15 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
 
         /// <summary>
         /// Returns an &lt;input&gt; element of type "radio" for the specified <paramref name="expression"/>.
+        /// Adds a "value" attribute to the element containing the <paramref name="value"/> parameter if that is
+        /// non-<c>null</c>.
+        /// Adds a "checked" attribute to the element if <paramref name="value"/> matches the first non-<c>null</c>
+        /// value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <paramref name="isChecked"/> parameter,
+        /// the <see cref="IHtmlHelper.ViewData"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
@@ -566,41 +411,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
-        /// </para>
-        /// <para>Determines element's "value" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item><paramref name="value"/> if non-<c>null</c>.</item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
-        /// <para>Determines &lt;input&gt; element's "checked" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item><paramref name="isChecked"/> if non-<c>null</c>.</item>
-        /// <item>
-        /// <see cref="ViewFeatures.ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a 
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
-        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
-        /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
-        /// property.
-        /// </item>
-        /// <item>Otherwise, does not include a "checked" attribute.</item>
-        /// </list>
-        /// <para>
-        /// In all but the default case, includes a "checked" attribute with
-        /// value "checked" if the <see cref="string"/> values is equal to a converted <see cref="string"/> for
-        /// <paramref name="value"/> or <paramref name="isChecked"/> is <c>true</c> (for that case); does not include
-        /// the attribute otherwise.
-        /// </para>
         /// </remarks>
         public static IHtmlContent RadioButton(
             this IHtmlHelper htmlHelper,
@@ -618,6 +431,12 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
 
         /// <summary>
         /// Returns an &lt;input&gt; element of type "radio" for the specified <paramref name="expression"/>.
+        /// Adds a "value" attribute to the element containing the <paramref name="value"/> parameter.
+        /// Adds a "checked" attribute to the element if <paramref name="value"/> matches the first non-<c>null</c>
+        /// value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper{TModel}.NameFor"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
@@ -626,28 +445,10 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and the string representation of the
         /// <paramref name="expression"/> to set &lt;select&gt; element's "name" attribute. Sanitizes the string
         /// representation of the <paramref name="expression"/> to set element's "id" attribute. Converts the
         /// <paramref name="value"/> to a <see cref="string"/> to set element's "value" attribute.
-        /// </para>
-        /// <para>Determines &lt;input&gt; element's "checked" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for the string representation of the
-        /// <paramref name="expression"/> if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// <paramref name="expression"/> result if it is non-<c>null</c> and can be parsed as a <see cref="string"/>.
-        /// </item>
-        /// <item>Otherwise, does not include a "checked" attribute.</item>
-        /// </list>
-        /// <para>
-        /// In all but the default case, includes a "checked" attribute with
-        /// value "checked" if the <see cref="string"/> values is equal to a converted <see cref="string"/> for
-        /// <paramref name="value"/>; does not include the attribute otherwise.
-        /// </para>
         /// </remarks>
         public static IHtmlContent RadioButtonFor<TModel, TResult>(
             this IHtmlHelper<TModel> htmlHelper,
@@ -673,35 +474,20 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="expression"/>.
+        /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="expression"/>. Adds a
+        /// "value" attribute to the element containing the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <see cref="IHtmlHelper.ViewData"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
-        /// </para>
-        /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// <see cref="ViewFeatures.ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a 
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
-        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
-        /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
-        /// property.
-        /// </item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         public static IHtmlContent TextBox(this IHtmlHelper htmlHelper, string expression)
         {
@@ -714,39 +500,22 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="expression"/>.
+        /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="expression"/>. Adds a
+        /// "value" attribute to the element containing the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <paramref name="value"/> parameter,
+        /// the <see cref="IHtmlHelper.ViewData"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
-        /// </para>
-        /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// <paramref name="value"/> if non-<c>null</c>.
-        /// </item>
-        /// <item>
-        /// <see cref="ViewFeatures.ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a 
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
-        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
-        /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
-        /// property.
-        /// </item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         public static IHtmlContent TextBox(
             this IHtmlHelper htmlHelper,
@@ -762,47 +531,26 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="expression"/>.
+        /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="expression"/>. Adds a
+        /// "value" attribute to the element containing the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <paramref name="value"/> parameter,
+        /// the <see cref="IHtmlHelper.ViewData"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
         /// <param name="format">
-        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx).
+        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx) used
+        /// to format the "value" attribute unless that came from model binding.
         /// </param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
-        /// </para>
-        /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// <paramref name="value"/> if non-<c>null</c>. Formats <paramref name="value"/> using
-        /// <paramref name="format"/> or converts <paramref name="value"/> to a <see cref="string"/> directly if
-        /// <paramref name="format"/> is <c>null</c> or empty.
-        /// </item>
-        /// <item>
-        /// <see cref="ViewFeatures.ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a 
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>. Formats entry using
-        /// <paramref name="format"/> or converts entry to a <see cref="string"/> directly if <paramref name="format"/>
-        /// is <c>null</c> or empty.
-        /// </item>
-        /// <item>
-        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
-        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
-        /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
-        /// property. Formats result using <paramref name="format"/> or converts result to a <see cref="string"/>
-        /// directly if <paramref name="format"/> is <c>null</c> or empty.
-        /// </item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         public static IHtmlContent TextBox(
             this IHtmlHelper htmlHelper,
@@ -819,7 +567,14 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="expression"/>.
+        /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="expression"/>. Adds a
+        /// "value" attribute to the element containing the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <paramref name="value"/> parameter,
+        /// the <see cref="IHtmlHelper.ViewData"/> entry with full name,
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>, or
+        /// the <paramref name="htmlAttributes"/> dictionary entry with key "value".
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
@@ -831,33 +586,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
-        /// </para>
-        /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// <paramref name="value"/> if non-<c>null</c>.
-        /// </item>
-        /// <item>
-        /// <see cref="ViewFeatures.ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a 
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
-        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
-        /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
-        /// property.
-        /// </item>
-        /// <item>Existing "value" entry in <paramref name="htmlAttributes"/> if any.</item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         public static IHtmlContent TextBox(
             this IHtmlHelper htmlHelper,
@@ -874,7 +605,11 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="expression"/>.
+        /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="expression"/>. Adds a
+        /// "value" attribute to the element containing the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper{TModel}.NameFor"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
@@ -882,22 +617,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and the string representation of the
         /// <paramref name="expression"/> to set &lt;input&gt; element's "name" attribute. Sanitizes the string
         /// representation of the <paramref name="expression"/> to set element's "id" attribute.
-        /// </para>
-        /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for the string representation of the
-        /// <paramref name="expression"/> if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// <paramref name="expression"/> result if it is non-<c>null</c> and can be parsed as a <see cref="string"/>.
-        /// </item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         public static IHtmlContent TextBoxFor<TModel, TResult>(
             this IHtmlHelper<TModel> htmlHelper,
@@ -917,35 +639,25 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="expression"/>.
+        /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="expression"/>. Adds a
+        /// "value" attribute to the element containing the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper{TModel}.NameFor"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="format">
-        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx).
+        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx) used
+        /// to format the <paramref name="expression"/> value when using that in the "value" attribute.
         /// </param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and the string representation of the
         /// <paramref name="expression"/> to set &lt;input&gt; element's "name" attribute. Sanitizes the string
         /// representation of the <paramref name="expression"/> to set element's "id" attribute.
-        /// </para>
-        /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for the string representation of the
-        /// <paramref name="expression"/> if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// <paramref name="expression"/> result if it is non-<c>null</c> and can be parsed as a <see cref="string"/>.
-        /// Formats result using <paramref name="format"/> or converts result to a <see cref="string"/> directly if
-        /// <paramref name="format"/> is <c>null</c> or empty.
-        /// </item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         public static IHtmlContent TextBoxFor<TModel, TResult>(
             this IHtmlHelper<TModel> htmlHelper,
@@ -966,7 +678,12 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="expression"/>.
+        /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="expression"/>. Adds a
+        /// "value" attribute to the element containing the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>, or
+        /// the <paramref name="htmlAttributes"/> dictionary entry with key "value".
+        /// See <see cref="IHtmlHelper{TModel}.NameFor"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
@@ -979,23 +696,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and the string representation of the
         /// <paramref name="expression"/> to set &lt;input&gt; element's "name" attribute. Sanitizes the string
         /// representation of the <paramref name="expression"/> to set element's "id" attribute.
-        /// </para>
-        /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for the string representation of the
-        /// <paramref name="expression"/> if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// <paramref name="expression"/> result if it is non-<c>null</c> and can be parsed as a <see cref="string"/>.
-        /// </item>
-        /// <item>Existing "value" entry in <paramref name="htmlAttributes"/> if any.</item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         public static IHtmlContent TextBoxFor<TModel, TResult>(
             this IHtmlHelper<TModel> htmlHelper,
@@ -1016,35 +719,20 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>.
+        /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>. Adds content to the
+        /// element body based on the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <see cref="IHtmlHelper.ViewData"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;textarea&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// &lt;textarea&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
-        /// </para>
-        /// <para>Determines &lt;textarea&gt; element's content based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// <see cref="ViewFeatures.ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a 
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
-        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
-        /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
-        /// property.
-        /// </item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         public static IHtmlContent TextArea(
             this IHtmlHelper htmlHelper,
@@ -1059,7 +747,12 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>.
+        /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>. Adds content to the
+        /// element body based on the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <see cref="IHtmlHelper.ViewData"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
@@ -1070,29 +763,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;textarea&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// &lt;textarea&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
-        /// </para>
-        /// <para>Determines &lt;textarea&gt; element's content based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// <see cref="ViewFeatures.ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a 
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
-        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
-        /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
-        /// property.
-        /// </item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         public static IHtmlContent TextArea(
             this IHtmlHelper htmlHelper,
@@ -1108,37 +781,22 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>.
+        /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>. Adds content to the
+        /// element body based on the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <paramref name="value"/> parameter,
+        /// the <see cref="IHtmlHelper.ViewData"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;textarea&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// &lt;textarea&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
-        /// </para>
-        /// <para>Determines &lt;textarea&gt; element's content based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item><paramref name="value"/> if non-<c>null</c>.</item>
-        /// <item>
-        /// <see cref="ViewFeatures.ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a 
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
-        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
-        /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
-        /// property.
-        /// </item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         public static IHtmlContent TextArea(
             this IHtmlHelper htmlHelper,
@@ -1154,7 +812,13 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>.
+        /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>. Adds content to the
+        /// element body based on the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <paramref name="value"/> parameter,
+        /// the <see cref="IHtmlHelper.ViewData"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
@@ -1166,30 +830,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;textarea&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// &lt;textarea&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
-        /// </para>
-        /// <para>Determines &lt;textarea&gt; element's content based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item><paramref name="value"/> if non-<c>null</c>.</item>
-        /// <item>
-        /// <see cref="ViewFeatures.ViewDataDictionary"/> entry for <paramref name="expression"/> (converted to a 
-        /// fully-qualified name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
-        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
-        /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
-        /// property.
-        /// </item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         public static IHtmlContent TextArea(
             this IHtmlHelper htmlHelper,
@@ -1206,7 +849,11 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>.
+        /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>. Adds content to the
+        /// element body based on the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper{TModel}.NameFor"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
@@ -1214,22 +861,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;textarea&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and the string representation of the
         /// <paramref name="expression"/> to set &lt;textarea&gt; element's "name" attribute. Sanitizes the string
         /// representation of the <paramref name="expression"/> to set element's "id" attribute.
-        /// </para>
-        /// <para>Determines &lt;textarea&gt; element's content based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for the string representation of the
-        /// <paramref name="expression"/> if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// <paramref name="expression"/> result if it is non-<c>null</c> and can be parsed as a <see cref="string"/>.
-        /// </item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         public static IHtmlContent TextAreaFor<TModel, TResult>(
             this IHtmlHelper<TModel> htmlHelper,
@@ -1249,7 +883,11 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>.
+        /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>. Adds content to the
+        /// element body based on the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper{TModel}.NameFor"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
@@ -1262,22 +900,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;textarea&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and the string representation of the
         /// <paramref name="expression"/> to set &lt;textarea&gt; element's "name" attribute. Sanitizes the string
         /// representation of the <paramref name="expression"/> to set element's "id" attribute.
-        /// </para>
-        /// <para>Determines &lt;textarea&gt; element's content based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for the string representation of the
-        /// <paramref name="expression"/> if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// <paramref name="expression"/> result if it is non-<c>null</c> and can be parsed as a <see cref="string"/>.
-        /// </item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         public static IHtmlContent TextAreaFor<TModel, TResult>(
             this IHtmlHelper<TModel> htmlHelper,

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/HtmlHelperInputExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/HtmlHelperInputExtensions.cs
@@ -543,8 +543,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
         /// <param name="format">
-        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx) used
-        /// to format the "value" attribute unless that came from model binding.
+        /// The format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to format the "value"
+        /// attribute unless that came from model binding.
         /// </param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
@@ -648,8 +648,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="format">
-        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx) used
-        /// to format the <paramref name="expression"/> value when using that in the "value" attribute.
+        /// The format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to format the
+        /// <paramref name="expression"/> value when using that in the "value" attribute.
         /// </param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/HtmlHelperNameExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/HtmlHelperNameExtensions.cs
@@ -11,7 +11,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
     public static class HtmlHelperNameExtensions
     {
         /// <summary>
-        /// Returns the full HTML element name for the current model.
+        /// Returns the full HTML element name for the current model. Uses
+        /// <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> (if non-empty) to reflect relationship between
+        /// current <see cref="ViewFeatures.ViewDataDictionary.Model"/> and the top-level view's model.
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <returns>A <see cref="string"/> containing the element name.</returns>

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/HtmlHelperSelectExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/HtmlHelperSelectExtensions.cs
@@ -14,15 +14,27 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
     public static class HtmlHelperSelectExtensions
     {
         /// <summary>
-        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>.
+        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>. Adds
+        /// &lt;option&gt; elements based on the <see cref="IHtmlHelper.ViewData"/> entry with full name. Adds a
+        /// "selected" attribute to an &lt;option&gt; if its <see cref="SelectListItem.Value"/> (if non-<c>null</c>) or
+        /// <see cref="SelectListItem.Text"/> matches the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;select&gt; element.</returns>
         /// <remarks>
+        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// &lt;select&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
+        /// </para>
+        /// <para>
+        /// The <see cref="IHtmlHelper.ViewData"/> entry with full name must be a non-<c>null</c> collection of
+        /// <see cref="SelectListItem"/> objects.
+        /// </para>
         /// </remarks>
         public static IHtmlContent DropDownList(this IHtmlHelper htmlHelper, string expression)
         {
@@ -35,8 +47,14 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>, using the
-        /// option label.
+        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>. Adds
+        /// &lt;option&gt; elements based on <paramref name="optionLabel"/> and the <see cref="IHtmlHelper.ViewData"/>
+        /// entry with full name. Adds a "selected" attribute to an &lt;option&gt; if its
+        /// <see cref="SelectListItem.Value"/> (if non-<c>null</c>) or <see cref="SelectListItem.Text"/> matches the
+        /// first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
@@ -45,9 +63,15 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;select&gt; element.</returns>
         /// <remarks>
+        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// &lt;select&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
+        /// </para>
+        /// <para>
+        /// The <see cref="IHtmlHelper.ViewData"/> entry with full name must be a non-<c>null</c> collection of
+        /// <see cref="SelectListItem"/> objects.
+        /// </para>
         /// </remarks>
         public static IHtmlContent DropDownList(
             this IHtmlHelper htmlHelper,
@@ -67,14 +91,22 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>, using the
-        /// specified list items.
+        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>. Adds
+        /// &lt;option&gt; elements based on <paramref name="selectList"/>. Adds a "selected" attribute to an
+        /// &lt;option&gt; if its <see cref="SelectListItem.Value"/> (if non-<c>null</c>) or
+        /// <see cref="SelectListItem.Text"/> matches the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <see cref="IHtmlHelper.ViewData"/> entry with full name (unless used instead of
+        /// <paramref name="selectList"/>), or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="selectList">
         /// A collection of <see cref="SelectListItem"/> objects used to populate the &lt;select&gt; element with
-        /// &lt;optgroup&gt; and &lt;option&gt; elements.
+        /// &lt;optgroup&gt; and &lt;option&gt; elements. If <c>null</c>, uses the <see cref="IHtmlHelper.ViewData"/>
+        /// entry with full name and that entry must be a collection of <see cref="SelectListItem"/> objects.
         /// </param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;select&gt; element.</returns>
         /// <remarks>
@@ -96,14 +128,22 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>, using the
-        /// specified list items and HTML attributes.
+        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>. Adds
+        /// &lt;option&gt; elements based on <paramref name="selectList"/>. Adds a "selected" attribute to an
+        /// &lt;option&gt; if its <see cref="SelectListItem.Value"/> (if non-<c>null</c>) or
+        /// <see cref="SelectListItem.Text"/> matches the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <see cref="IHtmlHelper.ViewData"/> entry with full name (unless used instead of
+        /// <paramref name="selectList"/>), or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="selectList">
         /// A collection of <see cref="SelectListItem"/> objects used to populate the &lt;select&gt; element with
-        /// &lt;optgroup&gt; and &lt;option&gt; elements.
+        /// &lt;optgroup&gt; and &lt;option&gt; elements. If <c>null</c>, uses the <see cref="IHtmlHelper.ViewData"/>
+        /// entry with full name and that entry must be a collection of <see cref="SelectListItem"/> objects.
         /// </param>
         /// <param name="htmlAttributes">
         /// An <see cref="object"/> that contains the HTML attributes for the &lt;select&gt; element. Alternatively, an
@@ -130,14 +170,22 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>, using the
-        /// specified list items and option label.
+        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>. Adds
+        /// &lt;option&gt; elements based on <paramref name="optionLabel"/> and <paramref name="selectList"/>. Adds a
+        /// "selected" attribute to an &lt;option&gt; if its <see cref="SelectListItem.Value"/> (if non-<c>null</c>) or
+        /// <see cref="SelectListItem.Text"/> matches the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <see cref="IHtmlHelper.ViewData"/> entry with full name (unless used instead of
+        /// <paramref name="selectList"/>), or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="selectList">
         /// A collection of <see cref="SelectListItem"/> objects used to populate the &lt;select&gt; element with
-        /// &lt;optgroup&gt; and &lt;option&gt; elements.
+        /// &lt;optgroup&gt; and &lt;option&gt; elements. If <c>null</c>, uses the <see cref="IHtmlHelper.ViewData"/>
+        /// entry with full name and that entry must be a collection of <see cref="SelectListItem"/> objects.
         /// </param>
         /// <param name="optionLabel">
         /// The text for a default empty item. Does not include such an item if argument is <c>null</c>.
@@ -163,14 +211,20 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>, using the
-        /// specified list items.
+        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>. Adds
+        /// &lt;option&gt; elements based on <paramref name="selectList"/>. Adds a "selected" attribute to an
+        /// &lt;option&gt; if its <see cref="SelectListItem.Value"/> (if non-<c>null</c>) or
+        /// <see cref="SelectListItem.Text"/> matches the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper{TModel}.NameFor"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="selectList">
         /// A collection of <see cref="SelectListItem"/> objects used to populate the &lt;select&gt; element with
-        /// &lt;optgroup&gt; and &lt;option&gt; elements.
+        /// &lt;optgroup&gt; and &lt;option&gt; elements. If <c>null</c>, uses the <see cref="IHtmlHelper.ViewData"/>
+        /// entry with full name and that entry must be a collection of <see cref="SelectListItem"/> objects.
         /// </param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
@@ -199,14 +253,20 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>, using the
-        /// specified list items and HTML attributes.
+        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>. Adds
+        /// &lt;option&gt; elements based on <paramref name="selectList"/>. Adds a "selected" attribute to an
+        /// &lt;option&gt; if its <see cref="SelectListItem.Value"/> (if non-<c>null</c>) or
+        /// <see cref="SelectListItem.Text"/> matches the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper{TModel}.NameFor"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="selectList">
         /// A collection of <see cref="SelectListItem"/> objects used to populate the &lt;select&gt; element with
-        /// &lt;optgroup&gt; and &lt;option&gt; elements.
+        /// &lt;optgroup&gt; and &lt;option&gt; elements. If <c>null</c>, uses the <see cref="IHtmlHelper.ViewData"/>
+        /// entry with full name and that entry must be a collection of <see cref="SelectListItem"/> objects.
         /// </param>
         /// <param name="htmlAttributes">
         /// An <see cref="object"/> that contains the HTML attributes for the &lt;select&gt; element. Alternatively, an
@@ -244,14 +304,20 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>, using the
-        /// specified list items and option label.
+        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>. Adds
+        /// &lt;option&gt; elements based on <paramref name="optionLabel"/> and <paramref name="selectList"/>. Adds a
+        /// "selected" attribute to an &lt;option&gt; if its <see cref="SelectListItem.Value"/> (if non-<c>null</c>) or
+        /// <see cref="SelectListItem.Text"/> matches the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper{TModel}.NameFor"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="selectList">
         /// A collection of <see cref="SelectListItem"/> objects used to populate the &lt;select&gt; element with
-        /// &lt;optgroup&gt; and &lt;option&gt; elements.
+        /// &lt;optgroup&gt; and &lt;option&gt; elements. If <c>null</c>, uses the <see cref="IHtmlHelper.ViewData"/>
+        /// entry with full name and that entry must be a collection of <see cref="SelectListItem"/> objects.
         /// </param>
         /// <param name="optionLabel">
         /// The text for a default empty item. Does not include such an item if argument is <c>null</c>.
@@ -284,15 +350,27 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns a multi-selection &lt;select&gt; element for the <paramref name="expression"/>.
+        /// Returns a multi-selection &lt;select&gt; element for the <paramref name="expression"/>. Adds
+        /// &lt;option&gt; elements based on the <see cref="IHtmlHelper.ViewData"/> entry with full name. Adds a
+        /// "selected" attribute to an &lt;option&gt; if its <see cref="SelectListItem.Value"/> (if non-<c>null</c>) or
+        /// <see cref="SelectListItem.Text"/> matches the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;select&gt; element.</returns>
         /// <remarks>
+        /// <para>
         /// Combines <see cref="ViewFeatures.TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// &lt;select&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
+        /// </para>
+        /// <para>
+        /// The <see cref="IHtmlHelper.ViewData"/> entry with full name must be a non-<c>null</c> collection of
+        /// <see cref="SelectListItem"/> objects.
+        /// </para>
         /// </remarks>
         public static IHtmlContent ListBox(this IHtmlHelper htmlHelper, string expression)
         {
@@ -305,14 +383,22 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns a multi-selection &lt;select&gt; element for the <paramref name="expression"/>, using the
-        /// specified list items.
+        /// Returns a multi-selection &lt;select&gt; element for the <paramref name="expression"/>. Adds
+        /// &lt;option&gt; elements based on <paramref name="selectList"/>. Adds a "selected" attribute to an
+        /// &lt;option&gt; if its <see cref="SelectListItem.Value"/> (if non-<c>null</c>) or
+        /// <see cref="SelectListItem.Text"/> matches the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <see cref="IHtmlHelper.ViewData"/> entry with full name (unless used instead of
+        /// <paramref name="selectList"/>), or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="selectList">
         /// A collection of <see cref="SelectListItem"/> objects used to populate the &lt;select&gt; element with
-        /// &lt;optgroup&gt; and &lt;option&gt; elements.
+        /// &lt;optgroup&gt; and &lt;option&gt; elements. If <c>null</c>, uses the <see cref="IHtmlHelper.ViewData"/>
+        /// entry with full name and that entry must be a collection of <see cref="SelectListItem"/> objects.
         /// </param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;select&gt; element.</returns>
         /// <remarks>
@@ -334,14 +420,20 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns a multi-selection &lt;select&gt; element for the  <paramref name="expression"/>, using the
-        /// specified list items.
+        /// Returns a multi-selection &lt;select&gt; element for the  <paramref name="expression"/>. Adds
+        /// &lt;option&gt; elements based on <paramref name="selectList"/>. Adds a "selected" attribute to an
+        /// &lt;option&gt; if its <see cref="SelectListItem.Value"/> (if non-<c>null</c>) or
+        /// <see cref="SelectListItem.Text"/> matches the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="selectList">
         /// A collection of <see cref="SelectListItem"/> objects used to populate the &lt;select&gt; element with
-        /// &lt;optgroup&gt; and &lt;option&gt; elements.
+        /// &lt;optgroup&gt; and &lt;option&gt; elements. If <c>null</c>, uses the <see cref="IHtmlHelper.ViewData"/>
+        /// entry with full name and that entry must be a collection of <see cref="SelectListItem"/> objects.
         /// </param>
         /// <typeparam name="TModel">The type of the model.</typeparam>
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/HtmlHelperValidationExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/HtmlHelperValidationExtensions.cs
@@ -20,7 +20,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <returns>
         /// A new <see cref="IHtmlContent"/> containing a <see cref="ViewContext.ValidationMessageElement"/> element.
-        /// <c>null</c> if the <paramref name="expression"/> is valid and client-side validation is disabled.
+        /// <see cref="HtmlString.Empty"/> if the <paramref name="expression"/> is valid and client-side validation is
+        /// disabled.
         /// </returns>
         /// <remarks>
         /// Method extracts an error string from the <see cref="ModelBinding.ModelStateDictionary"/> object. Message
@@ -51,7 +52,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>
         /// A new <see cref="IHtmlContent"/> containing a <see cref="ViewContext.ValidationMessageElement"/> element.
-        /// <c>null</c> if the <paramref name="expression"/> is valid and client-side validation is disabled.
+        /// <see cref="HtmlString.Empty"/> if the <paramref name="expression"/> is valid and client-side validation is
+        /// disabled.
         /// </returns>
         public static IHtmlContent ValidationMessage(
             this IHtmlHelper htmlHelper,
@@ -80,7 +82,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>
         /// A new <see cref="IHtmlContent"/> containing a <see cref="ViewContext.ValidationMessageElement"/> element.
-        /// <c>null</c> if the <paramref name="expression"/> is valid and client-side validation is disabled.
+        /// <see cref="HtmlString.Empty"/> if the <paramref name="expression"/> is valid and client-side validation is
+        /// disabled.
         /// </returns>
         /// <remarks>
         /// Method extracts an error string from the <see cref="ModelBinding.ModelStateDictionary"/> object. Message
@@ -115,8 +118,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <see cref="ViewContext.ValidationMessageElement"/>.
         /// </param>
         /// <returns>
-        /// A new <see cref="IHtmlContent"/> containing a <paramref name="tag"/> element. <c>null</c> if the
-        /// <paramref name="expression"/> is valid and client-side validation is disabled.
+        /// A new <see cref="IHtmlContent"/> containing a <paramref name="tag"/> element.
+        /// <see cref="HtmlString.Empty"/> if the <paramref name="expression"/> is valid and client-side validation is
+        /// disabled.
         /// </returns>
         public static IHtmlContent ValidationMessage(
             this IHtmlHelper htmlHelper,
@@ -151,7 +155,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>
         /// A new <see cref="IHtmlContent"/> containing a <see cref="ViewContext.ValidationMessageElement"/> element.
-        /// <c>null</c> if the <paramref name="expression"/> is valid and client-side validation is disabled.
+        /// <see cref="HtmlString.Empty"/> if the <paramref name="expression"/> is valid and client-side validation is
+        /// disabled.
         /// </returns>
         public static IHtmlContent ValidationMessage(
             this IHtmlHelper htmlHelper,
@@ -177,7 +182,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>
         /// A new <see cref="IHtmlContent"/> containing a <see cref="ViewContext.ValidationMessageElement"/> element.
-        /// <c>null</c> if the <paramref name="expression"/> is valid and client-side validation is disabled.
+        /// <see cref="HtmlString.Empty"/> if the <paramref name="expression"/> is valid and client-side validation is
+        /// disabled.
         /// </returns>
         /// <remarks>
         /// Method extracts an error string from the <see cref="ModelBinding.ModelStateDictionary"/> object. Message
@@ -215,7 +221,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>
         /// A new <see cref="IHtmlContent"/> containing a <see cref="ViewContext.ValidationMessageElement"/> element.
-        /// <c>null</c> if the <paramref name="expression"/> is valid and client-side validation is disabled.
+        /// <see cref="HtmlString.Empty"/> if the <paramref name="expression"/> is valid and client-side validation is
+        /// disabled.
         /// </returns>
         public static IHtmlContent ValidationMessageFor<TModel, TResult>(
             this IHtmlHelper<TModel> htmlHelper,
@@ -256,7 +263,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>
         /// A new <see cref="IHtmlContent"/> containing a <see cref="ViewContext.ValidationMessageElement"/> element.
-        /// <c>null</c> if the <paramref name="expression"/> is valid and client-side validation is disabled.
+        /// <see cref="HtmlString.Empty"/> if the <paramref name="expression"/> is valid and client-side validation is
+        /// disabled.
         /// </returns>
         public static IHtmlContent ValidationMessageFor<TModel, TResult>(
             this IHtmlHelper<TModel> htmlHelper,
@@ -295,8 +303,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <typeparam name="TModel">The type of the model.</typeparam>
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>
-        /// A new <see cref="IHtmlContent"/> containing the <paramref name="tag"/> element. <c>null</c> if the
-        /// <paramref name="expression"/> is valid and client-side validation is disabled.
+        /// A new <see cref="IHtmlContent"/> containing the <paramref name="tag"/> element.
+        /// <see cref="HtmlString.Empty"/> if the <paramref name="expression"/> is valid and client-side validation is
+        /// disabled.
         /// </returns>
         public static IHtmlContent ValidationMessageFor<TModel, TResult>(
             this IHtmlHelper<TModel> htmlHelper,
@@ -324,7 +333,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <returns>
         /// New <see cref="IHtmlContent"/> containing a &lt;div&gt; element wrapping the &lt;ul&gt; element.
-        /// <see cref="HtmlString.Empty"/> if the current model is valid and client-side validation is disabled).
+        /// <see cref="HtmlString.Empty"/> if the current model is valid and client-side validation is disabled.
         /// </returns>
         public static IHtmlContent ValidationSummary(this IHtmlHelper htmlHelper)
         {
@@ -350,7 +359,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>
         /// New <see cref="IHtmlContent"/> containing a &lt;div&gt; element wrapping the &lt;ul&gt; element.
-        /// <see cref="HtmlString.Empty"/> if the current model is valid and client-side validation is disabled).
+        /// <see cref="HtmlString.Empty"/> if the current model is valid and client-side validation is disabled.
         /// </returns>
         public static IHtmlContent ValidationSummary(this IHtmlHelper htmlHelper, bool excludePropertyErrors)
         {
@@ -376,7 +385,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// New <see cref="IHtmlContent"/> containing a &lt;div&gt; element wrapping the
         /// <see cref="ViewContext.ValidationSummaryMessageElement" /> element (which wraps the
         /// <paramref name="message"/>) and the &lt;ul&gt; element. <see cref="HtmlString.Empty"/> if the current model
-        /// is valid and client-side validation is disabled).
+        /// is valid and client-side validation is disabled.
         /// </returns>
         public static IHtmlContent ValidationSummary(this IHtmlHelper htmlHelper, string message)
         {
@@ -405,7 +414,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <returns>
         /// New <see cref="IHtmlContent"/> containing a &lt;div&gt; element wrapping the <paramref name="tag"/> element
         /// and the &lt;ul&gt; element. <see cref="HtmlString.Empty"/> if the current model is valid and client-side
-        /// validation is disabled).
+        /// validation is disabled.
         /// </returns>
         public static IHtmlContent ValidationSummary(this IHtmlHelper htmlHelper, string message, string tag)
         {
@@ -434,7 +443,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// New <see cref="IHtmlContent"/> containing a &lt;div&gt; element wrapping the
         /// <see cref="ViewContext.ValidationSummaryMessageElement" /> element (which, in turn, wraps the
         /// <paramref name="message"/>) and the &lt;ul&gt; element. <see cref="HtmlString.Empty"/> if the current model
-        /// is valid and client-side validation is disabled).
+        /// is valid and client-side validation is disabled.
         /// </returns>
         public static IHtmlContent ValidationSummary(
             this IHtmlHelper htmlHelper,
@@ -468,7 +477,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// New <see cref="IHtmlContent"/> containing a &lt;div&gt; element wrapping the
         /// <see cref="ViewContext.ValidationSummaryMessageElement" /> element (which wraps the
         /// <paramref name="message"/>) and the &lt;ul&gt; element. <see cref="HtmlString.Empty"/> if the current model
-        /// is valid and client-side validation is disabled).
+        /// is valid and client-side validation is disabled.
         /// </returns>
         public static IHtmlContent ValidationSummary(
             this IHtmlHelper htmlHelper,
@@ -505,7 +514,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <returns>
         /// New <see cref="IHtmlContent"/> containing a &lt;div&gt; element wrapping the <paramref name="tag"/> element
         /// and the &lt;ul&gt; element. <see cref="HtmlString.Empty"/> if the current model is valid and client-side
-        /// validation is disabled).
+        /// validation is disabled.
         /// </returns>
         public static IHtmlContent ValidationSummary(
             this IHtmlHelper htmlHelper,
@@ -541,7 +550,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <returns>
         /// New <see cref="IHtmlContent"/> containing a &lt;div&gt; element wrapping the <paramref name="tag"/> element
         /// and the &lt;ul&gt; element. <see cref="HtmlString.Empty"/> if the current model is valid and client-side
-        /// validation is disabled).
+        /// validation is disabled.
         /// </returns>
         public static IHtmlContent ValidationSummary(
             this IHtmlHelper htmlHelper,
@@ -579,7 +588,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// New <see cref="IHtmlContent"/> containing a &lt;div&gt; element wrapping the
         /// <see cref="ViewContext.ValidationSummaryMessageElement" /> element (which wraps the
         /// <paramref name="message"/>) and the &lt;ul&gt; element. <see cref="HtmlString.Empty"/> if the current model
-        /// is valid and client-side validation is disabled).
+        /// is valid and client-side validation is disabled.
         /// </returns>
         public static IHtmlContent ValidationSummary(
             this IHtmlHelper htmlHelper,

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/HtmlHelperValidationExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/HtmlHelperValidationExtensions.cs
@@ -20,8 +20,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <returns>
         /// A new <see cref="IHtmlContent"/> containing a <see cref="ViewContext.ValidationMessageElement"/> element.
-        /// <see cref="HtmlString.Empty"/> if the <paramref name="expression"/> is valid and client-side validation is
-        /// disabled.
+        /// An empty <see cref="IHtmlContent"/> if the <paramref name="expression"/> is valid and client-side
+        /// validation is disabled.
         /// </returns>
         /// <remarks>
         /// Method extracts an error string from the <see cref="ModelBinding.ModelStateDictionary"/> object. Message
@@ -52,8 +52,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>
         /// A new <see cref="IHtmlContent"/> containing a <see cref="ViewContext.ValidationMessageElement"/> element.
-        /// <see cref="HtmlString.Empty"/> if the <paramref name="expression"/> is valid and client-side validation is
-        /// disabled.
+        /// An empty <see cref="IHtmlContent"/> if the <paramref name="expression"/> is valid and client-side
+        /// validation is disabled.
         /// </returns>
         public static IHtmlContent ValidationMessage(
             this IHtmlHelper htmlHelper,
@@ -82,8 +82,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>
         /// A new <see cref="IHtmlContent"/> containing a <see cref="ViewContext.ValidationMessageElement"/> element.
-        /// <see cref="HtmlString.Empty"/> if the <paramref name="expression"/> is valid and client-side validation is
-        /// disabled.
+        /// An empty <see cref="IHtmlContent"/> if the <paramref name="expression"/> is valid and client-side
+        /// validation is disabled.
         /// </returns>
         /// <remarks>
         /// Method extracts an error string from the <see cref="ModelBinding.ModelStateDictionary"/> object. Message
@@ -118,8 +118,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <see cref="ViewContext.ValidationMessageElement"/>.
         /// </param>
         /// <returns>
-        /// A new <see cref="IHtmlContent"/> containing a <paramref name="tag"/> element.
-        /// <see cref="HtmlString.Empty"/> if the <paramref name="expression"/> is valid and client-side validation is
+        /// A new <see cref="IHtmlContent"/> containing a <paramref name="tag"/> element. An empty
+        /// <see cref="IHtmlContent"/> if the <paramref name="expression"/> is valid and client-side validation is
         /// disabled.
         /// </returns>
         public static IHtmlContent ValidationMessage(
@@ -155,8 +155,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>
         /// A new <see cref="IHtmlContent"/> containing a <see cref="ViewContext.ValidationMessageElement"/> element.
-        /// <see cref="HtmlString.Empty"/> if the <paramref name="expression"/> is valid and client-side validation is
-        /// disabled.
+        /// An empty <see cref="IHtmlContent"/> if the <paramref name="expression"/> is valid and client-side
+        /// validation is disabled.
         /// </returns>
         public static IHtmlContent ValidationMessage(
             this IHtmlHelper htmlHelper,
@@ -182,8 +182,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>
         /// A new <see cref="IHtmlContent"/> containing a <see cref="ViewContext.ValidationMessageElement"/> element.
-        /// <see cref="HtmlString.Empty"/> if the <paramref name="expression"/> is valid and client-side validation is
-        /// disabled.
+        /// An empty <see cref="IHtmlContent"/> if the <paramref name="expression"/> is valid and client-side
+        /// validation is disabled.
         /// </returns>
         /// <remarks>
         /// Method extracts an error string from the <see cref="ModelBinding.ModelStateDictionary"/> object. Message
@@ -221,8 +221,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>
         /// A new <see cref="IHtmlContent"/> containing a <see cref="ViewContext.ValidationMessageElement"/> element.
-        /// <see cref="HtmlString.Empty"/> if the <paramref name="expression"/> is valid and client-side validation is
-        /// disabled.
+        /// An empty <see cref="IHtmlContent"/> if the <paramref name="expression"/> is valid and client-side
+        /// validation is disabled.
         /// </returns>
         public static IHtmlContent ValidationMessageFor<TModel, TResult>(
             this IHtmlHelper<TModel> htmlHelper,
@@ -263,8 +263,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>
         /// A new <see cref="IHtmlContent"/> containing a <see cref="ViewContext.ValidationMessageElement"/> element.
-        /// <see cref="HtmlString.Empty"/> if the <paramref name="expression"/> is valid and client-side validation is
-        /// disabled.
+        /// An empty <see cref="IHtmlContent"/> if the <paramref name="expression"/> is valid and client-side
+        /// validation is disabled.
         /// </returns>
         public static IHtmlContent ValidationMessageFor<TModel, TResult>(
             this IHtmlHelper<TModel> htmlHelper,
@@ -303,8 +303,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <typeparam name="TModel">The type of the model.</typeparam>
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>
-        /// A new <see cref="IHtmlContent"/> containing the <paramref name="tag"/> element.
-        /// <see cref="HtmlString.Empty"/> if the <paramref name="expression"/> is valid and client-side validation is
+        /// A new <see cref="IHtmlContent"/> containing the <paramref name="tag"/> element. An empty
+        /// <see cref="IHtmlContent"/> if the <paramref name="expression"/> is valid and client-side validation is
         /// disabled.
         /// </returns>
         public static IHtmlContent ValidationMessageFor<TModel, TResult>(
@@ -333,7 +333,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <returns>
         /// New <see cref="IHtmlContent"/> containing a &lt;div&gt; element wrapping the &lt;ul&gt; element.
-        /// <see cref="HtmlString.Empty"/> if the current model is valid and client-side validation is disabled.
+        /// An empty <see cref="IHtmlContent"/> if the current model is valid and client-side validation is disabled.
         /// </returns>
         public static IHtmlContent ValidationSummary(this IHtmlHelper htmlHelper)
         {
@@ -359,7 +359,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>
         /// New <see cref="IHtmlContent"/> containing a &lt;div&gt; element wrapping the &lt;ul&gt; element.
-        /// <see cref="HtmlString.Empty"/> if the current model is valid and client-side validation is disabled.
+        /// An empty <see cref="IHtmlContent"/> if the current model is valid and client-side validation is disabled.
         /// </returns>
         public static IHtmlContent ValidationSummary(this IHtmlHelper htmlHelper, bool excludePropertyErrors)
         {
@@ -384,8 +384,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <returns>
         /// New <see cref="IHtmlContent"/> containing a &lt;div&gt; element wrapping the
         /// <see cref="ViewContext.ValidationSummaryMessageElement" /> element (which wraps the
-        /// <paramref name="message"/>) and the &lt;ul&gt; element. <see cref="HtmlString.Empty"/> if the current model
-        /// is valid and client-side validation is disabled.
+        /// <paramref name="message"/>) and the &lt;ul&gt; element. An empty <see cref="IHtmlContent"/> if the current
+        /// model is valid and client-side validation is disabled.
         /// </returns>
         public static IHtmlContent ValidationSummary(this IHtmlHelper htmlHelper, string message)
         {
@@ -413,8 +413,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>
         /// New <see cref="IHtmlContent"/> containing a &lt;div&gt; element wrapping the <paramref name="tag"/> element
-        /// and the &lt;ul&gt; element. <see cref="HtmlString.Empty"/> if the current model is valid and client-side
-        /// validation is disabled.
+        /// and the &lt;ul&gt; element. An empty <see cref="IHtmlContent"/> if the current model is valid and
+        /// client-side validation is disabled.
         /// </returns>
         public static IHtmlContent ValidationSummary(this IHtmlHelper htmlHelper, string message, string tag)
         {
@@ -442,8 +442,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <returns>
         /// New <see cref="IHtmlContent"/> containing a &lt;div&gt; element wrapping the
         /// <see cref="ViewContext.ValidationSummaryMessageElement" /> element (which, in turn, wraps the
-        /// <paramref name="message"/>) and the &lt;ul&gt; element. <see cref="HtmlString.Empty"/> if the current model
-        /// is valid and client-side validation is disabled.
+        /// <paramref name="message"/>) and the &lt;ul&gt; element. An empty <see cref="IHtmlContent"/> if the current
+        /// model is valid and client-side validation is disabled.
         /// </returns>
         public static IHtmlContent ValidationSummary(
             this IHtmlHelper htmlHelper,
@@ -476,8 +476,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <returns>
         /// New <see cref="IHtmlContent"/> containing a &lt;div&gt; element wrapping the
         /// <see cref="ViewContext.ValidationSummaryMessageElement" /> element (which wraps the
-        /// <paramref name="message"/>) and the &lt;ul&gt; element. <see cref="HtmlString.Empty"/> if the current model
-        /// is valid and client-side validation is disabled.
+        /// <paramref name="message"/>) and the &lt;ul&gt; element. An empty <see cref="IHtmlContent"/> if the current
+        /// model is valid and client-side validation is disabled.
         /// </returns>
         public static IHtmlContent ValidationSummary(
             this IHtmlHelper htmlHelper,
@@ -513,8 +513,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>
         /// New <see cref="IHtmlContent"/> containing a &lt;div&gt; element wrapping the <paramref name="tag"/> element
-        /// and the &lt;ul&gt; element. <see cref="HtmlString.Empty"/> if the current model is valid and client-side
-        /// validation is disabled.
+        /// and the &lt;ul&gt; element. An empty <see cref="IHtmlContent"/> if the current model is valid and
+        /// client-side validation is disabled.
         /// </returns>
         public static IHtmlContent ValidationSummary(
             this IHtmlHelper htmlHelper,
@@ -549,8 +549,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>
         /// New <see cref="IHtmlContent"/> containing a &lt;div&gt; element wrapping the <paramref name="tag"/> element
-        /// and the &lt;ul&gt; element. <see cref="HtmlString.Empty"/> if the current model is valid and client-side
-        /// validation is disabled.
+        /// and the &lt;ul&gt; element. An empty <see cref="IHtmlContent"/> if the current model is valid and
+        /// client-side validation is disabled.
         /// </returns>
         public static IHtmlContent ValidationSummary(
             this IHtmlHelper htmlHelper,
@@ -587,8 +587,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <returns>
         /// New <see cref="IHtmlContent"/> containing a &lt;div&gt; element wrapping the
         /// <see cref="ViewContext.ValidationSummaryMessageElement" /> element (which wraps the
-        /// <paramref name="message"/>) and the &lt;ul&gt; element. <see cref="HtmlString.Empty"/> if the current model
-        /// is valid and client-side validation is disabled.
+        /// <paramref name="message"/>) and the &lt;ul&gt; element. An empty <see cref="IHtmlContent"/> if the current
+        /// model is valid and client-side validation is disabled.
         /// </returns>
         public static IHtmlContent ValidationSummary(
             this IHtmlHelper htmlHelper,

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/HtmlHelperValueExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/HtmlHelperValueExtensions.cs
@@ -12,7 +12,12 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
     public static class HtmlHelperValueExtensions
     {
         /// <summary>
-        /// Returns the formatted value for the specified <paramref name="expression"/>.
+        /// Returns the formatted value for the specified <paramref name="expression"/>. Specifically, returns the
+        /// first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <see cref="IHtmlHelper.ViewData"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="expression">Expression name, relative to the current model.</param>
@@ -31,7 +36,11 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns the formatted value for the specified <paramref name="expression"/>.
+        /// Returns the formatted value for the specified <paramref name="expression"/>. Specifically, returns the
+        /// first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper{TModel}.NameFor"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
@@ -59,7 +68,12 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns the formatted value for the current model.
+        /// Returns the formatted value for the current model. Specifically, returns the
+        /// first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <see cref="IHtmlHelper.ViewData"/> entry with full name, or
+        /// the <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <returns>A <see cref="string"/> containing the formatted value.</returns>
@@ -77,11 +91,17 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
-        /// Returns the formatted value for the current model.
+        /// Returns the formatted value for the current model. Specifically, returns the
+        /// first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <see cref="IHtmlHelper.ViewData"/> entry with full name, or
+        /// the <see cref="ViewFeatures.ViewDataDictionary.Model"/>.
+        /// See <see cref="IHtmlHelper.Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="format">
-        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx).
+        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx) used
+        /// to format the return value unless that came from model binding.
         /// </param>
         /// <returns>A <see cref="string"/> containing the formatted value.</returns>
         /// <remarks>

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/HtmlHelperValueExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/HtmlHelperValueExtensions.cs
@@ -100,8 +100,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </summary>
         /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
         /// <param name="format">
-        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx) used
-        /// to format the return value unless that came from model binding.
+        /// The format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to format the return
+        /// value unless that came from model binding.
         /// </param>
         /// <returns>A <see cref="string"/> containing the formatted value.</returns>
         /// <remarks>

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/IHtmlHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/IHtmlHelper.cs
@@ -169,7 +169,12 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
 
         /// <summary>
         /// Returns an &lt;input&gt; element of type "checkbox" with value "true" and an &lt;input&gt; element of type
-        /// "hidden" with value "false".
+        /// "hidden" with value "false" for the specified <paramref name="expression"/>. Adds a "checked" attribute to
+        /// the "checkbox" element if first non-<c>null</c> value found is <c>true</c>. Looks for
+        /// <paramref name="isChecked"/>, <paramref name="htmlAttributes"/> entry or property named "checked", model
+        /// bound value with full name, <see cref="ViewData"/> entry with full name, then <paramref name="expression"/>
+        /// evaluated against <see cref="ViewDataDictionary.Model"/>. See <see cref="Name"/> for more information about
+        /// a "full name".
         /// </summary>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="isChecked">If <c>true</c>, checkbox is initially checked.</param>
@@ -179,35 +184,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; elements.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set checkbox
         /// element's "name" attribute. Sanitizes <paramref name="expression"/> to set checkbox element's "id"
         /// attribute.
-        /// </para>
-        /// <para>Determines checkbox element's "checked" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
-        /// name) if entry exists and can be converted to a <see cref="bool"/>.
-        /// </item>
-        /// <item><paramref name="isChecked"/> if non-<c>null</c>.</item>
-        /// <item>
-        /// <see cref="ViewData"/> entry for <paramref name="expression"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="bool"/>.
-        /// </item>
-        /// <item>
-        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
-        /// current model if result is non-<c>null</c> and can be converted to a <see cref="bool"/>. For example
-        /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
-        /// property.
-        /// </item>
-        /// <item>Existing "checked" entry in <paramref name="htmlAttributes"/> if any.</item>
-        /// <item>Otherwise, does not include a "checked" attribute.</item>
-        /// </list>
-        /// <para>
-        /// In all but the <paramref name="htmlAttributes"/> and default cases, includes a "checked" attribute with
-        /// value "checked" if the <see cref="bool"/> values is <c>true</c>; does not include the attribute otherwise.
-        /// </para>
         /// </remarks>
         IHtmlContent CheckBox(string expression, bool? isChecked, object htmlAttributes);
 
@@ -265,13 +244,19 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         string DisplayText(string expression);
 
         /// <summary>
-        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>,
-        /// using the specified list items, option label, and HTML attributes.
+        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>. Adds
+        /// &lt;option&gt; elements based on <paramref name="optionLabel"/> and <paramref name="selectList"/>. Adds a
+        /// "selected" attribute to an &lt;option&gt; if first non-<c>null</c> value found matches
+        /// <see cref="SelectListItem.Value"/> (if non-<c>null</c>) or <see cref="SelectListItem.Text"/>. Looks for
+        /// model bound value with full name, <see cref="ViewData"/> entry with full name, then
+        /// <paramref name="expression"/> evaluated against <see cref="ViewDataDictionary.Model"/>. See
+        /// <see cref="Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="selectList">
         /// A collection of <see cref="SelectListItem"/> objects used to populate the &lt;select&gt; element with
-        /// &lt;optgroup&gt; and &lt;option&gt; elements.
+        /// &lt;optgroup&gt; and &lt;option&gt; elements. If <c>null</c>, uses the <see cref="ViewData"/> entry with
+        /// full name and that entry must be a a collection of <see cref="SelectListItem"/> objects.
         /// </param>
         /// <param name="optionLabel">
         /// The text for a default empty item. Does not include such an item if argument is <c>null</c>.
@@ -364,7 +349,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// Returns an HTML element Id for the specified expression <paramref name="fullName"/>.
         /// </summary>
         /// <param name="fullName">
-        /// Fully-qualified expression name, ignoring the current model. Must not be <c>null</c>.
+        /// Fully-qualified expression name, ignoring the current model. Must not be <c>null</c>. See
+        /// <see cref="Name"/> for more information about a "full name".
         /// </param>
         /// <returns>A <see cref="string"/> containing the element Id.</returns>
         string GenerateIdFromName(string fullName);
@@ -398,7 +384,12 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         IEnumerable<SelectListItem> GetEnumSelectList(Type enumType);
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "hidden" for the specified <paramref name="expression"/>.
+        /// Returns an &lt;input&gt; element of type "hidden" for the specified <paramref name="expression"/>. Adds a
+        /// "value" attribute to the element containing the first non-<c>null</c> value found. Looks for model bound
+        /// value with full name, <paramref name="value"/>, <see cref="ViewData"/> entry with full name,
+        /// <paramref name="expression"/> evaluated against <see cref="ViewDataDictionary.Model"/>, then
+        /// <paramref name="htmlAttributes"/> entry or property named "value". See <see cref="Name"/> for more
+        /// information about a "full name".
         /// </summary>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
@@ -408,31 +399,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
-        /// </para>
-        /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
-        /// name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item><paramref name="value"/> if non-<c>null</c>.</item>
-        /// <item>
-        /// <see cref="ViewData"/> entry for <paramref name="expression"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
-        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
-        /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
-        /// property.
-        /// </item>
-        /// <item>Existing "value" entry in <paramref name="htmlAttributes"/> if any.</item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         IHtmlContent Hidden(string expression, object value, object htmlAttributes);
 
@@ -456,13 +425,18 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         IHtmlContent Label(string expression, string labelText, object htmlAttributes);
 
         /// <summary>
-        /// Returns a multi-selection &lt;select&gt; element for the <paramref name="expression"/>, using the
-        /// specified list items and HTML attributes.
+        /// Returns a multi-selection &lt;select&gt; element for the <paramref name="expression"/>. Adds
+        /// &lt;option&gt; elements based on <paramref name="selectList"/>. Adds a "selected" attribute to an
+        /// &lt;option&gt; if first non-<c>null</c> value found contains a match for <see cref="SelectListItem.Value"/>
+        /// (if non-<c>null</c>) or <see cref="SelectListItem.Text"/>. Looks for model bound value with full name,
+        /// <see cref="ViewData"/> entry with full name, then <paramref name="expression"/> evaluated against
+        /// <see cref="ViewDataDictionary.Model"/>. See <see cref="Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="selectList">
         /// A collection of <see cref="SelectListItem"/> objects used to populate the &lt;select&gt; element with
-        /// &lt;optgroup&gt; and &lt;option&gt; elements.
+        /// &lt;optgroup&gt; and &lt;option&gt; elements. If <c>null</c>, finds the <see cref="SelectListItem"/>
+        /// collection with name <paramref name="expression"/> in <see cref="ViewData"/>.
         /// </param>
         /// <param name="htmlAttributes">
         /// An <see cref="object"/> that contains the HTML attributes for the &lt;select&gt; element. Alternatively, an
@@ -477,7 +451,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         IHtmlContent ListBox(string expression, IEnumerable<SelectListItem> selectList, object htmlAttributes);
 
         /// <summary>
-        /// Returns the full HTML element name for the specified <paramref name="expression"/>.
+        /// Returns the full HTML element name for the specified <paramref name="expression"/>. Uses
+        /// <see cref="TemplateInfo.HtmlFieldPrefix"/> (if non-empty) to reflect relationship between current
+        /// <see cref="ViewDataDictionary.Model"/> and the top-level view's model.
         /// </summary>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <returns>A <see cref="string"/> containing the element name.</returns>
@@ -498,7 +474,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         Task<IHtmlContent> PartialAsync(string partialViewName, object model, ViewDataDictionary viewData);
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "password" for the specified <paramref name="expression"/>.
+        /// Returns an &lt;input&gt; element of type "password" for the specified <paramref name="expression"/>. Adds a
+        /// "value" attribute containing <paramref name="value"/> if it is non-<c>null</c>; otherwise uses
+        /// <paramref name="htmlAttributes"/> entry or property named "value" (if any).
         /// </summary>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
@@ -508,22 +486,19 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
-        /// </para>
-        /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item><paramref name="value"/> if non-<c>null</c>.</item>
-        /// <item>Existing "value" entry in <paramref name="htmlAttributes"/> if any.</item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         IHtmlContent Password(string expression, object value, object htmlAttributes);
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "radio" for the specified <paramref name="expression"/>.
+        /// Returns an &lt;input&gt; element of type "radio" for the specified <paramref name="expression"/>. Adds a
+        /// "checked" attribute to the element if first non-<c>null</c> value found matches
+        /// <paramref name="value"/>. Looks for <paramref name="isChecked"/>, <paramref name="htmlAttributes"/> entry
+        /// or property named "checked", model bound value with full name, <see cref="ViewData"/> entry with full name,
+        /// then <paramref name="expression"/> evaluated against <see cref="ViewDataDictionary.Model"/>. See
+        /// <see cref="Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">
@@ -542,43 +517,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
-        /// </para>
-        /// <para>Determines element's "value" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item><paramref name="value"/> if non-<c>null</c>.</item>
-        /// <item>Existing "value" entry in <paramref name="htmlAttributes"/> if any.</item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
-        /// <para>Determines &lt;input&gt; element's "checked" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
-        /// name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item><paramref name="isChecked"/> if non-<c>null</c>.</item>
-        /// <item>Existing "checked" entry in <paramref name="htmlAttributes"/> if any.</item>
-        /// <item>
-        /// <see cref="ViewData"/> entry for <paramref name="expression"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
-        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
-        /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
-        /// property.
-        /// </item>
-        /// <item>Otherwise, does not include a "checked" attribute.</item>
-        /// </list>
-        /// <para>
-        /// In all but the <paramref name="htmlAttributes"/> and default cases, includes a "checked" attribute with
-        /// value "checked" if the <see cref="string"/> values is equal to a converted <see cref="string"/> for
-        /// <paramref name="value"/> or <paramref name="isChecked"/> is <c>true</c> (for that case); does not include
-        /// the attribute otherwise.
-        /// </para>
         /// </remarks>
         IHtmlContent RadioButton(string expression, object value, bool? isChecked, object htmlAttributes);
 
@@ -641,7 +582,11 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             object htmlAttributes);
 
         /// <summary>
-        /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>.
+        /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>. Adds the first
+        /// non-<c>null</c> value found to the element body. Looks for model bound value with full name,
+        /// <paramref name="value"/>, <see cref="ViewData"/> entry with full name, then <paramref name="expression"/>
+        /// evaluated against <see cref="ViewDataDictionary.Model"/>. See <see cref="Name"/> for more information about
+        /// a "full name".
         /// </summary>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
@@ -653,35 +598,20 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;textarea&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="expression"/> to set
         /// &lt;textarea&gt; element's "name" attribute. Sanitizes <paramref name="expression"/> to set element's "id"
         /// attribute.
-        /// </para>
-        /// <para>Determines &lt;textarea&gt; element's content based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelStateDictionary"/> entry for <paramref name="expression"/> (converted to a fully-qualified
-        /// name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item><paramref name="value"/> if non-<c>null</c>.</item>
-        /// <item>
-        /// <see cref="ViewData"/> entry for <paramref name="expression"/> (converted to a fully-qualified name)
-        /// if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// Linq expression based on <paramref name="expression"/> (converted to a fully-qualified name) run against
-        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
-        /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
-        /// property.
-        /// </item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         IHtmlContent TextArea(string expression, string value, int rows, int columns, object htmlAttributes);
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="current"/>.
+        /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="current"/>. Adds a
+        /// "value" attribute to the element containing the first non-<c>null</c> value found. Looks for model bound
+        /// value with full name, <paramref name="value"/>, <see cref="ViewData"/> entry with full name,
+        /// <paramref name="current"/> evaluated against <see cref="ViewDataDictionary.Model"/>, then
+        /// <paramref name="htmlAttributes"/> entry or property named "value". Uses <paramref name="format"/> (if
+        /// non-<c>null</c>) to format any value except one from model binding. See <see cref="Name"/> for more
+        /// information about a "full name".
         /// </summary>
         /// <param name="current">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
@@ -694,37 +624,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and <paramref name="current"/> to set
         /// &lt;input&gt; element's "name" attribute. Sanitizes <paramref name="current"/> to set element's "id"
         /// attribute.
-        /// </para>
-        /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelStateDictionary"/> entry for <paramref name="current"/> (converted to a fully-qualified
-        /// name) if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// <paramref name="value"/> if non-<c>null</c>. Formats <paramref name="value"/> using
-        /// <paramref name="format"/> or converts <paramref name="value"/> to a <see cref="string"/> directly if
-        /// <paramref name="format"/> is <c>null</c> or empty.
-        /// </item>
-        /// <item>
-        /// <see cref="ViewData"/> entry for <paramref name="current"/> (converted to a fully-qualified name) if entry
-        /// exists and can be converted to a <see cref="string"/>. Formats entry using <paramref name="format"/> or
-        /// converts entry to a <see cref="string"/> directly if <paramref name="format"/> is <c>null</c> or empty.
-        /// </item>
-        /// <item>
-        /// Linq expression based on <paramref name="current"/> (converted to a fully-qualified name) run against
-        /// current model if result is non-<c>null</c> and can be converted to a <see cref="string"/>. For example
-        /// <c>string.Empty</c> identifies the current model and <c>"prop"</c> identifies the current model's "prop"
-        /// property. Formats result using <paramref name="format"/> or converts result to a <see cref="string"/>
-        /// directly if <paramref name="format"/> is <c>null</c> or empty.
-        /// </item>
-        /// <item>Existing "value" entry in <paramref name="htmlAttributes"/> if any.</item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         IHtmlContent TextBox(string current, object value, string format, object htmlAttributes);
 
@@ -780,7 +682,11 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             string tag);
 
         /// <summary>
-        /// Returns the formatted value for the specified <paramref name="expression"/>.
+        /// Returns the formatted value for the specified <paramref name="expression"/>. Specifically, returns the
+        /// first non-<c>null</c> value found. Looks for model bound value with full name, <see cref="ViewData"/> entry
+        /// with full name, then <paramref name="expression"/> evaluated against
+        /// <see cref="ViewDataDictionary.Model"/>. Uses <paramref name="format"/> (if non-<c>null</c>) to format any
+        /// value except one from model binding. See <see cref="Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="format">

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/IHtmlHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/IHtmlHelper.cs
@@ -349,8 +349,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </summary>
         /// <param name="value">The value.</param>
         /// <param name="format">
-        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx) used
-        /// to format the return value.
+        /// The format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to format the return
+        /// value.
         /// </param>
         /// <returns>A <see cref="string"/> containing the formatted value.</returns>
         /// <remarks>
@@ -646,8 +646,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <param name="current">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
         /// <param name="format">
-        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx) used
-        /// to format the "value" attribute unless that came from model binding.
+        /// The format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to format the "value"
+        /// attribute unless that came from model binding.
         /// </param>
         /// <param name="htmlAttributes">
         /// An <see cref="object"/> that contains the HTML attributes for the element. Alternatively, an
@@ -680,8 +680,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <see cref="ViewContext.ValidationMessageElement"/>.
         /// </param>
         /// <returns>
-        /// A new <see cref="IHtmlContent"/> containing a <paramref name="tag"/> element.
-        /// <see cref="HtmlString.Empty"/> if the <paramref name="expression"/> is valid and client-side validation is
+        /// A new <see cref="IHtmlContent"/> containing a <paramref name="tag"/> element. An empty
+        /// <see cref="IHtmlContent"/> if the <paramref name="expression"/> is valid and client-side validation is
         /// disabled.
         /// </returns>
         IHtmlContent ValidationMessage(string expression, string message, object htmlAttributes, string tag);
@@ -704,8 +704,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>
         /// New <see cref="IHtmlContent"/> containing a &lt;div&gt; element wrapping the <paramref name="tag"/> element
-        /// and the &lt;ul&gt; element. <see cref="HtmlString.Empty"/> if the current model is valid and client-side
-        /// validation is disabled.
+        /// and the &lt;ul&gt; element. An empty <see cref="IHtmlContent"/> if the current model is valid and
+        /// client-side validation is disabled.
         /// </returns>
         IHtmlContent ValidationSummary(
             bool excludePropertyErrors,
@@ -723,8 +723,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </summary>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="format">
-        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx) used
-        /// to format the return value unless that came from model binding.
+        /// The format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to format the return
+        /// value unless that came from model binding.
         /// </param>
         /// <returns>A <see cref="string"/> containing the formatted value.</returns>
         /// <remarks>

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/IHtmlHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/IHtmlHelper.cs
@@ -170,11 +170,15 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <summary>
         /// Returns an &lt;input&gt; element of type "checkbox" with value "true" and an &lt;input&gt; element of type
         /// "hidden" with value "false" for the specified <paramref name="expression"/>. Adds a "checked" attribute to
-        /// the "checkbox" element if first non-<c>null</c> value found is <c>true</c>. Looks for
-        /// <paramref name="isChecked"/>, <paramref name="htmlAttributes"/> entry or property named "checked", model
-        /// bound value with full name, <see cref="ViewData"/> entry with full name, then <paramref name="expression"/>
-        /// evaluated against <see cref="ViewDataDictionary.Model"/>. See <see cref="Name"/> for more information about
-        /// a "full name".
+        /// the "checkbox" element based on the first non-<c>null</c> value found in:
+        /// the <paramref name="htmlAttributes"/> dictionary entry with key "checked",
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <see cref="ViewData"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewDataDictionary.Model"/>.
+        /// If <paramref name="isChecked"/> is non-<c>null</c>, instead uses the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name, or
+        /// the <paramref name="isChecked"/> parameter.
+        /// See <see cref="Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="isChecked">If <c>true</c>, checkbox is initially checked.</param>
@@ -219,6 +223,10 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// Example <paramref name="expression"/>s include <c>string.Empty</c> which identifies the current model and
         /// <c>"prop"</c> which identifies the current model's "prop" property.
         /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>DisplayTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
         /// </remarks>
         IHtmlContent Display(
             string expression,
@@ -246,17 +254,18 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <summary>
         /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>. Adds
         /// &lt;option&gt; elements based on <paramref name="optionLabel"/> and <paramref name="selectList"/>. Adds a
-        /// "selected" attribute to an &lt;option&gt; if first non-<c>null</c> value found matches
-        /// <see cref="SelectListItem.Value"/> (if non-<c>null</c>) or <see cref="SelectListItem.Text"/>. Looks for
-        /// model bound value with full name, <see cref="ViewData"/> entry with full name, then
-        /// <paramref name="expression"/> evaluated against <see cref="ViewDataDictionary.Model"/>. See
-        /// <see cref="Name"/> for more information about a "full name".
+        /// "selected" attribute to an &lt;option&gt; if its <see cref="SelectListItem.Value"/> (if non-<c>null</c>) or
+        /// <see cref="SelectListItem.Text"/> matches the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <see cref="ViewData"/> entry with full name (unless used instead of <paramref name="selectList"/>), or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewDataDictionary.Model"/>.
+        /// See <see cref="Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="selectList">
         /// A collection of <see cref="SelectListItem"/> objects used to populate the &lt;select&gt; element with
         /// &lt;optgroup&gt; and &lt;option&gt; elements. If <c>null</c>, uses the <see cref="ViewData"/> entry with
-        /// full name and that entry must be a a collection of <see cref="SelectListItem"/> objects.
+        /// full name and that entry must be a collection of <see cref="SelectListItem"/> objects.
         /// </param>
         /// <param name="optionLabel">
         /// The text for a default empty item. Does not include such an item if argument is <c>null</c>.
@@ -306,6 +315,10 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// Example <paramref name="expression"/>s include <c>string.Empty</c> which identifies the current model and
         /// <c>"prop"</c> which identifies the current model's "prop" property.
         /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>EditorTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
         /// </remarks>
         IHtmlContent Editor(string expression, string templateName, string htmlFieldName, object additionalViewData);
 
@@ -336,7 +349,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </summary>
         /// <param name="value">The value.</param>
         /// <param name="format">
-        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx).
+        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx) used
+        /// to format the return value.
         /// </param>
         /// <returns>A <see cref="string"/> containing the formatted value.</returns>
         /// <remarks>
@@ -385,11 +399,13 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
 
         /// <summary>
         /// Returns an &lt;input&gt; element of type "hidden" for the specified <paramref name="expression"/>. Adds a
-        /// "value" attribute to the element containing the first non-<c>null</c> value found. Looks for model bound
-        /// value with full name, <paramref name="value"/>, <see cref="ViewData"/> entry with full name,
-        /// <paramref name="expression"/> evaluated against <see cref="ViewDataDictionary.Model"/>, then
-        /// <paramref name="htmlAttributes"/> entry or property named "value". See <see cref="Name"/> for more
-        /// information about a "full name".
+        /// "value" attribute to the element containing the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <paramref name="value"/> parameter,
+        /// the <see cref="ViewData"/> entry with full name,
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewDataDictionary.Model"/>, or
+        /// the <paramref name="htmlAttributes"/> dictionary entry with key "value".
+        /// See <see cref="Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
@@ -427,10 +443,12 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <summary>
         /// Returns a multi-selection &lt;select&gt; element for the <paramref name="expression"/>. Adds
         /// &lt;option&gt; elements based on <paramref name="selectList"/>. Adds a "selected" attribute to an
-        /// &lt;option&gt; if first non-<c>null</c> value found contains a match for <see cref="SelectListItem.Value"/>
-        /// (if non-<c>null</c>) or <see cref="SelectListItem.Text"/>. Looks for model bound value with full name,
-        /// <see cref="ViewData"/> entry with full name, then <paramref name="expression"/> evaluated against
-        /// <see cref="ViewDataDictionary.Model"/>. See <see cref="Name"/> for more information about a "full name".
+        /// &lt;option&gt; if its <see cref="SelectListItem.Value"/> (if non-<c>null</c>) or
+        /// <see cref="SelectListItem.Text"/> matches an entry in the first non-<c>null</c> collection found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <see cref="ViewData"/> entry with full name (unless used instead of <paramref name="selectList"/>), or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewDataDictionary.Model"/>.
+        /// See <see cref="Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="selectList">
@@ -475,8 +493,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
 
         /// <summary>
         /// Returns an &lt;input&gt; element of type "password" for the specified <paramref name="expression"/>. Adds a
-        /// "value" attribute containing <paramref name="value"/> if it is non-<c>null</c>; otherwise uses
-        /// <paramref name="htmlAttributes"/> entry or property named "value" (if any).
+        /// "value" attribute containing the first non-<c>null</c> value in:
+        /// the <paramref name="value"/> parameter, or
+        /// the <paramref name="htmlAttributes"/> dictionary entry with key "value".
         /// </summary>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
@@ -493,12 +512,20 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         IHtmlContent Password(string expression, object value, object htmlAttributes);
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "radio" for the specified <paramref name="expression"/>. Adds a
-        /// "checked" attribute to the element if first non-<c>null</c> value found matches
-        /// <paramref name="value"/>. Looks for <paramref name="isChecked"/>, <paramref name="htmlAttributes"/> entry
-        /// or property named "checked", model bound value with full name, <see cref="ViewData"/> entry with full name,
-        /// then <paramref name="expression"/> evaluated against <see cref="ViewDataDictionary.Model"/>. See
-        /// <see cref="Name"/> for more information about a "full name".
+        /// Returns an &lt;input&gt; element of type "radio" for the specified <paramref name="expression"/>.
+        /// Adds a "value" attribute to the element containing the first non-<c>null</c> value found in:
+        /// the <paramref name="value"/> parameter, or
+        /// the <paramref name="htmlAttributes"/> dictionary entry with key "value".
+        /// Adds a "checked" attribute to the element if <paramref name="value"/> matches the first non-<c>null</c>
+        /// value found in:
+        /// the <paramref name="htmlAttributes"/> dictionary entry with key "checked",
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <see cref="ViewData"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewDataDictionary.Model"/>.
+        /// If <paramref name="isChecked"/> is non-<c>null</c>, instead uses the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name, or
+        /// the <paramref name="isChecked"/> parameter.
+        /// See <see cref="Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">
@@ -582,11 +609,13 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             object htmlAttributes);
 
         /// <summary>
-        /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>. Adds the first
-        /// non-<c>null</c> value found to the element body. Looks for model bound value with full name,
-        /// <paramref name="value"/>, <see cref="ViewData"/> entry with full name, then <paramref name="expression"/>
-        /// evaluated against <see cref="ViewDataDictionary.Model"/>. See <see cref="Name"/> for more information about
-        /// a "full name".
+        /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>. Adds content to the
+        /// element body based on the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <paramref name="value"/> parameter,
+        /// the <see cref="ViewData"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewDataDictionary.Model"/>.
+        /// See <see cref="Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
@@ -606,17 +635,19 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
 
         /// <summary>
         /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="current"/>. Adds a
-        /// "value" attribute to the element containing the first non-<c>null</c> value found. Looks for model bound
-        /// value with full name, <paramref name="value"/>, <see cref="ViewData"/> entry with full name,
-        /// <paramref name="current"/> evaluated against <see cref="ViewDataDictionary.Model"/>, then
-        /// <paramref name="htmlAttributes"/> entry or property named "value". Uses <paramref name="format"/> (if
-        /// non-<c>null</c>) to format any value except one from model binding. See <see cref="Name"/> for more
-        /// information about a "full name".
+        /// "value" attribute to the element containing the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <paramref name="value"/> parameter,
+        /// the <see cref="ViewData"/> entry with full name,
+        /// the <paramref name="current"/> evaluated against <see cref="ViewDataDictionary.Model"/>, or
+        /// the <paramref name="htmlAttributes"/> dictionary entry with key "value".
+        /// See <see cref="Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="current">Expression name, relative to the current model.</param>
         /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
         /// <param name="format">
-        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx).
+        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx) used
+        /// to format the "value" attribute unless that came from model binding.
         /// </param>
         /// <param name="htmlAttributes">
         /// An <see cref="object"/> that contains the HTML attributes for the element. Alternatively, an
@@ -649,8 +680,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <see cref="ViewContext.ValidationMessageElement"/>.
         /// </param>
         /// <returns>
-        /// A new <see cref="IHtmlContent"/> containing a <paramref name="tag"/> element. <c>null</c> if the
-        /// <paramref name="expression"/> is valid and client-side validation is disabled.
+        /// A new <see cref="IHtmlContent"/> containing a <paramref name="tag"/> element.
+        /// <see cref="HtmlString.Empty"/> if the <paramref name="expression"/> is valid and client-side validation is
+        /// disabled.
         /// </returns>
         IHtmlContent ValidationMessage(string expression, string message, object htmlAttributes, string tag);
 
@@ -673,7 +705,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <returns>
         /// New <see cref="IHtmlContent"/> containing a &lt;div&gt; element wrapping the <paramref name="tag"/> element
         /// and the &lt;ul&gt; element. <see cref="HtmlString.Empty"/> if the current model is valid and client-side
-        /// validation is disabled).
+        /// validation is disabled.
         /// </returns>
         IHtmlContent ValidationSummary(
             bool excludePropertyErrors,
@@ -683,14 +715,16 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
 
         /// <summary>
         /// Returns the formatted value for the specified <paramref name="expression"/>. Specifically, returns the
-        /// first non-<c>null</c> value found. Looks for model bound value with full name, <see cref="ViewData"/> entry
-        /// with full name, then <paramref name="expression"/> evaluated against
-        /// <see cref="ViewDataDictionary.Model"/>. Uses <paramref name="format"/> (if non-<c>null</c>) to format any
-        /// value except one from model binding. See <see cref="Name"/> for more information about a "full name".
+        /// first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <see cref="ViewData"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewDataDictionary.Model"/>.
+        /// See <see cref="Name"/> for more information about a "full name".
         /// </summary>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="format">
-        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx).
+        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx) used
+        /// to format the return value unless that came from model binding.
         /// </param>
         /// <returns>A <see cref="string"/> containing the formatted value.</returns>
         /// <remarks>

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/IHtmlHelperOfT.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/IHtmlHelperOfT.cs
@@ -22,7 +22,15 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
 
         /// <summary>
         /// Returns an &lt;input&gt; element of type "checkbox" with value "true" and an &lt;input&gt; element of type
-        /// "hidden" with value "false".
+        /// "hidden" with value "false" for the specified <paramref name="expression"/>. Adds a "checked" attribute to
+        /// the "checkbox" element based on the first non-<c>null</c> value found in:
+        /// the <paramref name="htmlAttributes"/> dictionary entry with key "checked", or
+        /// the <see cref="ActionContext.ModelState"/> entry with full name.
+        /// If <paramref name="expression"/> evaluates to a non-<c>null</c> value, instead uses the first
+        /// non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewDataDictionary.Model"/>.
+        /// See <see cref="NameFor"/> for more information about a "full name".
         /// </summary>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="htmlAttributes">
@@ -31,28 +39,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </param>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; elements.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and the string representation of the
         /// <paramref name="expression"/> to set checkbox element's "name" attribute. Sanitizes the string
         /// representation of the <paramref name="expression"/> to set checkbox element's "id" attribute.
-        /// </para>
-        /// <para>Determines checkbox element's "checked" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for the string representation of the
-        /// <paramref name="expression"/> if entry exists and can be converted to a <see cref="bool"/>.
-        /// </item>
-        /// <item>
-        /// <paramref name="expression"/> result if it is non-<c>null</c> and can be parsed as a
-        /// <see cref="bool"/>.
-        /// </item>
-        /// <item>Existing "checked" entry in <paramref name="htmlAttributes"/> if any.</item>
-        /// <item>Otherwise, does not include a "checked" attribute.</item>
-        /// </list>
-        /// <para>
-        /// In all but the <paramref name="htmlAttributes"/> case, includes a "checked" attribute with value "checked"
-        /// if the <see cref="bool"/> values is <c>true</c>; does not include the attribute otherwise.
-        /// </para>
         /// </remarks>
         IHtmlContent CheckBoxFor(Expression<Func<TModel, bool>> expression, object htmlAttributes);
 
@@ -75,8 +64,14 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
         /// <remarks>
+        /// <para>
         /// For example the default <see cref="object"/> display template includes markup for each property in the
         /// <paramref name="expression"/> result.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>DisplayTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
         /// </remarks>
         IHtmlContent DisplayFor<TResult>(
             Expression<Func<TModel, TResult>> expression,
@@ -116,13 +111,19 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         string DisplayTextFor<TResult>(Expression<Func<TModel, TResult>> expression);
 
         /// <summary>
-        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>, using the
-        /// specified list items, option label, and HTML attributes.
+        /// Returns a single-selection HTML &lt;select&gt; element for the <paramref name="expression"/>. Adds
+        /// &lt;option&gt; elements based on <paramref name="optionLabel"/> and <paramref name="selectList"/>. Adds a
+        /// "selected" attribute to an &lt;option&gt; if its <see cref="SelectListItem.Value"/> (if non-<c>null</c>) or
+        /// <see cref="SelectListItem.Text"/> matches the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewDataDictionary.Model"/>.
+        /// See <see cref="NameFor"/> for more information about a "full name".
         /// </summary>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="selectList">
         /// A collection of <see cref="SelectListItem"/> objects used to populate the &lt;select&gt; element with
-        /// &lt;optgroup&gt; and &lt;option&gt; elements.
+        /// &lt;optgroup&gt; and &lt;option&gt; elements. If <c>null</c>, uses the <see cref="ViewData"/> entry with
+        /// full name and that entry must be a collection of <see cref="SelectListItem"/> objects.
         /// </param>
         /// <param name="optionLabel">
         /// The text for a default empty item. Does not include such an item if argument is <c>null</c>.
@@ -163,8 +164,14 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element(s).</returns>
         /// <remarks>
+        /// <para>
         /// For example the default <see cref="object"/> editor template includes &lt;label&gt; and &lt;input&gt;
         /// elements for each property in the <paramref name="expression"/> result.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>EditorTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
         /// </remarks>
         IHtmlContent EditorFor<TResult>(
             Expression<Func<TModel, TResult>> expression,
@@ -179,7 +186,12 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         new string Encode(string value);
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "hidden" for the specified <paramref name="expression"/>.
+        /// Returns an &lt;input&gt; element of type "hidden" for the specified <paramref name="expression"/>. Adds a
+        /// "value" attribute to the element containing the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewDataDictionary.Model"/>, or
+        /// the <paramref name="htmlAttributes"/> dictionary entry with key "value".
+        /// See <see cref="NameFor"/> for more information about a "full name".
         /// </summary>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="htmlAttributes">
@@ -189,24 +201,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and the string representation of the
         /// <paramref name="expression"/> to set &lt;input&gt; element's "name" attribute. Sanitizes the string
         /// representation of the <paramref name="expression"/> to set element's "id" attribute.
-        /// </para>
-        /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for the string representation of the
-        /// <paramref name="expression"/> if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// <paramref name="expression"/> result if it is non-<c>null</c> and can be parsed as a
-        /// <see cref="string"/>.
-        /// </item>
-        /// <item>Existing "value" entry in <paramref name="htmlAttributes"/> if any.</item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         IHtmlContent HiddenFor<TResult>(
             Expression<Func<TModel, TResult>> expression,
@@ -237,13 +234,19 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             object htmlAttributes);
 
         /// <summary>
-        /// Returns a multi-selection &lt;select&gt; element for the <paramref name="expression"/>, using the
-        /// specified list items and HTML attributes.
+        /// Returns a multi-selection &lt;select&gt; element for the <paramref name="expression"/>. Adds
+        /// &lt;option&gt; elements based on <paramref name="selectList"/>. Adds a "selected" attribute to an
+        /// &lt;option&gt; if its <see cref="SelectListItem.Value"/> (if non-<c>null</c>) or
+        /// <see cref="SelectListItem.Text"/> matches an entry in the first non-<c>null</c> collection found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewDataDictionary.Model"/>.
+        /// See <see cref="NameFor"/> for more information about a "full name".
         /// </summary>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="selectList">
         /// A collection of <see cref="SelectListItem"/> objects used to populate the &lt;select&gt; element with
-        /// &lt;optgroup&gt; and &lt;option&gt; elements.
+        /// &lt;optgroup&gt; and &lt;option&gt; elements. If <c>null</c>, finds the <see cref="SelectListItem"/>
+        /// collection with name <paramref name="expression"/> in <see cref="ViewData"/>.
         /// </param>
         /// <param name="htmlAttributes">
         /// An <see cref="object"/> that contains the HTML attributes for the &lt;select&gt; element. Alternatively, an
@@ -262,7 +265,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             object htmlAttributes);
 
         /// <summary>
-        /// Returns the full HTML element name for the specified <paramref name="expression"/>.
+        /// Returns the full HTML element name for the specified <paramref name="expression"/>. Uses
+        /// <see cref="TemplateInfo.HtmlFieldPrefix"/> (if non-empty) to reflect relationship between current
+        /// <see cref="ViewDataDictionary.Model"/> and the top-level view's model.
         /// </summary>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
@@ -270,7 +275,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         string NameFor<TResult>(Expression<Func<TModel, TResult>> expression);
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "password" for the specified <paramref name="expression"/>.
+        /// Returns an &lt;input&gt; element of type "password" for the specified <paramref name="expression"/>. Adds a
+        /// "value" attribute containing the <paramref name="htmlAttributes"/> dictionary entry with key "value" (if
+        /// any).
         /// </summary>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="htmlAttributes">
@@ -280,20 +287,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and the string representation of the
         /// <paramref name="expression"/> to set &lt;input&gt; element's "name" attribute. Sanitizes the string
         /// representation of the <paramref name="expression"/> to set element's "id" attribute.
-        /// </para>
-        /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <paramref name="expression"/> result if it is non-<c>null</c> and can be parsed as a
-        /// <see cref="string"/>.
-        /// </item>
-        /// <item>Existing "value" entry in <paramref name="htmlAttributes"/> if any.</item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         IHtmlContent PasswordFor<TResult>(
             Expression<Func<TModel, TResult>> expression,
@@ -301,6 +297,19 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
 
         /// <summary>
         /// Returns an &lt;input&gt; element of type "radio" for the specified <paramref name="expression"/>.
+        /// Adds a "value" attribute to the element containing the first non-<c>null</c> value found in:
+        /// the <paramref name="value"/> parameter, or
+        /// the <paramref name="htmlAttributes"/> dictionary entry with key "value".
+        /// Adds a "checked" attribute to the element if <paramref name="value"/> matches the first non-<c>null</c>
+        /// value found in:
+        /// the <paramref name="htmlAttributes"/> dictionary entry with key "checked", or
+        /// the <see cref="ActionContext.ModelState"/> entry with full name.
+        /// If <paramref name="expression"/> evaluates to a non-<c>null</c> value, instead uses the first
+        /// non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewDataDictionary.Model"/>.
+        /// See <see cref="NameFor"/> for more information about a "full name".
+        /// Adds a "value" attribute to the element containing the <paramref name="value"/> parameter.
         /// </summary>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="value">Value to include in the element. Must not be <c>null</c>.</param>
@@ -311,29 +320,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and the string representation of the
         /// <paramref name="expression"/> to set &lt;select&gt; element's "name" attribute. Sanitizes the string
-        /// representation of the <paramref name="expression"/> to set element's "id" attribute. Converts the
-        /// <paramref name="value"/> to a <see cref="string"/> to set element's "value" attribute.
-        /// </para>
-        /// <para>Determines &lt;input&gt; element's "checked" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for the string representation of the
-        /// <paramref name="expression"/> if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// <paramref name="expression"/> result if it is non-<c>null</c> and can be parsed as a <see cref="string"/>.
-        /// </item>
-        /// <item>Existing "checked" entry in <paramref name="htmlAttributes"/> if any.</item>
-        /// <item>Otherwise, does not include a "checked" attribute.</item>
-        /// </list>
-        /// <para>
-        /// In all but the <paramref name="htmlAttributes"/> and default cases, includes a "checked" attribute with
-        /// value "checked" if the <see cref="string"/> values is equal to a converted <see cref="string"/> for
-        /// <paramref name="value"/>; does not include the attribute otherwise.
-        /// </para>
+        /// representation of the <paramref name="expression"/> to set element's "id" attribute.
         /// </remarks>
         IHtmlContent RadioButtonFor<TResult>(
             Expression<Func<TModel, TResult>> expression,
@@ -347,7 +336,11 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         new IHtmlContent Raw(string value);
 
         /// <summary>
-        /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>.
+        /// Returns a &lt;textarea&gt; element for the specified <paramref name="expression"/>. Adds content to the
+        /// element body based on the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewDataDictionary.Model"/>.
+        /// See <see cref="NameFor"/> for more information about a "full name".
         /// </summary>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="rows">Number of rows in the textarea.</param>
@@ -359,22 +352,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;textarea&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and the string representation of the
         /// <paramref name="expression"/> to set &lt;textarea&gt; element's "name" attribute. Sanitizes the string
         /// representation of the <paramref name="expression"/> to set element's "id" attribute.
-        /// </para>
-        /// <para>Determines &lt;textarea&gt; element's content based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for the string representation of the
-        /// <paramref name="expression"/> if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// <paramref name="expression"/> result if it is non-<c>null</c> and can be parsed as a <see cref="string"/>.
-        /// </item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         IHtmlContent TextAreaFor<TResult>(
             Expression<Func<TModel, TResult>> expression,
@@ -383,11 +363,17 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             object htmlAttributes);
 
         /// <summary>
-        /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="expression"/>.
+        /// Returns an &lt;input&gt; element of type "text" for the specified <paramref name="expression"/>. Adds a
+        /// "value" attribute to the element containing the first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name,
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewDataDictionary.Model"/>, or
+        /// the <paramref name="htmlAttributes"/> dictionary entry with key "value".
+        /// See <see cref="NameFor"/> for more information about a "full name".
         /// </summary>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="format">
-        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx).
+        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx) used
+        /// to format the <paramref name="expression"/> value when using that in the "value" attribute.
         /// </param>
         /// <param name="htmlAttributes">
         /// An <see cref="object"/> that contains the HTML attributes for the element. Alternatively, an
@@ -396,25 +382,9 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
         /// <remarks>
-        /// <para>
         /// Combines <see cref="TemplateInfo.HtmlFieldPrefix"/> and the string representation of the
         /// <paramref name="expression"/> to set &lt;input&gt; element's "name" attribute. Sanitizes the string
         /// representation of the <paramref name="expression"/> to set element's "id" attribute.
-        /// </para>
-        /// <para>Determines &lt;input&gt; element's "value" attribute based on the following precedence:</para>
-        /// <list type="number">
-        /// <item>
-        /// <see cref="ModelBinding.ModelStateDictionary"/> entry for the string representation of the
-        /// <paramref name="expression"/> if entry exists and can be converted to a <see cref="string"/>.
-        /// </item>
-        /// <item>
-        /// <paramref name="expression"/> result if it is non-<c>null</c> and can be parsed as a <see cref="string"/>.
-        /// Formats result using <paramref name="format"/> or converts result to a <see cref="string"/> directly if
-        /// <paramref name="format"/> is <c>null</c> or empty.
-        /// </item>
-        /// <item>Existing "value" entry in <paramref name="htmlAttributes"/> if any.</item>
-        /// <item>Otherwise, <c>string.Empty</c>.</item>
-        /// </list>
         /// </remarks>
         IHtmlContent TextBoxFor<TResult>(
             Expression<Func<TModel, TResult>> expression,
@@ -451,11 +421,16 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             string tag);
 
         /// <summary>
-        /// Returns the formatted value for the specified <paramref name="expression"/>.
+        /// Returns the formatted value for the specified <paramref name="expression"/>. Specifically, returns the
+        /// first non-<c>null</c> value found in:
+        /// the <see cref="ActionContext.ModelState"/> entry with full name, or
+        /// the <paramref name="expression"/> evaluated against <see cref="ViewDataDictionary.Model"/>.
+        /// See <see cref="NameFor"/> for more information about a "full name".
         /// </summary>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="format">
-        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx).
+        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx) used
+        /// to format the <paramref name="expression"/> value when returning that value.
         /// </param>
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A <see cref="string"/> containing the formatted value.</returns>

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/IHtmlHelperOfT.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/IHtmlHelperOfT.cs
@@ -372,8 +372,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </summary>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="format">
-        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx) used
-        /// to format the <paramref name="expression"/> value when using that in the "value" attribute.
+        /// The format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to format the
+        /// <paramref name="expression"/> value when using that in the "value" attribute.
         /// </param>
         /// <param name="htmlAttributes">
         /// An <see cref="object"/> that contains the HTML attributes for the element. Alternatively, an
@@ -429,8 +429,8 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </summary>
         /// <param name="expression">An expression to be evaluated against the current model.</param>
         /// <param name="format">
-        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx) used
-        /// to format the <paramref name="expression"/> value when returning that value.
+        /// The format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to format the
+        /// <paramref name="expression"/> value when returning that value.
         /// </param>
         /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
         /// <returns>A <see cref="string"/> containing the formatted value.</returns>

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/TagBuilder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/TagBuilder.cs
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// Valid HTML 4.01 "id" attribute value for an element with the given <paramref name="name"/>.
         /// </returns>
         /// <remarks>
-        /// Valid "id" attributes are defined in http://www.w3.org/TR/html401/types.html#type-id
+        /// Valid "id" attributes are defined in https://www.w3.org/TR/html401/types.html#type-id.
         /// </remarks>
         public static string CreateSanitizedId(string name, string invalidCharReplacement)
         {

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ViewDataDictionary.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ViewDataDictionary.cs
@@ -379,7 +379,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         /// </summary>
         /// <param name="expression">Expression name, relative to the current model.</param>
         /// <param name="format">
-        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx).
+        /// The format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx).
         /// </param>
         /// <returns>
         /// Value of named <paramref name="expression"/> in this <see cref="ViewDataDictionary"/>, formatted using
@@ -400,7 +400,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         /// </summary>
         /// <param name="value">The value to format.</param>
         /// <param name="format">
-        /// The composite format <see cref="string"/> (see http://msdn.microsoft.com/en-us/library/txafckwd.aspx).
+        /// The format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx).
         /// </param>
         /// <returns>The formatted <see cref="string"/>.</returns>
         public static string FormatValue(object value, string format)

--- a/src/Microsoft.AspNetCore.Mvc.WebApiCompatShim/ContentNegotiator/MediaTypeConstants.cs
+++ b/src/Microsoft.AspNetCore.Mvc.WebApiCompatShim/ContentNegotiator/MediaTypeConstants.cs
@@ -101,7 +101,7 @@ namespace System.Net.Http.Formatting
         /// </value>
         /// <remarks>
         /// Not yet a standard. In particular this media type is not currently listed at
-        /// http://www.iana.org/assignments/media-types/application.
+        /// https://www.iana.org/assignments/media-types/application.
         /// </remarks>
         public static MediaTypeHeaderValue ApplicationBsonMediaType
         {

--- a/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/TestUtils/MediaTypeConstants.cs
+++ b/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/TestUtils/MediaTypeConstants.cs
@@ -99,7 +99,7 @@ namespace System.Net.Http.Formatting
         /// </value>
         /// <remarks>
         /// Not yet a standard. In particular this media type is not currently listed at
-        /// http://www.iana.org/assignments/media-types/application.
+        /// https://www.iana.org/assignments/media-types/application.
         /// </remarks>
         public static MediaTypeHeaderValue ApplicationBsonMediaType
         {


### PR DESCRIPTION
- #1999
- may have reordered the precedence comments as I double-checked the implementations
 - looks like `CheckBox()` and `RadioButton()` were examples of such updates

This PR is "[Design]" because I haven't made similar changes to `IHtmlHelper<TModel>` or the extension methods.