### PR TITLE
Added base 64 encoding of images specific to https://en.wikipedia.org…

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/FileBase64ContentProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/FileBase64ContentProvider.cs
@@ -1,0 +1,137 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.FileProviders;
+
+namespace Microsoft.AspNetCore.Mvc.TagHelpers.Internal
+{
+    /// <summary>
+    /// Provides base64 content a specified file.
+    /// </summary>
+    public class FileBase64ContentProvider
+    {
+        private const string VersionKey = "v";
+        private static readonly char[] QueryStringAndFragmentTokens = new [] { '?', '#' };
+        private readonly IFileProvider _fileProvider;
+        private readonly IMemoryCache _cache;
+        private readonly PathString _requestPathBase;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="FileVersionProvider"/>.
+        /// </summary>
+        /// <param name="fileProvider">The file provider to get and watch files.</param>
+        /// <param name="cache"><see cref="IMemoryCache"/> where versioned urls of files are cached.</param>
+        /// <param name="requestPathBase">The base path for the current HTTP request.</param>
+        public FileBase64ContentProvider(
+            IFileProvider fileProvider,
+            IMemoryCache cache,
+            PathString requestPathBase)
+        {
+            if (fileProvider == null)
+            {
+                throw new ArgumentNullException(nameof(fileProvider));
+            }
+
+            if (cache == null)
+            {
+                throw new ArgumentNullException(nameof(cache));
+            }
+
+            _fileProvider = fileProvider;
+            _cache = cache;
+            _requestPathBase = requestPathBase;
+        }
+
+
+        /// <summary>
+        /// Adds version query parameter to the specified file path.
+        /// </summary>
+        /// <param name="path">The path of the file to which version should be added.</param>
+        /// <returns>Path containing the version query string.</returns>
+        /// <remarks>
+        /// The version query string is appended with the key "v".
+        /// </remarks>
+        public string RetrieveBase64Data(string path)
+        {
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            var resolvedPath = path;
+
+            var queryStringOrFragmentStartIndex = path.IndexOfAny(QueryStringAndFragmentTokens);
+            if (queryStringOrFragmentStartIndex != -1)
+            {
+                resolvedPath = path.Substring(0, queryStringOrFragmentStartIndex);
+            }
+
+            Uri uri;
+            if (Uri.TryCreate(resolvedPath, UriKind.Absolute, out uri) && !uri.IsFile)
+            {
+                // Don't append version if the path is absolute.
+                return path;
+            }
+
+            string value;
+            if (!_cache.TryGetValue(path, out value))
+            {
+                var cacheEntryOptions = new MemoryCacheEntryOptions();
+                cacheEntryOptions.AddExpirationToken(_fileProvider.Watch(resolvedPath));
+                var fileInfo = _fileProvider.GetFileInfo(resolvedPath);
+
+                if (!fileInfo.Exists &&
+                    _requestPathBase.HasValue &&
+                    resolvedPath.StartsWith(_requestPathBase.Value, StringComparison.OrdinalIgnoreCase))
+                {
+                    var requestPathBaseRelativePath = resolvedPath.Substring(_requestPathBase.Value.Length);
+                    cacheEntryOptions.AddExpirationToken(_fileProvider.Watch(requestPathBaseRelativePath));
+                    fileInfo = _fileProvider.GetFileInfo(requestPathBaseRelativePath);
+                }
+
+                if (fileInfo.Exists)
+                {                    
+                    value = string.Format("{0}{1})",RetrieveBase64Prefix(fileInfo),GetContentsForFile(fileInfo));
+                }
+                else
+                {
+                    // if the file is not in the current server.
+                    value = path;
+                }
+
+                value = _cache.Set<string>(path, value, cacheEntryOptions);
+            }
+
+            return value;
+        }
+
+        private static string GetContentsForFile(IFileInfo fileInfo)
+        {
+            
+            var numberBytes=fileInfo.Length;
+            var contentFile =new byte[numberBytes];
+            using (var readStream = fileInfo.CreateReadStream())
+            {
+                var bytes=readStream.Read(contentFile,0,(int)numberBytes);
+                return Convert.ToBase64String(contentFile);
+            }
+            
+        }
+        private static string RetrieveBase64Prefix(IFileInfo fileInfo){
+            
+            string extension = Path.GetExtension(fileInfo.Name);
+            if(!extension.StartsWith(".")){
+                throw new NotSupportedException(fileInfo.Name);
+            }
+            extension =extension.Substring(1);//remove .
+
+            return string.Format("url(data:image/{0};base64,",extension);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/ImageTagBase64Helper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/ImageTagBase64Helper.cs
@@ -1,0 +1,125 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Razor.TagHelpers;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.TagHelpers.Internal;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Microsoft.AspNetCore.Mvc.TagHelpers
+{
+    /// <summary>
+    /// <see cref="ITagHelper"/> implementation targeting &lt;img&gt; elements that supports file versioning.
+    /// </summary>
+    /// <remarks>
+    /// The tag helper won't process for cases with just the 'src' attribute.
+    /// </remarks>
+    [HtmlTargetElement(
+        "img",
+        Attributes = AppendBase64AttributeName + "," + SrcAttributeName,
+        TagStructure = TagStructure.WithoutEndTag)]
+    public class ImageTagBase64Helper : UrlResolutionTagHelper
+    {
+        private static readonly string Namespace = typeof(ImageTagBase64Helper).Namespace;
+
+        private const string AppendBase64AttributeName = "asp-append-base64";
+        private const string SrcAttributeName = "src";
+
+        private FileBase64ContentProvider _fileBase64ContentProvider;
+
+        /// <summary>
+        /// Creates a new <see cref="ImageTagHelper"/>.
+        /// </summary>
+        /// <param name="hostingEnvironment">The <see cref="IHostingEnvironment"/>.</param>
+        /// <param name="cache">The <see cref="IMemoryCache"/>.</param>
+        /// <param name="htmlEncoder">The <see cref="HtmlEncoder"/> to use.</param>
+        /// <param name="urlHelperFactory">The <see cref="IUrlHelperFactory"/>.</param>
+        public ImageTagBase64Helper(
+            IHostingEnvironment hostingEnvironment,
+            IMemoryCache cache,
+            HtmlEncoder htmlEncoder,
+            IUrlHelperFactory urlHelperFactory)
+            : base(urlHelperFactory, htmlEncoder)
+        {
+            HostingEnvironment = hostingEnvironment;
+            Cache = cache;
+        }
+
+        /// <inheritdoc />
+        public override int Order
+        {
+            get
+            {
+                return -1000;
+            }
+        }
+
+        /// <summary>
+        /// Source of the image.
+        /// </summary>
+        /// <remarks>
+        /// Passed through to the generated HTML in all cases.
+        /// </remarks>
+        [HtmlAttributeName(SrcAttributeName)]
+        public string Src { get; set; }
+
+        /// <summary>
+        /// Value indicating if file version should be appended to the src urls.
+        /// </summary>
+        /// <remarks>
+        /// If <c>true</c> then a query string "v" with the encoded content of the file is added.
+        /// </remarks>
+        [HtmlAttributeName(AppendBase64AttributeName)]
+        public bool AppendBase64{ get; set; }
+
+        protected IHostingEnvironment HostingEnvironment { get; }
+
+        protected IMemoryCache Cache { get; }
+
+        /// <inheritdoc />
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (output == null)
+            {
+                throw new ArgumentNullException(nameof(output));
+            }
+
+            output.CopyHtmlAttribute(SrcAttributeName, context);
+            ProcessUrlAttribute(SrcAttributeName, output);
+
+            if (AppendBase64)
+            {
+                EnsureBase64ContentProvider();
+
+                // Retrieve the TagHelperOutput variation of the "src" attribute in case other TagHelpers in the
+                // pipeline have touched the value. If the value is already encoded this ImageTagHelper may
+                // not function properly.
+                Src = output.Attributes[SrcAttributeName].Value as string;
+
+                output.Attributes.SetAttribute(SrcAttributeName, _fileBase64ContentProvider.RetrieveBase64Data(Src));
+            }
+        }
+
+        private void EnsureBase64ContentProvider()
+        {
+            if (_fileBase64ContentProvider == null)
+            {
+                _fileBase64ContentProvider = new FileBase64ContentProvider(
+                    HostingEnvironment.WebRootFileProvider,
+                    Cache,
+                    ViewContext.HttpContext.Request.PathBase);
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/ImageTagBase64HelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/ImageTagBase64HelperTest.cs
@@ -1,0 +1,349 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.ViewEngines;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Extensions.WebEncoders.Testing;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.TagHelpers
+{
+    public class ImageTagBase64HelperTest
+    {
+        [Theory]
+        [InlineData(null, "test.jpg", "test.jpg")]
+        [InlineData("abcd.jpg", "test.jpg", "test.jpg")]
+        [InlineData(null, "~/test.jpg", "virtualRoot/test.jpg")]
+        [InlineData("abcd.jpg", "~/test.jpg", "virtualRoot/test.jpg")]
+        public void Process_SrcDefaultsToTagHelperBase64OutputSrcAttributeAddedByOtherTagHelper(
+            string src,
+            string srcOutput,
+            string expectedSrcPrefix)
+        {
+            // Arrange
+            var allAttributes = new TagHelperAttributeList(
+                new TagHelperAttributeList
+                {
+                    { "alt", new HtmlString("Testing") },
+                    { "asp-append-base64", true },
+                });
+            var context = MakeTagHelper64Context(allAttributes);
+            var outputAttributes = new TagHelperAttributeList
+                {
+                    { "alt", new HtmlString("Testing") },
+                    { "src", srcOutput },
+                };
+            var output = new TagHelperOutput(
+                "img",
+                outputAttributes,
+                getChildContentAsync: (useCachedResult, encoder) => Task.FromResult<TagHelperContent>(
+                    new DefaultTagHelperContent()));
+            var hostingEnvironment = MakeHostingEnvironment();
+            var viewContext = MakeViewContext();
+            var urlHelper = new Mock<IUrlHelper>();
+
+            // Ensure expanded path does not look like an absolute path on Linux, avoiding
+            // https://github.com/aspnet/External/issues/21
+            urlHelper
+                .Setup(urlhelper => urlhelper.Content(It.IsAny<string>()))
+                .Returns(new Func<string, string>(url => url.Replace("~/", "virtualRoot/")));
+            var urlHelperFactory = new Mock<IUrlHelperFactory>();
+            urlHelperFactory
+                .Setup(f => f.GetUrlHelper(It.IsAny<ActionContext>()))
+                .Returns(urlHelper.Object);
+
+            var helper = new ImageTagBase64Helper(
+                hostingEnvironment,
+                MakeCache(),
+                new HtmlTestEncoder(),
+                urlHelperFactory.Object)
+            {
+                ViewContext = viewContext,
+                AppendBase64 = true,
+                Src = src,
+            };
+
+            // Act
+            helper.Process(context, output);
+
+            // Assert
+            Assert.Equal(
+                "url(data:image/jpg;base64,SGVsbG8gV29ybGQh)",
+                (string)output.Attributes["src"].Value,
+                StringComparer.Ordinal);
+        }
+
+        [Fact]
+        public void PreservesOrderOfSourceAttributesWhenRun()
+        {
+            // Arrange
+            var context = MakeTagHelper64Context(
+                attributes: new TagHelperAttributeList
+                {
+                    { "alt", new HtmlString("alt text") },
+                    { "data-extra", new HtmlString("something") },
+                    { "title", new HtmlString("Image title") },
+                    { "src", "testimage.jpg" },
+                    { "asp-append-base64", "true" }
+                });
+            var output = MakeImageTagBase64HelperOutput(
+                attributes: new TagHelperAttributeList
+                {
+                    { "alt", new HtmlString("alt text") },
+                    { "data-extra", new HtmlString("something") },
+                    { "title", new HtmlString("Image title") },
+                });
+
+            var expectedOutput = MakeImageTagBase64HelperOutput(
+                attributes: new TagHelperAttributeList
+                {
+                    { "alt", new HtmlString("alt text") },
+                    { "data-extra", new HtmlString("something") },
+                    { "title", new HtmlString("Image title") },
+                    { "src", "url(data:image/jpg;base64,SGVsbG8gV29ybGQh)" }
+                });
+
+            var hostingEnvironment = MakeHostingEnvironment();
+            var viewContext = MakeViewContext();
+
+            var helper = new ImageTagBase64Helper(
+                hostingEnvironment,
+                MakeCache(),
+                new HtmlTestEncoder(),
+                MakeUrlHelperFactory())
+            {
+                ViewContext = viewContext,
+                Src = hostingEnvironment.WebRootFileProvider.GetFileInfo("").Name,
+                AppendBase64 = true,
+            };
+
+            // Act
+            helper.Process(context, output);
+
+            // Assert
+            Assert.Equal(expectedOutput.TagName, output.TagName);
+            Assert.Equal(4, output.Attributes.Count);
+
+            for (var i = 0; i < expectedOutput.Attributes.Count; i++)
+            {
+                var expectedAtribute = expectedOutput.Attributes[i];
+                var actualAttribute = output.Attributes[i];
+                Assert.Equal(expectedAtribute.Name, actualAttribute.Name);
+                Assert.Equal(expectedAtribute.Value.ToString(), actualAttribute.Value.ToString());
+            }
+        }
+
+        [Fact]
+        public void RendersImageTag_AddsFileVersion()
+        {
+            // Arrange
+            var context = MakeTagHelper64Context(
+                attributes: new TagHelperAttributeList
+                {
+                    { "alt", new HtmlString("Alt image text") },     
+                    { "src", "/images/test-image.jpg" },               
+                    { "asp-append-base64", "true" }
+                });
+            var output = MakeImageTagBase64HelperOutput(attributes: new TagHelperAttributeList
+            {
+                { "alt", new HtmlString("Alt image text") },
+            });
+            var hostingEnvironment = MakeHostingEnvironment();
+            var viewContext = MakeViewContext();
+
+            var helper = new ImageTagBase64Helper(hostingEnvironment, MakeCache(), new HtmlTestEncoder(), MakeUrlHelperFactory())
+            {
+                ViewContext = viewContext,
+                Src = hostingEnvironment.WebRootFileProvider.GetFileInfo("").Name,
+                AppendBase64 = true
+            };
+
+            // Act
+            helper.Process(context, output);
+
+            // Assert
+            Assert.True(output.Content.GetContent().Length == 0);
+            Assert.Equal("img", output.TagName);
+            Assert.Equal(2, output.Attributes.Count);
+            var srcAttribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("src"));
+            Assert.Equal("url(data:image/jpg;base64,SGVsbG8gV29ybGQh)", srcAttribute.Value);
+        }
+
+        [Fact]
+        public void RendersImageTag_DoesNotAddFileVersion()
+        {
+            // Arrange
+            var context = MakeTagHelper64Context(
+                attributes: new TagHelperAttributeList
+                {
+                    { "alt", new HtmlString("Alt image text") },
+                    { "src", "/images/test-image.png" },
+                    { "asp-append-base64", "false" }
+                });
+            var output = MakeImageTagBase64HelperOutput(attributes: new TagHelperAttributeList
+            {
+                { "alt", new HtmlString("Alt image text") },
+            });
+            var hostingEnvironment = MakeHostingEnvironment();
+            var viewContext = MakeViewContext();
+
+            var helper = new ImageTagBase64Helper(hostingEnvironment, MakeCache(), new HtmlTestEncoder(), MakeUrlHelperFactory())
+            {
+                ViewContext = viewContext,              
+                AppendBase64 = false
+            };
+
+            // Act
+            helper.Process(context, output);
+
+            // Assert
+            Assert.True(output.Content.GetContent().Length == 0);
+            Assert.Equal("img", output.TagName);
+            Assert.Equal(2, output.Attributes.Count);
+            var srcAttribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("src"));
+            Assert.Equal("/images/test-image.png", srcAttribute.Value);
+        }
+
+        [Fact]
+        public void RendersImageTag_AddsFileVersion_WithRequestPathBase()
+        {
+            // Arrange
+            var context = MakeTagHelper64Context(
+                attributes: new TagHelperAttributeList
+                {
+                    { "alt", new HtmlString("alt text") },  
+                    { "src", "/bar/images/image.jpg" },               
+                    { "asp-append-base64", "true" },
+                });
+            var output = MakeImageTagBase64HelperOutput(attributes: new TagHelperAttributeList
+            {
+                { "alt", new HtmlString("alt text") },
+            });
+            var hostingEnvironment = MakeHostingEnvironment();
+            var viewContext = MakeViewContext("/bar");
+
+            var helper = new ImageTagBase64Helper(hostingEnvironment, MakeCache(), new HtmlTestEncoder(), MakeUrlHelperFactory())
+            {
+                ViewContext = viewContext,               
+                AppendBase64 = true
+            };
+
+            // Act
+            helper.Process(context, output);
+            // Assert
+            Assert.True(output.Content.GetContent().Length == 0);
+            Assert.Equal("img", output.TagName);
+            Assert.Equal(2, output.Attributes.Count);
+            var srcAttribute = Assert.Single(output.Attributes, attr => attr.Name.Equals("src"));
+            Assert.Equal("url(data:image/jpg;base64,SGVsbG8gV29ybGQh)", srcAttribute.Value);
+        }
+
+        private static ViewContext MakeViewContext(string requestPathBase = null)
+        {
+            var actionContext = new ActionContext(new DefaultHttpContext(), new RouteData(), new ActionDescriptor());
+            if (requestPathBase != null)
+            {
+                actionContext.HttpContext.Request.PathBase = new Http.PathString(requestPathBase);
+            }
+
+            var metadataProvider = new EmptyModelMetadataProvider();
+            var viewData = new ViewDataDictionary(metadataProvider, new ModelStateDictionary());
+            var viewContext = new ViewContext(
+                actionContext,
+                Mock.Of<IView>(),
+                viewData,
+                Mock.Of<ITempDataDictionary>(),
+                TextWriter.Null,
+                new HtmlHelperOptions());
+
+            return viewContext;
+        }
+
+        private static TagHelperContext MakeTagHelper64Context(
+            TagHelperAttributeList attributes)
+        {
+            return new TagHelperContext(
+                attributes,
+                items: new Dictionary<object, object>(),
+                uniqueId: Guid.NewGuid().ToString("N"));
+        }
+
+        private static TagHelperOutput MakeImageTagBase64HelperOutput(TagHelperAttributeList attributes)
+        {
+            attributes = attributes ?? new TagHelperAttributeList();
+
+            return new TagHelperOutput(
+                "img",
+                attributes,
+                getChildContentAsync: (useCachedResult, encoder) =>
+                {
+                    var tagHelperContent = new DefaultTagHelperContent();
+                    tagHelperContent.SetContent(default(string));
+                    return Task.FromResult<TagHelperContent>(tagHelperContent);
+                });
+        }
+
+        private static IHostingEnvironment MakeHostingEnvironment()
+        {
+            var emptyDirectoryContents = new Mock<IDirectoryContents>();
+            emptyDirectoryContents.Setup(dc => dc.GetEnumerator())
+                .Returns(Enumerable.Empty<IFileInfo>().GetEnumerator());
+            var mockFile = new Mock<IFileInfo>();
+            mockFile.SetupGet(f => f.Name).Returns("andrei.jpg");
+            mockFile.SetupGet(f => f.Exists).Returns(true);
+            mockFile.SetupGet(f => f.Length).Returns(12);
+            mockFile
+                .Setup(m => m.CreateReadStream())                
+                .Returns(() => new MemoryStream(Encoding.UTF8.GetBytes("Hello World!")));
+
+            var mockFileProvider = new Mock<IFileProvider>();
+            mockFileProvider.Setup(fp => fp.GetDirectoryContents(It.IsAny<string>()))
+                .Returns(emptyDirectoryContents.Object);
+            mockFileProvider.Setup(fp => fp.GetFileInfo(It.IsAny<string>()))
+                .Returns(mockFile.Object);
+            mockFileProvider.Setup(fp => fp.Watch(It.IsAny<string>()))
+                .Returns(new TestFileChangeToken());
+            var hostingEnvironment = new Mock<IHostingEnvironment>();
+            hostingEnvironment.Setup(h => h.WebRootFileProvider).Returns(mockFileProvider.Object);
+
+            return hostingEnvironment.Object;
+        }
+
+        private static IMemoryCache MakeCache() => new MemoryCache(new MemoryCacheOptions());
+
+        private static IUrlHelperFactory MakeUrlHelperFactory()
+        {
+            var urlHelper = new Mock<IUrlHelper>();
+
+            urlHelper
+                .Setup(helper => helper.Content(It.IsAny<string>()))
+                .Returns(new Func<string, string>(url => url));
+
+            var urlHelperFactory = new Mock<IUrlHelperFactory>();
+            urlHelperFactory
+                .Setup(f => f.GetUrlHelper(It.IsAny<ActionContext>()))
+                .Returns(urlHelper.Object);
+
+            return urlHelperFactory.Object;
+        }
+    }
+}

--- a/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Image.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Image.cshtml
@@ -33,5 +33,24 @@
 
     <!-- Plain image tag with file version and path linking to some action -->
     <img src="/controller/action" alt="Path linking to some action" asp-append-version="true">
+
+    <br />
+    <h2>Image Tag Base64 Helper Test</h2>
+    <!-- Plain image tag -->
+    <img src="~/images/red.png" alt="Red block" title="&lt;the title>">
+    <!-- Plain image tag with file version -->
+    <img src="~/images/red.png" alt="Red versioned" title="Red versioned" asp-append-base64="true" />
+    <!-- Plain image tag with file version set to false -->
+    <img src="~/images/red.png" alt="Red explicitly not versioned" title="Red versioned" asp-append-base64="false">
+    <!-- Plain image tag with absolute path and file version -->
+    <img src="http://contoso.com/hello/world" alt="Absolute path versioned" asp-append-base64="true">
+    <!-- Plain image tag with file version and path to file that does not exist -->
+    <img src="~/images/fake.png" alt="Path to non existing file" asp-append-base64="true" />
+    <!-- Plain image tag with file version and path containing query string -->
+    <img src="~/images/red.png?abc=def" alt="Path with query string" asp-append-base64="true">
+    <!-- Plain image tag with file version and path containing fragment -->
+    <img src="~/images/red.png#abc" alt="Path with query string" asp-append-base64="true" />
+    <!-- Plain image tag with file version and path linking to some action -->
+    <img src="/controller/action" alt="Path linking to some action" asp-append-base64="true">
 </body>
 </html>


### PR DESCRIPTION
Summary of the changes 
 - Added files:
Added imagetagbase64helper.cs - the base file for asp-append-base64
Added filebase64contentprovider.cs   - the helper to provide base 64 content

 - Added test:
ImageTagBase64HelperTest.cs - to test automatically
Image.cshtml - to test in a visual form

Addresses #5729 