### PR TITLE
set core.autocrlf to input for enabling source link

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 init:
-  - git config --global core.autocrlf true
+  - git config --global core.autocrlf input
 branches:
   only:
     - master


### PR DESCRIPTION
I was [asked](https://github.com/aspnet/Mvc/pull/5905#pullrequestreview-25166571) by @dougbu to make this a separate pull request. Here it is.

To enable source linking, the files that are compiled must match the git repository. The line endings must not be changed. The setting that leaves line ending the same as they are in the repository is `core.autocrlf input`. `core.autocrlf true` and `core.autocrlf false` will end up with CRLF line endings that will not match.

This change is only for the build servers where source linking will be done: AppVeyor and TeamCity. This does not affect developers computers at all. The same type of settings can be applied to TeamCity using a build configuration like what is described [here in the comments](https://confluence.jetbrains.com/display/TCD9/Git).

If this is not done, SourceLink will attempt to convert all the line endings before compile to match. It costs 1-2 minutes in build time. Just setting `input` is easy and recommended.