### PR TITLE
Use RazorPagesOptions.RootDirectory when looking for page hierarchies.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/PageActionInvokerProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/PageActionInvokerProvider.cs
@@ -35,6 +35,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
         private readonly IModelMetadataProvider _modelMetadataProvider;
         private readonly ITempDataDictionaryFactory _tempDataFactory;
         private readonly HtmlHelperOptions _htmlHelperOptions;
+        private readonly RazorPagesOptions _razorPagesOptions;
         private readonly IPageHandlerMethodSelector _selector;
         private readonly TempDataPropertyProvider _propertyProvider;
         private readonly RazorProject _razorProject;
@@ -53,6 +54,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             ITempDataDictionaryFactory tempDataFactory,
             IOptions<MvcOptions> mvcOptions,
             IOptions<HtmlHelperOptions> htmlHelperOptions,
+            IOptions<RazorPagesOptions> razorPagesOptions,
             IPageHandlerMethodSelector selector,
             TempDataPropertyProvider propertyProvider,
             RazorProject razorProject,
@@ -69,6 +71,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             _modelMetadataProvider = modelMetadataProvider;
             _tempDataFactory = tempDataFactory;
             _htmlHelperOptions = htmlHelperOptions.Value;
+            _razorPagesOptions = razorPagesOptions.Value;
             _selector = selector;
             _propertyProvider = propertyProvider;
             _razorProject = razorProject;
@@ -201,7 +204,10 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
         internal List<Func<IRazorPage>> GetPageStartFactories(CompiledPageActionDescriptor descriptor)
         {
             var pageStartFactories = new List<Func<IRazorPage>>();
-            var pageStartItems = _razorProject.FindHierarchicalItems(descriptor.ViewEnginePath, PageStartFileName);
+            var pageStartItems = _razorProject.FindHierarchicalItems(
+                _razorPagesOptions.RootDirectory,
+                descriptor.RelativePath,
+                PageStartFileName);
             foreach (var item in pageStartItems)
             {
                 if (item.Exists)

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RazorPagesTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RazorPagesTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -228,6 +229,35 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
             Assert.Equal("/Login?ReturnUrl=%2FHelloWorldWithAuth", response.Headers.Location.PathAndQuery);
+        }
+
+
+        [Fact]
+        public async Task PageStart_IsDiscoveredWhenRootDirectoryIsNotSpecified()
+        {
+            // Test for https://github.com/aspnet/Mvc/issues/5915
+            //Arrange
+            var expected = $"Hello from _PageStart{Environment.NewLine}Hello from /Pages/WithPageStart/Index.cshtml!";
+
+            // Act
+            var response = await Client.GetStringAsync("/Pages/WithPageStart");
+
+            // Assert
+            Assert.Equal(expected, response.Trim());
+        }
+
+        [Fact]
+        public async Task PageImport_IsDiscoveredWhenRootDirectoryIsNotSpecified()
+        {
+            // Test for https://github.com/aspnet/Mvc/issues/5915
+            //Arrange
+            var expected = "Hello from CustomService!";
+
+            // Act
+            var response = await Client.GetStringAsync("/Pages/WithPageImport");
+
+            // Assert
+            Assert.Equal(expected, response.Trim());
         }
 
         private static string GetCookie(HttpResponseMessage response)

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RazorPagesWithBasePathTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RazorPagesWithBasePathTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -112,6 +113,34 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
             Assert.Equal("/Login?ReturnUrl=%2FConventions%2FAuthFolder", response.Headers.Location.PathAndQuery);
+        }
+
+        [Fact]
+        public async Task PageStart_IsDiscoveredWhenRootDirectoryIsSpecified()
+        {
+            // Test for https://github.com/aspnet/Mvc/issues/5915
+            //Arrange
+            var expected = $"Hello from _PageStart{Environment.NewLine}Hello from /Pages/WithPageStart/Index.cshtml!";
+
+            // Act
+            var response = await Client.GetStringAsync("/WithPageStart");
+
+            // Assert
+            Assert.Equal(expected, response.Trim());
+        }
+
+        [Fact]
+        public async Task PageImport_IsDiscoveredWhenRootDirectoryIsSpecified()
+        {
+            // Test for https://github.com/aspnet/Mvc/issues/5915
+            //Arrange
+            var expected = "Hello from CustomService!";
+
+            // Act
+            var response = await Client.GetStringAsync("/WithPageImport");
+
+            // Assert
+            Assert.Equal(expected, response.Trim());
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.TestCommon/TestOptionsManager.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TestCommon/TestOptionsManager.cs
@@ -1,17 +1,23 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Linq;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Mvc
 {
-    public class TestOptionsManager<T> : OptionsManager<T>
-        where T : class, new()
+    public class TestOptionsManager<TOptions> : IOptions<TOptions>
+        where TOptions : class, new()
     {
         public TestOptionsManager()
-            : base(Enumerable.Empty<IConfigureOptions<T>>())
+            : this(new TOptions())
         {
         }
+
+        public TestOptionsManager(TOptions value)
+        {
+            Value = value;
+        }
+
+        public TOptions Value { get; }
     }
 }

--- a/test/WebSites/RazorPagesWebSite/Pages/WithPageImport/Index.cshtml
+++ b/test/WebSites/RazorPagesWebSite/Pages/WithPageImport/Index.cshtml
@@ -1,0 +1,2 @@
+﻿@page
+Hello from @CustomService.Value!

--- a/test/WebSites/RazorPagesWebSite/Pages/WithPageImport/_PageImports.cshtml
+++ b/test/WebSites/RazorPagesWebSite/Pages/WithPageImport/_PageImports.cshtml
@@ -1,0 +1,1 @@
+﻿@using CustomNamespace

--- a/test/WebSites/RazorPagesWebSite/Pages/WithPageStart/Index.cshtml
+++ b/test/WebSites/RazorPagesWebSite/Pages/WithPageStart/Index.cshtml
@@ -1,0 +1,2 @@
+﻿@page
+Hello from @Path!

--- a/test/WebSites/RazorPagesWebSite/Pages/WithPageStart/_PageStart.cshtml
+++ b/test/WebSites/RazorPagesWebSite/Pages/WithPageStart/_PageStart.cshtml
@@ -1,0 +1,1 @@
+﻿Hello from _PageStart

--- a/test/WebSites/RazorPagesWebSite/Services/CustomService.cs
+++ b/test/WebSites/RazorPagesWebSite/Services/CustomService.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace CustomNamespace
+{
+    public static class CustomService
+    {
+        public static string Value => nameof(CustomService);
+    }
+}


### PR DESCRIPTION
Fixes #5915