### PR TITLE
Add culture constructor to RouteValueProvider

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/RouteValueProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/RouteValueProvider.cs
@@ -21,9 +21,21 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         /// </summary>
         /// <param name="bindingSource">The <see cref="BindingSource"/> of the data.</param>
         /// <param name="values">The values.</param>
+        /// <remarks>Sets <see cref="Culture"/> to <see cref="CultureInfo.InvariantCulture" />.</remarks>
         public RouteValueProvider(
             BindingSource bindingSource,
             RouteValueDictionary values)
+            : this(bindingSource, values, CultureInfo.InvariantCulture)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="RouteValueProvider"/>. 
+        /// </summary>
+        /// <param name="bindingSource">The <see cref="BindingSource"/> of the data.</param>
+        /// <param name="values">The values.</param>
+        /// <param name="culture">The culture for route value.</param>
+        public RouteValueProvider(BindingSource bindingSource, RouteValueDictionary values, CultureInfo culture)
             : base(bindingSource)
         {
             if (bindingSource == null)
@@ -36,7 +48,13 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 throw new ArgumentNullException(nameof(values));
             }
 
+            if (culture == null)
+            {
+                throw new ArgumentNullException(nameof(culture));
+            }
+
             _values = values;
+            Culture = culture;
         }
 
         protected PrefixContainer PrefixContainer
@@ -51,6 +69,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 return _prefixContainer;
             }
         }
+
+        protected CultureInfo Culture { get; }
 
         /// <inheritdoc />
         public override bool ContainsPrefix(string key)
@@ -70,7 +90,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             if (_values.TryGetValue(key, out value))
             {
                 var stringValue = value as string ?? value?.ToString() ?? string.Empty;
-                return new ValueProviderResult(stringValue, CultureInfo.InvariantCulture);
+                return new ValueProviderResult(stringValue, Culture);
             }
             else
             {

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/RouteValueProviderTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/RouteValueProviderTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Microsoft.AspNetCore.Routing;
 using Xunit;
 
@@ -59,6 +60,41 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 
             // Assert
             Assert.Equal(string.Empty, (string)result);
+        }
+
+        [Fact]
+        public void GetValue_ReturnsValue_WithDefaultCulture()
+        {
+            // Arrange
+            var values = new RouteValueDictionary(new Dictionary<string, object>
+            {
+                { "test-key", "test-value"}
+            });
+            var provider = new RouteValueProvider(BindingSource.Query, values);
+
+            // Act
+            var result = provider.GetValue("test-key");
+
+            // Assert
+            Assert.Equal(CultureInfo.InvariantCulture, result.Culture);
+        }
+
+        [Fact]
+        public void GetValue_ReturnsValue_WithCulture()
+        {
+            // Arrange
+            var values = new RouteValueDictionary(new Dictionary<string, object>
+            {
+                { "test-key", "test-value"}
+            });
+            var culture = new CultureInfo("fr-FR");
+            var provider = new RouteValueProvider(BindingSource.Query, values, culture);
+
+            // Act
+            var result = provider.GetValue("test-key");
+
+            // Assert
+            Assert.Equal(new CultureInfo("fr-FR"), result.Culture);
         }
 
         [Theory]


### PR DESCRIPTION
Fixes #5336 using a similar format to [ElementalValueProvider](https://github.com/aspnet/Mvc/blob/dev/src/Microsoft.AspNetCore.Mvc.Core/Internal/ElementalValueProvider.cs).