### PR TITLE
Avoid entry point assembly being loaded twice during assembly parts discovery

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/DefaultAssemblyPartDiscoveryProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/DefaultAssemblyPartDiscoveryProvider.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         public static IEnumerable<ApplicationPart> DiscoverAssemblyParts(string entryPointAssemblyName)
         {
             var entryAssembly = Assembly.Load(new AssemblyName(entryPointAssemblyName));
-            var context = DependencyContext.Load(Assembly.Load(new AssemblyName(entryPointAssemblyName)));
+            var context = DependencyContext.Load(entryAssembly);
 
             return GetCandidateAssemblies(entryAssembly, context).Select(p => new AssemblyPart(p));
         }


### PR DESCRIPTION
Addresses https://github.com/aspnet/Mvc/issues/6003