### PR TITLE
Added polymorphic json support for the root object

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Json/Internal/JsonResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Json/Internal/JsonResultExecutor.cs
@@ -126,7 +126,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Json.Internal
                     jsonWriter.CloseOutput = false;
 
                     var jsonSerializer = JsonSerializer.Create(serializerSettings);
-                    jsonSerializer.Serialize(jsonWriter, result.Value);
+                    jsonSerializer.Serialize(jsonWriter, result.Value, result.DeclaredType);
                 }
             }
 

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonOutputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonOutputFormatter.cs
@@ -69,6 +69,18 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         /// <param name="value">The value to write as JSON.</param>
         public void WriteObject(TextWriter writer, object value)
         {
+            WriteObject(writer, value, null);
+        }
+
+        /// <summary>
+        /// Writes the given <paramref name="value"/> with the given <paramref name="declaredType"/> as JSON using the given
+        /// <paramref name="writer"/>.
+        /// </summary>
+        /// <param name="writer">The <see cref="TextWriter"/> used to write the <paramref name="value"/></param>
+        /// <param name="value">The value to write as JSON.</param>
+        /// <param name="declaredType">The declared type of the value to write as JSON.</param>
+        public void WriteObject(TextWriter writer, object value, Type declaredType)
+        {
             if (writer == null)
             {
                 throw new ArgumentNullException(nameof(writer));
@@ -77,7 +89,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             using (var jsonWriter = CreateJsonWriter(writer))
             {
                 var jsonSerializer = CreateJsonSerializer();
-                jsonSerializer.Serialize(jsonWriter, value);
+                jsonSerializer.Serialize(jsonWriter, value, declaredType);
             }
         }
 
@@ -132,7 +144,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             var response = context.HttpContext.Response;
             using (var writer = context.WriterFactory(response.Body, selectedEncoding))
             {
-                WriteObject(writer, context.Object);
+                WriteObject(writer, context.Object, context.ObjectType);
 
                 // Perf: call FlushAsync to call WriteAsync on the stream with any content left in the TextWriter's
                 // buffers. This is better than just letting dispose handle it (which would result in a synchronous

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonResult.cs
@@ -60,6 +60,11 @@ namespace Microsoft.AspNetCore.Mvc
         /// </summary>
         public object Value { get; set; }
 
+        /// <summary>
+        /// Gets or sets the declared type of the value to be formatted.
+        /// </summary>
+        public Type DeclaredType { get; set; }
+
         /// <inheritdoc />
         public override Task ExecuteResultAsync(ActionContext context)
         {

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Json.Test/JsonOutputFormatterTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Json.Test/JsonOutputFormatterTests.cs
@@ -77,6 +77,33 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         }
 
         [Fact]
+        public async Task Using_TypeNameHandlingAuto_AppliesTypeNameToRoot()
+        {
+            // Arrange
+            var person = new User() { FullName = "John", age = 35 };
+            var outputFormatterContext = GetOutputFormatterContext(person, typeof(object));
+
+            var settings = new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.Auto
+            };
+            var expectedOutput = JsonConvert.SerializeObject(person, typeof(object), settings);
+            var jsonFormatter = new JsonOutputFormatter(settings, ArrayPool<char>.Shared);
+
+            // Act
+            await jsonFormatter.WriteResponseBodyAsync(outputFormatterContext, Encoding.UTF8);
+
+            // Assert
+            var body = outputFormatterContext.HttpContext.Response.Body;
+
+            Assert.NotNull(body);
+            body.Position = 0;
+
+            var content = new StreamReader(body, Encoding.UTF8).ReadToEnd();
+            Assert.Equal(expectedOutput, content);
+        }
+
+        [Fact]
         public async Task ChangesTo_SerializerSettings_AfterSerialization_DoNotAffectSerialization()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Json.Test/JsonResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Json.Test/JsonResultTest.cs
@@ -38,6 +38,33 @@ namespace Microsoft.AspNetCore.Mvc
             Assert.Equal("application/json; charset=utf-8", context.HttpContext.Response.ContentType);
         }
 
+        [Fact]
+        public async Task ExecuteAsync_WithTypeNameHandlingAuto_AppliesTypeNameToRoot()
+        {
+            // Arrange
+            var value = new { foo = "abcd" };
+            var serializerSettings = new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.Auto
+            };
+            var expected = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(value, typeof(object), serializerSettings));
+
+            var context = GetActionContext();
+
+            var result = new JsonResult(value, serializerSettings)
+            {
+                DeclaredType = typeof(object)
+            };
+
+            // Act
+            await result.ExecuteResultAsync(context);
+
+            // Assert
+            var written = GetWrittenBytes(context.HttpContext);
+            Assert.Equal(expected, written);
+            Assert.Equal("application/json; charset=utf-8", context.HttpContext.Response.ContentType);
+        }
+
         private static HttpContext GetHttpContext()
         {
             var httpContext = new DefaultHttpContext();


### PR DESCRIPTION
When using `TypeNameHandling.Auto` in order for the root object to serialize the type name a declared type must be passed into `Json.NET`'s `Serialize` methods. The current `JsonOutputFormatter` does not take into account a declared type as `JsonResult` does not have a `DeclaredType` property. This PR adds the needed `DeclaredType` property to `JsonResult` and updates `JsonOutputFormatter` and `JsonResultExecutor` to use this new property. Two tests were also added using this feature.