### PR TITLE
Added FallbackSrc attribute to ImageTagHelper

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/ImageTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/ImageTagHelper.cs
@@ -14,149 +14,149 @@ using Microsoft.Extensions.Caching.Memory;
 
 namespace Microsoft.AspNetCore.Mvc.TagHelpers
 {
-	/// <summary>
-	/// <see cref="ITagHelper"/> implementation targeting &lt;img&gt; elements that supports file versioning.
-	/// </summary>
-	/// <remarks>
-	/// The tag helper won't process for cases with just the 'src' attribute.
-	/// </remarks>
-	[HtmlTargetElement(
-		"img",
-		Attributes = AppendVersionAttributeName + "," + SrcAttributeName,
-		TagStructure = TagStructure.WithoutEndTag)]
-	[HtmlTargetElement(
-		"img",
-		Attributes = FallbackSrcAttributeName + "," + SrcAttributeName,
-		TagStructure = TagStructure.WithoutEndTag)]
-	public class ImageTagHelper : UrlResolutionTagHelper
-	{
-		private static readonly string Namespace = typeof(ImageTagHelper).Namespace;
+    /// <summary>
+    /// <see cref="ITagHelper"/> implementation targeting &lt;img&gt; elements that supports file versioning.
+    /// </summary>
+    /// <remarks>
+    /// The tag helper won't process for cases with just the 'src' attribute.
+    /// </remarks>
+    [HtmlTargetElement(
+        "img",
+        Attributes = AppendVersionAttributeName + "," + SrcAttributeName,
+        TagStructure = TagStructure.WithoutEndTag)]
+    [HtmlTargetElement(
+        "img",
+        Attributes = FallbackSrcAttributeName + "," + SrcAttributeName,
+        TagStructure = TagStructure.WithoutEndTag)]
+    public class ImageTagHelper : UrlResolutionTagHelper
+    {
+        private static readonly string Namespace = typeof(ImageTagHelper).Namespace;
 
-		private const string AppendVersionAttributeName = "asp-append-version";
-		private const string SrcAttributeName = "src";
-		private const string FallbackSrcAttributeName = "asp-fallback-src";
-		private const string OnErrorAttributeName = "onerror";
+        private const string AppendVersionAttributeName = "asp-append-version";
+        private const string SrcAttributeName = "src";
+        private const string FallbackSrcAttributeName = "asp-fallback-src";
+        private const string OnErrorAttributeName = "onerror";
 
-		private FileVersionProvider _fileVersionProvider;
+        private FileVersionProvider _fileVersionProvider;
 
-		/// <summary>
-		/// Creates a new <see cref="ImageTagHelper"/>.
-		/// </summary>
-		/// <param name="hostingEnvironment">The <see cref="IHostingEnvironment"/>.</param>
-		/// <param name="cache">The <see cref="IMemoryCache"/>.</param>
-		/// <param name="htmlEncoder">The <see cref="HtmlEncoder"/> to use.</param>
-		/// <param name="urlHelperFactory">The <see cref="IUrlHelperFactory"/>.</param>
-		public ImageTagHelper(
-			IHostingEnvironment hostingEnvironment,
-			IMemoryCache cache,
-			HtmlEncoder htmlEncoder,
-			IUrlHelperFactory urlHelperFactory)
-			: base(urlHelperFactory, htmlEncoder)
-		{
-			HostingEnvironment = hostingEnvironment;
-			Cache = cache;
-		}
+        /// <summary>
+        /// Creates a new <see cref="ImageTagHelper"/>.
+        /// </summary>
+        /// <param name="hostingEnvironment">The <see cref="IHostingEnvironment"/>.</param>
+        /// <param name="cache">The <see cref="IMemoryCache"/>.</param>
+        /// <param name="htmlEncoder">The <see cref="HtmlEncoder"/> to use.</param>
+        /// <param name="urlHelperFactory">The <see cref="IUrlHelperFactory"/>.</param>
+        public ImageTagHelper(
+            IHostingEnvironment hostingEnvironment,
+            IMemoryCache cache,
+            HtmlEncoder htmlEncoder,
+            IUrlHelperFactory urlHelperFactory)
+            : base(urlHelperFactory, htmlEncoder)
+        {
+            HostingEnvironment = hostingEnvironment;
+            Cache = cache;
+        }
 
-		/// <inheritdoc />
-		public override int Order
-		{
-			get
-			{
-				return -1000;
-			}
-		}
+        /// <inheritdoc />
+        public override int Order
+        {
+            get
+            {
+                return -1000;
+            }
+        }
 
-		/// <summary>
-		/// Source of the image.
-		/// </summary>
-		/// <remarks>
-		/// Passed through to the generated HTML in all cases.
-		/// </remarks>
-		[HtmlAttributeName(SrcAttributeName)]
-		public string Src { get; set; }
+        /// <summary>
+        /// Source of the image.
+        /// </summary>
+        /// <remarks>
+        /// Passed through to the generated HTML in all cases.
+        /// </remarks>
+        [HtmlAttributeName(SrcAttributeName)]
+        public string Src { get; set; }
 
-		/// <summary>
-		/// Value indicating if file version should be appended to the src urls.
-		/// </summary>
-		/// <remarks>
-		/// If <c>true</c> then a query string "v" with the encoded content of the file is added.
-		/// </remarks>
-		[HtmlAttributeName(AppendVersionAttributeName)]
-		public bool AppendVersion { get; set; }
+        /// <summary>
+        /// Value indicating if file version should be appended to the src urls.
+        /// </summary>
+        /// <remarks>
+        /// If <c>true</c> then a query string "v" with the encoded content of the file is added.
+        /// </remarks>
+        [HtmlAttributeName(AppendVersionAttributeName)]
+        public bool AppendVersion { get; set; }
 
-		/// <summary>
-		/// The URL of the Image tag to fallback to in the case the primary one fails
-		/// </summary>
-		/// <remarks>
-		/// Utilizes the onerror JavaScript handler for fallback
-		/// </remarks>
-		[HtmlAttributeName(FallbackSrcAttributeName)]
-		public string FallbackSrc { get; set; }
+        /// <summary>
+        /// The URL of the Image tag to fallback to in the case the primary one fails
+        /// </summary>
+        /// <remarks>
+        /// Utilizes the onerror JavaScript handler for fallback
+        /// </remarks>
+        [HtmlAttributeName(FallbackSrcAttributeName)]
+        public string FallbackSrc { get; set; }
 
-		protected IHostingEnvironment HostingEnvironment { get; }
+        protected IHostingEnvironment HostingEnvironment { get; }
 
-		protected IMemoryCache Cache { get; }
+        protected IMemoryCache Cache { get; }
 
-		/// <inheritdoc />
-		public override void Process(TagHelperContext context, TagHelperOutput output)
-		{
-			if (context == null)
-			{
-				throw new ArgumentNullException(nameof(context));
-			}
+        /// <inheritdoc />
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
 
-			if (output == null)
-			{
-				throw new ArgumentNullException(nameof(output));
-			}
+            if (output == null)
+            {
+                throw new ArgumentNullException(nameof(output));
+            }
 
-			output.CopyHtmlAttribute(SrcAttributeName, context);
-			ProcessUrlAttribute(SrcAttributeName, output);
+            output.CopyHtmlAttribute(SrcAttributeName, context);
+            ProcessUrlAttribute(SrcAttributeName, output);
 
-			if (AppendVersion)
-			{
-				EnsureFileVersionProvider();
+            if (AppendVersion)
+            {
+                EnsureFileVersionProvider();
 
-				// Retrieve the TagHelperOutput variation of the "src" attribute in case other TagHelpers in the
-				// pipeline have touched the value. If the value is already encoded this ImageTagHelper may
-				// not function properly.
-				Src = output.Attributes[SrcAttributeName].Value as string;
+                // Retrieve the TagHelperOutput variation of the "src" attribute in case other TagHelpers in the
+                // pipeline have touched the value. If the value is already encoded this ImageTagHelper may
+                // not function properly.
+                Src = output.Attributes[SrcAttributeName].Value as string;
 
-				output.Attributes.SetAttribute(SrcAttributeName, _fileVersionProvider.AddFileVersionToPath(Src));
-			}
+                output.Attributes.SetAttribute(SrcAttributeName, _fileVersionProvider.AddFileVersionToPath(Src));
+            }
 
-			//Retrieve any existing onerror handler code
-			var onError = output.Attributes[OnErrorAttributeName]?.Value as string;
+            //Retrieve any existing onerror handler code
+            var onError = output.Attributes[OnErrorAttributeName]?.Value as string;
 
-			//Check if there's a fallback source and no onerror handler
-			if (!string.IsNullOrWhiteSpace(FallbackSrc) && string.IsNullOrWhiteSpace(onError))
-			{
-				string resolvedUrl;
-				if (TryResolveUrl(FallbackSrc, out resolvedUrl))
-				{
-					FallbackSrc = resolvedUrl;
-				}
+            //Check if there's a fallback source and no onerror handler
+            if (!string.IsNullOrWhiteSpace(FallbackSrc) && string.IsNullOrWhiteSpace(onError))
+            {
+                string resolvedUrl;
+                if (TryResolveUrl(FallbackSrc, out resolvedUrl))
+                {
+                    FallbackSrc = resolvedUrl;
+                }
 
-				if (AppendVersion)
-				{
-					FallbackSrc = _fileVersionProvider.AddFileVersionToPath(FallbackSrc);
-				}
+                if (AppendVersion)
+                {
+                    FallbackSrc = _fileVersionProvider.AddFileVersionToPath(FallbackSrc);
+                }
 
-				//Apply fallback handler code
-				onError = $"this.src = '{FallbackSrc}'";
-				output.Attributes.SetAttribute(OnErrorAttributeName, onError);
-			}
-		}
+                //Apply fallback handler code
+                onError = $"this.src = '{FallbackSrc}'";
+                output.Attributes.SetAttribute(OnErrorAttributeName, onError);
+            }
+        }
 
-		private void EnsureFileVersionProvider()
-		{
-			if (_fileVersionProvider == null)
-			{
-				_fileVersionProvider = new FileVersionProvider(
-					HostingEnvironment.WebRootFileProvider,
-					Cache,
-					ViewContext.HttpContext.Request.PathBase);
-			}
-		}
-	}
+        private void EnsureFileVersionProvider()
+        {
+            if (_fileVersionProvider == null)
+            {
+                _fileVersionProvider = new FileVersionProvider(
+                    HostingEnvironment.WebRootFileProvider,
+                    Cache,
+                    ViewContext.HttpContext.Request.PathBase);
+            }
+        }
+    }
 }

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/ImageTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/ImageTagHelper.cs
@@ -14,112 +14,149 @@ using Microsoft.Extensions.Caching.Memory;
 
 namespace Microsoft.AspNetCore.Mvc.TagHelpers
 {
-    /// <summary>
-    /// <see cref="ITagHelper"/> implementation targeting &lt;img&gt; elements that supports file versioning.
-    /// </summary>
-    /// <remarks>
-    /// The tag helper won't process for cases with just the 'src' attribute.
-    /// </remarks>
-    [HtmlTargetElement(
-        "img",
-        Attributes = AppendVersionAttributeName + "," + SrcAttributeName,
-        TagStructure = TagStructure.WithoutEndTag)]
-    public class ImageTagHelper : UrlResolutionTagHelper
-    {
-        private static readonly string Namespace = typeof(ImageTagHelper).Namespace;
+	/// <summary>
+	/// <see cref="ITagHelper"/> implementation targeting &lt;img&gt; elements that supports file versioning.
+	/// </summary>
+	/// <remarks>
+	/// The tag helper won't process for cases with just the 'src' attribute.
+	/// </remarks>
+	[HtmlTargetElement(
+		"img",
+		Attributes = AppendVersionAttributeName + "," + SrcAttributeName,
+		TagStructure = TagStructure.WithoutEndTag)]
+	[HtmlTargetElement(
+		"img",
+		Attributes = FallbackSrcAttributeName + "," + SrcAttributeName,
+		TagStructure = TagStructure.WithoutEndTag)]
+	public class ImageTagHelper : UrlResolutionTagHelper
+	{
+		private static readonly string Namespace = typeof(ImageTagHelper).Namespace;
 
-        private const string AppendVersionAttributeName = "asp-append-version";
-        private const string SrcAttributeName = "src";
+		private const string AppendVersionAttributeName = "asp-append-version";
+		private const string SrcAttributeName = "src";
+		private const string FallbackSrcAttributeName = "asp-fallback-src";
+		private const string OnErrorAttributeName = "onerror";
 
-        private FileVersionProvider _fileVersionProvider;
+		private FileVersionProvider _fileVersionProvider;
 
-        /// <summary>
-        /// Creates a new <see cref="ImageTagHelper"/>.
-        /// </summary>
-        /// <param name="hostingEnvironment">The <see cref="IHostingEnvironment"/>.</param>
-        /// <param name="cache">The <see cref="IMemoryCache"/>.</param>
-        /// <param name="htmlEncoder">The <see cref="HtmlEncoder"/> to use.</param>
-        /// <param name="urlHelperFactory">The <see cref="IUrlHelperFactory"/>.</param>
-        public ImageTagHelper(
-            IHostingEnvironment hostingEnvironment,
-            IMemoryCache cache,
-            HtmlEncoder htmlEncoder,
-            IUrlHelperFactory urlHelperFactory)
-            : base(urlHelperFactory, htmlEncoder)
-        {
-            HostingEnvironment = hostingEnvironment;
-            Cache = cache;
-        }
+		/// <summary>
+		/// Creates a new <see cref="ImageTagHelper"/>.
+		/// </summary>
+		/// <param name="hostingEnvironment">The <see cref="IHostingEnvironment"/>.</param>
+		/// <param name="cache">The <see cref="IMemoryCache"/>.</param>
+		/// <param name="htmlEncoder">The <see cref="HtmlEncoder"/> to use.</param>
+		/// <param name="urlHelperFactory">The <see cref="IUrlHelperFactory"/>.</param>
+		public ImageTagHelper(
+			IHostingEnvironment hostingEnvironment,
+			IMemoryCache cache,
+			HtmlEncoder htmlEncoder,
+			IUrlHelperFactory urlHelperFactory)
+			: base(urlHelperFactory, htmlEncoder)
+		{
+			HostingEnvironment = hostingEnvironment;
+			Cache = cache;
+		}
 
-        /// <inheritdoc />
-        public override int Order
-        {
-            get
-            {
-                return -1000;
-            }
-        }
+		/// <inheritdoc />
+		public override int Order
+		{
+			get
+			{
+				return -1000;
+			}
+		}
 
-        /// <summary>
-        /// Source of the image.
-        /// </summary>
-        /// <remarks>
-        /// Passed through to the generated HTML in all cases.
-        /// </remarks>
-        [HtmlAttributeName(SrcAttributeName)]
-        public string Src { get; set; }
+		/// <summary>
+		/// Source of the image.
+		/// </summary>
+		/// <remarks>
+		/// Passed through to the generated HTML in all cases.
+		/// </remarks>
+		[HtmlAttributeName(SrcAttributeName)]
+		public string Src { get; set; }
 
-        /// <summary>
-        /// Value indicating if file version should be appended to the src urls.
-        /// </summary>
-        /// <remarks>
-        /// If <c>true</c> then a query string "v" with the encoded content of the file is added.
-        /// </remarks>
-        [HtmlAttributeName(AppendVersionAttributeName)]
-        public bool AppendVersion { get; set; }
+		/// <summary>
+		/// Value indicating if file version should be appended to the src urls.
+		/// </summary>
+		/// <remarks>
+		/// If <c>true</c> then a query string "v" with the encoded content of the file is added.
+		/// </remarks>
+		[HtmlAttributeName(AppendVersionAttributeName)]
+		public bool AppendVersion { get; set; }
 
-        protected IHostingEnvironment HostingEnvironment { get; }
+		/// <summary>
+		/// The URL of the Image tag to fallback to in the case the primary one fails
+		/// </summary>
+		/// <remarks>
+		/// Utilizes the onerror JavaScript handler for fallback
+		/// </remarks>
+		[HtmlAttributeName(FallbackSrcAttributeName)]
+		public string FallbackSrc { get; set; }
 
-        protected IMemoryCache Cache { get; }
+		protected IHostingEnvironment HostingEnvironment { get; }
 
-        /// <inheritdoc />
-        public override void Process(TagHelperContext context, TagHelperOutput output)
-        {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+		protected IMemoryCache Cache { get; }
 
-            if (output == null)
-            {
-                throw new ArgumentNullException(nameof(output));
-            }
+		/// <inheritdoc />
+		public override void Process(TagHelperContext context, TagHelperOutput output)
+		{
+			if (context == null)
+			{
+				throw new ArgumentNullException(nameof(context));
+			}
 
-            output.CopyHtmlAttribute(SrcAttributeName, context);
-            ProcessUrlAttribute(SrcAttributeName, output);
+			if (output == null)
+			{
+				throw new ArgumentNullException(nameof(output));
+			}
 
-            if (AppendVersion)
-            {
-                EnsureFileVersionProvider();
+			output.CopyHtmlAttribute(SrcAttributeName, context);
+			ProcessUrlAttribute(SrcAttributeName, output);
 
-                // Retrieve the TagHelperOutput variation of the "src" attribute in case other TagHelpers in the
-                // pipeline have touched the value. If the value is already encoded this ImageTagHelper may
-                // not function properly.
-                Src = output.Attributes[SrcAttributeName].Value as string;
+			if (AppendVersion)
+			{
+				EnsureFileVersionProvider();
 
-                output.Attributes.SetAttribute(SrcAttributeName, _fileVersionProvider.AddFileVersionToPath(Src));
-            }
-        }
+				// Retrieve the TagHelperOutput variation of the "src" attribute in case other TagHelpers in the
+				// pipeline have touched the value. If the value is already encoded this ImageTagHelper may
+				// not function properly.
+				Src = output.Attributes[SrcAttributeName].Value as string;
 
-        private void EnsureFileVersionProvider()
-        {
-            if (_fileVersionProvider == null)
-            {
-                _fileVersionProvider = new FileVersionProvider(
-                    HostingEnvironment.WebRootFileProvider,
-                    Cache,
-                    ViewContext.HttpContext.Request.PathBase);
-            }
-        }
-    }
+				output.Attributes.SetAttribute(SrcAttributeName, _fileVersionProvider.AddFileVersionToPath(Src));
+			}
+
+			//Retrieve any existing onerror handler code
+			var onError = output.Attributes[OnErrorAttributeName]?.Value as string;
+
+			//Check if there's a fallback source and no onerror handler
+			if (!string.IsNullOrWhiteSpace(FallbackSrc) && string.IsNullOrWhiteSpace(onError))
+			{
+				string resolvedUrl;
+				if (TryResolveUrl(FallbackSrc, out resolvedUrl))
+				{
+					FallbackSrc = resolvedUrl;
+				}
+
+				if (AppendVersion)
+				{
+					FallbackSrc = _fileVersionProvider.AddFileVersionToPath(FallbackSrc);
+				}
+
+				//Apply fallback handler code
+				onError = $"this.src = '{FallbackSrc}'";
+				output.Attributes.SetAttribute(OnErrorAttributeName, onError);
+			}
+		}
+
+		private void EnsureFileVersionProvider()
+		{
+			if (_fileVersionProvider == null)
+			{
+				_fileVersionProvider = new FileVersionProvider(
+					HostingEnvironment.WebRootFileProvider,
+					Cache,
+					ViewContext.HttpContext.Request.PathBase);
+			}
+		}
+	}
 }

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/ImageTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/ImageTagHelperTest.cs
@@ -186,9 +186,89 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             Assert.Equal(2, output.Attributes.Count);
             var srcAttribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("src"));
             Assert.Equal("/images/test-image.png?v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk", srcAttribute.Value);
-        }
+		}
 
-        [Fact]
+		[Fact]
+		public void RendersImageTag_FallbackSrc_AddsFileVersion()
+		{
+			// Arrange
+			var context = MakeTagHelperContext(
+				attributes: new TagHelperAttributeList
+				{
+					{ "alt", new HtmlString("Alt image text") },
+					{ "src", "/images/test-image.png" },
+					{ "asp-append-version", "true" },
+					{ "asp-fallback-src", "/images/fallback-image.png" }
+				});
+			var output = MakeImageTagHelperOutput(attributes: new TagHelperAttributeList
+			{
+				{ "alt", new HtmlString("Alt image text") },
+			});
+			var hostingEnvironment = MakeHostingEnvironment();
+			var viewContext = MakeViewContext();
+
+			var helper = new ImageTagHelper(hostingEnvironment, MakeCache(), new HtmlTestEncoder(), MakeUrlHelperFactory())
+			{
+				ViewContext = viewContext,
+				Src = "/images/test-image.png",
+				AppendVersion = true,
+				FallbackSrc = "/images/fallback-image.png"
+			};
+
+			// Act
+			helper.Process(context, output);
+
+			// Assert
+			Assert.True(output.Content.GetContent().Length == 0);
+			Assert.Equal("img", output.TagName);
+			Assert.Equal(3, output.Attributes.Count);
+			var srcAttribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("src"));
+			Assert.Equal("/images/test-image.png?v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk", srcAttribute.Value);
+
+			var onErrorAttribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("onerror"));
+			Assert.Equal("this.src = '/images/fallback-image.png?v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk'", onErrorAttribute.Value);
+		}
+
+		[Fact]
+		public void RendersImageTag_FallbackSrc_NoFileVersion()
+		{
+			// Arrange
+			var context = MakeTagHelperContext(
+				attributes: new TagHelperAttributeList
+				{
+					{ "alt", new HtmlString("Alt image text") },
+					{ "src", "/images/test-image.png" },
+					{ "asp-fallback-src", "/images/fallback-image.png" }
+				});
+			var output = MakeImageTagHelperOutput(attributes: new TagHelperAttributeList
+			{
+				{ "alt", new HtmlString("Alt image text") },
+			});
+			var hostingEnvironment = MakeHostingEnvironment();
+			var viewContext = MakeViewContext();
+
+			var helper = new ImageTagHelper(hostingEnvironment, MakeCache(), new HtmlTestEncoder(), MakeUrlHelperFactory())
+			{
+				ViewContext = viewContext,
+				Src = "/images/test-image.png",
+				FallbackSrc = "/images/fallback-image.png"
+			};
+
+			// Act
+			helper.Process(context, output);
+
+			// Assert
+			Assert.True(output.Content.GetContent().Length == 0);
+			Assert.Equal("img", output.TagName);
+			Assert.Equal(3, output.Attributes.Count);
+			var srcAttribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("src"));
+			Assert.Equal("/images/test-image.png", srcAttribute.Value);
+
+			var onErrorAttribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("onerror"));
+			Assert.Equal("this.src = '/images/fallback-image.png'", onErrorAttribute.Value);
+		}
+
+		[Fact]
         public void RendersImageTag_DoesNotAddFileVersion()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/ImageTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/ImageTagHelperTest.cs
@@ -186,89 +186,89 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             Assert.Equal(2, output.Attributes.Count);
             var srcAttribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("src"));
             Assert.Equal("/images/test-image.png?v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk", srcAttribute.Value);
-		}
+        }
 
-		[Fact]
-		public void RendersImageTag_FallbackSrc_AddsFileVersion()
-		{
-			// Arrange
-			var context = MakeTagHelperContext(
-				attributes: new TagHelperAttributeList
-				{
-					{ "alt", new HtmlString("Alt image text") },
-					{ "src", "/images/test-image.png" },
-					{ "asp-append-version", "true" },
-					{ "asp-fallback-src", "/images/fallback-image.png" }
-				});
-			var output = MakeImageTagHelperOutput(attributes: new TagHelperAttributeList
-			{
-				{ "alt", new HtmlString("Alt image text") },
-			});
-			var hostingEnvironment = MakeHostingEnvironment();
-			var viewContext = MakeViewContext();
+        [Fact]
+        public void RendersImageTag_FallbackSrc_AddsFileVersion()
+        {
+            // Arrange
+            var context = MakeTagHelperContext(
+                attributes: new TagHelperAttributeList
+                {
+                    { "alt", new HtmlString("Alt image text") },
+                    { "src", "/images/test-image.png" },
+                    { "asp-append-version", "true" },
+                    { "asp-fallback-src", "/images/fallback-image.png" }
+                });
+            var output = MakeImageTagHelperOutput(attributes: new TagHelperAttributeList
+            {
+                { "alt", new HtmlString("Alt image text") },
+            });
+            var hostingEnvironment = MakeHostingEnvironment();
+            var viewContext = MakeViewContext();
 
-			var helper = new ImageTagHelper(hostingEnvironment, MakeCache(), new HtmlTestEncoder(), MakeUrlHelperFactory())
-			{
-				ViewContext = viewContext,
-				Src = "/images/test-image.png",
-				AppendVersion = true,
-				FallbackSrc = "/images/fallback-image.png"
-			};
+            var helper = new ImageTagHelper(hostingEnvironment, MakeCache(), new HtmlTestEncoder(), MakeUrlHelperFactory())
+            {
+                ViewContext = viewContext,
+                Src = "/images/test-image.png",
+                AppendVersion = true,
+                FallbackSrc = "/images/fallback-image.png"
+            };
 
-			// Act
-			helper.Process(context, output);
+            // Act
+            helper.Process(context, output);
 
-			// Assert
-			Assert.True(output.Content.GetContent().Length == 0);
-			Assert.Equal("img", output.TagName);
-			Assert.Equal(3, output.Attributes.Count);
-			var srcAttribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("src"));
-			Assert.Equal("/images/test-image.png?v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk", srcAttribute.Value);
+            // Assert
+            Assert.True(output.Content.GetContent().Length == 0);
+            Assert.Equal("img", output.TagName);
+            Assert.Equal(3, output.Attributes.Count);
+            var srcAttribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("src"));
+            Assert.Equal("/images/test-image.png?v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk", srcAttribute.Value);
 
-			var onErrorAttribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("onerror"));
-			Assert.Equal("this.src = '/images/fallback-image.png?v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk'", onErrorAttribute.Value);
-		}
+            var onErrorAttribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("onerror"));
+            Assert.Equal("this.src = '/images/fallback-image.png?v=f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk'", onErrorAttribute.Value);
+        }
 
-		[Fact]
-		public void RendersImageTag_FallbackSrc_NoFileVersion()
-		{
-			// Arrange
-			var context = MakeTagHelperContext(
-				attributes: new TagHelperAttributeList
-				{
-					{ "alt", new HtmlString("Alt image text") },
-					{ "src", "/images/test-image.png" },
-					{ "asp-fallback-src", "/images/fallback-image.png" }
-				});
-			var output = MakeImageTagHelperOutput(attributes: new TagHelperAttributeList
-			{
-				{ "alt", new HtmlString("Alt image text") },
-			});
-			var hostingEnvironment = MakeHostingEnvironment();
-			var viewContext = MakeViewContext();
+        [Fact]
+        public void RendersImageTag_FallbackSrc_NoFileVersion()
+        {
+            // Arrange
+            var context = MakeTagHelperContext(
+                attributes: new TagHelperAttributeList
+                {
+                    { "alt", new HtmlString("Alt image text") },
+                    { "src", "/images/test-image.png" },
+                    { "asp-fallback-src", "/images/fallback-image.png" }
+                });
+            var output = MakeImageTagHelperOutput(attributes: new TagHelperAttributeList
+            {
+                { "alt", new HtmlString("Alt image text") },
+            });
+            var hostingEnvironment = MakeHostingEnvironment();
+            var viewContext = MakeViewContext();
 
-			var helper = new ImageTagHelper(hostingEnvironment, MakeCache(), new HtmlTestEncoder(), MakeUrlHelperFactory())
-			{
-				ViewContext = viewContext,
-				Src = "/images/test-image.png",
-				FallbackSrc = "/images/fallback-image.png"
-			};
+            var helper = new ImageTagHelper(hostingEnvironment, MakeCache(), new HtmlTestEncoder(), MakeUrlHelperFactory())
+            {
+                ViewContext = viewContext,
+                Src = "/images/test-image.png",
+                FallbackSrc = "/images/fallback-image.png"
+            };
 
-			// Act
-			helper.Process(context, output);
+            // Act
+            helper.Process(context, output);
 
-			// Assert
-			Assert.True(output.Content.GetContent().Length == 0);
-			Assert.Equal("img", output.TagName);
-			Assert.Equal(3, output.Attributes.Count);
-			var srcAttribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("src"));
-			Assert.Equal("/images/test-image.png", srcAttribute.Value);
+            // Assert
+            Assert.True(output.Content.GetContent().Length == 0);
+            Assert.Equal("img", output.TagName);
+            Assert.Equal(3, output.Attributes.Count);
+            var srcAttribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("src"));
+            Assert.Equal("/images/test-image.png", srcAttribute.Value);
 
-			var onErrorAttribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("onerror"));
-			Assert.Equal("this.src = '/images/fallback-image.png'", onErrorAttribute.Value);
-		}
+            var onErrorAttribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("onerror"));
+            Assert.Equal("this.src = '/images/fallback-image.png'", onErrorAttribute.Value);
+        }
 
-		[Fact]
+        [Fact]
         public void RendersImageTag_DoesNotAddFileVersion()
         {
             // Arrange


### PR DESCRIPTION
It's common to want to use a CDN to store images in addition to JavaScript and CSS files.  Currently, MVC has support for primary and fallback sources via tag helpers for JavaScript and CSS through an asp-fallback-src or asp-fallback-href attribute.  ImageTagHelper does not currently have that capability but should.

This change adds that functionality to ImageTagHelper in a similar way to its implementation in ScriptTagHelper and LinkTagHelper including support for using the version attribute.