### PR TITLE
SaveTempDataFilter handle write to body

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/SaveTempDataFilter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/SaveTempDataFilter.cs
@@ -29,6 +29,36 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
         /// <inheritdoc />
         public void OnResourceExecuting(ResourceExecutingContext context)
         {
+            if (!context.HttpContext.Response.HasStarted)
+            {
+                context.HttpContext.Response.OnStarting((state) =>
+                {
+                    var saveTempDataContext = (SaveTempDataContext)state;
+
+                    // If temp data was already saved, skip trying to save again as the calls here would potentially fail
+                    // because the session feature might not be available at this point.
+                    // Example: An action returns NoContentResult and since NoContentResult does not write anything to
+                    // the body of the response, this delegate would get executed way late in the pipeline at which point
+                    // the session feature would have been removed.
+                    object obj;
+                    if (saveTempDataContext.HttpContext.Items.TryGetValue(TempDataSavedKey, out obj))
+                    {
+                        return TaskCache.CompletedTask;
+                    }
+
+                    SaveTempData(
+                        result: null,
+                        factory: saveTempDataContext.TempDataDictionaryFactory,
+                        httpContext: saveTempDataContext.HttpContext);
+
+                    return TaskCache.CompletedTask;
+                },
+               state: new SaveTempDataContext()
+               {
+                   HttpContext = context.HttpContext,
+                   TempDataDictionaryFactory = _factory
+               });
+            }
         }
 
         /// <inheritdoc />
@@ -39,34 +69,6 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
         /// <inheritdoc />
         public void OnResultExecuting(ResultExecutingContext context)
         {
-            context.HttpContext.Response.OnStarting((state) =>
-            {
-                var saveTempDataContext = (SaveTempDataContext)state;
-
-                // If temp data was already saved, skip trying to save again as the calls here would potentially fail
-                // because the session feature might not be available at this point.
-                // Example: An action returns NoContentResult and since NoContentResult does not write anything to
-                // the body of the response, this delegate would get executed way late in the pipeline at which point
-                // the session feature would have been removed.
-                object obj;
-                if (saveTempDataContext.HttpContext.Items.TryGetValue(TempDataSavedKey, out obj))
-                {
-                    return TaskCache.CompletedTask;
-                }
-
-                SaveTempData(
-                    saveTempDataContext.ActionResult,
-                    saveTempDataContext.TempDataDictionaryFactory,
-                    saveTempDataContext.HttpContext);
-
-                return TaskCache.CompletedTask;
-            },
-            state: new SaveTempDataContext()
-            {
-                HttpContext = context.HttpContext,
-                ActionResult = context.Result,
-                TempDataDictionaryFactory = _factory
-            });
         }
 
         /// <inheritdoc />
@@ -78,7 +80,11 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             if (!context.HttpContext.Response.HasStarted)
             {
                 SaveTempData(context.Result, _factory, context.HttpContext);
-                context.HttpContext.Items.Add(TempDataSavedKey, true);
+                // If SaveTempDataFilter got added twice this might already be in there.
+                if (!context.HttpContext.Items.ContainsKey(TempDataSavedKey))
+                {
+                    context.HttpContext.Items.Add(TempDataSavedKey, true);
+                }
             }
         }
 
@@ -94,7 +100,6 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
         private class SaveTempDataContext
         {
             public HttpContext HttpContext { get; set; }
-            public IActionResult ActionResult { get; set; }
             public ITempDataDictionaryFactory TempDataDictionaryFactory { get; set; }
         }
     }

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/TempDataTestBase.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/TempDataTestBase.cs
@@ -163,6 +163,20 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
         }
 
         [Fact]
+        public async Task ResponseWrite_DoesNotCrashSaveTempDataFilter()
+        {
+            // Arrange
+            var nameValueCollection = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("Name", "Jordan"),
+            };
+            var content = new FormUrlEncodedContent(nameValueCollection);
+
+            // Act, checking it didn't throw
+            var response = await Client.GetAsync("/TempData/SetTempDataResponseWrite");
+        }
+
+        [Fact]
         public async Task SetInActionResultExecution_AvailableForNextRequest()
         {
             // Arrange

--- a/test/WebSites/BasicWebSite/Controllers/TempDataController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/TempDataController.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 namespace BasicWebSite.Controllers
@@ -57,6 +59,13 @@ namespace BasicWebSite.Controllers
             TempData["key4"] = datetimeValue;
             TempData["key5"] = guidValue;
             return RedirectToAction("GetTempDataMultiple");
+        }
+
+        public async Task SetTempDataResponseWrite()
+        {
+            TempData["value1"] = "steve";
+
+            await Response.WriteAsync("Steve!");
         }
 
         public string GetTempDataMultiple()


### PR DESCRIPTION
Fixes #5555. Also prevents problems that could be caused if OnResultExecuted is called twice (which could happen if the SaveTempDataFilter got added twice).