### PR TITLE
Update how `FormTagHelper` handles `get` method attributes.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/FormTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/FormTagHelper.cs
@@ -157,10 +157,6 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             {
                 output.CopyHtmlAttribute(nameof(Method), context);
             }
-            else
-            {
-                Method = "get";
-            }
 
             var antiforgeryDefault = true;
 
@@ -205,9 +201,16 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 if (string.IsNullOrEmpty(attributeValue))
                 {
                     // User is using the FormTagHelper like a normal <form> tag that has an empty or complex IHtmlContent action attribute.
-                    // e.g. <form action="" method="post"> or <form action="@CustomUrlIHtmlContent" method="post">
+                    // e.g. <form action="" method="..."> or <form action="@CustomUrlIHtmlContent" method="...">
 
-                    // Antiforgery default is already set to true
+                    if (string.Equals(Method ?? "get", "get", StringComparison.OrdinalIgnoreCase))
+                    {
+                        antiforgeryDefault = false;
+                    }
+                    else
+                    {
+                        // Antiforgery default is already set to true
+                    }
                 }
                 else
                 {
@@ -251,17 +254,18 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 }
 
                 TagBuilder tagBuilder = null;
-                if (Action == null && 
-                    Controller == null && 
-                    Route == null && 
-                    _routeValues == null && 
-                    Fragment == null && 
-                    Area == null && 
+                if (Action == null &&
+                    Controller == null &&
+                    Route == null &&
+                    _routeValues == null &&
+                    Fragment == null &&
+                    Area == null &&
                     Page == null &&
                     // Antiforgery will sometime be set globally via TagHelper Initializers, verify it was provided in the cshtml. 
                     !context.AllAttributes.ContainsName(AntiforgeryAttributeName))
                 {
-                    // Empty form tag such as <form></form>. Let it flow to the output as-is and only handle anti-forgery.
+                    // A <form> tag that doesn't utilize asp-* attributes. Let it flow to the output.
+                    Method = Method ?? "get";
                 }
                 else if (pageLink)
                 {
@@ -304,11 +308,11 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                         output.PostContent.AppendHtml(tagBuilder.InnerHtml);
                     }
                 }
-            }
 
-            if (string.Equals(Method, "get", StringComparison.OrdinalIgnoreCase))
-            {
-                antiforgeryDefault = false;
+                if (string.Equals(Method, "get", StringComparison.OrdinalIgnoreCase))
+                {
+                    antiforgeryDefault = false;
+                }
             }
 
             if (Antiforgery ?? antiforgeryDefault)

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/RazorPagesWebSite.SimpleForms.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/RazorPagesWebSite.SimpleForms.html
@@ -4,3 +4,4 @@
 <form action="" method="post"><input name="__RequestVerificationToken" type="hidden" value="{0}" /></form>
 <form action="/Foo/Bar/Baz.html" method="get"></form>
 <form action="/Foo/Bar/Baz.html" method="post"></form>
+<form action="/RedirectToPage" method="post"><input name="__RequestVerificationToken" type="hidden" value="{0}" /></form>

--- a/test/WebSites/RazorPagesWebSite/SimpleForms.cshtml
+++ b/test/WebSites/RazorPagesWebSite/SimpleForms.cshtml
@@ -7,3 +7,4 @@
 <form action="" method="post"></form>
 <form action="/Foo/Bar/Baz.html" method="get"></form>
 <form action="/Foo/Bar/Baz.html" method="post"></form>
+<form asp-controller="Redirect" asp-action="RedirectToPageAction"></form>


### PR DESCRIPTION
- Added functional test to verify `asp-*` attributes on form taghelpers work as expected.
- Added a unit test to validate `FormTagHelper` behaves as expected.
- Moved `Method == "get"` checks into appropriate code paths. These include the one where a user specifies an empty or non-existent `action` attribute and where a user doesn't utilize any `asp-*` attributes. In the later, we default `Method` to `"get"` if it's not provided.

#6006 

@dougbu had to do a few extra changes than the ones I showed you; therefore, here's the review 👍 .