### PR TITLE
Make CookieTempDataProvider the default ITempDataProvider

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/DependencyInjection/MvcViewFeaturesMvcBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/DependencyInjection/MvcViewFeaturesMvcBuilderExtensions.cs
@@ -67,6 +67,28 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
+        /// Registers <see cref="SessionStateTempDataProvider"/> as the default <see cref="ITempDataProvider"/>
+        /// in the <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
+        /// <returns>The <see cref="IMvcBuilder"/>.</returns>
+        public static IMvcBuilder AddSessionStateTempDataProvider(this IMvcBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            // Ensure the TempData basics are registered.
+            MvcViewFeaturesMvcCoreBuilderExtensions.AddViewServices(builder.Services);
+
+            var descriptor = ServiceDescriptor.Singleton(typeof(ITempDataProvider), typeof(SessionStateTempDataProvider));
+            builder.Services.Replace(descriptor);
+
+            return builder;
+        }
+
+        /// <summary>
         /// Registers <see cref="CookieTempDataProvider"/> as the default <see cref="ITempDataProvider"/> in the
         /// <see cref="IServiceCollection"/>.
         /// </summary>

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/DependencyInjection/MvcViewFeaturesMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/DependencyInjection/MvcViewFeaturesMvcCoreBuilderExtensions.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Extensions.DependencyInjection
             // Temp Data
             //
             // This does caching so it should stay singleton
-            services.TryAddSingleton<ITempDataProvider, SessionStateTempDataProvider>();
+            services.TryAddSingleton<ITempDataProvider, CookieTempDataProvider>();
 
             //
             // Antiforgery

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/TempDataInCookiesTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/TempDataInCookiesTest.cs
@@ -7,21 +7,22 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Internal;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Net.Http.Headers;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 {
-    public class TempDataInCookiesTest : TempDataTestBase, IClassFixture<MvcTestFixture<BasicWebSite.StartupWithCookieTempDataProvider>>
+    public class TempDataInCookiesTest : TempDataTestBase, IClassFixture<MvcTestFixture<BasicWebSite.Startup>>
     {
-        public TempDataInCookiesTest(MvcTestFixture<BasicWebSite.StartupWithCookieTempDataProvider> fixture)
+        public TempDataInCookiesTest(MvcTestFixture<BasicWebSite.Startup> fixture)
         {
             Client = fixture.Client;
         }
 
         protected override HttpClient Client { get; }
+
 
         [Theory]
         [InlineData(ChunkingCookieManager.DefaultChunkSize)]
@@ -39,8 +40,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
             // Assert 1
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            IEnumerable<string> setCookieValues;
-            Assert.True(response.Headers.TryGetValues(HeaderNames.SetCookie, out setCookieValues));
+            Assert.True(response.Headers.TryGetValues(HeaderNames.SetCookie, out IEnumerable<string> setCookieValues));
             setCookieValues = setCookieValues.Where(cookie => cookie.Contains(CookieTempDataProvider.CookieName));
             Assert.NotEmpty(setCookieValues);
             // Verify that all the cookies from CookieTempDataProvider are within the maximum size
@@ -99,8 +99,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
             // Assert 1
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            IEnumerable<string> setCookieValues;
-            Assert.True(response.Headers.TryGetValues(HeaderNames.SetCookie, out setCookieValues));
+            Assert.True(response.Headers.TryGetValues(HeaderNames.SetCookie, out IEnumerable<string> setCookieValues));
             var setCookieHeader = setCookieValues
                 .Select(setCookieValue => SetCookieHeaderValue.Parse(setCookieValue))
                 .FirstOrDefault(setCookieHeaderValue => setCookieHeaderValue.Name == CookieTempDataProvider.CookieName);
@@ -153,8 +152,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            IEnumerable<string> setCookieValues;
-            Assert.True(response.Headers.TryGetValues(HeaderNames.SetCookie, out setCookieValues));
+            Assert.True(response.Headers.TryGetValues(HeaderNames.SetCookie, out IEnumerable<string> setCookieValues));
             var setCookieHeader = setCookieValues
                 .Select(setCookieValue => SetCookieHeaderValue.Parse(setCookieValue))
                 .FirstOrDefault(setCookieHeaderValue => setCookieHeaderValue.Name == CookieTempDataProvider.CookieName);

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/TempDataInSessionTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/TempDataInSessionTest.cs
@@ -6,9 +6,9 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 {
-    public class TempDataInSessionTest : TempDataTestBase, IClassFixture<MvcTestFixture<BasicWebSite.Startup>>
+    public class TempDataInSessionTest : TempDataTestBase, IClassFixture<MvcTestFixture<BasicWebSite.StartupWithSessionTempDataProvider>>
     {
-        public TempDataInSessionTest(MvcTestFixture<BasicWebSite.Startup> fixture)
+        public TempDataInSessionTest(MvcTestFixture<BasicWebSite.StartupWithSessionTempDataProvider> fixture)
         {
             Client = fixture.Client;
         }

--- a/test/Microsoft.AspNetCore.Mvc.Test/MvcServiceCollectionExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Test/MvcServiceCollectionExtensionsTest.cs
@@ -289,7 +289,7 @@ namespace Microsoft.AspNetCore.Mvc
 
             // Assert
             var descriptor = Assert.Single(services, item => item.ServiceType == typeof(ITempDataProvider));
-            Assert.Equal(typeof(SessionStateTempDataProvider), descriptor.ImplementationType);
+            Assert.Equal(typeof(CookieTempDataProvider), descriptor.ImplementationType);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/DependencyInjection/MvcViewFeaturesMvcCoreBuilderExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/DependencyInjection/MvcViewFeaturesMvcCoreBuilderExtensionsTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             // Assert
             var descriptor = Assert.Single(services, item => item.ServiceType == typeof(ITempDataProvider));
-            Assert.Equal(typeof(SessionStateTempDataProvider), descriptor.ImplementationType);
+            Assert.Equal(typeof(CookieTempDataProvider), descriptor.ImplementationType);
         }
 
         [Fact]

--- a/test/WebSites/BasicWebSite/Startup.cs
+++ b/test/WebSites/BasicWebSite/Startup.cs
@@ -24,9 +24,6 @@ namespace BasicWebSite
             services.AddSingleton<IActionDescriptorProvider, ActionDescriptorCreationCounter>();
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.AddScoped<RequestIdService>();
-            services.AddMemoryCache();
-            services.AddDistributedMemoryCache();
-            services.AddSession();
         }
 
         public void Configure(IApplicationBuilder app)
@@ -37,8 +34,6 @@ namespace BasicWebSite
 
             // Initializes the RequestId service for each request
             app.UseMiddleware<RequestIdMiddleware>();
-
-            app.UseSession();
 
             // Add MVC to the request pipeline
             app.UseMvc(routes =>
@@ -55,4 +50,3 @@ namespace BasicWebSite
         }
     }
 }
-

--- a/test/WebSites/BasicWebSite/StartupWithSessionTempDataProvider.cs
+++ b/test/WebSites/BasicWebSite/StartupWithSessionTempDataProvider.cs
@@ -6,18 +6,21 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace BasicWebSite
 {
-    public class StartupWithCookieTempDataProvider
+    public class StartupWithSessionTempDataProvider
     {
         public void ConfigureServices(IServiceCollection services)
         {
+            // CookieTempDataProvider is the default ITempDataProvider, so we must override it with session.
             services
                 .AddMvc()
-                .AddCookieTempDataProvider();
+                .AddSessionStateTempDataProvider();
+            services.AddSession();
         }
 
         public void Configure(IApplicationBuilder app)
         {
             app.UseCultureReplacer();
+            app.UseSession();
             app.UseMvcWithDefaultRoute();
         }
     }


### PR DESCRIPTION
Fixes #5766.

Also added an extension for adding SessionsStateTempDataProvider.