### PR TITLE
Allow curly braces in LocalizedHtmlString without arguments

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Localization/LocalizedHtmlString.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Localization/LocalizedHtmlString.cs
@@ -93,11 +93,10 @@ namespace Microsoft.AspNetCore.Mvc.Localization
             {
                 throw new ArgumentNullException(nameof(encoder));
             }
-
-            IHtmlContent htmlContent;
+            
             if (_arguments != null)
             {
-                htmlContent = new HtmlFormattableString(Value, _arguments);
+                var htmlContent = new HtmlFormattableString(Value, _arguments);
                 htmlContent.WriteTo(writer, encoder);
             }
             else

--- a/src/Microsoft.AspNetCore.Mvc.Localization/LocalizedHtmlString.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Localization/LocalizedHtmlString.cs
@@ -33,18 +33,6 @@ namespace Microsoft.AspNetCore.Mvc.Localization
         /// <param name="value">The string resource.</param>
         /// <param name="isResourceNotFound">A flag that indicates if the resource is not found.</param>
         public LocalizedHtmlString(string name, string value, bool isResourceNotFound)
-            : this(name, value, isResourceNotFound, arguments: EmptyArray<string>.Instance)
-        {
-        }
-
-        /// <summary>
-        /// Creates an instance of <see cref="LocalizedHtmlString"/>.
-        /// </summary>
-        /// <param name="name">The name of the string resource.</param>
-        /// <param name="value">The string resource.</param>
-        /// <param name="isResourceNotFound">A flag that indicates if the resource is not found.</param>
-        /// <param name="arguments">The values to format the <paramref name="value"/> with.</param>
-        public LocalizedHtmlString(string name, string value, bool isResourceNotFound, params object[] arguments)
         {
             if (name == null)
             {
@@ -56,14 +44,26 @@ namespace Microsoft.AspNetCore.Mvc.Localization
                 throw new ArgumentNullException(nameof(value));
             }
 
+            Name = name;
+            Value = value;
+            IsResourceNotFound = isResourceNotFound;
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="LocalizedHtmlString"/>.
+        /// </summary>
+        /// <param name="name">The name of the string resource.</param>
+        /// <param name="value">The string resource.</param>
+        /// <param name="isResourceNotFound">A flag that indicates if the resource is not found.</param>
+        /// <param name="arguments">The values to format the <paramref name="value"/> with.</param>
+        public LocalizedHtmlString(string name, string value, bool isResourceNotFound, params object[] arguments)
+            : this(name, value, isResourceNotFound)
+        {
             if (arguments == null)
             {
                 throw new ArgumentNullException(nameof(arguments));
             }
 
-            Name = name;
-            Value = value;
-            IsResourceNotFound = isResourceNotFound;
             _arguments = arguments;
         }
 
@@ -95,8 +95,12 @@ namespace Microsoft.AspNetCore.Mvc.Localization
                 throw new ArgumentNullException(nameof(encoder));
             }
 
-            var formattableString = new HtmlFormattableString(Value, _arguments);
-            formattableString.WriteTo(writer, encoder);
+            IHtmlContent htmlContent;
+            if (_arguments != null)
+                htmlContent = new HtmlFormattableString(Value, _arguments);
+            else
+                htmlContent = new HtmlString(Value);
+            htmlContent.WriteTo(writer, encoder);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Localization/LocalizedHtmlString.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Localization/LocalizedHtmlString.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Html;
-using Microsoft.AspNetCore.Mvc.Internal;
 
 namespace Microsoft.AspNetCore.Mvc.Localization
 {
@@ -22,7 +21,7 @@ namespace Microsoft.AspNetCore.Mvc.Localization
         /// <param name="name">The name of the string resource.</param>
         /// <param name="value">The string resource.</param>
         public LocalizedHtmlString(string name, string value)
-            : this(name, value, isResourceNotFound: false, arguments: EmptyArray<string>.Instance)
+            : this(name, value, isResourceNotFound: false)
         {
         }
 
@@ -97,9 +96,13 @@ namespace Microsoft.AspNetCore.Mvc.Localization
 
             IHtmlContent htmlContent;
             if (_arguments != null)
+            {
                 htmlContent = new HtmlFormattableString(Value, _arguments);
+            }
             else
+            {
                 htmlContent = new HtmlString(Value);
+            }
             htmlContent.WriteTo(writer, encoder);
         }
     }

--- a/src/Microsoft.AspNetCore.Mvc.Localization/LocalizedHtmlString.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Localization/LocalizedHtmlString.cs
@@ -98,12 +98,12 @@ namespace Microsoft.AspNetCore.Mvc.Localization
             if (_arguments != null)
             {
                 htmlContent = new HtmlFormattableString(Value, _arguments);
+                htmlContent.WriteTo(writer, encoder);
             }
             else
             {
-                htmlContent = new HtmlString(Value);
+                writer.Write(Value);
             }
-            htmlContent.WriteTo(writer, encoder);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Localization.Test/HtmlLocalizerOfTTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Localization.Test/HtmlLocalizerOfTTest.cs
@@ -1,12 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Globalization;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.Extensions.Localization;
-using Microsoft.Extensions.PlatformAbstractions;
-using Microsoft.Extensions.WebEncoders.Testing;
 using Moq;
 using Xunit;
 
@@ -57,5 +51,9 @@ namespace Microsoft.AspNetCore.Mvc.Localization.Test
             // Assert
             Assert.Equal(localizedString, actualLocalizedString);
         }
+    }
+
+    public class TestClass
+    {
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Localization.Test/HtmlLocalizerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Localization.Test/HtmlLocalizerTest.cs
@@ -25,11 +25,11 @@ namespace Microsoft.AspNetCore.Mvc.Localization.Test
             var htmlLocalizer = new HtmlLocalizer(stringLocalizer);
 
             // Act
-            var actualLocalizedHtmlString = htmlLocalizer["Test"];
+            var actualLocalizedHtmlString = htmlLocalizer["Test <i>html</i>"];
 
             // Assert
-            Assert.Equal("Test", actualLocalizedHtmlString.Name);
-            Assert.Equal("Hello Test", actualLocalizedHtmlString.Value);
+            Assert.Equal("Test <i>html</i>", actualLocalizedHtmlString.Name);
+            Assert.Equal("Hello Test <i>html</i>", actualLocalizedHtmlString.Value);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.Localization.Test/HtmlLocalizerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Localization.Test/HtmlLocalizerTest.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.WebEncoders.Testing;
 using Moq;
 using Xunit;
-using Microsoft.AspNetCore.Html;
 
 namespace Microsoft.AspNetCore.Mvc.Localization.Test
 {
@@ -21,37 +20,37 @@ namespace Microsoft.AspNetCore.Mvc.Localization.Test
         public void HtmlLocalizer_UseIndexer_ReturnsLocalizedHtmlString()
         {
             // Arrange
-            var localizedString = new LocalizedString("Hello", "Bonjour");
-            var stringLocalizer = new Mock<IStringLocalizer>();
-            stringLocalizer.Setup(s => s["Hello"]).Returns(localizedString);
+            var stringLocalizer = new TestStringLocalizer();
 
-            var htmlLocalizer = new HtmlLocalizer(stringLocalizer.Object);
+            var htmlLocalizer = new HtmlLocalizer(stringLocalizer);
 
             // Act
-            var actualLocalizedHtmlString = htmlLocalizer["Hello"];
+            var actualLocalizedHtmlString = htmlLocalizer["Test"];
 
             // Assert
-            Assert.Equal(localizedString.Name, actualLocalizedHtmlString.Name);
-            Assert.Equal(localizedString.Value, actualLocalizedHtmlString.Value);
+            Assert.Equal("Test", actualLocalizedHtmlString.Name);
+            Assert.Equal("Hello Test", actualLocalizedHtmlString.Value);
         }
 
         [Fact]
         public void HtmlLocalizer_UseIndexerWithArguments_ReturnsLocalizedHtmlString()
         {
             // Arrange
-            var localizedString = new LocalizedString("Hello", "Bonjour test");
+            var stringLocalizer = new TestStringLocalizer();
 
-            var stringLocalizer = new Mock<IStringLocalizer>();
-            stringLocalizer.Setup(s => s["Hello"]).Returns(localizedString);
-
-            var htmlLocalizer = new HtmlLocalizer(stringLocalizer.Object);
+            var htmlLocalizer = new HtmlLocalizer(stringLocalizer);
 
             // Act
-            var actualLocalizedHtmlString = htmlLocalizer["Hello", "test"];
+            var actualLocalizedHtmlString = htmlLocalizer["Name {0}", "test"];
 
             // Assert
-            Assert.Equal(localizedString.Name, actualLocalizedHtmlString.Name);
-            Assert.Equal(localizedString.Value, actualLocalizedHtmlString.Value);
+            Assert.Equal("Name {0}", actualLocalizedHtmlString.Name);
+            Assert.Equal("Hello Name {0}", actualLocalizedHtmlString.Value);
+            using (var writer = new StringWriter())
+            {
+                actualLocalizedHtmlString.WriteTo(writer, new HtmlTestEncoder());
+                Assert.Equal("Hello Name HtmlEncode[[test]]", writer.ToString());
+            }
         }
 
         public static IEnumerable<object[]> HtmlData
@@ -142,13 +141,10 @@ namespace Microsoft.AspNetCore.Mvc.Localization.Test
         public void HtmlLocalizer_HtmlWithInvalidResourceString_ContentThrowsException(string format)
         {
             // Arrange
-            var localizedString = new LocalizedString("Hello", format);
+            var stringLocalizer = new TestStringLocalizer();
 
-            var stringLocalizer = new Mock<IStringLocalizer>();
-            stringLocalizer.Setup(s => s["Hello"]).Returns(localizedString);
-
-            var htmlLocalizer = new HtmlLocalizer(stringLocalizer.Object);
-            var content = htmlLocalizer.GetHtml("Hello", new object[] { });
+            var htmlLocalizer = new HtmlLocalizer(stringLocalizer);
+            var content = htmlLocalizer.GetHtml(format, new object[] { });
 
             // Act
             var exception = Assert.Throws<FormatException>(
@@ -166,22 +162,20 @@ namespace Microsoft.AspNetCore.Mvc.Localization.Test
         public void HtmlLocalizer_HtmlWithJsonText_ReturnsLocalizedHtmlString()
         {
             // Arrange
-            var localizedString = new LocalizedString("ExampleJson", "example JSON: {\"foo\":\"bar\"}");
-            var stringLocalizer = new Mock<IStringLocalizer>();
-            stringLocalizer.Setup(s => s["ExampleJson"]).Returns(localizedString);
+            var stringLocalizer = new TestStringLocalizer();
 
-            var htmlLocalizer = new HtmlLocalizer(stringLocalizer.Object);
+            var htmlLocalizer = new HtmlLocalizer(stringLocalizer);
 
             // Act
-            var localizedHtmlString = htmlLocalizer.GetHtml("ExampleJson");
+            var localizedHtmlString = htmlLocalizer.GetHtml("example JSON: {\"foo\":\"bar\"}");
 
             // Assert
-            Assert.Equal(localizedString.Name, localizedHtmlString.Name);
-            Assert.Equal(localizedString.Value, localizedHtmlString.Value);
+            Assert.Equal("example JSON: {\"foo\":\"bar\"}", localizedHtmlString.Name);
+            Assert.Equal("Hello example JSON: {\"foo\":\"bar\"}", localizedHtmlString.Value);
             using (var writer = new StringWriter())
             {
                 localizedHtmlString.WriteTo(writer, new HtmlTestEncoder());
-                Assert.Equal(localizedHtmlString.Value, writer.ToString());
+                Assert.Equal("Hello example JSON: {\"foo\":\"bar\"}", writer.ToString());
             }
         }
 
@@ -277,9 +271,5 @@ namespace Microsoft.AspNetCore.Mvc.Localization.Test
             Assert.Equal("World", allLocalizedStrings[0].Value);
             Assert.Equal("Bar", allLocalizedStrings[1].Value);
         }
-    }
-
-    public class TestClass
-    {
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Localization.Test/HtmlLocalizerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Localization.Test/HtmlLocalizerTest.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.WebEncoders.Testing;
 using Moq;
 using Xunit;
+using Microsoft.AspNetCore.Html;
 
 namespace Microsoft.AspNetCore.Mvc.Localization.Test
 {
@@ -156,6 +157,32 @@ namespace Microsoft.AspNetCore.Mvc.Localization.Test
             // Assert
             Assert.NotNull(exception);
             Assert.Equal("Input string was not in a correct format.", exception.Message);
+        }
+
+        /// <summary>
+        /// This tests that LocalizedString instances containing curly braces (e.g. JSON or code snippets) can be used without a FormatException when no arguments are provided.
+        /// </summary>
+        [Fact]
+        public void HtmlLocalizer_HtmlWithJsonText_ReturnsLocalizedHtmlString()
+        {
+            // Arrange
+            var localizedString = new LocalizedString("ExampleJson", "example JSON: {\"foo\":\"bar\"}");
+            var stringLocalizer = new Mock<IStringLocalizer>();
+            stringLocalizer.Setup(s => s["ExampleJson"]).Returns(localizedString);
+
+            var htmlLocalizer = new HtmlLocalizer(stringLocalizer.Object);
+
+            // Act
+            var localizedHtmlString = htmlLocalizer.GetHtml("ExampleJson");
+
+            // Assert
+            Assert.Equal(localizedString.Name, localizedHtmlString.Name);
+            Assert.Equal(localizedString.Value, localizedHtmlString.Value);
+            using (var writer = new StringWriter())
+            {
+                localizedHtmlString.WriteTo(writer, new HtmlTestEncoder());
+                Assert.Equal(localizedHtmlString.Value, writer.ToString());
+            }
         }
 
         [Fact]


### PR DESCRIPTION
This fixes a FormatException when a LocalizedString that contains unescaped curly braces is used to create a LocalizedHtmlString without arguments (so no formatting intended).

e.g. code snippets, json-ld tags or other content containing {} stored inside a Localization provider/factory

