### PR TITLE
[Fixes # #5413] JsonOutputFormatter adds all closing brackets when exceptions are thrown

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Json/Internal/JsonResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Json/Internal/JsonResultExecutor.cs
@@ -33,8 +33,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Json.Internal
         /// <param name="options">The <see cref="IOptions{MvcJsonOptions}"/>.</param>
         /// <param name="charPool">The <see cref="ArrayPool{Char}"/> for creating <see cref="T:char[]"/> buffers.</param>
         public JsonResultExecutor(
-            IHttpResponseStreamWriterFactory writerFactory, 
-            ILogger<JsonResultExecutor> logger, 
+            IHttpResponseStreamWriterFactory writerFactory,
+            ILogger<JsonResultExecutor> logger,
             IOptions<MvcJsonOptions> options,
             ArrayPool<char> charPool)
         {
@@ -124,6 +124,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Json.Internal
                 {
                     jsonWriter.ArrayPool = _charPool;
                     jsonWriter.CloseOutput = false;
+                    jsonWriter.AutoCompleteOnClose = false;
 
                     var jsonSerializer = JsonSerializer.Create(serializerSettings);
                     jsonSerializer.Serialize(jsonWriter, result.Value);

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonOutputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Json/JsonOutputFormatter.cs
@@ -97,6 +97,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             {
                 ArrayPool = _charPool,
                 CloseOutput = false,
+                AutoCompleteOnClose = false
             };
 
             return jsonWriter;

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Json.Test/Internal/JsonResultExecutorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Json.Test/Internal/JsonResultExecutorTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Buffers;
 using System.IO;
 using System.Text;
@@ -156,6 +157,31 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Json.Internal
             Assert.Equal("application/json; charset=utf-8", context.HttpContext.Response.ContentType);
         }
 
+        [Fact]
+        public async Task ExecuteAsync_ErrorDuringSerialization_DoesNotCloseTheBrackets()
+        {
+            // Arrange
+            var expected = Encoding.UTF8.GetBytes("{\"name\":\"Robert\"");
+            var context = GetActionContext();
+            var result = new JsonResult(new ModelWithSerializationError());
+            var executor = CreateExcutor();
+
+            // Act
+            try
+            {
+                await executor.ExecuteAsync(context, result);
+            }
+            catch (JsonSerializationException serializerException)
+            {
+                var expectedException = Assert.IsType<NotImplementedException>(serializerException.InnerException);
+                Assert.Equal("Property Age has not been implemented", expectedException.Message);
+            }
+
+            // Assert
+            var written = GetWrittenBytes(context.HttpContext);
+            Assert.Equal(expected, written);
+        }
+
         private static JsonResultExecutor CreateExcutor()
         {
             return new JsonResultExecutor(
@@ -187,6 +213,18 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Json.Internal
         {
             context.Response.Body.Seek(0, SeekOrigin.Begin);
             return Assert.IsType<MemoryStream>(context.Response.Body).ToArray();
+        }
+
+        private class ModelWithSerializationError
+        {
+            public string Name { get; } = "Robert";
+            public int Age
+            {
+                get
+                {
+                    throw new NotImplementedException($"Property {nameof(Age)} has not been implemented");
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
http://www.newtonsoft.com/json/help/html/P_Newtonsoft_Json_JsonWriter_AutoCompleteOnClose.htm