### PR TITLE
Bump `MemoryPoolHttpResponseStreamWriter` buffer size up to 16K `char`s

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/MemoryPoolHttpResponseStreamWriterFactory.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/MemoryPoolHttpResponseStreamWriterFactory.cs
@@ -15,9 +15,17 @@ namespace Microsoft.AspNetCore.Mvc.Internal
     public class MemoryPoolHttpResponseStreamWriterFactory : IHttpResponseStreamWriterFactory
     {
         /// <summary>
-        /// The default size of created char buffers.
+        /// The default size of buffers <see cref="HttpResponseStreamWriter"/>s will allocate.
         /// </summary>
-        public static readonly int DefaultBufferSize = 1024; // 1KB - results in a 4KB byte array for UTF8.
+        /// <value>
+        /// 16K causes each <see cref="HttpResponseStreamWriter"/> to allocate one 16K
+        /// <see langword="char"/> array and one 32K (for UTF8) <see langword="byte"/> array.
+        /// </value>
+        /// <remarks>
+        /// <see cref="MemoryPoolHttpResponseStreamWriterFactory"/> maintains <see cref="ArrayPool{T}"/>s
+        /// for these arrays.
+        /// </remarks>
+        public static readonly int DefaultBufferSize = 16 * 1024;
 
         private readonly ArrayPool<byte> _bytePool;
         private readonly ArrayPool<char> _charPool;

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ContentResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ContentResultTest.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.TestCommon;
 using Microsoft.AspNetCore.Mvc.ViewComponents;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -23,7 +22,8 @@ namespace Microsoft.AspNetCore.Mvc
 {
     public class ContentResultTest
     {
-        private const int DefaultCharacterChunkSize = HttpResponseStreamWriter.DefaultBufferSize;
+        private static readonly int DefaultCharacterChunkSize =
+            MemoryPoolHttpResponseStreamWriterFactory.DefaultBufferSize;
 
         [Fact]
         public async Task ContentResult_Response_NullContent_SetsContentTypeAndEncoding()


### PR DESCRIPTION
- #3516
- fix tests that relied on otherwise-unused `HttpResponseStreamWriter.DefaultBufferSize`