### PR TITLE
Functional test to show FSharpAsync works end-to-end

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/FSharpWebSiteTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/FSharpWebSiteTest.cs
@@ -28,5 +28,17 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Contains("<h1>Hello from FSharpWebSite</h1>", responseBody);
         }
+        
+        [Fact]
+        public async Task HomeAsyncAction_ReturnsContentAsynchronously()
+        {
+            // Act
+            var response = await Client.GetAsync("http://localhost/home/asyncaction");
+            var responseBody = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Contains("Action completed asynchronously", responseBody);
+        }
     }
 }

--- a/test/WebSites/FSharpWebSite/Controllers/HomeController.fs
+++ b/test/WebSites/FSharpWebSite/Controllers/HomeController.fs
@@ -14,3 +14,8 @@ type HomeController () =
 
     member this.Index () =
         this.View()
+
+    member this.AsyncAction () = async {
+        do! Async.Sleep 50
+        return this.Content("Action completed asynchronously")
+    }


### PR DESCRIPTION
This is to show that #5570 is now implemented.

Previously, MVC actions written in F# and returning native F# async results resulted in returning `{}` to the browser. Now we await the action result and process it as expected.