### PR TITLE
Fixes CookieTempDataProvider to set the secure attribute of a cookie …

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/CookieTempDataProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/CookieTempDataProvider.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 Path = string.IsNullOrEmpty(_options.Value.Path) ? GetPathBase(context) : _options.Value.Path,
                 Domain = string.IsNullOrEmpty(_options.Value.Domain) ? null : _options.Value.Domain,
                 HttpOnly = true,
-                Secure = true
+                Secure = context.Request.IsHttps,
             };
 
             var hasValues = (values != null && values.Count > 0);


### PR DESCRIPTION
…only if a request is secure

@Eilon @pranavkm @dougbu 

Fixes https://github.com/aspnet/Mvc/issues/5511