### PR TITLE
Fixed NullReferenceException that occurs in subsequent calls of Cache…

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/CacheTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/CacheTagHelper.cs
@@ -104,10 +104,11 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                                 // such that the tokens are inherited.
 
                                 result = ProcessContentAsync(output);
-                                content = await result;
 
                                 entry.SetOptions(options);
                                 entry.Value = result;
+
+                                content = await result;
                             }
                         }
                         catch

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/CacheTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/CacheTagHelperTest.cs
@@ -676,7 +676,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 }
             }
-            
+
             var tagHelperContext1 = GetTagHelperContext(id);
             var tagHelperContext2 = GetTagHelperContext(id);
             var tagHelperContext3 = GetTagHelperContext(id);

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/CacheTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/CacheTagHelperTest.cs
@@ -660,7 +660,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
             var counter = 0;
 
-            Func<bool, HtmlEncoder, Task<TagHelperContent>> getChildContentAsync = (useCachedResult, encoder) =>
+            Task<TagHelperContent> GetChildContentAsync(bool useCachedResult, HtmlEncoder encoder)
             {
                 counter++;
                 if (counter < 3)
@@ -675,18 +675,17 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                     tagHelperContent.SetHtmlContent(childContent);
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 }
-            };
-
+            }
+            
             var tagHelperContext1 = GetTagHelperContext(id);
             var tagHelperContext2 = GetTagHelperContext(id);
             var tagHelperContext3 = GetTagHelperContext(id);
             var tagHelperContext4 = GetTagHelperContext(id);
 
-
-            var tagHelperOutput1 = new TagHelperOutput("cache", new TagHelperAttributeList(), getChildContentAsync);
-            var tagHelperOutput2 = new TagHelperOutput("cache", new TagHelperAttributeList(), getChildContentAsync);
-            var tagHelperOutput3 = new TagHelperOutput("cache", new TagHelperAttributeList(), getChildContentAsync);
-            var tagHelperOutput4 = new TagHelperOutput("cache", new TagHelperAttributeList(), getChildContentAsync);
+            var tagHelperOutput1 = new TagHelperOutput("cache", new TagHelperAttributeList(), GetChildContentAsync);
+            var tagHelperOutput2 = new TagHelperOutput("cache", new TagHelperAttributeList(), GetChildContentAsync);
+            var tagHelperOutput3 = new TagHelperOutput("cache", new TagHelperAttributeList(), GetChildContentAsync);
+            var tagHelperOutput4 = new TagHelperOutput("cache", new TagHelperAttributeList(), GetChildContentAsync);
 
             var cacheTagHelper = new CacheTagHelper(cache, new HtmlTestEncoder())
             {


### PR DESCRIPTION
…TagHelper when first call caused exception when executing inner contents

Fixes #5988 