### PR TITLE
Update view compilation error message

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/DefaultRoslynCompilationService.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/DefaultRoslynCompilationService.cs
@@ -151,9 +151,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
                     string.Equals(CS0246, g.Id, StringComparison.OrdinalIgnoreCase)))
                 {
                     additionalMessage = Resources.FormatCompilation_DependencyContextIsNotSpecified(
-                        "preserveCompilationContext",
-                        "buildOptions",
-                        "project.json");
+                        "PreserveCompilationContext",
+                        "csproj");
                 }
 
                 var compilationFailure = new CompilationFailure(

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/DefaultRoslynCompilationService.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/DefaultRoslynCompilationService.cs
@@ -151,8 +151,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
                     string.Equals(CS0246, g.Id, StringComparison.OrdinalIgnoreCase)))
                 {
                     additionalMessage = Resources.FormatCompilation_DependencyContextIsNotSpecified(
-                        "PreserveCompilationContext",
-                        "csproj");
+                        "Microsoft.NET.Sdk.Web",
+                        "PreserveCompilationContext");
                 }
 
                 var compilationFailure = new CompilationFailure(

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Properties/Resources.Designer.cs
@@ -447,7 +447,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         }
 
         /// <summary>
-        /// One or more compilation references are missing. Possible causes include a missing '{0}' property in the application's '{1}' file.
+        /// One or more compilation references are missing. Ensure that your project is referencing '{0}' and the '{1}' property is not set to false.
         /// </summary>
         internal static string Compilation_DependencyContextIsNotSpecified
         {
@@ -455,7 +455,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         }
 
         /// <summary>
-        /// One or more compilation references are missing. Possible causes include a missing '{0}' property in the application's '{1}' file.
+        /// One or more compilation references are missing. Ensure that your project is referencing '{0}' and the '{1}' property is not set to false.
         /// </summary>
         internal static string FormatCompilation_DependencyContextIsNotSpecified(object p0, object p1)
         {

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Properties/Resources.Designer.cs
@@ -447,7 +447,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         }
 
         /// <summary>
-        /// One or more compilation references are missing. Possible causes include a missing '{0}' property under '{1}' in the application's {2}.
+        /// One or more compilation references are missing. Possible causes include a missing '{0}' property in the application's '{1}' file.
         /// </summary>
         internal static string Compilation_DependencyContextIsNotSpecified
         {
@@ -455,11 +455,11 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         }
 
         /// <summary>
-        /// One or more compilation references are missing. Possible causes include a missing '{0}' property under '{1}' in the application's {2}.
+        /// One or more compilation references are missing. Possible causes include a missing '{0}' property in the application's '{1}' file.
         /// </summary>
-        internal static string FormatCompilation_DependencyContextIsNotSpecified(object p0, object p1, object p2)
+        internal static string FormatCompilation_DependencyContextIsNotSpecified(object p0, object p1)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("Compilation_DependencyContextIsNotSpecified"), p0, p1, p2);
+            return string.Format(CultureInfo.CurrentCulture, GetString("Compilation_DependencyContextIsNotSpecified"), p0, p1);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Resources.resx
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Resources.resx
@@ -201,7 +201,7 @@
     <value>A circular layout reference was detected when rendering '{0}'. The layout page '{1}' has already been rendered.</value>
   </data>
   <data name="Compilation_DependencyContextIsNotSpecified" xml:space="preserve">
-    <value>One or more compilation references are missing. Possible causes include a missing '{0}' property under '{1}' in the application's {2}.</value>
+    <value>One or more compilation references are missing. Possible causes include a missing '{0}' property in the application's '{1}' file.</value>
   </data>
   <data name="ViewLocationFormatsIsRequired" xml:space="preserve">
     <value>'{0}' cannot be empty. These locations are required to locate a view for rendering.</value>

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Resources.resx
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Resources.resx
@@ -201,7 +201,7 @@
     <value>A circular layout reference was detected when rendering '{0}'. The layout page '{1}' has already been rendered.</value>
   </data>
   <data name="Compilation_DependencyContextIsNotSpecified" xml:space="preserve">
-    <value>One or more compilation references are missing. Possible causes include a missing '{0}' property in the application's '{1}' file.</value>
+    <value>One or more compilation references are missing. Ensure that your project is referencing '{0}' and the '{1}' property is not set to false.</value>
   </data>
   <data name="ViewLocationFormatsIsRequired" xml:space="preserve">
     <value>'{0}' cannot be empty. These locations are required to locate a view for rendering.</value>

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ErrorPageTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ErrorPageTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
     {
         private static readonly string PreserveCompilationContextMessage = HtmlEncoder.Default.Encode(
             "One or more compilation references are missing. Possible causes include a missing " +
-            "'preserveCompilationContext' property under 'buildOptions' in the application's project.json.");
+            "'PreserveCompilationContext' property in the application's 'csproj' file.");
         public ErrorPageTests(MvcTestFixture<ErrorPageMiddlewareWebSite.Startup> fixture)
         {
             Client = fixture.Client;

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ErrorPageTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ErrorPageTests.cs
@@ -17,8 +17,8 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
     public class ErrorPageTests : IClassFixture<MvcTestFixture<ErrorPageMiddlewareWebSite.Startup>>
     {
         private static readonly string PreserveCompilationContextMessage = HtmlEncoder.Default.Encode(
-            "One or more compilation references are missing. Possible causes include a missing " +
-            "'PreserveCompilationContext' property in the application's 'csproj' file.");
+            "One or more compilation references are missing. Ensure that your project is referencing " +
+            "'Microsoft.NET.Sdk.Web' and the 'PreserveCompilationContext' property is not set to false.");
         public ErrorPageTests(MvcTestFixture<ErrorPageMiddlewareWebSite.Startup> fixture)
         {
             Client = fixture.Client;


### PR DESCRIPTION
After encountering dotnet/sdk#120, I noticed that the error message had not been updated to the MSBuild project system from ```project.json```.

This PR updates the error message for the latest SDK.