### PR TITLE
Dynamic assembly checks to prevent NotSupprotedExceptions from System…

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/ApplicationParts/AssemblyPart.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ApplicationParts/AssemblyPart.cs
@@ -47,17 +47,22 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationParts
         /// <inheritdoc />
         public IEnumerable<string> GetReferencePaths()
         {
-            var dependencyContext = DependencyContext.Load(Assembly);
-            if (dependencyContext != null)
+            if (!Assembly.IsDynamic)
             {
-                return dependencyContext.CompileLibraries.SelectMany(library => library.ResolveReferencePaths());
+                var dependencyContext = DependencyContext.Load(Assembly);
+                if (dependencyContext != null)
+                {
+                    return dependencyContext.CompileLibraries.SelectMany(library => library.ResolveReferencePaths());
+                }
+
+                // If an application has been compiled without preserveCompilationContext, return the path to the assembly
+                // as a reference. For runtime compilation, this will allow the compilation to succeed as long as it least
+                // one application part has been compiled with preserveCompilationContext and contains a super set of types
+                // required for the compilation to succeed.
+                return new[] { Assembly.Location };
             }
 
-            // If an application has been compiled without preserveCompilationContext, return the path to the assembly
-            // as a reference. For runtime compilation, this will allow the compilation to succeed as long as it least
-            // one application part has been compiled with preserveCompilationContext and contains a super set of types
-            // required for the compilation to succeed.
-            return new[] { Assembly.Location };
+            return Enumerable.Empty<string>();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ApplicationParts/AssemblyPart.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ApplicationParts/AssemblyPart.cs
@@ -49,20 +49,22 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationParts
         {
             if (!Assembly.IsDynamic)
             {
-                var dependencyContext = DependencyContext.Load(Assembly);
-                if (dependencyContext != null)
-                {
-                    return dependencyContext.CompileLibraries.SelectMany(library => library.ResolveReferencePaths());
-                }
-
-                // If an application has been compiled without preserveCompilationContext, return the path to the assembly
-                // as a reference. For runtime compilation, this will allow the compilation to succeed as long as it least
-                // one application part has been compiled with preserveCompilationContext and contains a super set of types
-                // required for the compilation to succeed.
-                return new[] { Assembly.Location };
+                // Skip loading process for dynamic assemblies. This prevents DependencyContextLoader from reading the
+                // .deps.json file from either manifest resources or the assembly location, which will fail.
+                return Enumerable.Empty<string>();
             }
 
-            return Enumerable.Empty<string>();
+            var dependencyContext = DependencyContext.Load(Assembly);
+            if (dependencyContext != null)
+            {
+                return dependencyContext.CompileLibraries.SelectMany(library => library.ResolveReferencePaths());
+            }
+
+            // If an application has been compiled without preserveCompilationContext, return the path to the assembly
+            // as a reference. For runtime compilation, this will allow the compilation to succeed as long as it least
+            // one application part has been compiled with preserveCompilationContext and contains a super set of types
+            // required for the compilation to succeed.
+            return new[] { Assembly.Location };
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ApplicationParts/AssemblyPart.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ApplicationParts/AssemblyPart.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationParts
         /// <inheritdoc />
         public IEnumerable<string> GetReferencePaths()
         {
-            if (!Assembly.IsDynamic)
+            if (Assembly.IsDynamic)
             {
                 // Skip loading process for dynamic assemblies. This prevents DependencyContextLoader from reading the
                 // .deps.json file from either manifest resources or the assembly location, which will fail.

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Compilation/ViewsFeatureProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Compilation/ViewsFeatureProvider.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
         protected virtual Type GetViewInfoContainerType(AssemblyPart assemblyPart)
         {
 #if NETSTANDARD1_6
-            if (assemblyPart.Assembly.Location != null)
+            if (!assemblyPart.Assembly.IsDynamic && assemblyPart.Assembly.Location != null)
             {
                 var precompiledAssemblyFileName = assemblyPart.Assembly.GetName().Name
                     + PrecompiledViewsAssemblySuffix

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ApplicationParts/AssemblyPartTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ApplicationParts/AssemblyPartTest.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Emit;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.ApplicationParts
@@ -80,6 +82,24 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationParts
             // Assert
             var actual = Assert.Single(references);
             Assert.Equal(assembly.Location, actual);
+        }
+
+        [Fact]
+        public void GetReferencePaths_ReturnsEmptySequenceForDynamicAssembly()
+        {
+            // Arrange
+            var name = new AssemblyName($"DynamicAssembly-{Guid.NewGuid()}");
+            var builder = AssemblyBuilder.DefineDynamicAssembly(name,
+                AssemblyBuilderAccess.RunAndCollect);
+            var module = builder.DefineDynamicModule("Main");
+
+            var part = new AssemblyPart(builder);
+
+            // Act
+            var references = part.GetReferencePaths().ToList();
+
+            // Assert
+            Assert.Empty(references);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ApplicationParts/AssemblyPartTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ApplicationParts/AssemblyPartTest.cs
@@ -89,11 +89,10 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationParts
         {
             // Arrange
             var name = new AssemblyName($"DynamicAssembly-{Guid.NewGuid()}");
-            var builder = AssemblyBuilder.DefineDynamicAssembly(name,
+            var assembly = AssemblyBuilder.DefineDynamicAssembly(name,
                 AssemblyBuilderAccess.RunAndCollect);
-            var module = builder.DefineDynamicModule("Main");
 
-            var part = new AssemblyPart(builder);
+            var part = new AssemblyPart(assembly);
 
             // Act
             var references = part.GetReferencePaths().ToList();

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Compilation/ViewsFeatureProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Compilation/ViewsFeatureProviderTest.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Xunit;
+using System.Reflection.Emit;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
 {
@@ -69,6 +70,24 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
                 });
         }
 
+        [Fact]
+        public void GetViewInfoContainerType_ReturnsNullForEmptyDynamicAssembly()
+        {
+            // Arrange
+            var name = new AssemblyName($"DynamicAssembly-{Guid.NewGuid()}");
+            var builder = AssemblyBuilder.DefineDynamicAssembly(name,
+                AssemblyBuilderAccess.RunAndCollect);
+            var module = builder.DefineDynamicModule("Main");
+
+            var provider = new TestableViewsFeatureProvider2();
+
+            // Act
+            var type = provider.TestGetViewInfoContainerType(new AssemblyPart(builder));
+
+            // Assert
+            Assert.Null(type);
+        }
+
         private class TestableViewsFeatureProvider : ViewsFeatureProvider
         {
             private readonly Dictionary<AssemblyPart, Type> _containerLookup;
@@ -80,6 +99,14 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
 
             protected override Type GetViewInfoContainerType(AssemblyPart assemblyPart) =>
                 _containerLookup[assemblyPart];
+        }
+
+        private class TestableViewsFeatureProvider2 : ViewsFeatureProvider
+        {
+
+            public Type TestGetViewInfoContainerType(AssemblyPart assemblyPart) =>
+                GetViewInfoContainerType(assemblyPart);
+
         }
 
         private class ViewInfoContainer1 : ViewInfoContainer


### PR DESCRIPTION
Summary of the changes
- Added `Assembly.IsDynamic` checks to prevent `NotSupportedException` from throwing when using dynamically created controller types.
- Affects
  - `System.Reflection.Emit.AssemblyBuilder.Location`
  - `Microsoft.Extensions.DependencyModel.DependencyContext.Load`

Addresses #5487

Tested with example project: [gist](https://gist.github.com/mdschweda/ad0f962aaa5c9dd66a125b755130608b)