### PR TITLE
Adding AllowAnonymousToPage & AllowAnonymousToFolder

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/DependencyInjection/RazorPagesOptionsExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/DependencyInjection/RazorPagesOptionsExtensions.cs
@@ -37,6 +37,52 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
+        /// Adds a <see cref="AllowAnonymousFilter"/> to the page with the specified path.
+        /// </summary>
+        /// <param name="options">The <see cref="RazorPagesOptions"/> to configure.</param>
+        /// <param name="path">The path of the Razor Page.</param>
+        /// <returns>The <see cref="RazorPagesOptions"/>.</returns>
+        public static RazorPagesOptions AllowAnonymousToPage(this RazorPagesOptions options, string path)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            if (string.IsNullOrEmpty(path))
+            {
+                throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(path));
+            }
+
+            var anonymousFilter = new AllowAnonymousFilter();
+            options.Conventions.Add(new PageConvention(path, model => model.Filters.Add(anonymousFilter)));
+            return options;
+        }
+
+        /// <summary>
+        /// Adds a <see cref="AllowAnonymousFilter"/> to all pages under the specified path.
+        /// </summary>
+        /// <param name="options">The <see cref="RazorPagesOptions"/> to configure.</param>
+        /// <param name="folderPath">The folder path.</param>
+        /// <returns>The <see cref="RazorPagesOptions"/>.</returns>
+        public static RazorPagesOptions AllowAnonymousToFolder(this RazorPagesOptions options, string folderPath)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            if (string.IsNullOrEmpty(folderPath))
+            {
+                throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(folderPath));
+            }
+
+            var anonymousFilter = new AllowAnonymousFilter();
+            options.Conventions.Add(new FolderConvention(folderPath, model => model.Filters.Add(anonymousFilter)));
+            return options;
+        }
+
+        /// <summary>
         /// Adds a <see cref="AuthorizeFilter"/> with the specified policy to the page with the specified path.
         /// </summary>
         /// <param name="options">The <see cref="RazorPagesOptions"/> to configure.</param>

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RazorPagesTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RazorPagesTest.cs
@@ -249,6 +249,22 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal("/Login?ReturnUrl=%2FHelloWorldWithAuth", response.Headers.Location.PathAndQuery);
         }
 
+        [Fact]
+        public async Task AuthorizePage_AllowAnonymousForSpecificPages()
+        {
+            // Arrange
+            var url = "/Pages/Admin/Login";
+            
+            // Act
+            var response = await Client.GetAsync(url);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var content = await response.Content.ReadAsStringAsync();
+            Assert.Equal("Login Page", content);
+        }
+
 
         [Fact]
         public async Task PageStart_IsDiscoveredWhenRootDirectoryIsNotSpecified()

--- a/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/DependencyInjection/RazorPagesOptionsExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/DependencyInjection/RazorPagesOptionsExtensionsTest.cs
@@ -38,6 +38,79 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         [Fact]
+        public void AuthorizePage_AddsAllowAnonymousFilterToSpecificPage()
+        {
+            // Arrange
+            var options = new RazorPagesOptions();
+            var models = new[]
+            {
+                new PageApplicationModel("/Pages/Index.cshtml", "/Index.cshtml"),
+                new PageApplicationModel("/Pages/Users/Account.cshtml", "/Users/Account.cshtml"),
+                new PageApplicationModel("/Pages/Users/Contact.cshtml", "/Users/Contact.cshtml"),
+            };
+
+            // Act
+            options.AuthorizeFolder("/Users");
+            options.AllowAnonymousToPage("/Users/Contact.cshtml");
+            ApplyConventions(options, models);
+
+            // Assert
+            Assert.Collection(models,
+                model => Assert.Empty(model.Filters),
+                model =>
+                {
+                    Assert.Equal("/Users/Account.cshtml", model.ViewEnginePath);
+                    Assert.IsType<AuthorizeFilter>(Assert.Single(model.Filters));
+                },
+                model =>
+                {
+                    Assert.Equal("/Users/Contact.cshtml", model.ViewEnginePath);
+                    Assert.IsType<AuthorizeFilter>(model.Filters[0]);
+                    Assert.IsType<AllowAnonymousFilter>(model.Filters[1]);
+                });
+        }
+
+        [Theory]
+        [InlineData("/Users")]
+        [InlineData("/Users/")]
+        public void AuthorizePage_AddsAllowAnonymousFilterToPagesUnderFolder(string folderName)
+        {
+            // Arrange
+            var options = new RazorPagesOptions();
+            var models = new[]
+            {
+                new PageApplicationModel("/Pages/Index.cshtml", "/Index.cshtml"),
+                new PageApplicationModel("/Pages/Users/Account.cshtml", "/Users/Account.cshtml"),
+                new PageApplicationModel("/Pages/Users/Contact.cshtml", "/Users/Contact.cshtml"),
+            };
+
+            // Act
+            options.AuthorizeFolder("/");
+            options.AllowAnonymousToFolder("/Users");
+            ApplyConventions(options, models);
+
+            // Assert
+            Assert.Collection(models,
+                model =>
+                {
+                    Assert.Equal("/Index.cshtml", model.ViewEnginePath);
+                    Assert.IsType<AuthorizeFilter>(Assert.Single(model.Filters));
+                },
+                model =>
+                {
+                    Assert.Equal("/Users/Account.cshtml", model.ViewEnginePath);
+                    Assert.IsType<AuthorizeFilter>(model.Filters[0]);
+                    Assert.IsType<AllowAnonymousFilter>(model.Filters[1]);
+                },
+                model =>
+                {
+                    Assert.Equal("/Users/Contact.cshtml", model.ViewEnginePath);
+                    Assert.IsType<AuthorizeFilter>(model.Filters[0]);
+                    Assert.IsType<AllowAnonymousFilter>(model.Filters[1]);
+                });
+        }
+
+        [Fact]
         public void AuthorizePage_AddsAuthorizeFilterWithPolicyToSpecificPage()
         {
             // Arrange

--- a/test/WebSites/RazorPagesWebSite/Pages/Admin/Login.cshtml
+++ b/test/WebSites/RazorPagesWebSite/Pages/Admin/Login.cshtml
@@ -1,0 +1,2 @@
+﻿@page
+Login Page

--- a/test/WebSites/RazorPagesWebSite/Startup.cs
+++ b/test/WebSites/RazorPagesWebSite/Startup.cs
@@ -16,6 +16,8 @@ namespace RazorPagesWebSite
                 .AddRazorPagesOptions(options =>
                 {
                     options.AuthorizePage("/HelloWorldWithAuth");
+                    options.AuthorizeFolder("/Pages/Admin");
+                    options.AllowAnonymousToPage("/Pages/Admin/Login");
                 });
         }
 


### PR DESCRIPTION
After my last PR #5942, I notice that we missed some of auth functions after migrate the RazorPages code from the old repo https://github.com/aspnet/RazorPages/blob/master/src/Microsoft.AspNetCore.Mvc.RazorPages/DependencyInjection/PageModelConventionBuilderExtensions.cs#L14-L24, also I see @pranavkm mentioned this too in the issue #5884, so I created this PR to bring them back