### PR TITLE
Remove Usage of RazorIrNodeVisitorOfT

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.Host/InjectDirectiveIRNode.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Host/InjectDirectiveIRNode.cs
@@ -31,16 +31,6 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Host
             AcceptExtensionNode<InjectDirectiveIRNode>(this, visitor);
         }
 
-        public override TResult Accept<TResult>(RazorIRNodeVisitor<TResult> visitor)
-        {
-            if (visitor == null)
-            {
-                throw new ArgumentNullException(nameof(visitor));
-            }
-
-            return AcceptExtensionNode<InjectDirectiveIRNode, TResult>(this, visitor);
-        }
-
         public override void WriteNode(RuntimeTarget target, CSharpRenderingContext context)
         {
             if (target == null)


### PR DESCRIPTION
Follow up of  aspnet/razor#1089

The generic class `RazorIrNodeVisitor` gets deleted with the referenced PR