### PR TITLE
Disable colours in the AppVeyor and Travis logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ branches:
 before_install:
   - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
 script:
-  - ./build.sh
+  - ./build.sh /verbosity:quiet


### PR DESCRIPTION
- testing impact of a potential KoreBuild change to do this when `"$CI" != ""`

Also get rid of logging for packages folder setup in AppVeyor build, matching Travis build.