### PR TITLE
Redirects with fragment

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
@@ -721,7 +721,7 @@ namespace Microsoft.AspNetCore.Mvc
 
         /// <summary>
         /// Redirects to the specified route with <see cref="RedirectToRouteResult.Permanent"/> set to true
-        /// using the specified <paramref name="routeName"/>, and <paramref name="fragment"/>.
+        /// using the specified <paramref name="routeName"/> and <paramref name="fragment"/>.
         /// </summary>
         /// <param name="routeName">The name of the route.</param>
         /// <param name="fragment">The fragment to add to the URL.</param>

--- a/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
@@ -557,7 +557,7 @@ namespace Microsoft.AspNetCore.Mvc
         /// </summary>
         /// <param name="actionName">The name of the action.</param>
         /// <param name="controllerName">The name of the controller.</param>
-        /// <param name="fragment">The fragment to add to the URL</param>
+        /// <param name="fragment">The fragment to add to the URL.</param>
         /// <returns>The created <see cref="RedirectToActionResult"/> for the response.</returns>
         [NonAction]
         public virtual RedirectToActionResult RedirectToActionPermanent(
@@ -594,7 +594,7 @@ namespace Microsoft.AspNetCore.Mvc
         /// <param name="actionName">The name of the action.</param>
         /// <param name="controllerName">The name of the controller.</param>
         /// <param name="routeValues">The parameters for a route.</param>
-        /// <param name="fragment">The fragment to add to the URL</param>
+        /// <param name="fragment">The fragment to add to the URL.</param>
         /// <returns>The created <see cref="RedirectToActionResult"/> for the response.</returns>
         [NonAction]
         public virtual RedirectToActionResult RedirectToActionPermanent(
@@ -646,9 +646,39 @@ namespace Microsoft.AspNetCore.Mvc
         [NonAction]
         public virtual RedirectToRouteResult RedirectToRoute(string routeName, object routeValues)
         {
-            return new RedirectToRouteResult(routeName, routeValues)
+            return RedirectToRoute(routeName, routeValues, fragment: null);
+        }
+
+        /// <summary>
+        /// Redirects to the specified route using the specified <paramref name="routeName"/>
+        /// and <paramref name="fragment"/>.
+        /// </summary>
+        /// <param name="routeName">The name of the route.</param>
+        /// <param name="fragment">The fragment to add to the URL.</param>
+        /// <returns>The created <see cref="RedirectToRouteResult"/> for the response.</returns>
+        [NonAction]
+        public virtual RedirectToRouteResult RedirectToRoute(string routeName, string fragment)
+        {
+            return RedirectToRoute(routeName, routeValues: null, fragment: fragment);
+        }
+
+        /// <summary>
+        /// Redirects to the specified route using the specified <paramref name="routeName"/>,
+        /// <paramref name="routeValues"/>, and <paramref name="fragment"/>.
+        /// </summary>
+        /// <param name="routeName">The name of the route.</param>
+        /// <param name="routeValues">The parameters for a route.</param>
+        /// <param name="fragment">The fragment to add to the URL.</param>
+        /// <returns>The created <see cref="RedirectToRouteResult"/> for the response.</returns>
+        [NonAction]
+        public virtual RedirectToRouteResult RedirectToRoute(
+            string routeName,
+            object routeValues,
+            string fragment)
+        {
+            return new RedirectToRouteResult(routeName, routeValues, fragment)
             {
-                UrlHelper = Url,
+                UrlHelper = Url
             };
         }
 
@@ -686,9 +716,40 @@ namespace Microsoft.AspNetCore.Mvc
         [NonAction]
         public virtual RedirectToRouteResult RedirectToRoutePermanent(string routeName, object routeValues)
         {
-            return new RedirectToRouteResult(routeName, routeValues, permanent: true)
+            return RedirectToRoutePermanent(routeName, routeValues, fragment: null);
+        }
+
+        /// <summary>
+        /// Redirects to the specified route with <see cref="RedirectToRouteResult.Permanent"/> set to true
+        /// using the specified <paramref name="routeName"/>, and <paramref name="fragment"/>.
+        /// </summary>
+        /// <param name="routeName">The name of the route.</param>
+        /// <param name="fragment">The fragment to add to the URL.</param>
+        /// <returns>The created <see cref="RedirectToRouteResult"/> for the response.</returns>
+        [NonAction]
+        public virtual RedirectToRouteResult RedirectToRoutePermanent(string routeName, string fragment)
+        {
+            return RedirectToRoutePermanent(routeName, routeValues: null, fragment: fragment);
+        }
+
+        /// <summary>
+        /// Redirects to the specified route with <see cref="RedirectToRouteResult.Permanent"/> set to true
+        /// using the specified <paramref name="routeName"/>, <paramref name="routeValues"/>,
+        /// and <paramref name="fragment"/>.
+        /// </summary>
+        /// <param name="routeName">The name of the route.</param>
+        /// <param name="routeValues">The parameters for a route.</param>
+        /// <param name="fragment">The fragment to add to the URL.</param>
+        /// <returns>The created <see cref="RedirectToRouteResult"/> for the response.</returns>
+        [NonAction]
+        public virtual RedirectToRouteResult RedirectToRoutePermanent(
+            string routeName,
+            object routeValues,
+            string fragment)
+        {
+            return new RedirectToRouteResult(routeName, routeValues, permanent: true, fragment: fragment)
             {
-                UrlHelper = Url,
+                UrlHelper = Url
             };
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
@@ -552,6 +552,24 @@ namespace Microsoft.AspNetCore.Mvc
 
         /// <summary>
         /// Redirects to the specified action with <see cref="RedirectToActionResult.Permanent"/> set to true
+        /// using the specified <paramref name="actionName"/>,
+        /// <paramref name="controllerName"/>, and <paramref name="fragment"/>.
+        /// </summary>
+        /// <param name="actionName">The name of the action.</param>
+        /// <param name="controllerName">The name of the controller.</param>
+        /// <param name="fragment">The fragment to add to the URL</param>
+        /// <returns>The created <see cref="RedirectToActionResult"/> for the response.</returns>
+        [NonAction]
+        public virtual RedirectToActionResult RedirectToActionPermanent(
+            string actionName,
+            string controllerName,
+            string fragment)
+        {
+            return RedirectToActionPermanent(actionName, controllerName, routeValues: null, fragment: fragment);
+        }
+
+        /// <summary>
+        /// Redirects to the specified action with <see cref="RedirectToActionResult.Permanent"/> set to true
         /// using the specified <paramref name="actionName"/>, <paramref name="controllerName"/>,
         /// and <paramref name="routeValues"/>.
         /// </summary>
@@ -565,13 +583,34 @@ namespace Microsoft.AspNetCore.Mvc
             string controllerName,
             object routeValues)
         {
+            return RedirectToActionPermanent(actionName, controllerName, routeValues, fragment: null);
+        }
+
+        /// <summary>
+        /// Redirects to the specified action with <see cref="RedirectToActionResult.Permanent"/> set to true
+        /// using the specified <paramref name="actionName"/>, <paramref name="controllerName"/>,
+        /// <paramref name="routeValues"/>, and <paramref name="fragment"/>.
+        /// </summary>
+        /// <param name="actionName">The name of the action.</param>
+        /// <param name="controllerName">The name of the controller.</param>
+        /// <param name="routeValues">The parameters for a route.</param>
+        /// <param name="fragment">The fragment to add to the URL</param>
+        /// <returns>The created <see cref="RedirectToActionResult"/> for the response.</returns>
+        [NonAction]
+        public virtual RedirectToActionResult RedirectToActionPermanent(
+            string actionName,
+            string controllerName,
+            object routeValues,
+            string fragment)
+        {
             return new RedirectToActionResult(
                 actionName,
                 controllerName,
                 routeValues,
-                permanent: true)
+                permanent: true,
+                fragment: fragment)
             {
-                UrlHelper = Url,
+                UrlHelper = Url
             };
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
@@ -472,6 +472,14 @@ namespace Microsoft.AspNetCore.Mvc
             return RedirectToAction(actionName, controllerName, routeValues, fragment: null);
         }
 
+        /// <summary>
+        /// Redirects to the specified action using the specified <paramref name="actionName"/>,
+        /// <paramref name="controllerName"/>, and <paramref name="fragment"/>.
+        /// </summary>
+        /// <param name="actionName">The name of the action.</param>
+        /// <param name="controllerName">The name of the controller.</param>
+        /// <param name="fragment">The fragment to add to the URL</param>
+        /// <returns>The created <see cref="RedirectToActionResult"/> for the response.</returns>
         [NonAction]
         public virtual RedirectToActionResult RedirectToAction(
             string actionName,
@@ -481,6 +489,16 @@ namespace Microsoft.AspNetCore.Mvc
             return RedirectToAction(actionName, controllerName, routeValues: null, fragment: fragment);
         }
 
+        /// <summary>
+        /// Redirects to the specified action using the specified <paramref name="actionName"/>,
+        /// <paramref name="controllerName"/>, <paramref name="routeValues"/>,
+        /// and <paramref name="fragment"/>.
+        /// </summary>
+        /// <param name="actionName">The name of the action.</param>
+        /// <param name="controllerName">The name of the controller.</param>
+        /// <param name="routeValues">The parameters for a route.</param>
+        /// <param name="fragment">The fragment to add to the URL</param>
+        /// <returns>The created <see cref="RedirectToActionResult"/> for the response.</returns>
         [NonAction]
         public virtual RedirectToActionResult RedirectToAction(
             string actionName,

--- a/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
@@ -478,7 +478,7 @@ namespace Microsoft.AspNetCore.Mvc
         /// </summary>
         /// <param name="actionName">The name of the action.</param>
         /// <param name="controllerName">The name of the controller.</param>
-        /// <param name="fragment">The fragment to add to the URL</param>
+        /// <param name="fragment">The fragment to add to the URL.</param>
         /// <returns>The created <see cref="RedirectToActionResult"/> for the response.</returns>
         [NonAction]
         public virtual RedirectToActionResult RedirectToAction(
@@ -497,7 +497,7 @@ namespace Microsoft.AspNetCore.Mvc
         /// <param name="actionName">The name of the action.</param>
         /// <param name="controllerName">The name of the controller.</param>
         /// <param name="routeValues">The parameters for a route.</param>
-        /// <param name="fragment">The fragment to add to the URL</param>
+        /// <param name="fragment">The fragment to add to the URL.</param>
         /// <returns>The created <see cref="RedirectToActionResult"/> for the response.</returns>
         [NonAction]
         public virtual RedirectToActionResult RedirectToAction(

--- a/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
@@ -508,7 +508,7 @@ namespace Microsoft.AspNetCore.Mvc
         {
             return new RedirectToActionResult(actionName, controllerName, routeValues, fragment)
             {
-                UrlHelper = Url
+                UrlHelper = Url,
             };
         }
 
@@ -610,7 +610,7 @@ namespace Microsoft.AspNetCore.Mvc
                 permanent: true,
                 fragment: fragment)
             {
-                UrlHelper = Url
+                UrlHelper = Url,
             };
         }
 
@@ -678,7 +678,7 @@ namespace Microsoft.AspNetCore.Mvc
         {
             return new RedirectToRouteResult(routeName, routeValues, fragment)
             {
-                UrlHelper = Url
+                UrlHelper = Url,
             };
         }
 
@@ -749,7 +749,7 @@ namespace Microsoft.AspNetCore.Mvc
         {
             return new RedirectToRouteResult(routeName, routeValues, permanent: true, fragment: fragment)
             {
-                UrlHelper = Url
+                UrlHelper = Url,
             };
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
@@ -469,9 +469,28 @@ namespace Microsoft.AspNetCore.Mvc
             string controllerName,
             object routeValues)
         {
-            return new RedirectToActionResult(actionName, controllerName, routeValues)
+            return RedirectToAction(actionName, controllerName, routeValues, fragment: null);
+        }
+
+        [NonAction]
+        public virtual RedirectToActionResult RedirectToAction(
+            string actionName,
+            string controllerName,
+            string fragment)
+        {
+            return RedirectToAction(actionName, controllerName, routeValues: null, fragment: fragment);
+        }
+
+        [NonAction]
+        public virtual RedirectToActionResult RedirectToAction(
+            string actionName,
+            string controllerName,
+            object routeValues,
+            string fragment)
+        {
+            return new RedirectToActionResult(actionName, controllerName, routeValues, fragment)
             {
-                UrlHelper = Url,
+                UrlHelper = Url
             };
         }
 
@@ -1082,7 +1101,7 @@ namespace Microsoft.AspNetCore.Mvc
         /// <summary>
         /// Creates a <see cref="AcceptedAtRouteResult"/> object that produces an Accepted (202) response.
         /// </summary>
-        /// <param name="routeName">The name of the route to use for generating the URL.</param>       
+        /// <param name="routeName">The name of the route to use for generating the URL.</param>
         /// <returns>The created <see cref="AcceptedAtRouteResult"/> for the response.</returns>
         [NonAction]
         public virtual AcceptedAtRouteResult AcceptedAtRoute(string routeName)

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/RedirectToActionResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/RedirectToActionResultExecutor.cs
@@ -33,7 +33,13 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         {
             var urlHelper = result.UrlHelper ?? _urlHelperFactory.GetUrlHelper(context);
 
-            var destinationUrl = urlHelper.Action(result.ActionName, result.ControllerName, result.RouteValues, null, null, result.Fragment);
+            var destinationUrl = urlHelper.Action(
+                result.ActionName,
+                result.ControllerName,
+                result.RouteValues,
+                protocol: null,
+                host: null,
+                fragment: result.Fragment);
             if (string.IsNullOrEmpty(destinationUrl))
             {
                 throw new InvalidOperationException(Resources.NoRoutesMatched);

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/RedirectToActionResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/RedirectToActionResultExecutor.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         {
             var urlHelper = result.UrlHelper ?? _urlHelperFactory.GetUrlHelper(context);
 
-            var destinationUrl = urlHelper.Action(result.ActionName, result.ControllerName, result.RouteValues);
+            var destinationUrl = urlHelper.Action(result.ActionName, result.ControllerName, result.RouteValues, null, null, result.Fragment);
             if (string.IsNullOrEmpty(destinationUrl))
             {
                 throw new InvalidOperationException(Resources.NoRoutesMatched);

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/RedirectToRouteResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/RedirectToRouteResultExecutor.cs
@@ -33,7 +33,12 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         {
             var urlHelper = result.UrlHelper ?? _urlHelperFactory.GetUrlHelper(context);
 
-            var destinationUrl = urlHelper.RouteUrl(result.RouteName, result.RouteValues);
+            var destinationUrl = urlHelper.RouteUrl(
+                result.RouteName,
+                result.RouteValues,
+                protocol: null,
+                host: null,
+                fragment: result.Fragment);
             if (string.IsNullOrEmpty(destinationUrl))
             {
                 throw new InvalidOperationException(Resources.NoRoutesMatched);

--- a/src/Microsoft.AspNetCore.Mvc.Core/RedirectToActionResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RedirectToActionResult.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Mvc
         public RouteValueDictionary RouteValues { get; set; }
 
         /// <summary>
-        /// Gets or sets whether the redirect is permanent.
+        /// Gets or sets an indication that the redirect is permanent.
         /// </summary>
         public bool Permanent { get; set; }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/RedirectToActionResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RedirectToActionResult.cs
@@ -11,6 +11,13 @@ namespace Microsoft.AspNetCore.Mvc
 {
     public class RedirectToActionResult : ActionResult, IKeepTempDataResult
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RedirectToActionResult"/> with the values
+        /// provided.
+        /// </summary>
+        /// <param name="actionName">The name of the action to use for generating the URL.</param>
+        /// <param name="controllerName">The name of the controller to use for generating the URL.</param>
+        /// <param name="routeValues">The route data to use for generating the URL.</param>
         public RedirectToActionResult(
             string actionName,
             string controllerName,
@@ -36,6 +43,14 @@ namespace Microsoft.AspNetCore.Mvc
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RedirectToActionResult"/> with the values
+        /// provided.
+        /// </summary>
+        /// <param name="actionName">The name of the action to use for generating the URL.</param>
+        /// <param name="controllerName">The name of the controller to use for generating the URL.</param>
+        /// <param name="routeValues">The route data to use for generating the URL.</param>
+        /// <param name="permanent">If set to true, makes the redirect permanent (301). Otherwise a temporary redirect is used (302).</param>
         public RedirectToActionResult(
             string actionName,
             string controllerName,

--- a/src/Microsoft.AspNetCore.Mvc.Core/RedirectToActionResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RedirectToActionResult.cs
@@ -103,6 +103,9 @@ namespace Microsoft.AspNetCore.Mvc
         /// </summary>
         public RouteValueDictionary RouteValues { get; set; }
 
+        /// <summary>
+        /// Gets or sets whether the redirect is permanent.
+        /// </summary>
         public bool Permanent { get; set; }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Mvc.Core/RedirectToActionResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RedirectToActionResult.cs
@@ -73,6 +73,9 @@ namespace Microsoft.AspNetCore.Mvc
 
         public bool Permanent { get; set; }
 
+        /// <summary>
+        /// Gets or sets the fragment to add to the URL
+        /// </summary>
         public string Fragment { get; set; }
 
         /// <inheritdoc />

--- a/src/Microsoft.AspNetCore.Mvc.Core/RedirectToActionResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RedirectToActionResult.cs
@@ -9,6 +9,10 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Mvc
 {
+    /// <summary>
+    /// An <see cref="ActionResult"/> that returns a Found (302)
+    /// or Moved Permanently (301) response with a Location header.
+    /// </summary>
     public class RedirectToActionResult : ActionResult, IKeepTempDataResult
     {
         /// <summary>

--- a/src/Microsoft.AspNetCore.Mvc.Core/RedirectToActionResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RedirectToActionResult.cs
@@ -12,6 +12,7 @@ namespace Microsoft.AspNetCore.Mvc
     /// <summary>
     /// An <see cref="ActionResult"/> that returns a Found (302)
     /// or Moved Permanently (301) response with a Location header.
+    /// Targets a controller action.
     /// </summary>
     public class RedirectToActionResult : ActionResult, IKeepTempDataResult
     {

--- a/src/Microsoft.AspNetCore.Mvc.Core/RedirectToActionResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RedirectToActionResult.cs
@@ -19,6 +19,14 @@ namespace Microsoft.AspNetCore.Mvc
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RedirectToActionResult"/> with the values
+        /// provided.
+        /// </summary>
+        /// <param name="actionName">The name of the action to use for generating the URL.</param>
+        /// <param name="controllerName">The name of the controller to use for generating the URL.</param>
+        /// <param name="routeValues">The route data to use for generating the URL.</param>
+        /// <param name="fragment">The fragment to add to the URL.</param>
         public RedirectToActionResult(
             string actionName,
             string controllerName,
@@ -37,6 +45,15 @@ namespace Microsoft.AspNetCore.Mvc
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RedirectToActionResult"/> with the values
+        /// provided.
+        /// </summary>
+        /// <param name="actionName">The name of the action to use for generating the URL.</param>
+        /// <param name="controllerName">The name of the controller to use for generating the URL.</param>
+        /// <param name="routeValues">The route data to use for generating the URL.</param>
+        /// <param name="permanent">If set to true, makes the redirect permanent (301). Otherwise a temporary redirect is used (302).</param>
+        /// <param name="fragment">The fragment to add to the URL.</param>
         public RedirectToActionResult(
             string actionName,
             string controllerName,

--- a/src/Microsoft.AspNetCore.Mvc.Core/RedirectToActionResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RedirectToActionResult.cs
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.Mvc
         public bool Permanent { get; set; }
 
         /// <summary>
-        /// Gets or sets the fragment to add to the URL
+        /// Gets or sets the fragment to add to the URL.
         /// </summary>
         public string Fragment { get; set; }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/RedirectToActionResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RedirectToActionResult.cs
@@ -23,12 +23,32 @@ namespace Microsoft.AspNetCore.Mvc
             string actionName,
             string controllerName,
             object routeValues,
+            string fragment)
+            : this(actionName, controllerName, routeValues, permanent: false, fragment: fragment)
+        {
+        }
+
+        public RedirectToActionResult(
+            string actionName,
+            string controllerName,
+            object routeValues,
             bool permanent)
+            : this(actionName, controllerName, routeValues, permanent, fragment: null)
+        {
+        }
+
+        public RedirectToActionResult(
+            string actionName,
+            string controllerName,
+            object routeValues,
+            bool permanent,
+            string fragment)
         {
             ActionName = actionName;
             ControllerName = controllerName;
             RouteValues = routeValues == null ? null : new RouteValueDictionary(routeValues);
             Permanent = permanent;
+            Fragment = fragment;
         }
 
         /// <summary>
@@ -52,6 +72,8 @@ namespace Microsoft.AspNetCore.Mvc
         public RouteValueDictionary RouteValues { get; set; }
 
         public bool Permanent { get; set; }
+
+        public string Fragment { get; set; }
 
         /// <inheritdoc />
         public override void ExecuteResult(ActionContext context)

--- a/src/Microsoft.AspNetCore.Mvc.Core/RedirectToRouteResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RedirectToRouteResult.cs
@@ -105,7 +105,7 @@ namespace Microsoft.AspNetCore.Mvc
         public RouteValueDictionary RouteValues { get; set; }
 
         /// <summary>
-        /// Gets or sets whether the redirect is permanent.
+        /// Gets or sets an indication that the redirect is permanent.
         /// </summary>
         public bool Permanent { get; set; }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/RedirectToRouteResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RedirectToRouteResult.cs
@@ -11,11 +11,22 @@ namespace Microsoft.AspNetCore.Mvc
 {
     public class RedirectToRouteResult : ActionResult, IKeepTempDataResult
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RedirectToRouteResult"/> with the values
+        /// provided.
+        /// </summary>
+        /// <param name="routeValues">The parameters for the route.</param>
         public RedirectToRouteResult(object routeValues)
             : this(routeName: null, routeValues: routeValues)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RedirectToRouteResult"/> with the values
+        /// provided.
+        /// </summary>
+        /// <param name="routeName">The name of the route.</param>
+        /// <param name="routeValues">The parameters for the route.</param>
         public RedirectToRouteResult(
             string routeName,
             object routeValues)
@@ -23,6 +34,13 @@ namespace Microsoft.AspNetCore.Mvc
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RedirectToRouteResult"/> with the values
+        /// provided.
+        /// </summary>
+        /// <param name="routeName">The name of the route.</param>
+        /// <param name="routeValues">The parameters for the route.</param>
+        /// <param name="permanent">If set to true, makes the redirect permanent (301). Otherwise a temporary redirect is used (302).</param>
         public RedirectToRouteResult(
             string routeName,
             object routeValues,

--- a/src/Microsoft.AspNetCore.Mvc.Core/RedirectToRouteResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RedirectToRouteResult.cs
@@ -27,10 +27,28 @@ namespace Microsoft.AspNetCore.Mvc
             string routeName,
             object routeValues,
             bool permanent)
+            : this(routeName, routeValues, permanent, fragment: null)
+        {
+        }
+
+        public RedirectToRouteResult(
+            string routeName,
+            object routeValues,
+            string fragment)
+            : this(routeName, routeValues, permanent: false, fragment: fragment)
+        {
+        }
+
+        public RedirectToRouteResult(
+            string routeName,
+            object routeValues,
+            bool permanent,
+            string fragment)
         {
             RouteName = routeName;
             RouteValues = routeValues == null ? null : new RouteValueDictionary(routeValues);
             Permanent = permanent;
+            Fragment = fragment;
         }
 
         /// <summary>
@@ -49,6 +67,11 @@ namespace Microsoft.AspNetCore.Mvc
         public RouteValueDictionary RouteValues { get; set; }
 
         public bool Permanent { get; set; }
+
+        /// <summary>
+        /// Gets or sets the fragment to be added to the URL
+        /// </summary>
+        public string Fragment { get; set; }
 
         /// <inheritdoc />
         public override void ExecuteResult(ActionContext context)

--- a/src/Microsoft.AspNetCore.Mvc.Core/RedirectToRouteResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RedirectToRouteResult.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Mvc
         public bool Permanent { get; set; }
 
         /// <summary>
-        /// Gets or sets the fragment to be added to the URL
+        /// Gets or sets the fragment to add to the URL.
         /// </summary>
         public string Fragment { get; set; }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/RedirectToRouteResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RedirectToRouteResult.cs
@@ -31,6 +31,13 @@ namespace Microsoft.AspNetCore.Mvc
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RedirectToRouteResult"/> with the values
+        /// provided.
+        /// </summary>
+        /// <param name="routeName">The name of the route.</param>
+        /// <param name="routeValues">The parameters for the route.</param>
+        /// <param name="fragment">The fragment to add to the URL.</param>
         public RedirectToRouteResult(
             string routeName,
             object routeValues,
@@ -39,6 +46,14 @@ namespace Microsoft.AspNetCore.Mvc
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RedirectToRouteResult"/> with the values
+        /// provided.
+        /// </summary>
+        /// <param name="routeName">The name of the route.</param>
+        /// <param name="routeValues">The parameters for the route.</param>
+        /// <param name="permanent">If set to true, makes the redirect permanent (301). Otherwise a temporary redirect is used (302).</param>
+        /// <param name="fragment">The fragment to add to the URL.</param>
         public RedirectToRouteResult(
             string routeName,
             object routeValues,

--- a/src/Microsoft.AspNetCore.Mvc.Core/RedirectToRouteResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RedirectToRouteResult.cs
@@ -9,6 +9,11 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Mvc
 {
+    /// <summary>
+    /// An <see cref="ActionResult"/> that returns a Found (302)
+    /// or Moved Permanently (301) response with a Location header.
+    /// Targets a registered route.
+    /// </summary>
     public class RedirectToRouteResult : ActionResult, IKeepTempDataResult
     {
         /// <summary>

--- a/src/Microsoft.AspNetCore.Mvc.Core/RedirectToRouteResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RedirectToRouteResult.cs
@@ -99,6 +99,9 @@ namespace Microsoft.AspNetCore.Mvc
         /// </summary>
         public RouteValueDictionary RouteValues { get; set; }
 
+        /// <summary>
+        /// Gets or sets whether the redirect is permanent.
+        /// </summary>
         public bool Permanent { get; set; }
 
         /// <summary>

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ControllerBaseTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ControllerBaseTest.cs
@@ -276,6 +276,30 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
 
         [Theory]
         [MemberData(nameof(RedirectTestData))]
+        public void RedirectToAction_WithParameterActionAndControllerAndRouteValuesAndFragment_SetsResultProperties(
+            object routeValues,
+            IEnumerable<KeyValuePair<string, object>> expectedRouteValues)
+        {
+            // Arrange
+            var controller = new TestableController();
+            var expectedAction = "Action";
+            var expectedController = "Home";
+            var expectedFragment = "test";
+
+            // Act
+            var result = controller.RedirectToAction("Action", "Home", routeValues, "test");
+
+            // Assert
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.False(result.Permanent);
+            Assert.Equal(expectedAction, result.ActionName);
+            Assert.Equal(expectedRouteValues, result.RouteValues);
+            Assert.Equal(expectedController, result.ControllerName);
+            Assert.Equal(expectedFragment, result.Fragment);
+        }
+
+        [Theory]
+        [MemberData(nameof(RedirectTestData))]
         public void RedirectToActionPermanent_WithParameterActionAndRouteValues_SetsResultProperties(
             object routeValues,
             IEnumerable<KeyValuePair<string, object>> expected)
@@ -291,6 +315,30 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
             Assert.True(resultPermanent.Permanent);
             Assert.Null(resultPermanent.ActionName);
             Assert.Equal(expected, resultPermanent.RouteValues);
+        }
+
+        [Theory]
+        [MemberData(nameof(RedirectTestData))]
+        public void RedirectToActionPermanent_WithParameterActionAndControllerAndRouteValuesAndFragment_SetsResultProperties(
+            object routeValues,
+            IEnumerable<KeyValuePair<string, object>> expectedRouteValues)
+        {
+            // Arrange
+            var controller = new TestableController();
+            var expectedAction = "Action";
+            var expectedController = "Home";
+            var expectedFragment = "test";
+
+            // Act
+            var result = controller.RedirectToActionPermanent("Action", "Home", routeValues, "test");
+
+            // Assert
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.True(result.Permanent);
+            Assert.Equal(expectedAction, result.ActionName);
+            Assert.Equal(expectedRouteValues, result.RouteValues);
+            Assert.Equal(expectedController, result.ControllerName);
+            Assert.Equal(expectedFragment, result.Fragment);
         }
 
         [Theory]
@@ -313,6 +361,28 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
 
         [Theory]
         [MemberData(nameof(RedirectTestData))]
+        public void RedirectToRoute_WithParameterRouteNameAndRouteValuesAndFragment_SetsResultProperties(
+            object routeValues,
+            IEnumerable<KeyValuePair<string, object>> expectedRouteValues)
+        {
+            // Arrange
+            var controller = new TestableController();
+            var expectedRoute = "TestRoute";
+            var expectedFragment = "test";
+
+            // Act
+            var result = controller.RedirectToRoute("TestRoute", routeValues, "test");
+
+            // Assert
+            Assert.IsType<RedirectToRouteResult>(result);
+            Assert.False(result.Permanent);
+            Assert.Equal(expectedRoute, result.RouteName);
+            Assert.Equal(expectedRouteValues, result.RouteValues);
+            Assert.Equal(expectedFragment, result.Fragment);
+        }
+
+        [Theory]
+        [MemberData(nameof(RedirectTestData))]
         public void RedirectToRoutePermanent_WithParameterRouteValues_SetsResultEqualRouteValuesAndPermanent(
             object routeValues,
             IEnumerable<KeyValuePair<string, object>> expected)
@@ -327,6 +397,28 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
             Assert.IsType<RedirectToRouteResult>(resultPermanent);
             Assert.True(resultPermanent.Permanent);
             Assert.Equal(expected, resultPermanent.RouteValues);
+        }
+
+        [Theory]
+        [MemberData(nameof(RedirectTestData))]
+        public void RedirectToRoutePermanent_WithParameterRouteNameAndRouteValuesAndFragment_SetsResultProperties(
+            object routeValues,
+            IEnumerable<KeyValuePair<string, object>> expectedRouteValues)
+        {
+            // Arrange
+            var controller = new TestableController();
+            var expectedRoute = "TestRoute";
+            var expectedFragment = "test";
+
+            // Act
+            var result = controller.RedirectToRoutePermanent("TestRoute", routeValues, "test");
+
+            // Assert
+            Assert.IsType<RedirectToRouteResult>(result);
+            Assert.True(result.Permanent);
+            Assert.Equal(expectedRoute, result.RouteName);
+            Assert.Equal(expectedRouteValues, result.RouteValues);
+            Assert.Equal(expectedFragment, result.Fragment);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/RedirectToActionResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/RedirectToActionResultTest.cs
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.Mvc
             // Verifying if Redirect was called with the specific Url and parameter flag.
             // Thus we verify that the Url returned by UrlHelper is passed properly to
             // Redirect method and that the method is called exactly once.
-            httpResponse.Verify(r => r.Redirect(expectedUrl, expectedPermanentFlag), Times.Exactly(2));
+            httpResponse.Verify(r => r.Redirect(expectedUrl, expectedPermanentFlag), Times.Exactly(1));
         }
 
         private static IUrlHelper GetMockUrlHelper(string returnValue)

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/RedirectToActionResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/RedirectToActionResultTest.cs
@@ -83,6 +83,41 @@ namespace Microsoft.AspNetCore.Mvc
                 "No route matches the supplied values.");
         }
 
+        [Fact]
+        public async Task RedirectToAction_Execute_WithFragment_PassesCorrectValuesToRedirect()
+        {
+            // Arrange
+            var expectedUrl = "/Home/SampleAction#test";
+            var expectedPermanentFlag = false;
+
+            var httpContext = new Mock<HttpContext>();
+            httpContext
+                .SetupGet(o => o.RequestServices)
+                .Returns(CreateServices().BuildServiceProvider());
+
+            var httpResponse = new Mock<HttpResponse>();
+            httpContext
+                .Setup(o => o.Response)
+                .Returns(httpResponse.Object);
+
+            var actionContext = new ActionContext(httpContext.Object, new RouteData(), new ActionDescriptor());
+
+            var urlHelper = GetMockUrlHelper(expectedUrl);
+            var result = new RedirectToActionResult("SampleAction", "Home", null, false, "test")
+            {
+                UrlHelper = urlHelper,
+            };
+
+            // Act
+            await result.ExecuteResultAsync(actionContext);
+
+            // Assert
+            // Verifying if Redirect was called with the specific Url and parameter flag.
+            // Thus we verify that the Url returned by UrlHelper is passed properly to
+            // Redirect method and that the method is called exactly once.
+            httpResponse.Verify(r => r.Redirect(expectedUrl, expectedPermanentFlag), Times.Exactly(2));
+        }
+
         private static IUrlHelper GetMockUrlHelper(string returnValue)
         {
             var urlHelper = new Mock<IUrlHelper>();

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/RedirectToRouteResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/RedirectToRouteResultTest.cs
@@ -116,6 +116,31 @@ namespace Microsoft.AspNetCore.Mvc
             Assert.Equal(locationUrl, httpContext.Response.Headers["Location"]);
         }
 
+        [Fact]
+        public async Task ExecuteResultAsync_WithFragment_PassesCorrectValuesToRedirect()
+        {
+            // Arrange
+            var expectedUrl = "/SampleAction#test";
+            var expectedStatusCode = StatusCodes.Status301MovedPermanently;
+
+            var httpContext = GetHttpContext();
+
+            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+            var urlHelper = GetMockUrlHelper(expectedUrl);
+            var result = new RedirectToRouteResult("Sample", null, true, "test")
+            {
+                UrlHelper = urlHelper,
+            };
+
+            // Act
+            await result.ExecuteResultAsync(actionContext);
+
+            // Assert
+            Assert.Equal(expectedStatusCode, httpContext.Response.StatusCode);
+            Assert.Equal(expectedUrl, httpContext.Response.Headers["Location"]);
+        }
+
         private static HttpContext GetHttpContext(IUrlHelperFactory factory = null)
         {
             var services = CreateServices(factory);

--- a/test/WebSites/BasicWebSite/Controllers/HomeController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/HomeController.cs
@@ -35,19 +35,9 @@ namespace BasicWebSite.Controllers
             return RedirectToAction("ActionReturningTask");
         }
 
-        public IActionResult RedirectToActionWithFragment()
-        {
-            return RedirectToAction("ActionReturningTask", "Home", null, "test");
-        }
-
         public IActionResult RedirectToRouteActionAsMethodAction()
         {
             return RedirectToRoute("ActionAsMethod", new { action = "ActionReturningTask", controller = "Home" });
-        }
-
-        public IActionResult RedirectToRouteUsingRouteNameAndFragment()
-        {
-            return RedirectToRoutePermanent("ActionAsMethod", new { action = "ActionReturningTask", controller = "Home" }, fragment: "test");
         }
 
         public IActionResult RedirectToRouteUsingRouteName()

--- a/test/WebSites/BasicWebSite/Controllers/HomeController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/HomeController.cs
@@ -35,6 +35,11 @@ namespace BasicWebSite.Controllers
             return RedirectToAction("ActionReturningTask");
         }
 
+        public IActionResult RedirectToActionWithFragment()
+        {
+            return RedirectToAction("ActionReturningTask", "Home", fragment: "test");
+        }
+
         public IActionResult RedirectToRouteActionAsMethodAction()
         {
             return RedirectToRoute("ActionAsMethod", new { action = "ActionReturningTask", controller = "Home" });

--- a/test/WebSites/BasicWebSite/Controllers/HomeController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/HomeController.cs
@@ -45,6 +45,11 @@ namespace BasicWebSite.Controllers
             return RedirectToRoute("ActionAsMethod", new { action = "ActionReturningTask", controller = "Home" });
         }
 
+        public IActionResult RedirectToRouteUsingRouteNameAndFragment()
+        {
+            return RedirectToRoute("ActionAsMethod", new { action = "ActionReturningTask", controller = "Home" }, fragment: "test");
+        }
+
         public IActionResult RedirectToRouteUsingRouteName()
         {
             return RedirectToRoute("OrdersApi", new { id = 10 });

--- a/test/WebSites/BasicWebSite/Controllers/HomeController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/HomeController.cs
@@ -37,7 +37,7 @@ namespace BasicWebSite.Controllers
 
         public IActionResult RedirectToActionWithFragment()
         {
-            return RedirectToAction("ActionReturningTask", "Home", fragment: "test");
+            return RedirectToAction("ActionReturningTask", "Home", null, "test");
         }
 
         public IActionResult RedirectToRouteActionAsMethodAction()
@@ -47,7 +47,7 @@ namespace BasicWebSite.Controllers
 
         public IActionResult RedirectToRouteUsingRouteNameAndFragment()
         {
-            return RedirectToRoute("ActionAsMethod", new { action = "ActionReturningTask", controller = "Home" }, fragment: "test");
+            return RedirectToRoutePermanent("ActionAsMethod", new { action = "ActionReturningTask", controller = "Home" }, fragment: "test");
         }
 
         public IActionResult RedirectToRouteUsingRouteName()


### PR DESCRIPTION
Added overloads to the methods that return redirect results that allow specifying the fragment to add to the URL.
 - Added RedirectToAction, RedirectToActionPermanent, RedirectToRoute, and RedirectToRoutePermanent overloads that allow specifying the fragment
 - Added the Fragment property to RedirectToActionResult and RedirectToRouteResult
 - Modified RedirectToActionResultExecutor and RedirectToRouteResultExecutor to call the overload on UrlHelper that specifies the fragment. Left host and protocol to null as the other UrlHelper overloads do.

Addresses issue #3988 

This is my first PR to MVC Core, I would be happy about any feedback :)