### PR TITLE
Replace HashSet with a Hybrid HashSet/List

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Internal/ValidationStack.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Internal/ValidationStack.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.AspNetCore.Mvc.Internal;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Internal
+{
+    public class ValidationStack
+    {
+        public int Count => HashSet?.Count ?? List.Count;
+
+        // We tested the performance of a list at size 15 and found it still better than hashset, but to avoid a costly
+        // O(n) search at larger n we set the cutoff to 20. If someone finds the point where they intersect feel free to change this number.
+        internal const int CutOff = 20;
+
+        internal List<object> List { get; } = new List<object>();
+
+        internal HashSet<object> HashSet { get; set; }
+
+        public bool Push(object model)
+        {
+            if (HashSet != null)
+            {
+                return HashSet.Add(model);
+            }
+
+            if (ListContains(model))
+            {
+                return false;
+            }
+
+            List.Add(model);
+
+            if (HashSet == null && List.Count > CutOff)
+            {
+                HashSet = new HashSet<object>(List, ReferenceEqualityComparer.Instance);
+            }
+
+            return true;
+        }
+
+        public void Pop(object model)
+        {
+            if (HashSet != null)
+            {
+                HashSet.Remove(model);
+            }
+            else
+            {
+                if (model != null)
+                {
+                    Debug.Assert(ReferenceEquals(List[List.Count - 1], model));
+                    List.RemoveAt(List.Count - 1);
+                }
+            }
+        }
+
+        private bool ListContains(object model)
+        {
+            for (var i = 0; i < List.Count; i++)
+            {
+                if (ReferenceEquals(model, List[i]))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Internal/ValidationStackTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Internal/ValidationStackTest.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Internal
+{
+    public class ValidationStackTest
+    {
+        [Theory]
+        [InlineData(0)]
+        [InlineData(5)]
+        [InlineData(ValidationStack.CutOff + 1)]
+        public void Push_ReturnsFalseIfValueAlreadyExists(int preloadCount)
+        {
+            // Arrange
+            var validationStack = new TestValidationStack();
+            var model = "This is a value";
+
+            PreLoad(preloadCount, validationStack);
+
+            // Act & Assert
+            Assert.True(validationStack.Push(model));
+            Assert.False(validationStack.Push(model));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(5)]
+        [InlineData(ValidationStack.CutOff + 1)]
+        public void Pop_RemovesValueFromTheStack(int preloadCount)
+        {
+            // Arrange
+            var validationStack = new TestValidationStack();
+            var model = "This is a value";
+
+            PreLoad(preloadCount, validationStack);
+
+            // Act
+            validationStack.Push(model);
+            validationStack.Pop(model);
+
+            // Assert
+            Assert.False(validationStack.Contains(model));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(5)]
+        [InlineData(ValidationStack.CutOff + 1)]
+        public void Pop_DoesNotThrowIfValueIsNull(int preloadCount)
+        {
+            // Arrange
+            var validationStack = new TestValidationStack();
+
+            PreLoad(preloadCount, validationStack);
+
+            // Act & Assert
+            // Poping null when it's not there must not throw
+            validationStack.Pop(null);
+        }
+
+        [Fact]
+        public void PushingMoreThanCutOffElements_SwitchesToHashSet()
+        {
+            // Arrange
+            var size = ValidationStack.CutOff + 1;
+
+            var validationStack = new TestValidationStack();
+            var models = new List<Model>();
+            for (var i = 0; i < size; i++)
+            {
+                models.Add(new Model { Position = i });
+            }
+
+            // Act & Assert
+            foreach (var model in models)
+            {
+                validationStack.Push(model);
+            }
+
+            Assert.Equal(size, validationStack.Count);
+
+            models.Reverse();
+            foreach (var model in models)
+            {
+                validationStack.Pop(model);
+            }
+
+            Assert.Equal(0, validationStack.Count);
+            Assert.True(validationStack.UsingHashSet());
+        }
+
+        private void PreLoad(int preloadCount, ValidationStack stack)
+        {
+            for (var i = 0; i < preloadCount; i++)
+            {
+                stack.Push(i);
+            }
+        }
+
+        private class Model
+        {
+            public int Position { get; set; }
+        }
+
+        private class TestValidationStack : ValidationStack
+        {
+            public bool Contains(object model)
+            {
+                if (HashSet != null)
+                {
+                    return HashSet.Contains(model);
+                }
+                else
+                {
+                    return List.Contains(model);
+                }
+            }
+
+            public bool UsingHashSet()
+            {
+                return HashSet != null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5361. Replace HashSet with a hybrid HashSet/List to improve performance on less nested models while protecting heavily nested models from possibly terrible performance from list traversal.