### PR TITLE
Fix warning as error

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor/RazorPage.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/RazorPage.cs
@@ -36,24 +36,6 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         public ITempDataDictionary TempData => ViewContext?.TempData;
 
         /// <summary>
-        /// Format an error message about using an indexer when the tag helper property is <c>null</c>.
-        /// </summary>
-        /// <param name="attributeName">Name of the HTML attribute associated with the indexer.</param>
-        /// <param name="tagHelperTypeName">Full name of the tag helper <see cref="Type"/>.</param>
-        /// <param name="propertyName">Dictionary property in the tag helper.</param>
-        /// <returns>An error message about using an indexer when the tag helper property is <c>null</c>.</returns>
-        public static string InvalidTagHelperIndexerAssignment(
-            string attributeName,
-            string tagHelperTypeName,
-            string propertyName)
-        {
-            return Resources.FormatRazorPage_InvalidTagHelperIndexerAssignment(
-                attributeName,
-                tagHelperTypeName,
-                propertyName);
-        }
-
-        /// <summary>
         /// In a Razor layout page, renders the portion of a content page that is not within a named section.
         /// </summary>
         /// <returns>The HTML content to render.</returns>

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RazorPagesTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RazorPagesTest.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             var content = await response.Content.ReadAsStringAsync();
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal("<a href=\"/Show?id=2\">Post title</a>", content.Trim());
+            Assert.StartsWith("<a href=\"/Show?id=2\">Post title</a>", content.Trim());
         }
 
         [Fact]

--- a/test/WebSites/RazorPagesWebSite/TagHelpers.cshtml
+++ b/test/WebSites/RazorPagesWebSite/TagHelpers.cshtml
@@ -1,9 +1,6 @@
 ﻿@page
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 
-<!-- Tests that RazorPage includes InvalidTagHelperIndexerAssignment which is called when the page has an indexer
-     Issue https://github.com/aspnet/Mvc/issues/5920 -->
-
 @functions {
         public class Post
         {
@@ -14,3 +11,6 @@
 }
 
 <a asp-route-page="/Show" asp-route-id="@post.Id">@post.Title</a>
+
+<!-- Tests that RazorPage includes InvalidTagHelperIndexerAssignment which is called when the page has an indexer
+     Issue https://github.com/aspnet/Mvc/issues/5920 -->


### PR DESCRIPTION
Fixes the broken build by fixing the "hides inherited member" warning as error.