### PR TITLE
Do not call `Encoding.GetEncoding()` with a string from the request

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Formatters/TextInputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Formatters/TextInputFormatter.cs
@@ -50,9 +50,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             { "unicode-1-1-utf-8", "utf-8" },
             { "unicode-2-0-utf-7", "utf-7" },
             { "unicode-2-0-utf-8", "utf-8" },
-            // People get confused about the FFFE here.  We can't change this because it'd break existing apps.
-            // This has been this way for a long time, including in Mlang.
-            // Big Endian, BOM seems backwards, think of the BOM in little endian order.
             { "unicodeFFFE", "utf-16BE"},
             { "us", "us-ascii" },
             { "UTF-16LE", "utf-16"},

--- a/src/Microsoft.AspNetCore.Mvc.Core/Formatters/TextInputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Formatters/TextInputFormatter.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Core;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Mvc.Formatters
 {
@@ -15,6 +16,53 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
     /// </summary>
     public abstract class TextInputFormatter : InputFormatter
     {
+        // ASP.NET Core MVC 1.0 used Encoding.GetEncoding() when comparing the request charset with SupportedEncodings.
+        // That method supports the following alternate names for system-supported encodings. This table maps from
+        // .NET Core's keys in s_encodingDataTable to values in s_encodingDataTableItems, less identity mappings. It
+        // should be kept in sync with those Unix-specific tables in
+        // https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/Globalization/EncodingTable.Unix.cs
+        // or their Windows equivalents (also for .NET Core not desktop .NET): COMNlsInfo::EncodingDataTable and
+        // COMNlsInfo::CodePageDataTable in EncodingData in
+        // https://github.com/dotnet/coreclr/blob/master/src/classlibnative/nls/encodingdata.cpp
+        private static readonly IReadOnlyDictionary<string, string> EncodingAliases = new Dictionary<string, string>
+        {
+            { "ANSI_X3.4-1968", "us-ascii" },
+            { "ANSI_X3.4-1986", "us-ascii" },
+            { "ascii", "us-ascii" },
+            { "cp367", "us-ascii" },
+            { "cp819", "iso-8859-1" },
+            { "csASCII", "us-ascii" },
+            { "csISOLatin1", "iso-8859-1" },
+            { "csUnicode11UTF7", "utf-7" },
+            { "IBM367", "us-ascii" },
+            { "ibm819", "iso-8859-1" },
+            { "ISO-10646-UCS-2", "utf-16" },
+            { "iso-ir-100", "iso-8859-1" },
+            { "iso-ir-6", "us-ascii" },
+            { "ISO646-US", "us-ascii" },
+            { "ISO_646.irv:1991", "us-ascii" },
+            { "iso_8859-1:1987", "iso-8859-1" },
+            { "l1", "iso-8859-1" },
+            { "latin1", "iso-8859-1" },
+            { "ucs-2", "utf-16" },
+            { "unicode", "utf-16"},
+            { "unicode-1-1-utf-7", "utf-7" },
+            { "unicode-1-1-utf-8", "utf-8" },
+            { "unicode-2-0-utf-7", "utf-7" },
+            { "unicode-2-0-utf-8", "utf-8" },
+            // People get confused about the FFFE here.  We can't change this because it'd break existing apps.
+            // This has been this way for a long time, including in Mlang.
+            // Big Endian, BOM seems backwards, think of the BOM in little endian order.
+            { "unicodeFFFE", "utf-16BE"},
+            { "us", "us-ascii" },
+            { "UTF-16LE", "utf-16"},
+            { "UTF-32LE", "utf-32" },
+            { "x-unicode-1-1-utf-7", "utf-7" },
+            { "x-unicode-1-1-utf-8", "utf-8" },
+            { "x-unicode-2-0-utf-7", "utf-7" },
+            { "x-unicode-2-0-utf-8", "utf-8" },
+        };
+
         /// <summary>
         /// Returns UTF8 Encoding without BOM and throws on invalid bytes.
         /// </summary>
@@ -64,7 +112,9 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         /// <param name="context">The <see cref="InputFormatterContext"/>.</param>
         /// <param name="encoding">The <see cref="Encoding"/> used to read the request body.</param>
         /// <returns>A <see cref="Task"/> that on completion deserializes the request body.</returns>
-        public abstract Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context, Encoding encoding);
+        public abstract Task<InputFormatterResult> ReadRequestBodyAsync(
+            InputFormatterContext context,
+            Encoding encoding);
 
         /// <summary>
         /// Returns an <see cref="Encoding"/> based on <paramref name="context"/>'s
@@ -84,21 +134,27 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
             if (SupportedEncodings?.Count == 0)
             {
-                var message = Resources.FormatTextInputFormatter_SupportedEncodingsMustNotBeEmpty(nameof(SupportedEncodings));
+                var message = Resources.FormatTextInputFormatter_SupportedEncodingsMustNotBeEmpty(
+                    nameof(SupportedEncodings));
                 throw new InvalidOperationException(message);
             }
 
-            var request = context.HttpContext.Request;
-
-            var requestEncoding = request.ContentType == null ? null : MediaType.GetEncoding(request.ContentType);
-            if (requestEncoding != null)
+            var requestContentType = context.HttpContext.Request.ContentType;
+            var requestEncoding = requestContentType == null ?
+                default(StringSegment) :
+                new MediaType(requestContentType).Charset;
+            if (requestEncoding.HasValue)
             {
+                string encodingName;
+                if (!EncodingAliases.TryGetValue(requestEncoding.Value, out encodingName))
+                {
+                    // Given name was not an encoding alias. Use the original value.
+                    encodingName = requestEncoding.Value;
+                }
+
                 for (int i = 0; i < SupportedEncodings.Count; i++)
                 {
-                    if (string.Equals(
-                        requestEncoding.WebName,
-                        SupportedEncodings[i].WebName,
-                        StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(encodingName, SupportedEncodings[i].WebName, StringComparison.OrdinalIgnoreCase))
                     {
                         return SupportedEncodings[i];
                     }
@@ -116,7 +172,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             // cases where the client doesn't send a content type header or sends a content
             // type header without encoding. For that reason we pick the first encoding of the
             // list of supported encodings and try to use that to read the body. This encoding
-            // is UTF-8 by default on our formatters, which generally is a safe choice for the
+            // is UTF-8 by default in our formatters, which generally is a safe choice for the
             // encoding.
             return SupportedEncodings[0];
         }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Formatters/TextInputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Formatters/TextInputFormatter.cs
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 throw new ArgumentNullException(nameof(context));
             }
 
-            if (SupportedEncodings?.Count == 0)
+            if (SupportedEncodings.Count == 0)
             {
                 var message = Resources.FormatTextInputFormatter_SupportedEncodingsMustNotBeEmpty(
                     nameof(SupportedEncodings));
@@ -145,11 +145,12 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 new MediaType(requestContentType).Charset;
             if (requestEncoding.HasValue)
             {
-                string encodingName;
-                if (!EncodingAliases.TryGetValue(requestEncoding.Value, out encodingName))
+                var encodingName = requestEncoding.Value;
+                string alias;
+                if (EncodingAliases.TryGetValue(encodingName, out alias))
                 {
-                    // Given name was not an encoding alias. Use the original value.
-                    encodingName = requestEncoding.Value;
+                    // Given name was an encoding alias. Use the preferred name.
+                    encodingName = alias;
                 }
 
                 for (int i = 0; i < SupportedEncodings.Count; i++)


### PR DESCRIPTION
- #5351
- fix affects only `TextInputFormatter`
 - `TextOutputFormatter` already does the Right Thing:tm: with `Accept-Charset` headers
 - `ResponseContentTypeHelper` uses `Encoding.GetEncoding()` but is not passed request data