### PR TITLE
Specify route name to UrlHelper Action Method

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/Routing/UrlActionContext.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/Routing/UrlActionContext.cs
@@ -63,5 +63,14 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             get;
             set;
         }
+
+        /// <summary>
+        /// The name of the route that <see cref="IUrlHelper.Action(UrlActionContext)"/> will use to generate url.
+        /// </summary>
+        public string RouteName
+        {
+            get;
+            set;
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Routing/UrlHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Routing/UrlHelper.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Mvc.Routing
                 valuesDictionary["controller"] = actionContext.Controller;
             }
 
-            var virtualPathData = GetVirtualPathData(routeName: null, values: valuesDictionary);
+            var virtualPathData = GetVirtualPathData(routeName: actionContext.RouteName, values: valuesDictionary);
             return GenerateUrl(actionContext.Protocol, actionContext.Host, virtualPathData, actionContext.Fragment);
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/UrlHelperExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/UrlHelperExtensions.cs
@@ -157,10 +157,12 @@ namespace Microsoft.AspNetCore.Mvc
             return helper.Action(action, controller, values, protocol, host, fragment: null);
         }
 
+
+
         /// <summary>
         /// Generates a URL with an absolute path for an action method, which contains the specified
         /// <paramref name="action"/> name, <paramref name="controller"/> name, route <paramref name="values"/>,
-        /// <paramref name="protocol"/> to use, <paramref name="host"/> name, and <paramref name="fragment"/>.
+        /// <paramref name="protocol"/> to use, <paramref name="host"/> name and <paramref name="fragment"/>.
         /// Generates an absolute URL if the <paramref name="protocol"/> and <paramref name="host"/> are
         /// non-<c>null</c>.
         /// </summary>
@@ -186,6 +188,41 @@ namespace Microsoft.AspNetCore.Mvc
                 throw new ArgumentNullException(nameof(helper));
             }
 
+            return helper.Action(action, controller, values, protocol, host, fragment, routeName: null);
+        }
+
+        /// <summary>
+        /// Generates a URL with an absolute path for an action method, which contains the specified
+        /// <paramref name="action"/> name, <paramref name="controller"/> name, route <paramref name="values"/>,
+        /// <paramref name="protocol"/> to use, <paramref name="host"/> name, <paramref name="fragment"/>
+        /// and uses route with specified <paramref name="routeName"/>.
+        /// Generates an absolute URL if the <paramref name="protocol"/> and <paramref name="host"/> are
+        /// non-<c>null</c>.
+        /// </summary>
+        /// <param name="helper">The <see cref="IUrlHelper"/>.</param>
+        /// <param name="action">The name of the action method.</param>
+        /// <param name="controller">The name of the controller.</param>
+        /// <param name="values">An object that contains route values.</param>
+        /// <param name="protocol">The protocol for the URL, such as "http" or "https".</param>
+        /// <param name="host">The host name for the URL.</param>
+        /// <param name="fragment">The fragment for the URL.</param>
+        /// <param name="routeName">The name of the route to be used.</param>
+        /// <returns>The generated URL.</returns>
+        public static string Action(
+            this IUrlHelper helper,
+            string action,
+            string controller,
+            object values,
+            string protocol,
+            string host,
+            string fragment,
+            string routeName)
+        {
+            if (helper == null)
+            {
+                throw new ArgumentNullException(nameof(helper));
+            }
+
             return helper.Action(new UrlActionContext()
             {
                 Action = action,
@@ -193,7 +230,8 @@ namespace Microsoft.AspNetCore.Mvc
                 Host = host,
                 Values = values,
                 Protocol = protocol,
-                Fragment = fragment
+                Fragment = fragment,
+                RouteName = routeName
             });
         }
 


### PR DESCRIPTION
If there is more than one named route - allows to specify which one to use for generating the url.