### PR TITLE
Enum DisplayTemplate fixes

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/HtmlHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/HtmlHelper.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -524,23 +523,6 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             string templateName,
             object additionalViewData)
         {
-            var modelEnum = modelExplorer.Model as Enum;
-            if (modelExplorer.Metadata.IsEnum && modelEnum != null)
-            {
-                var value = modelEnum.ToString("d");
-                var enumGrouped = modelExplorer.Metadata.EnumGroupedDisplayNamesAndValues;
-                Debug.Assert(enumGrouped != null);
-                foreach (var kvp in enumGrouped)
-                {
-                    if (kvp.Value == value)
-                    {
-                        // Creates a ModelExplorer with the same Metadata except that the Model is a string instead of an Enum
-                        modelExplorer = modelExplorer.GetExplorerForModel(kvp.Key.Name);
-                        break;
-                    }
-                }
-            }
-
             var templateBuilder = new TemplateBuilder(
                 _viewEngine,
                 _bufferScope,

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/HtmlGenerationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/HtmlGenerationTest.cs
@@ -71,6 +71,16 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             }
         }
 
+        [Fact]
+        public async Task EnumValues_SerializeCorrectly()
+        {
+            // Arrange & Act
+            var response = await Client.GetStringAsync("http://localhost/HtmlGeneration_Home/Enum");
+
+            // Assert
+            Assert.Equal($"Vrijdag{Environment.NewLine}Month: January", response, ignoreLineEndingDifferences: true);
+        }
+
         [Theory]
         [MemberData(nameof(WebPagesData))]
         public async Task HtmlGenerationWebSite_GeneratesExpectedResults(string action, string antiforgeryPath)

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperEditorExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperEditorExtensionsTest.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.TestCommon;
+using Microsoft.AspNetCore.Mvc.ViewEngines;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.Rendering
+{
+    public class HtmlHelperEditorExtensionsTest
+    {
+        [Theory]
+        [MemberData(nameof(HtmlHelperDisplayExtensionsTest.EnumUnformattedModels),
+            MemberType = typeof(HtmlHelperDisplayExtensionsTest))]
+        public void Display_UsesTemplateUnFormatted(HtmlHelperDisplayExtensionsTest.FormatModel model, string expectedResult)
+        {
+            // Arrange
+            var view = new Mock<IView>();
+            view.Setup(v => v.RenderAsync(It.IsAny<ViewContext>()))
+                .Callback((ViewContext v) => v.Writer.WriteAsync(v.ViewData.TemplateInfo.FormattedModelValue.ToString()))
+                .Returns(Task.FromResult(0));
+            var viewEngine = new Mock<ICompositeViewEngine>(MockBehavior.Strict);
+            viewEngine
+                .Setup(v => v.GetView(/*executingFilePath*/ null, It.IsAny<string>(), /*isMainPage*/ false))
+                .Returns(ViewEngineResult.NotFound(string.Empty, Enumerable.Empty<string>()));
+            viewEngine
+                .Setup(v => v.FindView(It.IsAny<ActionContext>(), "EditorTemplates/Status", /*isMainPage*/ false))
+                .Returns(ViewEngineResult.Found("Status", view.Object))
+                .Verifiable();
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper(model, viewEngine.Object);
+
+            // Act
+            var displayResult = helper.EditorFor(x => x.NonFormatProperty);
+
+            // Assert
+            Assert.Equal(expectedResult, HtmlContentUtilities.HtmlContentToString(displayResult));
+        }
+
+        [Theory]
+        [MemberData(nameof(HtmlHelperDisplayExtensionsTest.EnumFormatModels), MemberType = typeof(HtmlHelperDisplayExtensionsTest))]
+        public void Display_UsesTemplateFormatted(HtmlHelperDisplayExtensionsTest.FormatModel model, string expectedResult)
+        {
+            // Arrange
+            var view = new Mock<IView>();
+            view.Setup(v => v.RenderAsync(It.IsAny<ViewContext>()))
+                .Callback((ViewContext v) => v.Writer.WriteAsync(v.ViewData.TemplateInfo.FormattedModelValue.ToString()))
+                .Returns(Task.FromResult(0));
+            var viewEngine = new Mock<ICompositeViewEngine>(MockBehavior.Strict);
+            viewEngine
+                .Setup(v => v.GetView(/*executingFilePath*/ null, It.IsAny<string>(), /*isMainPage*/ false))
+                .Returns(ViewEngineResult.NotFound(string.Empty, Enumerable.Empty<string>()));
+            viewEngine
+                .Setup(v => v.FindView(It.IsAny<ActionContext>(), "EditorTemplates/Status", /*isMainPage*/ false))
+                .Returns(ViewEngineResult.Found("Status", view.Object))
+                .Verifiable();
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper(model, viewEngine.Object);
+
+            // Act
+            var displayResult = helper.EditorFor(x => x.FormatProperty);
+
+            // Assert
+            Assert.Equal(expectedResult, HtmlContentUtilities.HtmlContentToString(displayResult));
+        }
+    }
+}

--- a/test/WebSites/HtmlGenerationWebSite/Controllers/HtmlGeneration_HomeController.cs
+++ b/test/WebSites/HtmlGenerationWebSite/Controllers/HtmlGeneration_HomeController.cs
@@ -54,6 +54,11 @@ namespace HtmlGenerationWebSite.Controllers
             _productsListWithSelection = new SelectList(_products, "Number", "ProductName", 2);
         }
 
+        public IActionResult Enum()
+        {
+            return View(new AClass { DayOfWeek = Models.DayOfWeek.Friday, Month = Month.FirstOne });
+        }
+
         public IActionResult Order()
         {
             ViewData["Items"] = _productsListWithSelection;

--- a/test/WebSites/HtmlGenerationWebSite/Models/AClass.cs
+++ b/test/WebSites/HtmlGenerationWebSite/Models/AClass.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace HtmlGenerationWebSite.Models
+{
+    public class AClass
+    {
+        public DayOfWeek DayOfWeek { get; set; }
+        [DisplayFormat(DataFormatString = "Month: {0}")]
+        public Month Month { get; set; }
+    }
+}

--- a/test/WebSites/HtmlGenerationWebSite/Models/DayOfWeek.cs
+++ b/test/WebSites/HtmlGenerationWebSite/Models/DayOfWeek.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace HtmlGenerationWebSite.Models
+{
+    public enum DayOfWeek
+    {
+        Monday,
+        Tuesday,
+        Wednesday,
+        Thursday,
+        Friday,
+        Saturday,
+        Sunday
+    }
+}

--- a/test/WebSites/HtmlGenerationWebSite/Models/Month.cs
+++ b/test/WebSites/HtmlGenerationWebSite/Models/Month.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace HtmlGenerationWebSite.Models
+{
+    public enum Month
+    {
+        [Display(Name = "January")]
+        FirstOne,
+        LastOne
+    }
+}

--- a/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Enum.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Enum.cshtml
@@ -1,0 +1,4 @@
+﻿@using HtmlGenerationWebSite.Models
+@model AClass
+@Html.DisplayFor(x => x.DayOfWeek)
+@Html.DisplayFor(x => x.Month)

--- a/test/WebSites/HtmlGenerationWebSite/Views/Shared/DisplayTemplates/DayOfWeek.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/Shared/DisplayTemplates/DayOfWeek.cshtml
@@ -1,0 +1,26 @@
+﻿@model HtmlGenerationWebSite.Models.DayOfWeek
+
+@switch (Model)
+{
+    case HtmlGenerationWebSite.Models.DayOfWeek.Monday:
+        <text>Maandag</text>
+        break;
+    case HtmlGenerationWebSite.Models.DayOfWeek.Tuesday:
+        <text>Dinsdag</text>
+        break;
+    case HtmlGenerationWebSite.Models.DayOfWeek.Wednesday:
+        <text>Woensdag</text>
+        break;
+    case HtmlGenerationWebSite.Models.DayOfWeek.Thursday:
+        <text>Donderdag</text>
+        break;
+    case HtmlGenerationWebSite.Models.DayOfWeek.Friday:
+        <text>Vrijdag</text>
+        break;
+    case HtmlGenerationWebSite.Models.DayOfWeek.Saturday:
+        <text>Zaterdag</text>
+        break;
+    case HtmlGenerationWebSite.Models.DayOfWeek.Sunday:
+        <text>Zondag</text>
+        break;
+}


### PR DESCRIPTION
Fixes #5547.

We seperate the "view" of how we display a model from the model itself by using FormattedModelValue