### PR TITLE
Added check for null arguments to GetArgumentDictionary

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/DefaultViewComponentHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/DefaultViewComponentHelper.cs
@@ -135,9 +135,9 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
         // Internal for testing
         internal IDictionary<string, object> GetArgumentDictionary(ViewComponentDescriptor descriptor, object arguments)
         {
-            if (descriptor.Parameters.Count == 1)
+            if (arguments != null)
             {
-                if (arguments == null || descriptor.Parameters[0].ParameterType.IsAssignableFrom(arguments.GetType()))
+                if (descriptor.Parameters.Count == 1 && descriptor.Parameters[0].ParameterType.IsAssignableFrom(arguments.GetType()))
                 {
                     return new Dictionary<string, object>(capacity: 1, comparer: StringComparer.OrdinalIgnoreCase)
                     {

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/DefaultViewComponentHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/DefaultViewComponentHelper.cs
@@ -135,12 +135,15 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
         // Internal for testing
         internal IDictionary<string, object> GetArgumentDictionary(ViewComponentDescriptor descriptor, object arguments)
         {
-            if (descriptor.Parameters.Count == 1 && descriptor.Parameters[0].ParameterType.IsAssignableFrom(arguments.GetType()))
+            if (descriptor.Parameters.Count == 1)
             {
-                return new Dictionary<string, object>(capacity: 1, comparer: StringComparer.OrdinalIgnoreCase)
+                if (arguments == null || descriptor.Parameters[0].ParameterType.IsAssignableFrom(arguments.GetType()))
                 {
-                    { descriptor.Parameters[0].Name, arguments }
-                };
+                    return new Dictionary<string, object>(capacity: 1, comparer: StringComparer.OrdinalIgnoreCase)
+                    {
+                        { descriptor.Parameters[0].Name, arguments }
+                    };
+                }
             }
 
             return PropertyHelper.ObjectToDictionary(arguments);

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponents/DefaultViewComponentHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponents/DefaultViewComponentHelperTest.cs
@@ -26,12 +26,8 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
             var argumentDictionary = helper.GetArgumentDictionary(descriptor, null);
 
             // Assert
-            Assert.Collection(argumentDictionary,
-                item =>
-                {
-                    Assert.Equal("a", item.Key);
-                    Assert.Null(item.Value);
-                });
+            Assert.Equal(0, argumentDictionary.Count);
+            Assert.IsType(typeof(Dictionary<string,object>),argumentDictionary);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponents/DefaultViewComponentHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponents/DefaultViewComponentHelperTest.cs
@@ -16,6 +16,25 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
     public class DefaultViewComponentHelperTest
     {
         [Fact]
+        public void GetArgumentDictionary_SupportsNullArguments()
+        {
+            // Arrange
+            var helper = CreateHelper();
+            var descriptor = CreateDescriptorForType(typeof(ViewComponentSingleParam));
+
+            // Act
+            var argumentDictionary = helper.GetArgumentDictionary(descriptor, null);
+
+            // Assert
+            Assert.Collection(argumentDictionary,
+                item =>
+                {
+                    Assert.Equal("a", item.Key);
+                    Assert.Null(item.Value);
+                });
+        }
+
+        [Fact]
         public void GetArgumentDictionary_SupportsAnonymouslyTypedArguments()
         {
             // Arrange


### PR DESCRIPTION
Is this desired behavior? Or should I instead check for null and skip allocating of a new Dictionary object if `object arguments` is null? 

Addresses #5423 

cc @rynowak 