### PR TITLE
Skip test `AssemblyPartTest.GetReferencePaths_ReturnsReferencesFromDependencyContext_IfPreserveCompilationContextIsSet`

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ApplicationParts/AssemblyPartTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ApplicationParts/AssemblyPartTest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationParts
             Assert.Equal(part.Assembly, assembly);
         }
 
-        [Fact]
+        [Fact(Skip= "https://github.com/aspnet/Mvc/issues/6138")]
         public void GetReferencePaths_ReturnsReferencesFromDependencyContext_IfPreserveCompilationContextIsSet()
         {
             // Arrange


### PR DESCRIPTION
- Workaround for "Can not find compilation library location for package" (https://github.com/dotnet/cli/issues/6318)