### PR TITLE
[Feature] String should be an acceptable value for a checkbox if it can be parsed as a boolean

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/InputTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/InputTagHelper.cs
@@ -255,21 +255,43 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         private void GenerateCheckBox(ModelExplorer modelExplorer, TagHelperOutput output)
         {
             var isValidBool = false;
-            if (modelExplorer.ModelType == typeof(string))
+            if (modelExplorer.ModelType == typeof(bool))
+            {
+                isValidBool = true;
+            }
+            else if (modelExplorer.ModelType == typeof(string))
             {
                 bool potentialBool;
                 isValidBool = bool.TryParse(modelExplorer.Model?.ToString() ?? string.Empty, out potentialBool);
             }
 
-            if (typeof(bool) != modelExplorer.ModelType && !isValidBool)
+            if (!isValidBool)
             {
-                throw new InvalidOperationException(Resources.FormatInputTagHelper_InvalidExpressionResult(
-                    "<input>",
-                    ForAttributeName,
-                    modelExplorer.ModelType.FullName,
-                    typeof(bool).FullName,
-                    "type",
-                    "checkbox"));
+                if (modelExplorer.ModelType == typeof(string))
+                {
+                    if (modelExplorer.Model != null)
+                    {
+                        throw new InvalidOperationException(Resources.FormatInputTagHelper_InvalidStringResult(
+                            "<input>",
+                            ForAttributeName,
+                            modelExplorer.ModelType.FullName,
+                            typeof(string).FullName,
+                            typeof(bool).FullName,
+                            "checkbox"));
+                    }
+                }
+                else if (modelExplorer.ModelType != typeof(bool))
+                {
+                    throw new InvalidOperationException(Resources.FormatInputTagHelper_InvalidExpressionResult(
+                       "<input>",
+                       ForAttributeName,
+                       modelExplorer.ModelType.FullName,
+                       typeof(bool).FullName,
+                       typeof(string).FullName,
+                       "type",
+                       "checkbox"));
+                }
+                
             }
 
             // Prepare to move attributes from current element to <input type="checkbox"/> generated just below.

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/InputTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/InputTagHelper.cs
@@ -254,35 +254,23 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
         private void GenerateCheckBox(ModelExplorer modelExplorer, TagHelperOutput output)
         {
-            var isValidBool = false;
-            if (modelExplorer.ModelType == typeof(bool))
+            if (modelExplorer.ModelType == typeof(string))
             {
-                isValidBool = true;
-            }
-            else if (modelExplorer.ModelType == typeof(string))
-            {
-                bool potentialBool;
-                isValidBool = bool.TryParse(modelExplorer.Model?.ToString() ?? string.Empty, out potentialBool);
-            }
-
-            if (!isValidBool)
-            {
-                if (modelExplorer.ModelType == typeof(string))
+                if (modelExplorer.Model != null)
                 {
-                    if (modelExplorer.Model != null)
+                    bool potentialBool;
+                    if (!bool.TryParse(modelExplorer.Model.ToString(), out potentialBool))
                     {
                         throw new InvalidOperationException(Resources.FormatInputTagHelper_InvalidStringResult(
-                            "<input>",
                             ForAttributeName,
-                            modelExplorer.ModelType.FullName,
-                            typeof(string).FullName,
-                            typeof(bool).FullName,
-                            "checkbox"));
+                            modelExplorer.Model.ToString(),
+                            typeof(bool).FullName));
                     }
                 }
-                else if (modelExplorer.ModelType != typeof(bool))
-                {
-                    throw new InvalidOperationException(Resources.FormatInputTagHelper_InvalidExpressionResult(
+            }
+            else if (modelExplorer.ModelType != typeof(bool))
+            {
+                throw new InvalidOperationException(Resources.FormatInputTagHelper_InvalidExpressionResult(
                        "<input>",
                        ForAttributeName,
                        modelExplorer.ModelType.FullName,
@@ -290,8 +278,6 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                        typeof(string).FullName,
                        "type",
                        "checkbox"));
-                }
-                
             }
 
             // Prepare to move attributes from current element to <input type="checkbox"/> generated just below.

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/InputTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/InputTagHelper.cs
@@ -254,7 +254,14 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
         private void GenerateCheckBox(ModelExplorer modelExplorer, TagHelperOutput output)
         {
-            if (typeof(bool) != modelExplorer.ModelType)
+            var isValidBool = false;
+            if (modelExplorer.ModelType == typeof(string))
+            {
+                bool potentialBool;
+                isValidBool = bool.TryParse(modelExplorer.Model.ToString(), out potentialBool);
+            }
+
+            if (typeof(bool) != modelExplorer.ModelType && !isValidBool)
             {
                 throw new InvalidOperationException(Resources.FormatInputTagHelper_InvalidExpressionResult(
                     "<input>",

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/InputTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/InputTagHelper.cs
@@ -258,7 +258,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             if (modelExplorer.ModelType == typeof(string))
             {
                 bool potentialBool;
-                isValidBool = bool.TryParse(modelExplorer.Model.ToString(), out potentialBool);
+                isValidBool = bool.TryParse(modelExplorer.Model?.ToString() ?? string.Empty, out potentialBool);
             }
 
             if (typeof(bool) != modelExplorer.ModelType && !isValidBool)

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/Properties/Resources.Designer.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         }
 
         /// <summary>
-        /// Unexpected '{1}' expression result type '{2}' for {0}. '{1}' is of type '{3}' for {5} but cannot be parsed as a '{4}'.
+        /// Unexpected expression result value '{1}' for {0}. '{1}' cannot be parsed as a '{2}'.
         /// </summary>
         internal static string InputTagHelper_InvalidStringResult
         {
@@ -83,11 +83,11 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         }
 
         /// <summary>
-        /// Unexpected '{1}' expression result type '{2}' for {0}. '{1}' is of type '{3}' for {5} but cannot be parsed as a '{4}'.
+        /// Unexpected expression result value '{1}' for {0}. '{1}' cannot be parsed as a '{2}'.
         /// </summary>
-        internal static string FormatInputTagHelper_InvalidStringResult(object p0, object p1, object p2, object p3, object p4, object p5)
+        internal static string FormatInputTagHelper_InvalidStringResult(object p0, object p1, object p2)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("InputTagHelper_InvalidStringResult"), p0, p1, p2, p3, p4, p5);
+            return string.Format(CultureInfo.CurrentCulture, GetString("InputTagHelper_InvalidStringResult"), p0, p1, p2);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/Properties/Resources.Designer.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         }
 
         /// <summary>
-        /// Unexpected '{1}' expression result type '{2}' for {0}. '{1}' must be of type '{3}' if '{4}' is '{5}'.
+        /// Unexpected '{1}' expression result type '{2}' for {0}. '{1}' must be of type '{3}' or '{4}' that can be parsed as a '{3}' if '{5}' is '{6}'.
         /// </summary>
         internal static string InputTagHelper_InvalidExpressionResult
         {
@@ -67,11 +67,27 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         }
 
         /// <summary>
-        /// Unexpected '{1}' expression result type '{2}' for {0}. '{1}' must be of type '{3}' if '{4}' is '{5}'.
+        /// Unexpected '{1}' expression result type '{2}' for {0}. '{1}' must be of type '{3}' or '{4}' that can be parsed as a '{3}' if '{5}' is '{6}'.
         /// </summary>
-        internal static string FormatInputTagHelper_InvalidExpressionResult(object p0, object p1, object p2, object p3, object p4, object p5)
+        internal static string FormatInputTagHelper_InvalidExpressionResult(object p0, object p1, object p2, object p3, object p4, object p5, object p6)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("InputTagHelper_InvalidExpressionResult"), p0, p1, p2, p3, p4, p5);
+            return string.Format(CultureInfo.CurrentCulture, GetString("InputTagHelper_InvalidExpressionResult"), p0, p1, p2, p3, p4, p5, p6);
+        }
+
+        /// <summary>
+        /// Unexpected '{1}' expression result type '{2}' for {0}. '{1}' is of type '{3}' for {5} but cannot be parsed as a '{4}'.
+        /// </summary>
+        internal static string InputTagHelper_InvalidStringResult
+        {
+            get { return GetString("InputTagHelper_InvalidStringResult"); }
+        }
+
+        /// <summary>
+        /// Unexpected '{1}' expression result type '{2}' for {0}. '{1}' is of type '{3}' for {5} but cannot be parsed as a '{4}'.
+        /// </summary>
+        internal static string FormatInputTagHelper_InvalidStringResult(object p0, object p1, object p2, object p3, object p4, object p5)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("InputTagHelper_InvalidStringResult"), p0, p1, p2, p3, p4, p5);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/Resources.resx
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/Resources.resx
@@ -156,7 +156,4 @@
   <data name="FormActionTagHelper_CannotDetermineFormActionRouteActionOrControllerSpecified" xml:space="preserve">
     <value>Cannot determine a '{4}' attribute for &lt;{0}&gt;. &lt;{0}&gt; elements with a specified '{1}' must not have an '{2}', '{3}', or '{5}' attribute.</value>
   </data>
-  <data name="FormatInputTagHelper_InvalidStringResult" xml:space="preserve">
-    <value>Unexpected '{1}' expression result type '{2}' for {0}. '{1}' is of type '{3}' for {5} but cannot be parsed as a '{4}'.</value>
-  </data>
 </root>

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/Resources.resx
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/Resources.resx
@@ -130,7 +130,7 @@
     <value>Unexpected '{1}' expression result type '{2}' for {0}. '{1}' must be of type '{3}' or '{4}' that can be parsed as a '{3}' if '{5}' is '{6}'.</value>
   </data>
   <data name="InputTagHelper_InvalidStringResult" xml:space="preserve">
-    <value>Unexpected '{1}' expression result type '{2}' for {0}. '{1}' is of type '{3}' for {5} but cannot be parsed as a '{4}'.</value>
+    <value>Unexpected expression result value '{1}' for {0}. '{1}' cannot be parsed as a '{2}'.</value>
   </data>
   <data name="InputTagHelper_ValueRequired" xml:space="preserve">
     <value>'{1}' must not be null for {0} if '{2}' is '{3}'.</value>

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/Resources.resx
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/Resources.resx
@@ -127,7 +127,10 @@
     <value>Cannot override the '{1}' attribute for {0}. A {0} with a specified '{1}' must not have attributes starting with '{7}' or an '{2}', '{3}', '{4}', '{5}', or '{6}' attribute.</value>
   </data>
   <data name="InputTagHelper_InvalidExpressionResult" xml:space="preserve">
-    <value>Unexpected '{1}' expression result type '{2}' for {0}. '{1}' must be of type '{3}' if '{4}' is '{5}'.</value>
+    <value>Unexpected '{1}' expression result type '{2}' for {0}. '{1}' must be of type '{3}' or '{4}' that can be parsed as a '{3}' if '{5}' is '{6}'.</value>
+  </data>
+  <data name="InputTagHelper_InvalidStringResult" xml:space="preserve">
+    <value>Unexpected '{1}' expression result type '{2}' for {0}. '{1}' is of type '{3}' for {5} but cannot be parsed as a '{4}'.</value>
   </data>
   <data name="InputTagHelper_ValueRequired" xml:space="preserve">
     <value>'{1}' must not be null for {0} if '{2}' is '{3}'.</value>
@@ -152,5 +155,8 @@
   </data>
   <data name="FormActionTagHelper_CannotDetermineFormActionRouteActionOrControllerSpecified" xml:space="preserve">
     <value>Cannot determine a '{4}' attribute for &lt;{0}&gt;. &lt;{0}&gt; elements with a specified '{1}' must not have an '{2}', '{3}', or '{5}' attribute.</value>
+  </data>
+  <data name="FormatInputTagHelper_InvalidStringResult" xml:space="preserve">
+    <value>Unexpected '{1}' expression result type '{2}' for {0}. '{1}' is of type '{3}' for {5} but cannot be parsed as a '{4}'.</value>
   </data>
 </root>

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/InputTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/InputTagHelperTest.cs
@@ -120,9 +120,9 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             string possibleBool)
         {
             // Arrange
-            var originalContent = "original content";
-            var originalTagName = "input";
-            var forAttributeName = "asp-for";
+            const string content = "original content";
+            const string tagName = "input";
+            const string forAttributeName = "asp-for";
 
             var expected = Resources.FormatInputTagHelper_InvalidExpressionResult(
                 "<input>",
@@ -143,13 +143,13 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 items: new Dictionary<object, object>(),
                 uniqueId: "test");
             var output = new TagHelperOutput(
-                originalTagName,
+                tagName,
                 attributes,
                 getChildContentAsync: (useCachedResult, encoder) => Task.FromResult<TagHelperContent>(result: null))
             {
                 TagMode = TagMode.SelfClosing,
             };
-            output.Content.AppendHtml(originalContent);
+            output.Content.AppendHtml(content);
             var htmlGenerator = new TestableHtmlGenerator(new EmptyModelMetadataProvider());
             var tagHelper = GetTagHelper(htmlGenerator, model: possibleBool, propertyName: nameof(Model.IsACar));
 
@@ -165,8 +165,14 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             string possibleBool)
         {
             // Arrange
-            var originalContent = "original content";
-            var originalTagName = "input";
+            const string content = "original content";
+            const string tagName = "input";
+            const string isChecked = " checked=\"HtmlEncode[[checked]]\"";
+            var expectedContent = content + "<input" + (bool.Parse(possibleBool) ? isChecked : string.Empty) + " class=\"HtmlEncode[[form-control]]\" " +
+                                           "id=\"HtmlEncode[[IsACar]]\" name=\"HtmlEncode[[IsACar]]\" type=\"HtmlEncode[[checkbox]]\" " +
+                                           "value=\"HtmlEncode[[true]]\" /><input name=\"HtmlEncode[[IsACar]]\" type=\"HtmlEncode[[hidden]]\" " +
+                                           "value=\"HtmlEncode[[false]]\" />";
+
 
             var attributes = new TagHelperAttributeList
             {
@@ -179,13 +185,13 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 items: new Dictionary<object, object>(),
                 uniqueId: "test");
             var output = new TagHelperOutput(
-                originalTagName,
+                tagName,
                 attributes,
                 getChildContentAsync: (useCachedResult, encoder) => Task.FromResult<TagHelperContent>(result: null))
             {
                 TagMode = TagMode.SelfClosing,
             };
-            output.Content.AppendHtml(originalContent);
+            output.Content.AppendHtml(content);
             var htmlGenerator = new TestableHtmlGenerator(new EmptyModelMetadataProvider());
             var tagHelper = GetTagHelper(htmlGenerator, model: possibleBool, propertyName: nameof(Model.IsACar));
 
@@ -194,6 +200,11 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             
             // Assert
             Assert.Null(ex);
+
+            Assert.Empty(output.Attributes);    // Moved to Content and cleared
+            Assert.Equal(expectedContent, HtmlContentUtilities.HtmlContentToString(output.Content));
+            Assert.Equal(TagMode.SelfClosing, output.TagMode);
+            Assert.Null(output.TagName);       // Cleared
         }
 
         // Top-level container (List<Model> or Model instance), immediate container type (Model or NestModel),

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/InputTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/InputTagHelperTest.cs
@@ -116,6 +116,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         [Theory]
         [InlineData("bad")]
         [InlineData("notbool")]
+        [InlineData(null)]
         public void CheckBoxHandlesNonParsableStringsAsBoolsCorrectly(
             string possibleBool)
         {
@@ -144,26 +145,14 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             var htmlGenerator = new TestableHtmlGenerator(new EmptyModelMetadataProvider());
             var tagHelper = GetTagHelper(htmlGenerator, model: possibleBool, propertyName: nameof(Model.IsACar));
 
-            Type exceptionType = null;
-            try
-            {
-                // Act
-                tagHelper.Process(context, output);
-            }
-            catch(Exception ex)
-            {
-                exceptionType = ex.GetType();
-            }
-            // Assert
-            Assert.NotNull(exceptionType);
-            Assert.Equal(exceptionType, typeof(InvalidOperationException));
+            Assert.Throws<InvalidOperationException>(() => tagHelper.Process(context, output));
         }
 
         [Theory]
         [InlineData("trUE")]
         [InlineData("FAlse")]
         public void CheckBoxHandlesParsableStringsAsBoolsCorrectly(
-        string possibleBool)
+            string possibleBool)
         {
             // Arrange
             var originalContent = "original content";
@@ -190,18 +179,11 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             var htmlGenerator = new TestableHtmlGenerator(new EmptyModelMetadataProvider());
             var tagHelper = GetTagHelper(htmlGenerator, model: possibleBool, propertyName: nameof(Model.IsACar));
 
-            Type exceptionType = null;
-            try
-            {
-                // Act
-                tagHelper.Process(context, output);
-            }
-            catch (Exception ex)
-            {
-                exceptionType = ex.GetType();
-            }
+            // Act
+            var ex = Record.Exception(() => tagHelper.Process(context, output));
+            
             // Assert
-            Assert.Null(exceptionType);
+            Assert.Null(ex);
         }
 
         // Top-level container (List<Model> or Model instance), immediate container type (Model or NestModel),

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/InputTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/InputTagHelperTest.cs
@@ -125,12 +125,9 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             const string forAttributeName = "asp-for";
 
             var expected = Resources.FormatInputTagHelper_InvalidStringResult(
-                "<input>",
                 forAttributeName,
-                possibleBool.GetType().FullName,
-                typeof(string).FullName,
-                typeof(bool).FullName,
-                "checkbox");
+                possibleBool,
+                typeof(bool).FullName);
 
             var attributes = new TagHelperAttributeList
             {
@@ -216,9 +213,9 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             const string isCheckedAttr = " checked=\"HtmlEncode[[checked]]\"";
             var isChecked = (bool.Parse(possibleBool) ? isCheckedAttr : string.Empty);
             var expectedContent = $"{content}<input{isChecked} class=\"HtmlEncode[[form-control]]\" " +
-                                           "id=\"HtmlEncode[[IsACar]]\" name=\"HtmlEncode[[IsACar]]\" type=\"HtmlEncode[[checkbox]]\" " +
-                                           "value=\"HtmlEncode[[true]]\" /><input name=\"HtmlEncode[[IsACar]]\" type=\"HtmlEncode[[hidden]]\" " +
-                                           "value=\"HtmlEncode[[false]]\" />";
+                "id=\"HtmlEncode[[IsACar]]\" name=\"HtmlEncode[[IsACar]]\" type=\"HtmlEncode[[checkbox]]\" " +
+                "value=\"HtmlEncode[[true]]\" /><input name=\"HtmlEncode[[IsACar]]\" type=\"HtmlEncode[[hidden]]\" " +
+                "value=\"HtmlEncode[[false]]\" />";
 
 
             var attributes = new TagHelperAttributeList

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/InputTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/InputTagHelperTest.cs
@@ -116,13 +116,21 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         [Theory]
         [InlineData("bad")]
         [InlineData("notbool")]
-        [InlineData(null)]
         public void CheckBoxHandlesNonParsableStringsAsBoolsCorrectly(
             string possibleBool)
         {
             // Arrange
             var originalContent = "original content";
             var originalTagName = "input";
+            string forAttributeName = "asp-for";
+
+            var expected = Resources.FormatInputTagHelper_InvalidExpressionResult(
+                "<input>",
+                forAttributeName,
+                possibleBool.GetType().FullName,
+                typeof(bool).FullName,
+                "type",
+                "checkbox");
 
             var attributes = new TagHelperAttributeList
             {
@@ -145,7 +153,9 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             var htmlGenerator = new TestableHtmlGenerator(new EmptyModelMetadataProvider());
             var tagHelper = GetTagHelper(htmlGenerator, model: possibleBool, propertyName: nameof(Model.IsACar));
 
-            Assert.Throws<InvalidOperationException>(() => tagHelper.Process(context, output));
+            // Act and Assert
+            var ex = Assert.Throws<InvalidOperationException>(() => tagHelper.Process(context, output));
+            Assert.Equal(expected, ex.Message);
         }
 
         [Theory]

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/InputTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/InputTagHelperTest.cs
@@ -122,7 +122,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             // Arrange
             var originalContent = "original content";
             var originalTagName = "input";
-            string forAttributeName = "asp-for";
+            var forAttributeName = "asp-for";
 
             var expected = Resources.FormatInputTagHelper_InvalidExpressionResult(
                 "<input>",

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/InputTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/InputTagHelperTest.cs
@@ -113,6 +113,97 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             Assert.Null(output.TagName); // Cleared
         }
 
+        [Theory]
+        [InlineData("bad")]
+        [InlineData("notbool")]
+        public void CheckBoxHandlesNonParsableStringsAsBoolsCorrectly(
+            string possibleBool)
+        {
+            // Arrange
+            var originalContent = "original content";
+            var originalTagName = "input";
+
+            var attributes = new TagHelperAttributeList
+            {
+                { "class", "form-control" },
+            };
+
+            var context = new TagHelperContext(
+                allAttributes: new TagHelperAttributeList(
+                    Enumerable.Empty<TagHelperAttribute>()),
+                items: new Dictionary<object, object>(),
+                uniqueId: "test");
+            var output = new TagHelperOutput(
+                originalTagName,
+                attributes,
+                getChildContentAsync: (useCachedResult, encoder) => Task.FromResult<TagHelperContent>(result: null))
+            {
+                TagMode = TagMode.SelfClosing,
+            };
+            output.Content.AppendHtml(originalContent);
+            var htmlGenerator = new TestableHtmlGenerator(new EmptyModelMetadataProvider());
+            var tagHelper = GetTagHelper(htmlGenerator, model: possibleBool, propertyName: nameof(Model.IsACar));
+
+            Type exceptionType = null;
+            try
+            {
+                // Act
+                tagHelper.Process(context, output);
+            }
+            catch(Exception ex)
+            {
+                exceptionType = ex.GetType();
+            }
+            // Assert
+            Assert.NotNull(exceptionType);
+            Assert.Equal(exceptionType, typeof(InvalidOperationException));
+        }
+
+        [Theory]
+        [InlineData("trUE")]
+        [InlineData("FAlse")]
+        public void CheckBoxHandlesParsableStringsAsBoolsCorrectly(
+        string possibleBool)
+        {
+            // Arrange
+            var originalContent = "original content";
+            var originalTagName = "input";
+
+            var attributes = new TagHelperAttributeList
+            {
+                { "class", "form-control" },
+            };
+
+            var context = new TagHelperContext(
+                allAttributes: new TagHelperAttributeList(
+                    Enumerable.Empty<TagHelperAttribute>()),
+                items: new Dictionary<object, object>(),
+                uniqueId: "test");
+            var output = new TagHelperOutput(
+                originalTagName,
+                attributes,
+                getChildContentAsync: (useCachedResult, encoder) => Task.FromResult<TagHelperContent>(result: null))
+            {
+                TagMode = TagMode.SelfClosing,
+            };
+            output.Content.AppendHtml(originalContent);
+            var htmlGenerator = new TestableHtmlGenerator(new EmptyModelMetadataProvider());
+            var tagHelper = GetTagHelper(htmlGenerator, model: possibleBool, propertyName: nameof(Model.IsACar));
+
+            Type exceptionType = null;
+            try
+            {
+                // Act
+                tagHelper.Process(context, output);
+            }
+            catch (Exception ex)
+            {
+                exceptionType = ex.GetType();
+            }
+            // Assert
+            Assert.Null(exceptionType);
+        }
+
         // Top-level container (List<Model> or Model instance), immediate container type (Model or NestModel),
         // model accessor, expression path / id, expected value.
         public static TheoryData<object, Type, object, NameAndId, string> TestDataSet


### PR DESCRIPTION
If the asp-for value is string with the values "true" or "false" the code is able to process that as valid boolean and generate a proper checkbox around that.

However the typeof check in the GenerateCheckBox method prevents that. 

Added a check that allows the value to be processed and create a checkbox if the value is a valid bool string.