### PR TITLE
CookieTempDataProvider: Use request PathBase value to set cookie path only if it has a non-nu…

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/CookieTempDataProviderOptions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/CookieTempDataProviderOptions.cs
@@ -12,7 +12,9 @@ namespace Microsoft.AspNetCore.Mvc
     public class CookieTempDataProviderOptions
     {
         /// <summary>
-        /// The path set for a cookie. If not specified, current request's <see cref="HttpRequest.PathBase"/> value is used.
+        /// The path set on the cookie. If set to <c>null</c>, the "path" attribute on the cookie is set to the current
+        /// request's <see cref="HttpRequest.PathBase"/> value. If the value of <see cref="HttpRequest.PathBase"/> is
+        /// <c>null</c> or empty, then the "path" attribute is set to the value of <see cref="CookieOptions.Path"/>.
         /// </summary>
         public string Path { get; set; }
 

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/CookieTempDataProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/CookieTempDataProvider.cs
@@ -63,13 +63,11 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 
             var cookieOptions = new CookieOptions()
             {
-                // Check for PathBase as it can empty in which case the clients would not send the cookie
-                // in subsequent requests.
-                Path = string.IsNullOrEmpty(_options.Value.Path) ? GetPathBase(context) : _options.Value.Path,
                 Domain = string.IsNullOrEmpty(_options.Value.Domain) ? null : _options.Value.Domain,
                 HttpOnly = true,
                 Secure = context.Request.IsHttps,
             };
+            SetCookiePath(context, cookieOptions);
 
             var hasValues = (values != null && values.Count > 0);
             if (hasValues)
@@ -85,14 +83,20 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             }
         }
 
-        private string GetPathBase(HttpContext httpContext)
+        private void SetCookiePath(HttpContext httpContext, CookieOptions cookieOptions)
         {
-            var pathBase = httpContext.Request.PathBase.ToString();
-            if (string.IsNullOrEmpty(pathBase))
+            if (!string.IsNullOrEmpty(_options.Value.Path))
             {
-                pathBase = "/";
+                cookieOptions.Path = _options.Value.Path;
             }
-            return pathBase;
+            else
+            {
+                var pathBase = httpContext.Request.PathBase.ToString();
+                if (!string.IsNullOrEmpty(pathBase))
+                {
+                    cookieOptions.Path = pathBase;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
…ll & non-empty value

@Eilon @DamianEdwards 