### PR TITLE
Revert "Skip test `AssemblyPartTest.GetReferencePaths_ReturnsReferencesFromDependencyContext_IfPreserveCompilationContextIsSet`"

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ApplicationParts/AssemblyPartTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ApplicationParts/AssemblyPartTest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationParts
             Assert.Equal(part.Assembly, assembly);
         }
 
-        [Fact(Skip= "https://github.com/aspnet/Mvc/issues/6138")]
+        [Fact]
         public void GetReferencePaths_ReturnsReferencesFromDependencyContext_IfPreserveCompilationContextIsSet()
         {
             // Arrange


### PR DESCRIPTION
This reverts commit c69e48f06b0c141e26bc560e37bb19d32e89c377.