### PR TITLE
XmlResult and FromBodyXmlAttribute new features in the project "Microsoft.AspNetCore.Mvc.Formatters.Xml".

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,3 +1,6 @@
 {
-    "projects": ["src", "test/WebSites", "samples"]
+    "projects": [ "src", "test/WebSites", "samples" ],
+    "sdk": {
+        "version": "1.0.0-preview2-003121"
+    }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "projects": [ "src", "test/WebSites", "samples" ],
     "sdk": {
-        "version": "1.0.0-preview2-003121"
+        "version": "1.0.0-preview2-003131"
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/DependencyInjection/MvcXmlMvcBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/DependencyInjection/MvcXmlMvcBuilderExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -51,6 +52,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             services.TryAddEnumerable(
                 ServiceDescriptor.Transient<IConfigureOptions<MvcOptions>, MvcXmlDataContractSerializerMvcOptionsSetup>());
+            services.TryAddSingleton<XmlDcResultExecutor>();
         }
 
         // Internal for testing.
@@ -58,6 +60,8 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             services.TryAddEnumerable(
                 ServiceDescriptor.Transient<IConfigureOptions<MvcOptions>, MvcXmlSerializerMvcOptionsSetup>());
+            services.TryAddSingleton<XmlResultExecutor>();
+            services.TryAddTransient<BodyXmlModelBinder>();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/DependencyInjection/MvcXmlMvcBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/DependencyInjection/MvcXmlMvcBuilderExtensions.cs
@@ -53,6 +53,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddEnumerable(
                 ServiceDescriptor.Transient<IConfigureOptions<MvcOptions>, MvcXmlDataContractSerializerMvcOptionsSetup>());
             services.TryAddSingleton<XmlDcResultExecutor>();
+            services.TryAddTransient<BodyDcXmlModelBinder>();
+            services.TryAddTransient<BodyDcXmlModelBinderOnly>();
         }
 
         // Internal for testing.
@@ -62,6 +64,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 ServiceDescriptor.Transient<IConfigureOptions<MvcOptions>, MvcXmlSerializerMvcOptionsSetup>());
             services.TryAddSingleton<XmlResultExecutor>();
             services.TryAddTransient<BodyXmlModelBinder>();
+            services.TryAddTransient<BodyXmlModelBinderOnly>();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/DependencyInjection/MvcXmlMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/DependencyInjection/MvcXmlMvcCoreBuilderExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -51,6 +52,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             services.TryAddEnumerable(
                 ServiceDescriptor.Transient<IConfigureOptions<MvcOptions>, MvcXmlDataContractSerializerMvcOptionsSetup>());
+            services.TryAddSingleton<XmlDcResultExecutor>();
         }
 
         // Internal for testing.
@@ -58,6 +60,8 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             services.TryAddEnumerable(
                 ServiceDescriptor.Transient<IConfigureOptions<MvcOptions>, MvcXmlSerializerMvcOptionsSetup>());
+            services.TryAddSingleton<XmlResultExecutor>();
+            services.TryAddTransient<BodyXmlModelBinder>();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/DependencyInjection/MvcXmlMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/DependencyInjection/MvcXmlMvcCoreBuilderExtensions.cs
@@ -53,6 +53,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddEnumerable(
                 ServiceDescriptor.Transient<IConfigureOptions<MvcOptions>, MvcXmlDataContractSerializerMvcOptionsSetup>());
             services.TryAddSingleton<XmlDcResultExecutor>();
+            services.TryAddTransient<BodyDcXmlModelBinder>();
+            services.TryAddTransient<BodyDcXmlModelBinderOnly>();
         }
 
         // Internal for testing.
@@ -62,6 +64,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 ServiceDescriptor.Transient<IConfigureOptions<MvcOptions>, MvcXmlSerializerMvcOptionsSetup>());
             services.TryAddSingleton<XmlResultExecutor>();
             services.TryAddTransient<BodyXmlModelBinder>();
+            services.TryAddTransient<BodyXmlModelBinderOnly>();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/FromBodyXmlAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/FromBodyXmlAttribute.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+
+namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
+{
+    /// <summary>
+    /// Specifies that a parameter or property should be bound using the request body.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public class FromBodyXmlAttribute : Attribute, IBinderTypeProviderMetadata
+    {
+        /// <inheritdoc />
+        public BindingSource BindingSource => BindingSource.Body;
+
+        //TODO: Add proper type of binder provider
+        /// <inheritdoc />
+        public Type BinderType => UseDataContractSerializer ? typeof(BodyDcXmlModelBinder) : typeof(BodyXmlModelBinder);
+
+        /// <summary>
+        /// Gets or sets the type of used xml serializer.
+        /// </summary>
+        public bool UseDataContractSerializer { get; set; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/FromBodyXmlAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/FromBodyXmlAttribute.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
 {
     /// <summary>
-    /// Specifies that a parameter or property should be bound using the request body.
+    /// Specifies that a parameter or property should be bound using the request body XML.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public class FromBodyXmlAttribute : Attribute, IBinderTypeProviderMetadata
@@ -16,13 +16,21 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
         /// <inheritdoc />
         public BindingSource BindingSource => BindingSource.Body;
 
-        //TODO: Add proper type of binder provider
+        /// Gets the proper type of the XML binder provider
         /// <inheritdoc />
-        public Type BinderType => UseDataContractSerializer ? typeof(BodyDcXmlModelBinder) : typeof(BodyXmlModelBinder);
+        public Type BinderType => UseXmlBinderOnly ?
+                                    (UseDataContractXmlBinder ? typeof(BodyDcXmlModelBinderOnly) : typeof(BodyXmlModelBinderOnly)) :
+                                    (UseDataContractXmlBinder ? typeof(BodyDcXmlModelBinder) : typeof(BodyXmlModelBinder));
 
         /// <summary>
-        /// Gets or sets the type of used xml serializer.
+        /// Gets or sets the flag that selects a Data Contract XML input formatter.
         /// </summary>
-        public bool UseDataContractSerializer { get; set; }
+        public bool UseDataContractXmlBinder { get; set; }
+
+        /// <summary>
+        /// Gets or sets the flag that limits an input formatter to  XML  or Data Contract XML <see cref="UseDataContractXmlBinder"/>.
+        /// </summary>
+        public bool UseXmlBinderOnly { get; set; }
+
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/FromBodyXmlAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/FromBodyXmlAttribute.cs
@@ -19,16 +19,16 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
         /// Gets the proper type of the XML binder provider
         /// <inheritdoc />
         public Type BinderType => UseXmlBinderOnly ?
-                                    (UseDataContractXmlBinder ? typeof(BodyDcXmlModelBinderOnly) : typeof(BodyXmlModelBinderOnly)) :
-                                    (UseDataContractXmlBinder ? typeof(BodyDcXmlModelBinder) : typeof(BodyXmlModelBinder));
+                                    (XmlSerializerType == XmlSerializerType.DataContractSerializer ? typeof(BodyDcXmlModelBinderOnly) : typeof(BodyXmlModelBinderOnly)) :
+                                    (XmlSerializerType == XmlSerializerType.DataContractSerializer ? typeof(BodyDcXmlModelBinder) : typeof(BodyXmlModelBinder));
 
         /// <summary>
         /// Gets or sets the flag that selects a Data Contract XML input formatter.
         /// </summary>
-        public bool UseDataContractXmlBinder { get; set; }
+        public XmlSerializerType XmlSerializerType { get; set; }
 
         /// <summary>
-        /// Gets or sets the flag that limits an input formatter to  XML  or Data Contract XML <see cref="UseDataContractXmlBinder"/>.
+        /// Gets or sets the flag that limits an input formatter to  XML  or Data Contract XML <see cref="XmlSerializerType"/>.
         /// </summary>
         public bool UseXmlBinderOnly { get; set; }
 

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/FromBodyXmlAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/FromBodyXmlAttribute.cs
@@ -9,6 +9,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
 {
     /// <summary>
     /// Specifies that a parameter or property should be bound using the request body XML.
+    /// Requires the XML DataContractSerializer formatters or/and the XML Serializer formatters to be add to MVC.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public class FromBodyXmlAttribute : Attribute, IBinderTypeProviderMetadata
@@ -18,6 +19,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
 
         /// Gets the proper type of the XML binder provider
         /// <inheritdoc />
+        ///<remarks> Requires the XML DataContractSerializer formatters or/and the XML Serializer formatters to be add to MVC.</remarks>
         public Type BinderType => UseXmlBinderOnly ?
                                     (XmlSerializerType == XmlSerializerType.DataContractSerializer ? typeof(BodyDcXmlModelBinderOnly) : typeof(BodyXmlModelBinderOnly)) :
                                     (XmlSerializerType == XmlSerializerType.DataContractSerializer ? typeof(BodyDcXmlModelBinder) : typeof(BodyXmlModelBinder));

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/IXmlResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/IXmlResultExecutor.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
+{
+    public interface IXmlResultExecutor
+    {
+        /// <summary>
+        /// Executes the <see cref="XmlResult"/> and writes the response.
+        /// </summary>
+        /// <param name="context">The <see cref="ActionContext"/>.</param>
+        /// <param name="result">The <see cref="XmlResult"/>.</param>
+        /// <returns>A <see cref="Task"/> which will complete when writing has completed.</returns>
+        Task ExecuteAsync(ActionContext context, XmlResult result);
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/MvcXmlLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/MvcXmlLoggerExtensions.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
+{
+    internal static class MvcXmlLoggerExtensions
+    {
+        private static readonly Action<ILogger, string, Exception> _noExecutor;
+        private static readonly Action<ILogger, IOutputFormatter, string, Exception> _formatterSelected;
+        private static readonly Action<ILogger, string, Exception> _xmlResultExecuting;
+
+        static MvcXmlLoggerExtensions()
+        {
+            _noExecutor = LoggerMessage.Define<string>
+                                     (LogLevel.Warning, 1, "No output formatter was found for content type '{ContentType}' to write the response.");
+
+            _formatterSelected = LoggerMessage.Define<IOutputFormatter, string>
+                                    (LogLevel.Debug, 2, "Selected output formatter '{OutputFormatter}' and content type '{ContentType}' to write the response.");
+
+            _xmlResultExecuting = LoggerMessage.Define<string>
+                                    (LogLevel.Information, 3, "Executing XmlResult, writing value {Value}.");
+        }
+
+
+        public static void NoExecutor(this ILogger logger, OutputFormatterWriteContext formatterContext)
+        {
+            if (logger.IsEnabled(LogLevel.Warning))
+            {
+                _noExecutor(logger, Convert.ToString(formatterContext.ContentType), null);
+            }
+        }
+
+
+        public static void FormatterSelected(this ILogger logger, IOutputFormatter outputFormatter, OutputFormatterWriteContext context)
+        {
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                var contentType = Convert.ToString(context.ContentType);
+                _formatterSelected(logger, outputFormatter, contentType, null);
+            }
+        }
+
+        public static void XmlResultExecuting(this ILogger logger, object value)
+        {
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                _xmlResultExecuting(logger, Convert.ToString(value), null);
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/MvcXmlLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/MvcXmlLoggerExtensions.cs
@@ -3,19 +3,27 @@
 
 using System;
 using Microsoft.Extensions.Logging;
+using System.IO;
+using Microsoft.AspNetCore.Http;
+using System.Text;
 
 namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
 {
     internal static class MvcXmlLoggerExtensions
     {
         private static readonly Action<ILogger, string, Exception> _noExecutor;
+        private static readonly Action<ILogger, string, Exception> _noFormatter;
+
         private static readonly Action<ILogger, IOutputFormatter, string, Exception> _formatterSelected;
         private static readonly Action<ILogger, string, Exception> _xmlResultExecuting;
 
         static MvcXmlLoggerExtensions()
         {
             _noExecutor = LoggerMessage.Define<string>
-                                     (LogLevel.Warning, 1, "No output formatter was found for content type '{ContentType}' to write the response.");
+                                     (LogLevel.Warning, 1, "No output XmlResultExecutor was found for XmlSerializerType type '{Value}' to write the response.");
+
+            _noFormatter = LoggerMessage.Define<string>
+                                     (LogLevel.Warning, 1, "No output formatter was found for content type '{Value}' to write the response.");
 
             _formatterSelected = LoggerMessage.Define<IOutputFormatter, string>
                                     (LogLevel.Debug, 2, "Selected output formatter '{OutputFormatter}' and content type '{ContentType}' to write the response.");
@@ -25,14 +33,21 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
         }
 
 
-        public static void NoExecutor(this ILogger logger, OutputFormatterWriteContext formatterContext)
+        public static void NoFormatter(this ILogger logger, OutputFormatterWriteContext formatterContext)
         {
             if (logger.IsEnabled(LogLevel.Warning))
             {
-                _noExecutor(logger, Convert.ToString(formatterContext.ContentType), null);
+                _noFormatter(logger, Convert.ToString(formatterContext.ContentType), null);
             }
         }
 
+        public static void NoExecutor(this ILogger logger, string xmlSerializerType)
+        {
+            if (logger.IsEnabled(LogLevel.Warning))
+            {
+                _noExecutor(logger, xmlSerializerType, null);
+            }
+        }
 
         public static void FormatterSelected(this ILogger logger, IOutputFormatter outputFormatter, OutputFormatterWriteContext context)
         {
@@ -49,6 +64,12 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
             {
                 _xmlResultExecuting(logger, Convert.ToString(value), null);
             }
+        }
+
+        public static void StringToHttpContext(HttpContext httpContext, string message)
+        {
+            var bytes = Encoding.UTF8.GetBytes(message);
+            httpContext.Response.Body.Write(bytes, 0, bytes.Length);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/XmlDcResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/XmlDcResultExecutor.cs
@@ -1,0 +1,138 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Buffers;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
+using System.Xml;
+using Microsoft.Extensions.Primitives;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
+{
+    /// <summary>
+    /// Executes a <see cref="XmlResult"/> to write to the response.
+    /// </summary>
+    public class XmlDcResultExecutor
+    {
+        private static readonly string DefaultContentType = new MediaTypeHeaderValue("application/xml")
+        {
+            Encoding = Encoding.UTF8
+        }.ToString();
+
+        /// <summary>
+        /// Creates a new <see cref="XmlDcResultExecutor"/>.
+        /// </summary>
+        /// <param name="writerFactory">The <see cref="IHttpResponseStreamWriterFactory"/>.</param>
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
+        /// <param name="options">The <see cref="IOptions{MvcXmlOptions}"/>.</param>
+        public XmlDcResultExecutor(
+            IHttpResponseStreamWriterFactory writerFactory,
+            ILoggerFactory loggerFactory,
+            IOptions<MvcOptions> options)
+        {
+            if (writerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(writerFactory));
+            }
+
+            if (loggerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+
+            WriterFactory = writerFactory;
+            Logger = loggerFactory.CreateLogger<XmlDcResultExecutor>();
+            Options = options.Value;
+            OptionsFormatters = Options.OutputFormatters;
+        }
+
+        // TODO: pass them from XmlResult
+        XmlWriterSettings XmlWriterSettings { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="ILogger"/>.
+        /// </summary>
+        protected ILogger Logger { get; }
+
+        /// <summary>
+        /// Gets the <see cref="MvcOptions"/>.
+        /// </summary>
+        protected MvcOptions Options { get; }
+
+        /// <summary>
+        /// Gets the list of <see cref="IOutputFormatter"/> instances from <see cref="MvcOptions"/>.
+        /// </summary>
+        protected FormatterCollection<IOutputFormatter> OptionsFormatters { get; }
+
+        /// <summary>
+        /// Gets the <see cref="IHttpResponseStreamWriterFactory"/>.
+        /// </summary>
+        protected IHttpResponseStreamWriterFactory WriterFactory { get; }
+
+        /// <summary>
+        /// Executes the <see cref="XmlResult"/> and writes the response.
+        /// </summary>
+        /// <param name="context">The <see cref="ActionContext"/>.</param>
+        /// <param name="result">The <see cref="XmlResult"/>.</param>
+        /// <returns>A <see cref="Task"/> which will complete when writing has completed.</returns>
+        public Task ExecuteAsync(ActionContext context, XmlResult result)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (result == null)
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
+            var response = context.HttpContext.Response;
+
+            string resolvedContentType = null;
+            Encoding resolvedContentTypeEncoding = null;
+            ResponseContentTypeHelper.ResolveContentTypeAndEncoding(
+                                                    result.ContentType,
+                                                    response.ContentType,
+                                                    DefaultContentType,
+                                                    out resolvedContentType,
+                                                    out resolvedContentTypeEncoding);
+
+            response.ContentType = resolvedContentType;
+
+            if (result.StatusCode != null)
+            {
+                response.StatusCode = result.StatusCode.Value;
+            }
+
+            var serializerSettings = result.XmlSerializerSettings ?? FormattingUtilities.GetDefaultXmlWriterSettings();
+
+            TextOutputFormatter formatter;
+            // create the proper formatter
+            formatter = new XmlDataContractSerializerOutputFormatter(serializerSettings);
+            var outputFormatterWriterContext = new OutputFormatterWriteContext(
+                                                        context.HttpContext,
+                                                        WriterFactory.CreateWriter,
+                                                        result.Value.GetType(), result.Value);
+
+            outputFormatterWriterContext.ContentType = new StringSegment(resolvedContentType);
+
+            // TODO: Logger.XmlResultExecuting(result.Value);
+            // TODO: get formatter from proper place
+
+            return formatter.WriteAsync(outputFormatterWriterContext);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/XmlDcResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/XmlDcResultExecutor.cs
@@ -16,17 +16,12 @@ using Microsoft.AspNetCore.Http;
 namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
 {
     /// <summary>
-    /// Executes a <see cref="XmlResult"/> to write to the response.
+    /// Executes a <see cref="XmlResult"/> to write to the DataContract xml response.
     /// </summary>
     public class XmlDcResultExecutor : IXmlResultExecutor
     {
-        private static readonly string DefaultContentType = new MediaTypeHeaderValue("application/xml")
-        {
-            Encoding = Encoding.UTF8
-        }.ToString();
-
         /// <summary>
-        /// Creates a new <see cref="XmlDcResultExecutor"/>.
+        /// Creates a new <see cref="XmlResultExecutor"/>.
         /// </summary>
         /// <param name="writerFactory">The <see cref="IHttpResponseStreamWriterFactory"/>.</param>
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
@@ -44,78 +39,32 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
                 throw new ArgumentNullException(nameof(loggerFactory));
             }
 
-
-
             WriterFactory = writerFactory;
-            Logger = loggerFactory.CreateLogger<XmlResult>();
-
+            LoggerFactory = loggerFactory;
         }
 
         /// <summary>
+        /// Gets the <see cref="XmlResultExecutorBase"/>.
+        /// </summary>
+        XmlResultExecutorBase XmlResultExecutorBase { get; }
+        /// <summary>
         /// Gets the <see cref="ILogger"/>.
         /// </summary>
-        protected ILogger Logger { get; }
-
+        protected ILoggerFactory LoggerFactory { get; }
 
         /// <summary>
         /// Gets the <see cref="IHttpResponseStreamWriterFactory"/>.
         /// </summary>
         protected IHttpResponseStreamWriterFactory WriterFactory { get; }
 
-        /// <summary>
-        /// Executes the <see cref="XmlResult"/> and writes the response.
-        /// </summary>
-        /// <param name="context">The <see cref="ActionContext"/>.</param>
-        /// <param name="result">The <see cref="XmlResult"/>.</param>
-        /// <returns>A <see cref="Task"/> which will complete when writing has completed.</returns>
         public Task ExecuteAsync(ActionContext context, XmlResult result)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            if (result == null)
-            {
-                throw new ArgumentNullException(nameof(result));
-            }
-
-            var response = context.HttpContext.Response;
-
-            string resolvedContentType = null;
-            Encoding resolvedContentTypeEncoding = null;
-            ResponseContentTypeHelper.ResolveContentTypeAndEncoding(
-                                                    result.ContentType,
-                                                    response.ContentType,
-                                                    DefaultContentType,
-                                                    out resolvedContentType,
-                                                    out resolvedContentTypeEncoding);
-
-            response.ContentType = resolvedContentType;
-
-            if (result.StatusCode != null)
-            {
-                response.StatusCode = result.StatusCode.Value;
-            }
-
             var serializerSettings = result.XmlSerializerSettings ?? FormattingUtilities.GetDefaultXmlWriterSettings();
-
             TextOutputFormatter formatter;
             // create the proper formatter
             formatter = new XmlDataContractSerializerOutputFormatter(serializerSettings);
-            var outputFormatterWriterContext = new OutputFormatterWriteContext(
-                                                        context.HttpContext,
-                                                        WriterFactory.CreateWriter,
-                                                        result.Value.GetType(), result.Value);
-
-            outputFormatterWriterContext.ContentType = new StringSegment(resolvedContentType);
-
-            //  Logger formatter and value of object
-
-            Logger.FormatterSelected(formatter, outputFormatterWriterContext);
-            Logger.XmlResultExecuting(result.Value);
-
-            return formatter.WriteAsync(outputFormatterWriterContext);
+            XmlResultExecutorBase xmlBase = new XmlResultExecutorBase(WriterFactory, LoggerFactory, formatter);
+            return xmlBase.ExecuteAsync(context, result);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/XmlDcResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/XmlDcResultExecutor.cs
@@ -30,11 +30,9 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
         /// </summary>
         /// <param name="writerFactory">The <see cref="IHttpResponseStreamWriterFactory"/>.</param>
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
-        /// <param name="options">The <see cref="IOptions{MvcXmlOptions}"/>.</param>
         public XmlDcResultExecutor(
             IHttpResponseStreamWriterFactory writerFactory,
-            ILoggerFactory loggerFactory,
-            IOptions<MvcOptions> options)
+            ILoggerFactory loggerFactory)
         {
             if (writerFactory == null)
             {
@@ -46,35 +44,18 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
                 throw new ArgumentNullException(nameof(loggerFactory));
             }
 
-            if (options == null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
 
 
             WriterFactory = writerFactory;
             Logger = loggerFactory.CreateLogger<XmlDcResultExecutor>();
-            Options = options.Value;
-            OptionsFormatters = Options.OutputFormatters;
-        }
 
-        // TODO: pass them from XmlResult
-        XmlWriterSettings XmlWriterSettings { get; set; }
+        }
 
         /// <summary>
         /// Gets the <see cref="ILogger"/>.
         /// </summary>
         protected ILogger Logger { get; }
 
-        /// <summary>
-        /// Gets the <see cref="MvcOptions"/>.
-        /// </summary>
-        protected MvcOptions Options { get; }
-
-        /// <summary>
-        /// Gets the list of <see cref="IOutputFormatter"/> instances from <see cref="MvcOptions"/>.
-        /// </summary>
-        protected FormatterCollection<IOutputFormatter> OptionsFormatters { get; }
 
         /// <summary>
         /// Gets the <see cref="IHttpResponseStreamWriterFactory"/>.
@@ -129,8 +110,10 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
 
             outputFormatterWriterContext.ContentType = new StringSegment(resolvedContentType);
 
-            // TODO: Logger.XmlResultExecuting(result.Value);
-            // TODO: get formatter from proper place
+            //  Logger formatter and value of object
+
+            Logger.FormatterSelected(formatter, outputFormatterWriterContext);
+            Logger.XmlResultExecuting(result.Value);
 
             return formatter.WriteAsync(outputFormatterWriterContext);
         }

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/XmlDcResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/XmlDcResultExecutor.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
     /// <summary>
     /// Executes a <see cref="XmlResult"/> to write to the response.
     /// </summary>
-    public class XmlDcResultExecutor
+    public class XmlDcResultExecutor : IXmlResultExecutor
     {
         private static readonly string DefaultContentType = new MediaTypeHeaderValue("application/xml")
         {
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
 
 
             WriterFactory = writerFactory;
-            Logger = loggerFactory.CreateLogger<XmlDcResultExecutor>();
+            Logger = loggerFactory.CreateLogger<XmlResult>();
 
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/XmlResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/XmlResultExecutor.cs
@@ -16,15 +16,10 @@ using Microsoft.AspNetCore.Http;
 namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
 {
     /// <summary>
-    /// Executes a <see cref="XmlResult"/> to write to the response.
+    /// Executes a <see cref="XmlResult"/> to write to the XML response.
     /// </summary>
     public class XmlResultExecutor : IXmlResultExecutor
     {
-        private static readonly string DefaultContentType = new MediaTypeHeaderValue("application/xml")
-        {
-            Encoding = Encoding.UTF8
-        }.ToString();
-
         /// <summary>
         /// Creates a new <see cref="XmlResultExecutor"/>.
         /// </summary>
@@ -45,78 +40,32 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
             }
 
             WriterFactory = writerFactory;
-            Logger = loggerFactory.CreateLogger<XmlResult>();
+            LoggerFactory = loggerFactory;
         }
 
         /// <summary>
+        /// Gets the <see cref="XmlResultExecutorBase"/>.
+        /// </summary>
+        XmlResultExecutorBase XmlResultExecutorBase { get; }
+        /// <summary>
         /// Gets the <see cref="ILogger"/>.
         /// </summary>
-        protected ILogger Logger { get; }
+        protected ILoggerFactory LoggerFactory { get; }
 
         /// <summary>
         /// Gets the <see cref="IHttpResponseStreamWriterFactory"/>.
         /// </summary>
         protected IHttpResponseStreamWriterFactory WriterFactory { get; }
 
-        /// <summary>
-        /// Executes the <see cref="XmlResult"/> and writes the response.
-        /// </summary>
-        /// <param name="context">The <see cref="ActionContext"/>.</param>
-        /// <param name="result">The <see cref="XmlResult"/>.</param>
-        /// <returns>A <see cref="Task"/> which will complete when writing has completed.</returns>
         public Task ExecuteAsync(ActionContext context, XmlResult result)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            if (result == null)
-            {
-                throw new ArgumentNullException(nameof(result));
-            }
-
-            var response = context.HttpContext.Response;
-
-            string resolvedContentType = null;
-            Encoding resolvedContentTypeEncoding = null;
-            ResponseContentTypeHelper.ResolveContentTypeAndEncoding(
-                                                    result.ContentType,
-                                                    response.ContentType,
-                                                    DefaultContentType,
-                                                    out resolvedContentType,
-                                                    out resolvedContentTypeEncoding);
-
-            response.ContentType = resolvedContentType;
-
-            if (result.StatusCode != null)
-            {
-                response.StatusCode = result.StatusCode.Value;
-            }
-
             var serializerSettings = result.XmlSerializerSettings ?? FormattingUtilities.GetDefaultXmlWriterSettings();
-
             TextOutputFormatter formatter;
             // create the proper formatter
-
             formatter = new XmlSerializerOutputFormatter(serializerSettings);
-
-            var outputFormatterWriterContext = new OutputFormatterWriteContext(
-                                                        context.HttpContext,
-                                                        WriterFactory.CreateWriter,
-                                                        result.Value.GetType(), result.Value);
-
-            outputFormatterWriterContext.ContentType = new StringSegment(resolvedContentType);
-
-            //  Logger formatter and value of object
-
-            Logger.FormatterSelected(formatter, outputFormatterWriterContext);
-            Logger.XmlResultExecuting(result.Value);
-
-            return formatter.WriteAsync(outputFormatterWriterContext);
+            XmlResultExecutorBase xmlBase = new XmlResultExecutorBase(WriterFactory, LoggerFactory, formatter);
+            return xmlBase.ExecuteAsync(context, result);
         }
-
-
     }
 }
 

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/XmlResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/XmlResultExecutor.cs
@@ -30,11 +30,9 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
         /// </summary>
         /// <param name="writerFactory">The <see cref="IHttpResponseStreamWriterFactory"/>.</param>
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
-        /// <param name="options">The <see cref="IOptions{MvcXmlOptions}"/>.</param>
         public XmlResultExecutor(
             IHttpResponseStreamWriterFactory writerFactory,
-            ILoggerFactory loggerFactory,
-            IOptions<MvcOptions> options)
+            ILoggerFactory loggerFactory)
         {
             if (writerFactory == null)
             {
@@ -46,35 +44,14 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
                 throw new ArgumentNullException(nameof(loggerFactory));
             }
 
-            if (options == null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
-
-
             WriterFactory = writerFactory;
             Logger = loggerFactory.CreateLogger<XmlResultExecutor>();
-            Options = options.Value;
-            OptionsFormatters = Options.OutputFormatters;
         }
-
-        // TODO: pass them from XmlResult
-        XmlWriterSettings XmlWriterSettings { get; set; }
 
         /// <summary>
         /// Gets the <see cref="ILogger"/>.
         /// </summary>
         protected ILogger Logger { get; }
-
-        /// <summary>
-        /// Gets the <see cref="MvcOptions"/>.
-        /// </summary>
-        protected MvcOptions Options { get; }
-
-        /// <summary>
-        /// Gets the list of <see cref="IOutputFormatter"/> instances from <see cref="MvcOptions"/>.
-        /// </summary>
-        protected FormatterCollection<IOutputFormatter> OptionsFormatters { get; }
 
         /// <summary>
         /// Gets the <see cref="IHttpResponseStreamWriterFactory"/>.
@@ -131,10 +108,15 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
 
             outputFormatterWriterContext.ContentType = new StringSegment(resolvedContentType);
 
-            // TODO: Logger.XmlResultExecuting(result.Value);
-            // TODO: get formatter from proper place
+            //  Logger formatter and value of object
+
+            Logger.FormatterSelected(formatter, outputFormatterWriterContext);
+            Logger.XmlResultExecuting(result.Value);
 
             return formatter.WriteAsync(outputFormatterWriterContext);
         }
+
+
     }
 }
+

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/XmlResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/XmlResultExecutor.cs
@@ -1,0 +1,140 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Buffers;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
+using System.Xml;
+using Microsoft.Extensions.Primitives;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
+{
+    /// <summary>
+    /// Executes a <see cref="XmlResult"/> to write to the response.
+    /// </summary>
+    public class XmlResultExecutor
+    {
+        private static readonly string DefaultContentType = new MediaTypeHeaderValue("application/xml")
+        {
+            Encoding = Encoding.UTF8
+        }.ToString();
+
+        /// <summary>
+        /// Creates a new <see cref="XmlResultExecutor"/>.
+        /// </summary>
+        /// <param name="writerFactory">The <see cref="IHttpResponseStreamWriterFactory"/>.</param>
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
+        /// <param name="options">The <see cref="IOptions{MvcXmlOptions}"/>.</param>
+        public XmlResultExecutor(
+            IHttpResponseStreamWriterFactory writerFactory,
+            ILoggerFactory loggerFactory,
+            IOptions<MvcOptions> options)
+        {
+            if (writerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(writerFactory));
+            }
+
+            if (loggerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+
+            WriterFactory = writerFactory;
+            Logger = loggerFactory.CreateLogger<XmlResultExecutor>();
+            Options = options.Value;
+            OptionsFormatters = Options.OutputFormatters;
+        }
+
+        // TODO: pass them from XmlResult
+        XmlWriterSettings XmlWriterSettings { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="ILogger"/>.
+        /// </summary>
+        protected ILogger Logger { get; }
+
+        /// <summary>
+        /// Gets the <see cref="MvcOptions"/>.
+        /// </summary>
+        protected MvcOptions Options { get; }
+
+        /// <summary>
+        /// Gets the list of <see cref="IOutputFormatter"/> instances from <see cref="MvcOptions"/>.
+        /// </summary>
+        protected FormatterCollection<IOutputFormatter> OptionsFormatters { get; }
+
+        /// <summary>
+        /// Gets the <see cref="IHttpResponseStreamWriterFactory"/>.
+        /// </summary>
+        protected IHttpResponseStreamWriterFactory WriterFactory { get; }
+
+        /// <summary>
+        /// Executes the <see cref="XmlResult"/> and writes the response.
+        /// </summary>
+        /// <param name="context">The <see cref="ActionContext"/>.</param>
+        /// <param name="result">The <see cref="XmlResult"/>.</param>
+        /// <returns>A <see cref="Task"/> which will complete when writing has completed.</returns>
+        public Task ExecuteAsync(ActionContext context, XmlResult result)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (result == null)
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
+            var response = context.HttpContext.Response;
+
+            string resolvedContentType = null;
+            Encoding resolvedContentTypeEncoding = null;
+            ResponseContentTypeHelper.ResolveContentTypeAndEncoding(
+                                                    result.ContentType,
+                                                    response.ContentType,
+                                                    DefaultContentType,
+                                                    out resolvedContentType,
+                                                    out resolvedContentTypeEncoding);
+
+            response.ContentType = resolvedContentType;
+
+            if (result.StatusCode != null)
+            {
+                response.StatusCode = result.StatusCode.Value;
+            }
+
+            var serializerSettings = result.XmlSerializerSettings ?? FormattingUtilities.GetDefaultXmlWriterSettings();
+
+            TextOutputFormatter formatter;
+            // create the proper formatter
+
+            formatter = new XmlSerializerOutputFormatter(serializerSettings);
+
+            var outputFormatterWriterContext = new OutputFormatterWriteContext(
+                                                        context.HttpContext,
+                                                        WriterFactory.CreateWriter,
+                                                        result.Value.GetType(), result.Value);
+
+            outputFormatterWriterContext.ContentType = new StringSegment(resolvedContentType);
+
+            // TODO: Logger.XmlResultExecuting(result.Value);
+            // TODO: get formatter from proper place
+
+            return formatter.WriteAsync(outputFormatterWriterContext);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/XmlResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/XmlResultExecutor.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
     /// <summary>
     /// Executes a <see cref="XmlResult"/> to write to the response.
     /// </summary>
-    public class XmlResultExecutor
+    public class XmlResultExecutor : IXmlResultExecutor
     {
         private static readonly string DefaultContentType = new MediaTypeHeaderValue("application/xml")
         {
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
             }
 
             WriterFactory = writerFactory;
-            Logger = loggerFactory.CreateLogger<XmlResultExecutor>();
+            Logger = loggerFactory.CreateLogger<XmlResult>();
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/XmlResultExecutorBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/XmlResultExecutorBase.cs
@@ -1,0 +1,127 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Buffers;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
+using System.Xml;
+using Microsoft.Extensions.Primitives;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
+{
+    /// <summary>
+    /// Executes a <see cref="XmlResult"/> to write to the response.
+    /// </summary>
+    public class XmlResultExecutorBase : IXmlResultExecutor
+    {
+        private static readonly string DefaultContentType = new MediaTypeHeaderValue("application/xml")
+        {
+            Encoding = Encoding.UTF8
+        }.ToString();
+
+        /// <summary>
+        /// Creates a new <see cref="XmlResultExecutor"/>.
+        /// </summary>
+        /// <param name="writerFactory">The <see cref="IHttpResponseStreamWriterFactory"/>.</param>
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
+        /// <param name="outputFormatter">The <see cref="TextOutputFormatter"/>.</param>
+        public XmlResultExecutorBase(
+            IHttpResponseStreamWriterFactory writerFactory,
+            ILoggerFactory loggerFactory, TextOutputFormatter outputFormatter)
+        {
+            if (writerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(writerFactory));
+            }
+
+            if (outputFormatter == null)
+            {
+                throw new ArgumentNullException(nameof(outputFormatter));
+            }
+
+            if (loggerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            WriterFactory = writerFactory;
+            Logger = loggerFactory.CreateLogger<XmlResult>();
+            OutputFormatter = outputFormatter;
+        }
+
+        TextOutputFormatter OutputFormatter { get; }
+        /// <summary>
+        /// Gets the <see cref="ILogger"/>.
+        /// </summary>
+        protected ILogger Logger { get; }
+
+        /// <summary>
+        /// Gets the <see cref="IHttpResponseStreamWriterFactory"/>.
+        /// </summary>
+        protected IHttpResponseStreamWriterFactory WriterFactory { get; }
+
+        /// <summary>
+        /// Executes the <see cref="XmlResult"/> and writes the response.
+        /// </summary>
+        /// <param name="context">The <see cref="ActionContext"/>.</param>
+        /// <param name="result">The <see cref="XmlResult"/>.</param>
+        /// <returns>A <see cref="Task"/> which will complete when writing has completed.</returns>
+        public Task ExecuteAsync(ActionContext context, XmlResult result)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (result == null)
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
+            var response = context.HttpContext.Response;
+
+            string resolvedContentType = null;
+            Encoding resolvedContentTypeEncoding = null;
+            ResponseContentTypeHelper.ResolveContentTypeAndEncoding(
+                                                    result.ContentType,
+                                                    response.ContentType,
+                                                    DefaultContentType,
+                                                    out resolvedContentType,
+                                                    out resolvedContentTypeEncoding);
+
+            response.ContentType = resolvedContentType;
+
+            if (result.StatusCode != null)
+            {
+                response.StatusCode = result.StatusCode.Value;
+            }
+
+            var serializerSettings = result.XmlSerializerSettings ?? FormattingUtilities.GetDefaultXmlWriterSettings();
+
+           
+
+            var outputFormatterWriterContext = new OutputFormatterWriteContext(
+                                                        context.HttpContext,
+                                                        WriterFactory.CreateWriter,
+                                                        result.Value.GetType(), result.Value);
+
+            outputFormatterWriterContext.ContentType = new StringSegment(resolvedContentType);
+
+            //  Logger formatter and value of object
+
+            Logger.FormatterSelected(OutputFormatter, outputFormatterWriterContext);
+            Logger.XmlResultExecuting(result.Value);
+
+            return OutputFormatter.WriteAsync(outputFormatterWriterContext);
+        }
+
+
+    }
+}
+

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/ModelBinding/Binders/BodyDcXmlModelBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/ModelBinding/Binders/BodyDcXmlModelBinder.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Core;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Internal;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
+{
+    /// <summary>
+    /// An <see cref="IModelBinder"/> which binds models from the request body using an <see cref="IInputFormatter"/>
+    /// when a model has the binding source <see cref="BindingSource.Body"/>.
+    /// </summary>
+    public class BodyDcXmlModelBinder : BodyModelBinder// IModelBinder
+    {
+       
+        /// <summary>
+        /// Creates a new <see cref="BodyXmlModelBinder"/>.
+        /// </summary>
+
+        /// <param name="readerFactory">
+        /// The <see cref="IHttpRequestStreamReaderFactory"/>, used to create <see cref="System.IO.TextReader"/>
+        /// instances for reading the request body.
+        /// </param>
+        public BodyDcXmlModelBinder(IHttpRequestStreamReaderFactory readerFactory) : base(new List<IInputFormatter>() { new XmlDataContractSerializerInputFormatter() }, readerFactory)
+        {
+        }
+
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/ModelBinding/Binders/BodyDcXmlModelBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/ModelBinding/Binders/BodyDcXmlModelBinder.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             IList<IInputFormatter> _formatters = options.Value.InputFormatters;
             var list = new List<IInputFormatter>() { new XmlDataContractSerializerInputFormatter() };
             list.AddRange(_formatters);
-            _bodyModelBinder = new BodyModelBinder(_formatters, readerFactory);
+            _bodyModelBinder = new BodyModelBinder(list, readerFactory);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/ModelBinding/Binders/BodyDcXmlModelBinderOnly.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/ModelBinding/Binders/BodyDcXmlModelBinderOnly.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Core;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Internal;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
+{
+    /// <summary>
+    /// An <see cref="IModelBinder"/> which binds models from the request body using an <see cref="XmlDataContractSerializerInputFormatter"/> only
+    /// when a model has the binding source <see cref="BindingSource.Body"/>.
+    /// </summary>
+    public class BodyDcXmlModelBinderOnly : BodyModelBinder
+    {
+        /// <summary>
+        /// Creates a new <see cref="BodyDcXmlModelBinderOnly"/>.
+        /// </summary>
+        /// <param name="readerFactory">
+        /// The <see cref="IHttpRequestStreamReaderFactory"/>, used to create <see cref="System.IO.TextReader"/>
+        /// instances for reading the request body.
+        /// </param>
+        public BodyDcXmlModelBinderOnly(IHttpRequestStreamReaderFactory readerFactory) : base(new List<IInputFormatter>() { new XmlDataContractSerializerInputFormatter() }, readerFactory)
+        {
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/ModelBinding/Binders/BodyXmlModelBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/ModelBinding/Binders/BodyXmlModelBinder.cs
@@ -1,35 +1,53 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Text;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc.Core;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.Extensions.Options;
+using System;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
 {
     /// <summary>
-    /// An <see cref="IModelBinder"/> which binds models from the request body using an <see cref="IInputFormatter"/>
+    /// An <see cref="IModelBinder"/> which binds models from the request body using an <see cref="XmlSerializerInputFormatter"/>as the first entry in the list of formatters
     /// when a model has the binding source <see cref="BindingSource.Body"/>.
     /// </summary>
-    public class BodyXmlModelBinder : BodyModelBinder// IModelBinder
+    public class BodyXmlModelBinder : IModelBinder
     {
-       
+        BodyModelBinder _bodyModelBinder { get; }
+
         /// <summary>
         /// Creates a new <see cref="BodyXmlModelBinder"/>.
         /// </summary>
-
+        /// <param name="options">The configuration for the MVC framework.</param>
         /// <param name="readerFactory">
         /// The <see cref="IHttpRequestStreamReaderFactory"/>, used to create <see cref="System.IO.TextReader"/>
         /// instances for reading the request body.
         /// </param>
-        public BodyXmlModelBinder(IHttpRequestStreamReaderFactory readerFactory) : base(new List<IInputFormatter>() { new XmlSerializerInputFormatter() }, readerFactory)
+        public BodyXmlModelBinder(IOptions<MvcOptions> options, IHttpRequestStreamReaderFactory readerFactory)
         {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            if (readerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(readerFactory));
+            }
+
+            IList<IInputFormatter> _formatters = options.Value.InputFormatters;
+            var list = new List<IInputFormatter>() { new XmlSerializerInputFormatter() };
+            list.AddRange(_formatters);
+            _bodyModelBinder = new BodyModelBinder(list, readerFactory);
         }
 
+        /// <inheritdoc />
+        public Task BindModelAsync(ModelBindingContext bindingContext)
+        {
+            return _bodyModelBinder.BindModelAsync(bindingContext);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/ModelBinding/Binders/BodyXmlModelBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/ModelBinding/Binders/BodyXmlModelBinder.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Core;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Internal;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
+{
+    /// <summary>
+    /// An <see cref="IModelBinder"/> which binds models from the request body using an <see cref="IInputFormatter"/>
+    /// when a model has the binding source <see cref="BindingSource.Body"/>.
+    /// </summary>
+    public class BodyXmlModelBinder : BodyModelBinder// IModelBinder
+    {
+       
+        /// <summary>
+        /// Creates a new <see cref="BodyXmlModelBinder"/>.
+        /// </summary>
+
+        /// <param name="readerFactory">
+        /// The <see cref="IHttpRequestStreamReaderFactory"/>, used to create <see cref="System.IO.TextReader"/>
+        /// instances for reading the request body.
+        /// </param>
+        public BodyXmlModelBinder(IHttpRequestStreamReaderFactory readerFactory) : base(new List<IInputFormatter>() { new XmlSerializerInputFormatter() }, readerFactory)
+        {
+        }
+
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/ModelBinding/Binders/BodyXmlModelBinderOnly.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/ModelBinding/Binders/BodyXmlModelBinderOnly.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Core;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Internal;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
+{
+    /// <summary>
+    /// An <see cref="IModelBinder"/> which binds models from the request body using an <see cref="XmlSerializerInputFormatter"/> only
+    /// when a model has the binding source <see cref="BindingSource.Body"/>.
+    /// </summary>
+    public class BodyXmlModelBinderOnly : BodyModelBinder
+    {
+        /// <summary>
+        /// Creates a new <see cref="BodyXmlModelBinderOnly"/>.
+        /// </summary>
+        /// <param name="readerFactory">
+        /// The <see cref="IHttpRequestStreamReaderFactory"/>, used to create <see cref="System.IO.TextReader"/>
+        /// instances for reading the request body.
+        /// </param>
+        public BodyXmlModelBinderOnly(IHttpRequestStreamReaderFactory readerFactory) : base(new List<IInputFormatter>() { new XmlSerializerInputFormatter() }, readerFactory)
+        {
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Properties/Resources.Designer.cs
@@ -58,6 +58,14 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             return string.Format(CultureInfo.CurrentCulture, GetString("WrapperProvider_MismatchType"), p0, p1);
         }
 
+        /// <summary>
+        ///   The XML formatter {0} was not added MVC, use proper  AddXml...Formatters() extension..
+        /// </summary>
+        public static string XmlFromater_WasNotSetup_To_Mvc(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("XmlFromater_WasNotSetup_To_Mvc"), p0);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Resources.resx
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Resources.resx
@@ -126,4 +126,7 @@
   <data name="WrapperProvider_MismatchType" xml:space="preserve">
     <value>The object to be wrapped must be of type '{0}' but was of type '{1}'.</value>
   </data>
+  <data name="XmlFromater_WasNotSetup_To_Mvc" xml:space="preserve">
+    <value>XML formatter {0} was not added MVC, use proper  AddXml...Formatters() extension.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/XmlResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/XmlResult.cs
@@ -1,0 +1,100 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Serialization;
+using Microsoft.AspNetCore.Mvc.Formatters.Xml;
+using Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Mvc.Formatters;
+
+namespace Microsoft.AspNetCore.Mvc
+{
+    /// <summary>
+    /// An action result which formats the given object as XML.
+    /// </summary>
+    public class XmlResult : ActionResult
+    {
+        /// <summary>
+        /// Creates a new <see cref="XmlResult"/> with the given <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to format as xml.</param>
+        public XmlResult(object value)
+        {
+            Value = value;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="XmlResult"/> with the given <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to format as XML.</param>
+        /// <param name="serializerSettings">The <see cref="XmlWriterSettings"/> to be used by
+        /// the formatter.</param>
+        public XmlResult(object value, XmlWriterSettings serializerSettings)
+        {
+            if (serializerSettings == null)
+            {
+                throw new ArgumentNullException(nameof(serializerSettings));
+            }
+
+            Value = value;
+            XmlSerializerSettings = serializerSettings;
+        }
+
+        //TODO: have a look at an idea of using
+        public FormatterCollection<IOutputFormatter> Formatters { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of used xml serializer.
+        /// </summary>
+        public bool UseDataContractSerializer { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Net.Http.Headers.MediaTypeHeaderValue"/> representing the Content-Type header of the response.
+        /// </summary>
+        public string ContentType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="XmlWriterSettings"/>.
+        /// </summary>
+        public XmlWriterSettings XmlSerializerSettings { get; set; }
+
+        /// <summary>
+        /// Gets or sets the HTTP status code.
+        /// </summary>
+        public int? StatusCode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value to be formatted.
+        /// </summary>
+        public object Value { get; set; }
+
+        /// <inheritdoc />
+        public override Task ExecuteResultAsync(ActionContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            var services = context.HttpContext.RequestServices;
+            if (UseDataContractSerializer)
+            {
+                var dcExecutor = services.GetRequiredService<XmlDcResultExecutor>();
+                if (dcExecutor == null)
+                {
+                    throw new ArgumentNullException(nameof(XmlDcResultExecutor));
+                }
+                return dcExecutor.ExecuteAsync(context, this);
+            }
+            var executor = services.GetRequiredService<XmlResultExecutor>();
+            if (executor == null)
+            {
+                throw new ArgumentNullException(nameof(XmlResultExecutor));
+            }
+            return executor.ExecuteAsync(context, this);
+        }
+
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/XmlResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/XmlResult.cs
@@ -21,6 +21,7 @@ namespace Microsoft.AspNetCore.Mvc
     {
         /// <summary>
         /// Creates a new <see cref="XmlResult"/> with the given <paramref name="value"/>.
+        /// Requires the XML DataContractSerializer formatters or/and the XML Serializer formatters to be add to MVC.
         /// </summary>
         /// <param name="value">The value to format as xml.</param>
         public XmlResult(object value)
@@ -30,6 +31,7 @@ namespace Microsoft.AspNetCore.Mvc
 
         /// <summary>
         /// Creates a new <see cref="XmlResult"/> with the given <paramref name="value"/>.
+        /// Requires the XML DataContractSerializer formatters or/and the XML Serializer formatters to be add to MVC.
         /// </summary>
         /// <param name="value">The value to format as XML.</param>
         /// <param name="serializerSettings">The <see cref="XmlWriterSettings"/> to be used by

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/XmlSerializerType.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/XmlSerializerType.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc
+{
+    /// <summary>
+    /// Defines the type selector of the serializer
+    /// </summary>
+    public enum XmlSerializerType
+    {
+        XmlSeriralizer,
+        DataContractSerializer
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/FromBodyXmlAttributeTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/FromBodyXmlAttributeTest.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+using System;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
+{
+    public class FromBodyXmlAttributeTest
+    {
+        [Theory]
+        [InlineData(XmlSerializerType.XmlSeriralizer, false,typeof(BodyXmlModelBinder))]
+        [InlineData(XmlSerializerType.XmlSeriralizer, true,typeof(BodyXmlModelBinderOnly))]
+        [InlineData(XmlSerializerType.DataContractSerializer, false, typeof(BodyDcXmlModelBinder))]
+        [InlineData(XmlSerializerType.DataContractSerializer, true, typeof(BodyDcXmlModelBinderOnly))]
+        public void Create_FromBodyXmlAttribute(XmlSerializerType xmlSerializerType, bool useXmlBinderOnly,Type expectedType)
+        {
+            // Act
+            var att = new FromBodyXmlAttribute()
+            {
+                XmlSerializerType = xmlSerializerType,
+                UseXmlBinderOnly = useXmlBinderOnly
+            };
+            //Assert
+
+            Assert.Equal(expectedType, att.BinderType);
+            Assert.Equal(BindingSource.Body, att.BindingSource);
+
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/Internal/XmlExecutorResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/Internal/XmlExecutorResultTest.cs
@@ -1,0 +1,134 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Buffers;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Testing;
+using Xunit;
+using Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Mvc.Formatters.Xml.Test.Models;
+using System.Xml;
+using System.Runtime.Serialization;
+using System.Xml.Serialization;
+
+namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
+{
+    public class XmlExecutorResultTest
+    {
+        [Fact]
+        public async Task ExecuteAsync_XmlExecutorContent()
+        {
+            // Arrange
+            var value = new PurchaseOrder();
+            var xmlWriterSettings = FormattingUtilities.GetDefaultXmlWriterSettings();
+            xmlWriterSettings.CloseOutput = false;
+            var textw = new StringWriter();
+            var writer = XmlWriter.Create(textw, xmlWriterSettings);
+            var xmlSerializer = new XmlSerializer(value.GetType());
+            xmlSerializer.Serialize(writer, value);
+            var expected = Encoding.UTF8.GetBytes(textw.ToString());
+            var context = GetActionContext();
+            CreateServices(context.HttpContext);
+
+            var services = context.HttpContext.RequestServices;
+            IXmlResultExecutor executor = null;
+            executor = services.GetService<XmlResultExecutor>();
+            var result = new XmlResult(value);
+
+            // Act
+            await executor.ExecuteAsync(context,result);
+
+            // Assert
+            var written = GetWrittenBytes(context.HttpContext);
+
+            var s1 = Encoding.UTF8.GetString(expected);
+            var s2 = Encoding.UTF8.GetString(written);
+
+            Assert.Equal(expected, written);
+            Assert.Equal(s1, s2);
+            Assert.Equal("application/xml; charset=utf-8", context.HttpContext.Response.ContentType);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_XmlExecutorDataContractContent()
+        {
+            // Arrange
+            var value = new PurchaseOrder();
+            var context = GetActionContext();
+            CreateServices(context.HttpContext);
+
+            //
+            var result = new XmlResult(value) { XmlSerializerType = XmlSerializerType.DataContractSerializer };
+            var services = context.HttpContext.RequestServices;
+            IXmlResultExecutor executor = null;
+            executor = services.GetService<XmlDcResultExecutor>();
+
+            // Act
+            await executor.ExecuteAsync(context, result);
+
+            // Assert
+            Assert.Equal("application/xml; charset=utf-8", context.HttpContext.Response.ContentType);
+
+            // Verify to as the new restored object 
+            //There may be differ DataContract style has been used
+            var written = GetWrittenBytes(context.HttpContext);
+            var sWritten = Encoding.UTF8.GetString(written);
+
+            StringReader sreader = new StringReader(sWritten);
+            DataContractSerializer ser = new DataContractSerializer(typeof(PurchaseOrder));
+            PurchaseOrder newValue = (PurchaseOrder)ser.ReadObject(XmlReader.Create(sreader));
+
+            Assert.Equal(value.billTo.street, newValue.billTo.street);
+            Assert.Equal(value.shipTo.street, newValue.shipTo.street);
+        }
+
+
+        private static HttpContext CreateServices(HttpContext httpContext, bool empty = false)
+        {
+            IHttpResponseStreamWriterFactory writerFactory = new TestHttpResponseStreamWriterFactory();
+            ILoggerFactory loggerFactory = NullLoggerFactory.Instance;
+
+            var services = new ServiceCollection();
+
+            services.AddSingleton(writerFactory);
+            services.AddSingleton(loggerFactory);
+
+            if (!empty)
+            {
+                var executorXml = new XmlResultExecutor(writerFactory, loggerFactory);
+                var executorDcXml = new XmlDcResultExecutor(writerFactory, loggerFactory);
+                services.AddSingleton(executorXml);
+                services.AddSingleton(executorDcXml);
+            }
+            httpContext.RequestServices = services.BuildServiceProvider();
+            return httpContext;
+        }
+
+        private static HttpContext GetHttpContext()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Response.Body = new MemoryStream();
+            return httpContext;
+        }
+
+
+        private static ActionContext GetActionContext()
+        {
+            return new ActionContext(GetHttpContext(), new RouteData(), new ActionDescriptor());
+        }
+
+        private static byte[] GetWrittenBytes(HttpContext context)
+        {
+            context.Response.Body.Seek(0, SeekOrigin.Begin);
+            return Assert.IsType<MemoryStream>(context.Response.Body).ToArray();
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/Models/Binders/BodyXmlModelBindersTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/Models/Binders/BodyXmlModelBindersTest.cs
@@ -1,0 +1,195 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Buffers;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Testing;
+using Xunit;
+using Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Mvc.Formatters.Xml.Test.Models;
+using System.Xml;
+using System.Runtime.Serialization;
+using System.Xml.Serialization;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Http.Internal;
+using System.Globalization;
+using Microsoft.Extensions.Primitives;
+using System;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Test.Models.Binders
+{
+    public class BodyXmlModelBindersTest
+    {
+        [Fact]
+        public void BindTheXmlToTheValue()
+        {
+
+            var att = new FromBodyXmlAttribute()
+            {
+                XmlSerializerType = XmlSerializerType.XmlSeriralizer,
+                UseXmlBinderOnly = false
+            };
+            var attList = new List<object>() { att };
+            var bindingInfo = BindingInfo.GetBindingInfo(attList);
+
+            var parameterDescriptor = new ParameterDescriptor
+            {
+                Name = "value",
+                ParameterType = typeof(PurchaseOrder),
+                BindingInfo = bindingInfo
+            };
+
+            var actionDescriptor = new ActionDescriptor()
+            {
+                Parameters = new List<ParameterDescriptor>() { parameterDescriptor }
+            };
+
+            var actionContext = GetActionContext(actionDescriptor);
+            //TODO: Add service 
+            ServiceCollection services = CreateServices();
+
+
+            var servicesProvider = services.BuildServiceProvider();
+            actionContext.HttpContext.RequestServices = servicesProvider;
+
+            var metadataProvider = new TestModelMetadataProvider();
+
+            metadataProvider.ForType(parameterDescriptor.ParameterType).BindingDetails
+                (
+                (b) =>
+                    {
+                        b.BindingSource = BindingSource.Body;
+                        b.BinderType = att.BinderType;
+                    }
+            );
+
+            ModelMetadata parameterModelMetadata = metadataProvider.GetMetadataForType(parameterDescriptor.ParameterType);
+
+            var original = CreateDefaultValueProvider();
+
+            //*1
+            ModelBindingContext modelBindingContext = DefaultModelBindingContext.CreateBindingContext(
+            actionContext,
+            original,
+            parameterModelMetadata,
+            parameterDescriptor.BindingInfo,
+            "model");
+
+            //*2
+            ModelBinderProviderContext modelBinderProviderContext = new TestModelBinderProviderContext(parameterModelMetadata, parameterDescriptor.BindingInfo, metadataProvider);
+
+            BinderTypeModelBinderProvider binderTypeModelBinderProvider = new BinderTypeModelBinderProvider();
+            
+           var binderforType =  binderTypeModelBinderProvider.GetBinder(modelBinderProviderContext);
+
+        }
+
+        private static CompositeValueProvider CreateDefaultValueProvider()
+        {
+            var result = new CompositeValueProvider();
+            result.Add(new RouteValueProvider(BindingSource.Path, new RouteValueDictionary()));
+            result.Add(new QueryStringValueProvider(
+                BindingSource.Query,
+                new QueryCollection(),
+                CultureInfo.InvariantCulture));
+            result.Add(new FormValueProvider(
+                BindingSource.Form,
+                new FormCollection(new Dictionary<string, StringValues>()),
+                CultureInfo.CurrentCulture));
+            return result;
+        }
+
+        private static ServiceCollection CreateServices()
+        {
+            IHttpResponseStreamWriterFactory writerFactory = new TestHttpResponseStreamWriterFactory();
+            ILoggerFactory loggerFactory = NullLoggerFactory.Instance;
+            var services = new ServiceCollection();
+
+            services.AddOptions();
+
+            services.AddSingleton(writerFactory);
+            services.AddSingleton(loggerFactory);
+
+            services.TryAddTransient<BodyDcXmlModelBinder>();
+            services.TryAddTransient<BodyDcXmlModelBinderOnly>();
+
+            services.TryAddTransient<BodyXmlModelBinder>();
+            services.TryAddTransient<BodyXmlModelBinderOnly>();
+                        
+            return services;
+        }
+
+        private static HttpContext GetHttpContext()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Response.Body = new MemoryStream();
+            return httpContext;
+        }
+
+
+        private static ActionContext GetActionContext(ActionDescriptor actionDescriptor)
+        {
+            return new ActionContext(GetHttpContext(), new RouteData(), actionDescriptor);
+        }
+
+        private static byte[] GetWrittenBytes(HttpContext context)
+        {
+            context.Response.Body.Seek(0, SeekOrigin.Begin);
+            return Assert.IsType<MemoryStream>(context.Response.Body).ToArray();
+        }
+    }
+
+    internal class TestModelBinderProviderContext : ModelBinderProviderContext
+    {
+        private BindingInfo bindingInfo;
+        private ModelMetadata parameterModelMetadata;
+        private IModelMetadataProvider modelMetadataProvider;
+
+        public TestModelBinderProviderContext(ModelMetadata parameterModelMetadata, BindingInfo bindingInfo, IModelMetadataProvider modelMetadataProvider)
+        {
+            this.parameterModelMetadata = parameterModelMetadata;
+            this.bindingInfo = bindingInfo;
+            this.modelMetadataProvider = modelMetadataProvider;
+        }
+
+        public override BindingInfo BindingInfo
+        {
+            get
+            {
+                return bindingInfo;
+            }
+        }
+
+        public override ModelMetadata Metadata
+        {
+            get
+            {
+                return parameterModelMetadata;
+            }
+        }
+
+        public override IModelMetadataProvider MetadataProvider
+        {
+            get
+            {
+                return modelMetadataProvider;
+            }
+        }
+
+        public override IModelBinder CreateBinder(ModelMetadata metadata)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/Models/PurchaseOrder.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/Models/PurchaseOrder.cs
@@ -1,0 +1,27 @@
+﻿using System.Runtime.Serialization;
+
+namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Test.Models
+{
+
+    [DataContract(Namespace = "http://puchase.Interface.org/Purchase.Order")]
+    public class PurchaseOrder
+    {
+        public PurchaseOrder()
+        {
+            billTo = new Address() { street = "Bill to Address" };
+            shipTo = new Address() { street = "Ship to  Address" };
+        }
+        [DataMember]
+        public Address billTo;
+        [DataMember]
+        public Address shipTo;
+    }
+
+    [DataContract(Namespace = "http://puchase.Interface.org/Purchase.Order.Address")]
+    public class Address
+    {
+        [DataMember]
+        public string street;
+    }
+
+}

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlResultTest.cs
@@ -1,0 +1,169 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Buffers;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Testing;
+using Xunit;
+using Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Mvc.Formatters.Xml.Test.Models;
+using System.Xml;
+using System.Runtime.Serialization;
+using System.Xml.Serialization;
+
+namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
+{
+    public class XmlResultTest
+    {
+        [Fact]
+        public async Task ExecuteAsync_WritesXmlContent()
+        {
+            // Arrange
+            var value = new PurchaseOrder();
+            var xmlWriterSettings = FormattingUtilities.GetDefaultXmlWriterSettings();
+            xmlWriterSettings.CloseOutput = false;
+            var textw = new StringWriter();
+            var writer = XmlWriter.Create(textw, xmlWriterSettings);
+            var xmlSerializer = new XmlSerializer(value.GetType());
+            xmlSerializer.Serialize(writer, value);
+            var expected = Encoding.UTF8.GetBytes(textw.ToString());
+            var context = GetActionContext();
+            CreateServices(context.HttpContext);
+
+            //
+            var result = new XmlResult(value);
+
+            // Act
+            await result.ExecuteResultAsync(context);
+
+            // Assert
+            var written = GetWrittenBytes(context.HttpContext);
+
+            var s1 = Encoding.UTF8.GetString(expected);
+            var s2 = Encoding.UTF8.GetString(written);
+
+            Assert.Equal(expected, written);
+            Assert.Equal(s1, s2);
+            Assert.Equal("application/xml; charset=utf-8", context.HttpContext.Response.ContentType);
+        }
+        [Fact]
+        public async Task ExecuteAsync_WritesXmlContent_Negative()
+        {
+            // Arrange
+            var value = new PurchaseOrder();
+            var xmlWriterSettings = FormattingUtilities.GetDefaultXmlWriterSettings();
+            xmlWriterSettings.CloseOutput = false;
+            var textw = new StringWriter();
+            var writer = XmlWriter.Create(textw, xmlWriterSettings);
+            var xmlSerializer = new XmlSerializer(value.GetType());
+            xmlSerializer.Serialize(writer, value);
+            var expected = Encoding.UTF8.GetBytes(textw.ToString());
+            var context = GetActionContext();
+            CreateServices(context.HttpContext, true);
+
+            //
+            var result = new XmlResult(value);
+
+            // Act
+            await result.ExecuteResultAsync(context);
+
+            // Assert
+            Assert.Equal(context.HttpContext.Response.StatusCode, StatusCodes.Status406NotAcceptable);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WritesXmlDataContractContent()
+        {
+            // Arrange
+            var value = new PurchaseOrder();
+            var context = GetActionContext();
+            CreateServices(context.HttpContext);
+
+            //
+            var result = new XmlResult(value) { XmlSerializerType = XmlSerializerType.DataContractSerializer };
+
+            // Act
+            await result.ExecuteResultAsync(context);
+
+            // Assert
+            Assert.Equal("application/xml; charset=utf-8", context.HttpContext.Response.ContentType);
+
+            // Verify to as the new restored object 
+            //There may be differ DataContract style has been used
+            var written = GetWrittenBytes(context.HttpContext);
+            var sWritten = Encoding.UTF8.GetString(written);
+
+            StringReader sreader = new StringReader(sWritten);
+            DataContractSerializer ser = new DataContractSerializer(typeof(PurchaseOrder));
+            PurchaseOrder newValue = (PurchaseOrder)ser.ReadObject(XmlReader.Create(sreader));
+
+            Assert.Equal(value.billTo.street, newValue.billTo.street);
+            Assert.Equal(value.shipTo.street, newValue.shipTo.street);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WritesXmlDataContractContent_Negative()
+        {
+            // Arrange
+            var value = new PurchaseOrder();
+            var context = GetActionContext();
+            CreateServices(context.HttpContext,true);
+
+            //
+            var result = new XmlResult(value) { XmlSerializerType = XmlSerializerType.DataContractSerializer };
+
+            // Act
+            await result.ExecuteResultAsync(context);
+
+            Assert.Equal(context.HttpContext.Response.StatusCode, StatusCodes.Status406NotAcceptable);
+        }
+
+        private static HttpContext CreateServices(HttpContext httpContext, bool empty = false)
+        {
+            IHttpResponseStreamWriterFactory writerFactory = new TestHttpResponseStreamWriterFactory();
+            ILoggerFactory loggerFactory = NullLoggerFactory.Instance;
+
+            var services = new ServiceCollection();
+
+            services.AddSingleton(writerFactory);
+            services.AddSingleton(loggerFactory);
+
+            if (!empty)
+            {
+                var executorXml = new XmlResultExecutor(writerFactory, loggerFactory);
+                var executorDcXml = new XmlDcResultExecutor(writerFactory, loggerFactory);
+                services.AddSingleton(executorXml);
+                services.AddSingleton(executorDcXml);
+            }
+            httpContext.RequestServices = services.BuildServiceProvider();
+            return httpContext;
+        }
+
+        private static HttpContext GetHttpContext()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Response.Body = new MemoryStream();
+            return httpContext;
+        }
+
+
+        private static ActionContext GetActionContext()
+        {
+            return new ActionContext(GetHttpContext(), new RouteData(), new ActionDescriptor());
+        }
+
+        private static byte[] GetWrittenBytes(HttpContext context)
+        {
+            context.Response.Body.Seek(0, SeekOrigin.Begin);
+            return Assert.IsType<MemoryStream>(context.Response.Body).ToArray();
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/project.json
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/project.json
@@ -12,7 +12,9 @@
       "type": "build",
       "version": "1.0.0-*"
     },
-    "Microsoft.AspNetCore.Testing": "1.0.0-rtm-21431"
+
+    "Microsoft.AspNetCore.Testing": "1.0.0-rtm-21431",
+    "Microsoft.Extensions.Logging.Testing": "1.0.0-rtm-21431",
   },
   "testRunner": "xunit",
   "frameworks": {


### PR DESCRIPTION
###Reasons for adding these features into the aspnet/MVC project:

1. When ASP.NET CORE is using as the base for development for Web REST API there is no controllable by code flexibility to have deal with flat XML and DataContract XML.
2. Without work around, Indeed, it is possible to use only one type of XML formatters per application.
3.  Currently used ObjectResult cannot provide the compulsory return XML or DataContract XML as an action result. 
4. The order of applying:  
		services.AddMvc().AddXmlDataContractSerializerFormatters().AddXmlSerializerFormatters();
	and   
		services.AddMvc().AddXmlSerializerFormatters().AddXmlDataContractSerializerFormatters();
	affects on using the type of xml formatters for Content Type : "application/xml"

To improve the quality and flexibility  XML based Web REST API were developed the following features:

### "XmlResult" feature:
\Mvc\src\Microsoft.AspNetCore.Mvc.Formatters.Xml\XmlResult.cs (new)
\Mvc\src\Microsoft.AspNetCore.Mvc.Formatters.Xml\Internal\XmlDcResultExecutor.cs (new)
\Mvc\src\Microsoft.AspNetCore.Mvc.Formatters.Xml\Internal\XmlResultExecutor.cs (new)
\Mvc\src\Microsoft.AspNetCore.Mvc.Formatters.Xml\Internal\XmlResultExecutorBase.cs (new)
\Mvc\test\Microsoft.AspNetCore.Mvc.Formatters.Xml.Test\XmlResultTest.cs(new)
\Mvc\test\Microsoft.AspNetCore.Mvc.Formatters.Xml.Test\Models\PurchaseOrder.cs(new, shared)

\Mvc\src\Microsoft.AspNetCore.Mvc.Formatters.Xml\DependencyInjection\MvcXmlMvcBuilderExtensions.cs(changes, shared)
\Mvc\src\Microsoft.AspNetCore.Mvc.Formatters.Xml\DependencyInjection\MvcXmlMvcCoreBuilderExtensions.cs(changes, shared)

### Description:
1. The XmlResult is the similar feature to JsonResult in project "Microsoft.AspNetCore.Mvc.Formatters.Json".
2. It allows to return Xml formatted response in the body, as Action result.
3. This feature improve the  consistence of the type XML used formatter.
4. XmlResult allows to return XML serialized object with using ether "DataContractSerializer" ether "XmlSerializer". It allows to satisfy all REST communication scenarios from JAVA  to .NET.

### Example of using in the application:

Startup.cs
```
public void ConfigureServices(IServiceCollection services)
        {
            // Add framework services.
            services.AddMvc().AddXmlDataContractSerializerFormatters().AddXmlSerializerFormatters();
        }

Controller: 

   ```
    // GET api/[controller]/xml
        [HttpGet("xml")]
        public ActionResult GetXmlObject()
        {
            object obj = new PurchaseOrder();
            return new XmlResult(obj);
        }

        // GET api/[controller]/dcxml
        [HttpGet("dcxml")]
        public ActionResult GetDcXmlObject()
        {
            object obj = new PurchaseOrder();
            return new XmlResult(obj) { XmlSerializerType = XmlSerializerType.DataContractSerializer };
        }




### "FromBodyXmlAttribute" feature:

\Mvc\src\Microsoft.AspNetCore.Mvc.Formatters.Xml\FromBodyXmlAttribute.cs(new)
\Mvc\src\Microsoft.AspNetCore.Mvc.Formatters.Xml\ModelBinding\Binders\BodyXmlModelBinder.cs(new)
\Mvc\src\Microsoft.AspNetCore.Mvc.Formatters.Xml\ModelBinding\Binders\BodyXmlModelBinderOnly.cs(new)
\Mvc\src\Microsoft.AspNetCore.Mvc.Formatters.Xml\ModelBinding\Binders\BodyDcXmlModelBinder.cs(new)
\Mvc\src\Microsoft.AspNetCore.Mvc.Formatters.Xml\ModelBinding\Binders\BodyDcXmlModelBinderOnly.cs(new)
\Mvc\test\Microsoft.AspNetCore.Mvc.Formatters.Xml.Test\Models\Binders\BodyXmlModelBindersTest.cs(new)
\Mvc\test\Microsoft.AspNetCore.Mvc.Formatters.Xml.Test\Models\PurchaseOrder.cs(new, shared)

\Mvc\src\Microsoft.AspNetCore.Mvc.Formatters.Xml\DependencyInjection\MvcXmlMvcBuilderExtensions.cs(changes, shared)
\Mvc\src\Microsoft.AspNetCore.Mvc.Formatters.Xml\DependencyInjection\MvcXmlMvcCoreBuilderExtensions.cs(changes, shared)

### Description:
FromBodyXmlAttribute forces try to get  XML serialized object from the http request body with using ether "DataContractSerializer" or "XmlSerializer".

### Example of using in the application:

Startup.cs

```
public void ConfigureServices(IServiceCollection services)
        {
            // Add framework services.
            services.AddMvc().AddXmlDataContractSerializerFormatters().AddXmlSerializerFormatters();
        }

```

Controller: 

    ```
    // POST api/[controller]/xml
        [HttpPost("xml")]
        public void PostXml([FromBodyXml]PurchaseOrder value)
        {
            var x = value;
            x.billTo.street += " 123";
        }

        // POST api/[controller]/dcxml
        [HttpPost("dcxml")]
        public void PostDcXml([FromBodyXml(XmlSerializerType = XmlSerializerType.DataContractSerializer)]PurchaseOrder value)
        {
            var x = value;
            x.billTo.street += "No -10";
       }




Where:

 ```
   [DataContract (Namespace ="http://puchase.Interface.org/Purchase.Order")]
    public class PurchaseOrder
    {
        public PurchaseOrder()
        {
            billTo = new Address() { street = "Bill to Address" };
            shipTo = new Address() { street = "Ship to  Address" };
        }
        [DataMember]
        public Address billTo;
        [DataMember]
        public Address shipTo;
    }


    [DataContract(Namespace = "http://puchase.Interface.org/Purchase.Order.Address")]
    public class Address
    {
        [DataMember]
        public string street;
    }



