### PR TITLE
Re-enable functional tests on full .NET Framework

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/TextInputFormatterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/TextInputFormatterTest.cs
@@ -114,8 +114,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         [Theory]
         [InlineData("unicode-1-1-utf-8")]
         [InlineData("unicode-2-0-utf-8")]
-        [InlineData("unicode-1-1-utf-8")]
-        [InlineData("unicode-2-0-utf-8")]
         public void SelectCharacterEncoding_ReturnsUTF8Encoding_IfContentTypeIsAnAlias(string charset)
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/Microsoft.AspNetCore.Mvc.FunctionalTests.csproj
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/Microsoft.AspNetCore.Mvc.FunctionalTests.csproj
@@ -2,8 +2,15 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-    <PackageTargetFallback>$(PackageTargetFallback);portable-net451+win8</PackageTargetFallback>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp1.1</TargetFrameworks>
+    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">$(PackageTargetFallback);portable-net451+win8</PackageTargetFallback>
+
+    <!--
+      Generate an EXE to take advantage of Microsoft.NET.RuntimeIdentifierInference.targets special cases. This works
+      around #5873. Also avoids dotnet/sdk#926 when building with msbuild.exe e.g. in Visual Studio.
+    -->
+    <OutputType Condition=" '$(TargetFramework)' != 'netcoreapp1.1' ">EXE</OutputType>
 
     <DefineConstants Condition="'$(GenerateBaselines)'=='true'">$(DefineConstants);GENERATE_BASELINES</DefineConstants>
     <DefineConstants>$(DefineConstants);__RemoveThisBitTo__GENERATE_BASELINES</DefineConstants>


### PR DESCRIPTION
- #5873
- creating an EXE for the test project seems to work around #5873
  - also avoids dotnet/sdk#926 when building in Visual Studio

nit: clean up duplicate test data