### PR TITLE
Fix #6159 - Fix deep copy for ControllerModel and ActionModel

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/ApplicationModels/ActionModel.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ApplicationModels/ActionModel.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
 
             // Make a deep copy of other 'model' types.
             ApiExplorer = new ApiExplorerModel(other.ApiExplorer);
-            Parameters = new List<ParameterModel>(other.Parameters.Select(p => new ParameterModel(p)));
+            Parameters = new List<ParameterModel>(other.Parameters.Select(p => new ParameterModel(p) { Action = this }));
             Selectors = new List<SelectorModel>(other.Selectors.Select(s => new SelectorModel(s)));
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/ApplicationModels/ControllerModel.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ApplicationModels/ControllerModel.cs
@@ -61,10 +61,10 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
             Properties = new Dictionary<object, object>(other.Properties);
 
             // Make a deep copy of other 'model' types.
-            Actions = new List<ActionModel>(other.Actions.Select(a => new ActionModel(a)));
+            Actions = new List<ActionModel>(other.Actions.Select(a => new ActionModel(a) { Controller = this }));
             ApiExplorer = new ApiExplorerModel(other.ApiExplorer);
             ControllerProperties =
-                new List<PropertyModel>(other.ControllerProperties.Select(p => new PropertyModel(p)));
+                new List<PropertyModel>(other.ControllerProperties.Select(p => new PropertyModel(p) { Controller = this }));
             Selectors = new List<SelectorModel>(other.Selectors.Select(s => new SelectorModel(s)));
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ApplicationModel/ActionModelTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ApplicationModel/ActionModelTest.cs
@@ -39,12 +39,19 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
             var action2 = new ActionModel(action);
 
             // Assert
-            Assert.NotSame(action, action2.Parameters[0]);
+            Assert.NotSame(action.Parameters, action2.Parameters);
+            Assert.NotNull(action2.Parameters);
+            Assert.Single(action2.Parameters);
+            Assert.NotSame(parameter, action2.Parameters[0]);
             Assert.NotSame(apiExplorer, action2.ApiExplorer);
             Assert.NotSame(action.Selectors, action2.Selectors);
             Assert.NotNull(action2.Selectors);
             Assert.Single(action2.Selectors);
+            Assert.NotSame(action.Selectors[0], action2.Selectors[0]);
             Assert.NotSame(route, action2.Selectors[0].AttributeRouteModel);
+
+            Assert.NotSame(action, action2.Parameters[0].Action);
+            Assert.Same(action2, action2.Parameters[0].Action);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ApplicationModel/ControllerModelTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ApplicationModel/ControllerModelTest.cs
@@ -27,6 +27,10 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
             controller.Actions.Add(action);
             action.Controller = controller;
 
+            controller.ControllerProperties.Add(new PropertyModel(
+                controller.ControllerType.AsType().GetProperty("TestProperty"),
+                new List<object>() { }));
+
             var route = new AttributeRouteModel(new HttpGetAttribute("api/Products"));
             controller.Selectors.Add(new SelectorModel() { AttributeRouteModel = route });
 
@@ -39,6 +43,8 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
 
             // Assert
             Assert.NotSame(action, controller2.Actions[0]);
+            Assert.NotNull(controller2.ControllerProperties);
+            Assert.Single(controller2.ControllerProperties);
             Assert.NotNull(controller2.Selectors);
             Assert.Single(controller2.Selectors);
             Assert.NotSame(route, controller2.Selectors[0].AttributeRouteModel);
@@ -49,6 +55,11 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
             Assert.NotSame(controller.Attributes, controller2.Attributes);
             Assert.NotSame(controller.Filters, controller2.Filters);
             Assert.NotSame(controller.RouteValues, controller2.RouteValues);
+
+            Assert.NotSame(controller, controller2.Actions[0].Controller);
+            Assert.Same(controller2, controller2.Actions[0].Controller);
+            Assert.NotSame(controller, controller2.ControllerProperties[0].Controller);
+            Assert.Same(controller2, controller2.ControllerProperties[0].Controller);
         }
 
         [Fact]


### PR DESCRIPTION
The issue here is that `ControllerModel` and `ActionModel` do not set the reference to themselves for deep copied model types in the constructor.

The fix is to set `this` to the deep copied model types after creation in the object initializer.