### PR TITLE
Add `[ValidateNever]` and `IPropertyValidationFilter`

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelMetadata.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelMetadata.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding
@@ -294,6 +295,13 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         /// Gets a string used by the templating system to discover display-templates and editor-templates.
         /// </summary>
         public abstract string TemplateHint { get; }
+
+        /// <summary>
+        /// Gets an <see cref="IShouldValidate"/> implementation that indicates whether this model should be validated.
+        /// If <c>null</c>, properties with this <see cref="ModelMetadata"/> are validated.
+        /// </summary>
+        /// <value>Defaults to <c>null</c>.</value>
+        public abstract IShouldValidate ShouldValidate { get; }
 
         /// <summary>
         /// Gets a value that indicates whether properties or elements of the model should be validated.

--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelMetadata.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelMetadata.cs
@@ -297,11 +297,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         public abstract string TemplateHint { get; }
 
         /// <summary>
-        /// Gets an <see cref="IShouldValidate"/> implementation that indicates whether this model should be validated.
-        /// If <c>null</c>, properties with this <see cref="ModelMetadata"/> are validated.
+        /// Gets an <see cref="IPropertyValidationFilter"/> implementation that indicates whether this model should be
+        /// validated. If <c>null</c>, properties with this <see cref="ModelMetadata"/> are validated.
         /// </summary>
         /// <value>Defaults to <c>null</c>.</value>
-        public abstract IShouldValidate ShouldValidate { get; }
+        public virtual IPropertyValidationFilter PropertyValidationFilter => null;
 
         /// <summary>
         /// Gets a value that indicates whether properties or elements of the model should be validated.

--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/Validation/IPropertyValidationFilter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/Validation/IPropertyValidationFilter.cs
@@ -7,9 +7,9 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
     /// Contract for attributes that determine whether associated properties should be validated. When the attribute is
     /// applied to a property, the validation system calls <see cref="ShouldValidateEntry"/> to determine whether to
     /// validate that property. When applied to a type, the validation system calls <see cref="ShouldValidateEntry"/>
-    /// for each property within that type to determine whether to validate it.
+    /// for each property that type defines to determine whether to validate it.
     /// </summary>
-    public interface IShouldValidate
+    public interface IPropertyValidationFilter
     {
         /// <summary>
         /// Gets an indication whether the <paramref name="entry"/> should be validated.

--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/Validation/IShouldValidate.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/Validation/IShouldValidate.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
+{
+    /// <summary>
+    /// Contract for attributes that determine whether associated properties should be validated. When the attribute is
+    /// applied to a property, the validation system calls <see cref="ShouldValidateEntry"/> to determine whether to
+    /// validate that property. When applied to a type, the validation system calls <see cref="ShouldValidateEntry"/>
+    /// for each property within that type to determine whether to validate it.
+    /// </summary>
+    public interface IShouldValidate
+    {
+        /// <summary>
+        /// Gets an indication whether the <paramref name="entry"/> should be validated.
+        /// </summary>
+        /// <param name="entry"><see cref="ValidationEntry"/> to check.</param>
+        /// <param name="parentEntry"><see cref="ValidationEntry"/> containing <paramref name="entry"/>.</param>
+        /// <returns><c>true</c> if <paramref name="entry"/> should be validated; <c>false</c> otherwise.</returns>
+        bool ShouldValidateEntry(ValidationEntry entry, ValidationEntry parentEntry);
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/Validation/ValidationEntry.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/Validation/ValidationEntry.cs
@@ -10,6 +10,9 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
     /// </summary>
     public struct ValidationEntry
     {
+        private object _model;
+        private Func<object> _modelAccessor;
+
         /// <summary>
         /// Creates a new <see cref="ValidationEntry"/>.
         /// </summary>
@@ -30,7 +33,37 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
 
             Metadata = metadata;
             Key = key;
-            Model = model;
+            _model = model;
+            _modelAccessor = null;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ValidationEntry"/>.
+        /// </summary>
+        /// <param name="metadata">The <see cref="ModelMetadata"/> associated with the <see cref="Model"/>.</param>
+        /// <param name="key">The model prefix associated with the <see cref="Model"/>.</param>
+        /// <param name="modelAccessor">A delegate that will return the <see cref="Model"/>.</param>
+        public ValidationEntry(ModelMetadata metadata, string key, Func<object> modelAccessor)
+        {
+            if (metadata == null)
+            {
+                throw new ArgumentNullException(nameof(metadata));
+            }
+
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            if (modelAccessor == null)
+            {
+                throw new ArgumentNullException(nameof(modelAccessor));
+            }
+
+            Metadata = metadata;
+            Key = key;
+            _model = null;
+            _modelAccessor = modelAccessor;
         }
 
         /// <summary>
@@ -46,6 +79,18 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
         /// <summary>
         /// The model object.
         /// </summary>
-        public object Model { get; }
+        public object Model
+        {
+            get
+            {
+                if (_modelAccessor != null)
+                {
+                    _model = _modelAccessor();
+                    _modelAccessor = null;
+                }
+
+                return _model;
+            }
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/DefaultValidationMetadataProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/DefaultValidationMetadataProvider.cs
@@ -37,21 +37,22 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 }
             }
 
-            // IShouldValidate attributes on a type affect properties in that type, not properties that have that type.
-            // Thus, we ignore context.TypeAttributes for properties and don't check at all for types.
+            // IPropertyValidationFilter attributes on a type affect properties in that type, not properties that have
+            // that type. Thus, we ignore context.TypeAttributes for properties and not check at all for types.
             if (context.Key.MetadataKind == ModelMetadataKind.Property)
             {
-                var shouldValidate = context.PropertyAttributes.OfType<IShouldValidate>().FirstOrDefault();
-                if (shouldValidate == null)
+                var validationFilter = context.PropertyAttributes.OfType<IPropertyValidationFilter>().FirstOrDefault();
+                if (validationFilter == null)
                 {
-                    // No [ValidateNever] on the property. Check if container has this attribute.
-                    shouldValidate = context.Key.ContainerType.GetTypeInfo()
+                    // No IPropertyValidationFilter attributes on the property.
+                    // Check if container has such an attribute.
+                    validationFilter = context.Key.ContainerType.GetTypeInfo()
                         .GetCustomAttributes(inherit: true)
-                        .OfType<IShouldValidate>()
+                        .OfType<IPropertyValidationFilter>()
                         .FirstOrDefault();
                 }
 
-                context.ValidationMetadata.ShouldValidate = shouldValidate;
+                context.ValidationMetadata.PropertyValidationFilter = validationFilter;
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/BindNeverAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/BindNeverAttribute.cs
@@ -7,8 +7,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 {
     /// <summary>
     /// Indicates that a property should be excluded from model binding. When applied to a property, the model binding
-    /// system excludes that property. When applied to a type, the model binding system excludes all properties of that
-    /// type.
+    /// system excludes that property. When applied to a type, the model binding system excludes all properties within
+    /// that type.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public sealed class BindNeverAttribute : BindingBehaviorAttribute

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/BindNeverAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/BindNeverAttribute.cs
@@ -7,8 +7,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 {
     /// <summary>
     /// Indicates that a property should be excluded from model binding. When applied to a property, the model binding
-    /// system excludes that property. When applied to a type, the model binding system excludes all properties within
-    /// that type.
+    /// system excludes that property. When applied to a type, the model binding system excludes all properties that
+    /// type defines.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public sealed class BindNeverAttribute : BindingBehaviorAttribute

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/BindRequiredAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/BindRequiredAttribute.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
     /// <summary>
     /// Indicates that a property is required for model binding. When applied to a property, the model binding system
     /// requires a value for that property. When applied to a type, the model binding system requires values for all
-    /// properties of that type.
+    /// properties within that type.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public sealed class BindRequiredAttribute : BindingBehaviorAttribute

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/BindRequiredAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/BindRequiredAttribute.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
     /// <summary>
     /// Indicates that a property is required for model binding. When applied to a property, the model binding system
     /// requires a value for that property. When applied to a type, the model binding system requires values for all
-    /// properties within that type.
+    /// properties that type defines.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public sealed class BindRequiredAttribute : BindingBehaviorAttribute

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Metadata/DefaultModelMetadata.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Metadata/DefaultModelMetadata.cs
@@ -533,11 +533,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
         }
 
         /// <inheritdoc />
-        public override IShouldValidate ShouldValidate
+        public override IPropertyValidationFilter PropertyValidationFilter
         {
             get
             {
-                return ValidationMetadata.ShouldValidate;
+                return ValidationMetadata.PropertyValidationFilter;
             }
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Metadata/DefaultModelMetadata.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Metadata/DefaultModelMetadata.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
 {
@@ -528,6 +529,15 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
             get
             {
                 return DisplayMetadata.TemplateHint;
+            }
+        }
+
+        /// <inheritdoc />
+        public override IShouldValidate ShouldValidate
+        {
+            get
+            {
+                return ValidationMetadata.ShouldValidate;
             }
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Metadata/ExcludeBindingMetadataProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Metadata/ExcludeBindingMetadataProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
         /// Creates a new <see cref="ExcludeBindingMetadataProvider"/> for the given <paramref name="type"/>.
         /// </summary>
         /// <param name="type">
-        /// The <see cref="Type"/>. All properties of this <see cref="Type"/> will have
+        /// The <see cref="Type"/>. All properties with this <see cref="Type"/> will have
         /// <see cref="ModelMetadata.IsBindingAllowed"/> set to <c>false</c>.
         /// </param>
         public ExcludeBindingMetadataProvider(Type type)

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Metadata/ValidationMetadata.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Metadata/ValidationMetadata.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
 {
@@ -19,8 +20,14 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
         public bool? IsRequired { get; set; }
 
         /// <summary>
+        /// Gets or sets an <see cref="IShouldValidate"/> implementation that indicates whether this model should be
+        /// validated. See <see cref="ModelMetadata.ShouldValidate"/>.
+        /// </summary>
+        public IShouldValidate ShouldValidate { get; set; }
+
+        /// <summary>
         /// Gets or sets a value that indicates whether children of the model should be validated. If <c>null</c>
-        /// then <see cref="ModelMetadata.ValidateChildren"/> will be <c>true</c> if either of 
+        /// then <see cref="ModelMetadata.ValidateChildren"/> will be <c>true</c> if either of
         /// <see cref="ModelMetadata.IsComplexType"/> or <see cref="ModelMetadata.IsEnumerableType"/> is <c>true</c>;
         /// <c>false</c> otherwise.
         /// </summary>

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Metadata/ValidationMetadata.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Metadata/ValidationMetadata.cs
@@ -20,10 +20,10 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
         public bool? IsRequired { get; set; }
 
         /// <summary>
-        /// Gets or sets an <see cref="IShouldValidate"/> implementation that indicates whether this model should be
-        /// validated. See <see cref="ModelMetadata.ShouldValidate"/>.
+        /// Gets or sets an <see cref="IPropertyValidationFilter"/> implementation that indicates whether this model
+        /// should be validated. See <see cref="ModelMetadata.PropertyValidationFilter"/>.
         /// </summary>
-        public IShouldValidate ShouldValidate { get; set; }
+        public IPropertyValidationFilter PropertyValidationFilter { get; set; }
 
         /// <summary>
         /// Gets or sets a value that indicates whether children of the model should be validated. If <c>null</c>

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Validation/ValidateNeverAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Validation/ValidateNeverAttribute.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
+{
+    /// <summary>
+    /// <see cref="IShouldValidate"/> implementation that unconditionally indicates a property should be excluded from
+    /// validation. When applied to a property, the validation system excludes that property. When applied to a type,
+    /// the validation system excludes all properties within that type.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public sealed class ValidateNeverAttribute : Attribute, IShouldValidate
+    {
+        /// <inheritdoc />
+        public bool ShouldValidateEntry(ValidationEntry entry, ValidationEntry parentEntry)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Validation/ValidateNeverAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Validation/ValidateNeverAttribute.cs
@@ -6,12 +6,12 @@ using System;
 namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
 {
     /// <summary>
-    /// <see cref="IShouldValidate"/> implementation that unconditionally indicates a property should be excluded from
-    /// validation. When applied to a property, the validation system excludes that property. When applied to a type,
-    /// the validation system excludes all properties within that type.
+    /// <see cref="IPropertyValidationFilter"/> implementation that unconditionally indicates a property should be
+    /// excluded from validation. When applied to a property, the validation system excludes that property. When
+    /// applied to a type, the validation system excludes all properties within that type.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-    public sealed class ValidateNeverAttribute : Attribute, IShouldValidate
+    public sealed class ValidateNeverAttribute : Attribute, IPropertyValidationFilter
     {
         /// <inheritdoc />
         public bool ShouldValidateEntry(ValidationEntry entry, ValidationEntry parentEntry)

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Validation/ValidationVisitor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Validation/ValidationVisitor.cs
@@ -185,52 +185,26 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
             {
                 if (_metadata.IsEnumerableType)
                 {
-                    return VisitEnumerableType();
+                    return VisitComplexType(DefaultCollectionValidationStrategy.Instance);
                 }
-                else if (_metadata.IsComplexType)
+
+                if (_metadata.IsComplexType)
                 {
-                    return VisitComplexType();
+                    return VisitComplexType(DefaultComplexObjectValidationStrategy.Instance);
                 }
-                else
-                {
-                    return VisitSimpleType();
-                }
+
+                return VisitSimpleType();
             }
         }
 
-        private bool VisitEnumerableType()
+        // Covers everything VisitSimpleType does not i.e. both enumerations and complex types.
+        private bool VisitComplexType(IValidationStrategy defaultStrategy)
         {
             var isValid = true;
 
             if (_model != null && _metadata.ValidateChildren)
             {
-                var strategy = _strategy ?? DefaultCollectionValidationStrategy.Instance;
-                isValid = VisitChildren(strategy);
-            }
-            else if (_model != null)
-            {
-                // Suppress validation for the entries matching this prefix. This will temporarily set
-                // the current node to 'skipped' but we're going to visit it right away, so subsequent
-                // code will set it to 'valid' or 'invalid'
-                SuppressValidation(_key);
-            }
-
-            // Double-checking HasReachedMaxErrors just in case this model has no elements.
-            if (isValid && !_modelState.HasReachedMaxErrors)
-            {
-                isValid &= ValidateNode();
-            }
-
-            return isValid;
-        }
-
-        private bool VisitComplexType()
-        {
-            var isValid = true;
-
-            if (_model != null && _metadata.ValidateChildren)
-            {
-                var strategy = _strategy ?? DefaultComplexObjectValidationStrategy.Instance;
+                var strategy = _strategy ?? defaultStrategy;
                 isValid = VisitChildren(strategy);
             }
             else if (_model != null)
@@ -265,14 +239,20 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
         {
             var isValid = true;
             var enumerator = strategy.GetChildren(_metadata, _key, _model);
+            var parentEntry = new ValidationEntry(_metadata, _key, _model);
 
             while (enumerator.MoveNext())
             {
-                var metadata = enumerator.Current.Metadata;
-                var model = enumerator.Current.Model;
-                var key = enumerator.Current.Key;
+                var entry = enumerator.Current;
+                var metadata = entry.Metadata;
+                var key = entry.Key;
+                if (metadata.ShouldValidate?.ShouldValidateEntry(entry, parentEntry) == false)
+                {
+                    SuppressValidation(key);
+                    continue;
+                }
 
-                isValid &= Visit(metadata, key, model);
+                isValid &= Visit(metadata, key, entry.Model);
             }
 
             return isValid;

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Validation/ValidationVisitor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Validation/ValidationVisitor.cs
@@ -246,7 +246,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
                 var entry = enumerator.Current;
                 var metadata = entry.Metadata;
                 var key = entry.Key;
-                if (metadata.ShouldValidate?.ShouldValidateEntry(entry, parentEntry) == false)
+                if (metadata.PropertyValidationFilter?.ShouldValidateEntry(entry, parentEntry) == false)
                 {
                     SuppressValidation(key);
                     continue;

--- a/src/Microsoft.AspNetCore.Mvc.DataAnnotations/HiddenInputAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.DataAnnotations/HiddenInputAttribute.cs
@@ -6,8 +6,8 @@ using System;
 namespace Microsoft.AspNetCore.Mvc
 {
     /// <summary>
-    /// Indicates associated property or all properties of associated type should be edited using an &lt;input&gt;
-    /// element of type "hidden".
+    /// Indicates associated property or all properties with the associated type should be edited using an
+    /// &lt;input&gt; element of type "hidden".
     /// </summary>
     /// <remarks>
     /// When overriding a <see cref="HiddenInputAttribute"/> inherited from a base class, should apply both

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ViewDataInfo.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ViewDataInfo.cs
@@ -27,8 +27,8 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ViewDataInfo"/> class with info about a
-        /// <see cref="ViewDataDictionary"/> lookup which is evaluated when <see cref="Value"/> is read. 
-        /// It uses <see cref="System.Reflection.PropertyInfo.GetValue(object)"/> on <paramref name="propertyInfo"/> 
+        /// <see cref="ViewDataDictionary"/> lookup which is evaluated when <see cref="Value"/> is read.
+        /// It uses <see cref="System.Reflection.PropertyInfo.GetValue(object)"/> on <paramref name="propertyInfo"/>
         /// passing parameter <paramref name="container"/> to lazily evaluate the value.
         /// </summary>
         /// <param name="container">The <see cref="object"/> that <see cref="Value"/> will be evaluated from.</param>
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         /// </summary>
         /// <param name="container">The <see cref="object"/> that has the <see cref="Value"/>.</param>
         /// <param name="propertyInfo">The <see cref="PropertyInfo"/> that represents <see cref="Value"/>'s property.</param>
-        /// <param name="valueAccessor"></param>
+        /// <param name="valueAccessor">A delegate that will return the <see cref="Value"/>.</param>
         public ViewDataInfo(object container, PropertyInfo propertyInfo, Func<object> valueAccessor)
         {
             Container = container;

--- a/test/Microsoft.AspNetCore.Mvc.Abstractions.Test/ModelBinding/ModelMetadataTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Abstractions.Test/ModelBinding/ModelMetadataTest.cs
@@ -577,7 +577,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 }
             }
 
-            public override IShouldValidate ShouldValidate
+            public override IPropertyValidationFilter PropertyValidationFilter
             {
                 get
                 {

--- a/test/Microsoft.AspNetCore.Mvc.Abstractions.Test/ModelBinding/ModelMetadataTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Abstractions.Test/ModelBinding/ModelMetadataTest.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding
@@ -569,6 +570,14 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             }
 
             public override string TemplateHint
+            {
+                get
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            public override IShouldValidate ShouldValidate
             {
                 get
                 {

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Metadata/DefaultModelMetadataTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Metadata/DefaultModelMetadataTest.cs
@@ -8,6 +8,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Xml;
 using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using Moq;
 using Xunit;
 
@@ -50,6 +51,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
             Assert.False(metadata.IsRequired); // Defaults to false for reference types
             Assert.True(metadata.ShowForDisplay);
             Assert.True(metadata.ShowForEdit);
+            Assert.False(metadata.ValidateChildren); // Defaults to true for complex and enumerable types.
 
             Assert.Null(metadata.DataTypeName);
             Assert.Null(metadata.Description);
@@ -60,9 +62,10 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
             Assert.Null(metadata.EnumGroupedDisplayNamesAndValues);
             Assert.Null(metadata.EnumNamesAndValues);
             Assert.Null(metadata.NullDisplayText);
-            Assert.Null(metadata.TemplateHint);
+            Assert.Null(metadata.ShouldValidate);
             Assert.Null(metadata.SimpleDisplayProperty);
             Assert.Null(metadata.Placeholder);
+            Assert.Null(metadata.TemplateHint);
 
             Assert.Equal(10000, ModelMetadata.DefaultOrder);
             Assert.Equal(ModelMetadata.DefaultOrder, metadata.Order);
@@ -657,6 +660,42 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
 
             // Assert
             Assert.True(validateChildren);
+        }
+
+        public static TheoryData<IShouldValidate> ShouldValidateData
+        {
+            get
+            {
+                return new TheoryData<IShouldValidate>
+                {
+                    null,
+                    new ValidateNeverAttribute(),
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ShouldValidateData))]
+        public void ShouldValidate_ReflectsShouldValidate_FromValidationMetadata(IShouldValidate value)
+        {
+            // Arrange
+            var detailsProvider = new EmptyCompositeMetadataDetailsProvider();
+            var provider = new DefaultModelMetadataProvider(detailsProvider);
+
+            var key = ModelMetadataIdentity.ForType(typeof(int));
+            var cache = new DefaultMetadataDetails(key, new ModelAttributes(new object[0]));
+            cache.ValidationMetadata = new ValidationMetadata
+            {
+                ShouldValidate = value,
+            };
+
+            var metadata = new DefaultModelMetadata(provider, detailsProvider, cache);
+
+            // Act
+            var shouldValidate = metadata.ShouldValidate;
+
+            // Assert
+            Assert.Same(value, shouldValidate);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Metadata/DefaultModelMetadataTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Metadata/DefaultModelMetadataTest.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
             Assert.Null(metadata.EnumGroupedDisplayNamesAndValues);
             Assert.Null(metadata.EnumNamesAndValues);
             Assert.Null(metadata.NullDisplayText);
-            Assert.Null(metadata.ShouldValidate);
+            Assert.Null(metadata.PropertyValidationFilter);
             Assert.Null(metadata.SimpleDisplayProperty);
             Assert.Null(metadata.Placeholder);
             Assert.Null(metadata.TemplateHint);
@@ -662,11 +662,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
             Assert.True(validateChildren);
         }
 
-        public static TheoryData<IShouldValidate> ShouldValidateData
+        public static TheoryData<IPropertyValidationFilter> ValidationFilterData
         {
             get
             {
-                return new TheoryData<IShouldValidate>
+                return new TheoryData<IPropertyValidationFilter>
                 {
                     null,
                     new ValidateNeverAttribute(),
@@ -675,8 +675,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
         }
 
         [Theory]
-        [MemberData(nameof(ShouldValidateData))]
-        public void ShouldValidate_ReflectsShouldValidate_FromValidationMetadata(IShouldValidate value)
+        [MemberData(nameof(ValidationFilterData))]
+        public void PropertyValidationFilter_ReflectsFilter_FromValidationMetadata(IPropertyValidationFilter value)
         {
             // Arrange
             var detailsProvider = new EmptyCompositeMetadataDetailsProvider();
@@ -686,16 +686,16 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
             var cache = new DefaultMetadataDetails(key, new ModelAttributes(new object[0]));
             cache.ValidationMetadata = new ValidationMetadata
             {
-                ShouldValidate = value,
+                PropertyValidationFilter = value,
             };
 
             var metadata = new DefaultModelMetadata(provider, detailsProvider, cache);
 
             // Act
-            var shouldValidate = metadata.ShouldValidate;
+            var validationFilter = metadata.PropertyValidationFilter;
 
             // Assert
-            Assert.Same(value, shouldValidate);
+            Assert.Same(value, validationFilter);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Metadata/DefaultValidationMetadataProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Metadata/DefaultValidationMetadataProviderTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
     public class DefaultValidationMetadataProviderTest
     {
         [Fact]
-        public void ShouldValidate_ShouldValidateEntry_False_IfPropertyHasValidateNever()
+        public void PropertyValidationFilter_ShouldValidateEntry_False_IfPropertyHasValidateNever()
         {
             // Arrange
             var provider = new DefaultValidationMetadataProvider();
@@ -25,14 +25,14 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
             provider.CreateValidationMetadata(context);
 
             // Assert
-            Assert.NotNull(context.ValidationMetadata.ShouldValidate);
-            Assert.False(context.ValidationMetadata.ShouldValidate.ShouldValidateEntry(
+            Assert.NotNull(context.ValidationMetadata.PropertyValidationFilter);
+            Assert.False(context.ValidationMetadata.PropertyValidationFilter.ShouldValidateEntry(
                 new ValidationEntry(),
                 new ValidationEntry()));
         }
 
         [Fact]
-        public void ShouldValidate_Null_IfPropertyHasValidateNeverOnItsType()
+        public void PropertyValidationFilter_Null_IfPropertyHasValidateNeverOnItsType()
         {
             // Arrange
             var provider = new DefaultValidationMetadataProvider();
@@ -45,11 +45,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
             provider.CreateValidationMetadata(context);
 
             // Assert
-            Assert.Null(context.ValidationMetadata.ShouldValidate);
+            Assert.Null(context.ValidationMetadata.PropertyValidationFilter);
         }
 
         [Fact]
-        public void ShouldValidate_Null_ForType()
+        public void PropertyValidationFilter_Null_ForType()
         {
             // Arrange
             var provider = new DefaultValidationMetadataProvider();
@@ -62,11 +62,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
             provider.CreateValidationMetadata(context);
 
             // Assert
-            Assert.Null(context.ValidationMetadata.ShouldValidate);
+            Assert.Null(context.ValidationMetadata.PropertyValidationFilter);
         }
 
         [Fact]
-        public void ShouldValidate_ShouldValidateEntry_False_IfContainingTypeHasValidateNever()
+        public void PropertyValidationFilter_ShouldValidateEntry_False_IfContainingTypeHasValidateNever()
         {
             // Arrange
             var provider = new DefaultValidationMetadataProvider();
@@ -81,14 +81,14 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
             provider.CreateValidationMetadata(context);
 
             // Assert
-            Assert.NotNull(context.ValidationMetadata.ShouldValidate);
-            Assert.False(context.ValidationMetadata.ShouldValidate.ShouldValidateEntry(
+            Assert.NotNull(context.ValidationMetadata.PropertyValidationFilter);
+            Assert.False(context.ValidationMetadata.PropertyValidationFilter.ShouldValidateEntry(
                 new ValidationEntry(),
                 new ValidationEntry()));
         }
 
         [Fact]
-        public void ShouldValidate_ShouldValidateEntry_False_IfContainingTypeInheritsValidateNever()
+        public void PropertyValidationFilter_ShouldValidateEntry_False_IfContainingTypeInheritsValidateNever()
         {
             // Arrange
             var provider = new DefaultValidationMetadataProvider();
@@ -103,8 +103,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
             provider.CreateValidationMetadata(context);
 
             // Assert
-            Assert.NotNull(context.ValidationMetadata.ShouldValidate);
-            Assert.False(context.ValidationMetadata.ShouldValidate.ShouldValidateEntry(
+            Assert.NotNull(context.ValidationMetadata.PropertyValidationFilter);
+            Assert.False(context.ValidationMetadata.PropertyValidationFilter.ShouldValidateEntry(
                 new ValidationEntry(),
                 new ValidationEntry()));
         }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Metadata/DefaultValidationMetadataProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Metadata/DefaultValidationMetadataProviderTest.cs
@@ -12,6 +12,104 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
     public class DefaultValidationMetadataProviderTest
     {
         [Fact]
+        public void ShouldValidate_ShouldValidateEntry_False_IfPropertyHasValidateNever()
+        {
+            // Arrange
+            var provider = new DefaultValidationMetadataProvider();
+
+            var attributes = new Attribute[] { new ValidateNeverAttribute() };
+            var key = ModelMetadataIdentity.ForProperty(typeof(int), "Length", typeof(string));
+            var context = new ValidationMetadataProviderContext(key, new ModelAttributes(attributes, new object[0]));
+
+            // Act
+            provider.CreateValidationMetadata(context);
+
+            // Assert
+            Assert.NotNull(context.ValidationMetadata.ShouldValidate);
+            Assert.False(context.ValidationMetadata.ShouldValidate.ShouldValidateEntry(
+                new ValidationEntry(),
+                new ValidationEntry()));
+        }
+
+        [Fact]
+        public void ShouldValidate_Null_IfPropertyHasValidateNeverOnItsType()
+        {
+            // Arrange
+            var provider = new DefaultValidationMetadataProvider();
+
+            var attributes = new Attribute[] { new ValidateNeverAttribute() };
+            var key = ModelMetadataIdentity.ForProperty(typeof(int), "Length", typeof(string));
+            var context = new ValidationMetadataProviderContext(key, new ModelAttributes(new object[0], attributes));
+
+            // Act
+            provider.CreateValidationMetadata(context);
+
+            // Assert
+            Assert.Null(context.ValidationMetadata.ShouldValidate);
+        }
+
+        [Fact]
+        public void ShouldValidate_Null_ForType()
+        {
+            // Arrange
+            var provider = new DefaultValidationMetadataProvider();
+
+            var attributes = new Attribute[] { new ValidateNeverAttribute() };
+            var key = ModelMetadataIdentity.ForType(typeof(ValidateNeverClass));
+            var context = new ValidationMetadataProviderContext(key, new ModelAttributes(attributes));
+
+            // Act
+            provider.CreateValidationMetadata(context);
+
+            // Assert
+            Assert.Null(context.ValidationMetadata.ShouldValidate);
+        }
+
+        [Fact]
+        public void ShouldValidate_ShouldValidateEntry_False_IfContainingTypeHasValidateNever()
+        {
+            // Arrange
+            var provider = new DefaultValidationMetadataProvider();
+
+            var key = ModelMetadataIdentity.ForProperty(
+                typeof(string),
+                nameof(ValidateNeverClass.ClassName),
+                typeof(ValidateNeverClass));
+            var context = new ValidationMetadataProviderContext(key, new ModelAttributes(new object[0], new object[0]));
+
+            // Act
+            provider.CreateValidationMetadata(context);
+
+            // Assert
+            Assert.NotNull(context.ValidationMetadata.ShouldValidate);
+            Assert.False(context.ValidationMetadata.ShouldValidate.ShouldValidateEntry(
+                new ValidationEntry(),
+                new ValidationEntry()));
+        }
+
+        [Fact]
+        public void ShouldValidate_ShouldValidateEntry_False_IfContainingTypeInheritsValidateNever()
+        {
+            // Arrange
+            var provider = new DefaultValidationMetadataProvider();
+
+            var key = ModelMetadataIdentity.ForProperty(
+                typeof(string),
+                nameof(ValidateNeverSubclass.SubclassName),
+                typeof(ValidateNeverSubclass));
+            var context = new ValidationMetadataProviderContext(key, new ModelAttributes(new object[0], new object[0]));
+
+            // Act
+            provider.CreateValidationMetadata(context);
+
+            // Assert
+            Assert.NotNull(context.ValidationMetadata.ShouldValidate);
+            Assert.False(context.ValidationMetadata.ShouldValidate.ShouldValidateEntry(
+                new ValidationEntry(),
+                new ValidationEntry()));
+        }
+
+        [Fact]
         public void GetValidationDetails_MarkedWithClientValidator_ReturnsValidator()
         {
             // Arrange
@@ -67,6 +165,17 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
             // Assert
             var validatorMetadata = Assert.Single(context.ValidationMetadata.ValidatorMetadata);
             Assert.Same(attribute, validatorMetadata);
+        }
+
+        [ValidateNever]
+        private class ValidateNeverClass
+        {
+            public string ClassName { get; set; }
+        }
+
+        private class ValidateNeverSubclass : ValidateNeverClass
+        {
+            public string SubclassName { get; set; }
         }
 
         private class TestModelValidationAttribute : Attribute, IModelValidator

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/ValidationIntegrationTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/ValidationIntegrationTests.cs
@@ -12,6 +12,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -1220,6 +1222,347 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
 
             var error = entry.Errors[0];
             Assert.Equal("The value '-123' is not valid for Zip.", error.ErrorMessage);
+        }
+
+        private class NeverValid : IValidatableObject
+        {
+            public string NeverValidProperty { get; set; }
+
+            public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+            {
+                return new[] { new ValidationResult("This is not valid.") };
+            }
+        }
+
+        private class NeverValidAttribute : ValidationAttribute
+        {
+            protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+            {
+                // By default, ValidationVisitor visits _all_ properties within a non-null complex object.
+                // But, like most reasonable ValidationAttributes, NeverValidAttribute ignores null property values.
+                if (value == null)
+                {
+                    return ValidationResult.Success;
+                }
+
+                return new ValidationResult("Properties with this are not valid.");
+            }
+        }
+
+        private class ValidateSomeProperties
+        {
+            public NeverValid NeverValid { get; set; }
+
+            [NeverValid]
+            public string NeverValidBecauseAttribute { get; set; }
+
+            [ValidateNever]
+            [NeverValid]
+            public string ValidateNever { get; set; }
+
+            [ValidateNever]
+            public int ValidateNeverLength => ValidateNever.Length;
+        }
+
+        [ValidateNever]
+        private class ValidateNoProperties : ValidateSomeProperties
+        {
+        }
+
+        [Fact]
+        public async Task IValidatableObject_IsValidated()
+        {
+            // Arrange
+            var parameter = new ParameterDescriptor
+            {
+                Name = "parameter",
+                ParameterType = typeof(ValidateSomeProperties),
+            };
+
+            var testContext = ModelBindingTestHelper.GetTestContext(
+                request => request.QueryString
+                    = new QueryString($"?{nameof(ValidateSomeProperties.NeverValid)}.{nameof(NeverValid.NeverValidProperty)}=1"));
+
+            var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
+            var modelState = testContext.ModelState;
+
+            // Act
+            var result = await argumentBinder.BindModelAsync(parameter, testContext);
+
+            // Assert
+            Assert.True(result.IsModelSet);
+            var model = Assert.IsType<ValidateSomeProperties>(result.Model);
+            Assert.Equal("1", model.NeverValid.NeverValidProperty);
+
+            Assert.False(modelState.IsValid);
+            Assert.Equal(1, modelState.ErrorCount);
+            Assert.Collection(
+                modelState,
+                state =>
+                {
+                    Assert.Equal(nameof(ValidateSomeProperties.NeverValid), state.Key);
+                    Assert.Equal(ModelValidationState.Invalid, state.Value.ValidationState);
+
+                    var error = Assert.Single(state.Value.Errors);
+                    Assert.Equal("This is not valid.", error.ErrorMessage);
+                    Assert.Null(error.Exception);
+                },
+                state =>
+                {
+                    Assert.Equal(
+                        $"{nameof(ValidateSomeProperties.NeverValid)}.{nameof(NeverValid.NeverValidProperty)}",
+                        state.Key);
+                    Assert.Equal(ModelValidationState.Valid, state.Value.ValidationState);
+                });
+        }
+
+        [Fact]
+        public async Task CustomValidationAttribute_IsValidated()
+        {
+            // Arrange
+            var parameter = new ParameterDescriptor
+            {
+                Name = "parameter",
+                ParameterType = typeof(ValidateSomeProperties),
+            };
+
+            var testContext = ModelBindingTestHelper.GetTestContext(
+                request => request.QueryString
+                    = new QueryString($"?{nameof(ValidateSomeProperties.NeverValidBecauseAttribute)}=1"));
+
+            var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
+            var modelState = testContext.ModelState;
+
+            // Act
+            var result = await argumentBinder.BindModelAsync(parameter, testContext);
+
+            // Assert
+            Assert.True(result.IsModelSet);
+            var model = Assert.IsType<ValidateSomeProperties>(result.Model);
+            Assert.Equal("1", model.NeverValidBecauseAttribute);
+
+            Assert.False(modelState.IsValid);
+            Assert.Equal(1, modelState.ErrorCount);
+            var kvp = Assert.Single(modelState);
+            Assert.Equal(nameof(ValidateSomeProperties.NeverValidBecauseAttribute), kvp.Key);
+            var state = kvp.Value;
+            Assert.NotNull(state);
+            Assert.Equal(ModelValidationState.Invalid, state.ValidationState);
+            var error = Assert.Single(state.Errors);
+            Assert.Equal("Properties with this are not valid.", error.ErrorMessage);
+            Assert.Null(error.Exception);
+        }
+
+        [Fact]
+        public async Task ValidateNeverProperty_IsSkipped()
+        {
+            // Arrange
+            var parameter = new ParameterDescriptor
+            {
+                Name = "parameter",
+                ParameterType = typeof(ValidateSomeProperties),
+            };
+
+            var testContext = ModelBindingTestHelper.GetTestContext(
+                request => request.QueryString
+                    = new QueryString($"?{nameof(ValidateSomeProperties.ValidateNever)}=1"));
+
+            var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
+            var modelState = testContext.ModelState;
+
+            // Act
+            var result = await argumentBinder.BindModelAsync(parameter, testContext);
+
+            // Assert
+            Assert.True(result.IsModelSet);
+            var model = Assert.IsType<ValidateSomeProperties>(result.Model);
+            Assert.Equal("1", model.ValidateNever);
+
+            Assert.True(modelState.IsValid);
+            var kvp = Assert.Single(modelState);
+            Assert.Equal(nameof(ValidateSomeProperties.ValidateNever), kvp.Key);
+            var state = kvp.Value;
+            Assert.NotNull(state);
+            Assert.Equal(ModelValidationState.Skipped, state.ValidationState);
+        }
+
+        [Fact]
+        public async Task ValidateNeverProperty_IsSkippedWithoutAccessingModel()
+        {
+            // Arrange
+            var parameter = new ParameterDescriptor
+            {
+                Name = "parameter",
+                ParameterType = typeof(ValidateSomeProperties),
+            };
+
+            var testContext = ModelBindingTestHelper.GetTestContext();
+            var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
+            var modelState = testContext.ModelState;
+
+            // Act
+            var result = await argumentBinder.BindModelAsync(parameter, testContext);
+
+            // Assert
+            Assert.True(result.IsModelSet);
+            var model = Assert.IsType<ValidateSomeProperties>(result.Model);
+
+            // Note this Exception is not thrown earlier.
+            Assert.Throws<NullReferenceException>(() => model.ValidateNeverLength);
+
+            Assert.True(modelState.IsValid);
+            Assert.Empty(modelState);
+        }
+
+        [Theory]
+        [InlineData(nameof(ValidateSomeProperties.NeverValid) + "." + nameof(NeverValid.NeverValidProperty))]
+        [InlineData(nameof(ValidateSomeProperties.NeverValidBecauseAttribute))]
+        [InlineData(nameof(ValidateSomeProperties.ValidateNever))]
+        public async Task PropertyWithinValidateNeverType_IsSkipped(string propertyName)
+        {
+            // Arrange
+            var parameter = new ParameterDescriptor
+            {
+                Name = "parameter",
+                ParameterType = typeof(ValidateNoProperties),
+            };
+
+            var testContext = ModelBindingTestHelper.GetTestContext(
+                request => request.QueryString = new QueryString($"?{propertyName}=1"));
+
+            var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
+            var modelState = testContext.ModelState;
+
+            // Act
+            var result = await argumentBinder.BindModelAsync(parameter, testContext);
+
+            // Assert
+            Assert.True(result.IsModelSet);
+            Assert.IsType<ValidateNoProperties>(result.Model);
+
+            Assert.True(modelState.IsValid);
+            var kvp = Assert.Single(modelState);
+            Assert.Equal(propertyName, kvp.Key);
+            var state = kvp.Value;
+            Assert.NotNull(state);
+            Assert.Equal(ModelValidationState.Skipped, state.ValidationState);
+        }
+
+        private class ValidateSometimesAttribute : Attribute, IShouldValidate
+        {
+            private readonly string _otherProperty;
+
+            public ValidateSometimesAttribute(string otherProperty)
+            {
+                // Would null-check otherProperty in real life.
+                _otherProperty = otherProperty;
+            }
+
+            public bool ShouldValidateEntry(ValidationEntry entry, ValidationEntry parentEntry)
+            {
+                if (entry.Metadata.MetadataKind == ModelMetadataKind.Property &&
+                    parentEntry.Metadata != null)
+                {
+                    // In real life, would throw an InvalidOperationException if otherProperty were null i.e. the
+                    // property was not known. Could also assert container is non-null (see ValidationVisitor).
+                    var container = parentEntry.Model;
+                    var otherProperty = parentEntry.Metadata.Properties[_otherProperty];
+                    if (otherProperty.PropertyGetter(container) == null)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        private class ValidateSomePropertiesSometimes
+        {
+            public string Control { get; set; }
+
+            [ValidateSometimes(nameof(Control))]
+            public int ControlLength => Control.Length;
+        }
+
+        [Fact]
+        public async Task PropertyToSometimesSkip_IsSkipped_IfControlIsNull()
+        {
+            // Arrange
+            var parameter = new ParameterDescriptor
+            {
+                Name = "parameter",
+                ParameterType = typeof(ValidateSomePropertiesSometimes),
+            };
+
+            var testContext = ModelBindingTestHelper.GetTestContext();
+            var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
+            var modelState = testContext.ModelState;
+
+            // Add an entry for the ControlLength property so that we can observe Skipped versus Valid states.
+            modelState.SetModelValue(
+                nameof(ValidateSomePropertiesSometimes.ControlLength),
+                rawValue: null,
+                attemptedValue: null);
+
+            // Act
+            var result = await argumentBinder.BindModelAsync(parameter, testContext);
+
+            // Assert
+            Assert.True(result.IsModelSet);
+            var model = Assert.IsType<ValidateSomePropertiesSometimes>(result.Model);
+            Assert.Null(model.Control);
+
+            // Note this Exception is not thrown earlier.
+            Assert.Throws<NullReferenceException>(() => model.ControlLength);
+
+            Assert.True(modelState.IsValid);
+            var kvp = Assert.Single(modelState);
+            Assert.Equal(nameof(ValidateSomePropertiesSometimes.ControlLength), kvp.Key);
+            Assert.Equal(ModelValidationState.Skipped, kvp.Value.ValidationState);
+        }
+
+        [Fact]
+        public async Task PropertyToSometimesSkip_IsValidated_IfControlIsNotNull()
+        {
+            // Arrange
+            var parameter = new ParameterDescriptor
+            {
+                Name = "parameter",
+                ParameterType = typeof(ValidateSomePropertiesSometimes),
+            };
+
+            var testContext = ModelBindingTestHelper.GetTestContext(
+                request => request.QueryString = new QueryString(
+                    $"?{nameof(ValidateSomePropertiesSometimes.Control)}=1"));
+
+            var argumentBinder = ModelBindingTestHelper.GetArgumentBinder();
+            var modelState = testContext.ModelState;
+
+            // Add an entry for the ControlLength property so that we can observe Skipped versus Valid states.
+            modelState.SetModelValue(
+                nameof(ValidateSomePropertiesSometimes.ControlLength),
+                rawValue: null,
+                attemptedValue: null);
+
+            // Act
+            var result = await argumentBinder.BindModelAsync(parameter, testContext);
+
+            // Assert
+            Assert.True(result.IsModelSet);
+            var model = Assert.IsType<ValidateSomePropertiesSometimes>(result.Model);
+            Assert.Equal("1", model.Control);
+            Assert.Equal(1, model.ControlLength);
+
+            Assert.True(modelState.IsValid);
+            Assert.Collection(
+                modelState,
+                state => Assert.Equal(nameof(ValidateSomePropertiesSometimes.Control), state.Key),
+                state =>
+                {
+                    Assert.Equal(nameof(ValidateSomePropertiesSometimes.ControlLength), state.Key);
+                    Assert.Equal(ModelValidationState.Valid, state.Value.ValidationState);
+                });
         }
 
         private class Order11

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/ValidationIntegrationTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/ValidationIntegrationTests.cs
@@ -1448,7 +1448,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.Equal(ModelValidationState.Skipped, state.ValidationState);
         }
 
-        private class ValidateSometimesAttribute : Attribute, IShouldValidate
+        private class ValidateSometimesAttribute : Attribute, IPropertyValidationFilter
         {
             private readonly string _otherProperty;
 


### PR DESCRIPTION
- #5642
- lazy-load `ValidationEntry.Model`
  - avoids `Exception`s when moving to a property that will not be validated

nits:
- remove duplicate code in `ValidationVisitor`
- clarify "all properties of" doc comments
  - also add missing `<param>` doc in `ViewDataInfo`

was:
~~See individual commits for details~~
- ~~first and third commits are about nits hit while doing this work~~
- ~~other early commits require users to subclass `DefaultObjectValidator` and `ValidationVisitor`~~
 - ~~required a breaking change to the `ValidationVisitor` constructor because that's effectively `internal` now~~
- ~~can go back to that if we decide current approach has downsides~~