### PR TITLE
Change `FormTagHelper` to apply to all form tags.

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/AntiforgeryTestHelper.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/AntiforgeryTestHelper.cs
@@ -19,21 +19,15 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
             foreach (var form in htmlDocument.Descendants("form"))
             {
-                foreach (var attribute in form.Attributes())
+                foreach (var input in form.Descendants("input"))
                 {
-                    if (string.Equals(attribute.Name.LocalName, "action", StringComparison.OrdinalIgnoreCase))
+                    if (input.Attribute("name") != null &&
+                        input.Attribute("type") != null &&
+                        input.Attribute("type").Value == "hidden" &&
+                        (input.Attribute("name").Value == "__RequestVerificationToken" ||
+                         input.Attribute("name").Value == "HtmlEncode[[__RequestVerificationToken]]"))
                     {
-                        foreach (var input in form.Descendants("input"))
-                        {
-                            if (input.Attribute("name") != null &&
-                                input.Attribute("type") != null &&
-                                input.Attribute("type").Value == "hidden" &&
-                                (input.Attribute("name").Value == "__RequestVerificationToken" ||
-                                 input.Attribute("name").Value == "HtmlEncode[[__RequestVerificationToken]]"))
-                            {
-                                return input.Attributes("value").First().Value;
-                            }
-                        }
+                        return input.Attributes("value").First().Value;
                     }
                 }
             }

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/RazorPagesWebSite.SimpleForms.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/RazorPagesWebSite.SimpleForms.html
@@ -1,0 +1,6 @@
+<form></form>
+<form method="get"></form>
+<form method="post"><input name="__RequestVerificationToken" type="hidden" value="{0}" /></form>
+<form action="" method="post"><input name="__RequestVerificationToken" type="hidden" value="{0}" /></form>
+<form action="/Foo/Bar/Baz.html" method="get"></form>
+<form action="/Foo/Bar/Baz.html" method="post"></form>

--- a/test/WebSites/RazorPagesWebSite/SimpleForms.cshtml
+++ b/test/WebSites/RazorPagesWebSite/SimpleForms.cshtml
@@ -1,0 +1,9 @@
+﻿@page
+@addTagHelper "*, Microsoft.AspNetCore.Mvc.TagHelpers"
+
+<form></form>
+<form method="get"></form>
+<form method="post"></form>
+<form action="" method="post"></form>
+<form action="/Foo/Bar/Baz.html" method="get"></form>
+<form action="/Foo/Bar/Baz.html" method="post"></form>


### PR DESCRIPTION
- Added functional test to validate that non-attributed form tags have an antiforgery input generated. Re-generated baseline to reflect changes.
- Added a unit test to validate that parameterless `FormTagHelper`s behave as expected.

#6006