### PR TITLE
Remove usage of NotFoundProjectItem

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor/DependencyInjection/MvcRazorMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/DependencyInjection/MvcRazorMvcCoreBuilderExtensions.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Extensions.DependencyInjection
             //
             // Razor compilation infrastructure
             //
-            services.TryAddSingleton<RazorProject, DefaultRazorProject>();
+            services.TryAddSingleton<RazorProject, FileProviderRazorProject>();
             services.TryAddSingleton<RazorTemplateEngine, MvcRazorTemplateEngine>();
             services.TryAddSingleton<RazorCompiler>();
             services.TryAddSingleton<LazyMetadataReferenceFeature>();

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/FileProviderRazorProject.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/FileProviderRazorProject.cs
@@ -9,18 +9,18 @@ using Microsoft.Extensions.FileProviders;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 {
-    public class DefaultRazorProject : RazorProject
+    public class FileProviderRazorProject : RazorProject
     {
         private const string RazorFileExtension = ".cshtml";
         private readonly IFileProvider _provider;
 
-        public DefaultRazorProject(IRazorViewEngineFileProviderAccessor accessor)
+        public FileProviderRazorProject(IRazorViewEngineFileProviderAccessor accessor)
             : this(accessor.FileProvider)
         {
         }
 
         // Internal for unit testing
-        internal DefaultRazorProject(IFileProvider provider)
+        internal FileProviderRazorProject(IFileProvider provider)
         {
             _provider = provider;
         }
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
         {
             path = NormalizeAndEnsureValidPath(path);
             var fileInfo = _provider.GetFileInfo(path);
-            return new DefaultRazorProjectItem(fileInfo, basePath: string.Empty, path: path);
+            return new FileProviderProjectItem(fileInfo, basePath: string.Empty, path: path);
         }
 
         public override IEnumerable<RazorProjectItem> EnumerateItems(string path)
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
                     }
                     else if (string.Equals(RazorFileExtension, Path.GetExtension(file.Name), StringComparison.OrdinalIgnoreCase))
                     {
-                        yield return new DefaultRazorProjectItem(file, basePath, prefix + "/" + file.Name);
+                        yield return new FileProviderProjectItem(file, basePath, prefix + "/" + file.Name);
                     }
                 }
             }

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/FileProviderRazorProject.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/FileProviderRazorProject.cs
@@ -19,8 +19,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
         {
         }
 
-        // Internal for unit testing
-        internal FileProviderRazorProject(IFileProvider provider)
+        public FileProviderRazorProject(IFileProvider provider)
         {
             _provider = provider;
         }
@@ -29,7 +28,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
         {
             path = NormalizeAndEnsureValidPath(path);
             var fileInfo = _provider.GetFileInfo(path);
-            return new FileProviderProjectItem(fileInfo, basePath: string.Empty, path: path);
+            return new FileProviderRazorProjectItem(fileInfo, basePath: string.Empty, path: path);
         }
 
         public override IEnumerable<RazorProjectItem> EnumerateItems(string path)
@@ -56,7 +55,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
                     }
                     else if (string.Equals(RazorFileExtension, Path.GetExtension(file.Name), StringComparison.OrdinalIgnoreCase))
                     {
-                        yield return new FileProviderProjectItem(file, basePath, prefix + "/" + file.Name);
+                        yield return new FileProviderRazorProjectItem(file, basePath, prefix + "/" + file.Name);
                     }
                 }
             }

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/FileProviderRazorProjectItem.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/FileProviderRazorProjectItem.cs
@@ -7,9 +7,9 @@ using Microsoft.Extensions.FileProviders;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 {
-    public class FileProviderProjectItem : RazorProjectItem
+    public class FileProviderRazorProjectItem : RazorProjectItem
     {
-        public FileProviderProjectItem(IFileInfo fileInfo, string basePath, string path)
+        public FileProviderRazorProjectItem(IFileInfo fileInfo, string basePath, string path)
         {
             FileInfo = fileInfo;
             BasePath = basePath;

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/FileProviderRazorProjectItem.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/FileProviderRazorProjectItem.cs
@@ -7,9 +7,9 @@ using Microsoft.Extensions.FileProviders;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 {
-    public class DefaultRazorProjectItem : RazorProjectItem
+    public class FileProviderProjectItem : RazorProjectItem
     {
-        public DefaultRazorProjectItem(IFileInfo fileInfo, string basePath, string path)
+        public FileProviderProjectItem(IFileInfo fileInfo, string basePath, string path)
         {
             FileInfo = fileInfo;
             BasePath = basePath;

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/CompilerCacheTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/CompilerCacheTest.cs
@@ -122,7 +122,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var fileProvider = new TestFileProvider();
             var fileInfo = fileProvider.AddFile(ViewPath, "some content");
 
-            var foundItem = new FileProviderProjectItem(fileInfo, "", ViewPath);
+            var foundItem = new FileProviderRazorProjectItem(fileInfo, "", ViewPath);
 
             var notFoundItem = new Mock<RazorProjectItem>();
             notFoundItem
@@ -437,7 +437,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             {
                 return cache.GetOrAdd("/Views/Home/Index.cshtml", path =>
                 {
-                    var projectItem = new FileProviderProjectItem(new TestFileInfo(), "", path);
+                    var projectItem = new FileProviderRazorProjectItem(new TestFileInfo(), "", path);
                     return new CompilerCacheContext(projectItem, Enumerable.Empty<RazorProjectItem>(), compile1);
                 });
             });
@@ -447,7 +447,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
                 // Event 4
                 return cache.GetOrAdd("/Views/Home/About.cshtml", path =>
                 {
-                    var projectItem = new FileProviderProjectItem(new TestFileInfo(), "", path);
+                    var projectItem = new FileProviderRazorProjectItem(new TestFileInfo(), "", path);
                     return new CompilerCacheContext(projectItem, Enumerable.Empty<RazorProjectItem>(), compile2);
                 });
             });
@@ -490,7 +490,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             {
                 return cache.GetOrAdd(ViewPath, path =>
                 {
-                    var projectItem = new FileProviderProjectItem(new TestFileInfo(), "", path);
+                    var projectItem = new FileProviderRazorProjectItem(new TestFileInfo(), "", path);
                     return new CompilerCacheContext(projectItem, Enumerable.Empty<RazorProjectItem>(), compile);
                 });
             });
@@ -625,7 +625,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
         private CompilerCacheContext ThrowsIfCalled(string path, Exception exception)
         {
             exception = exception ?? new Exception("Shouldn't be called");
-            var projectItem = new FileProviderProjectItem(new TestFileInfo(), "", path);
+            var projectItem = new FileProviderRazorProjectItem(new TestFileInfo(), "", path);
 
             return new CompilerCacheContext(
                 projectItem,
@@ -640,12 +640,12 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
         private CompilerCacheContext CreateCacheContext(CompilationResult compile, string path = ViewPath)
         {
-            var projectItem = new FileProviderProjectItem(new TestFileInfo(), "", path);
+            var projectItem = new FileProviderRazorProjectItem(new TestFileInfo(), "", path);
 
             var imports = new List<RazorProjectItem>();
             foreach (var importFilePath in _viewImportsPath)
             {
-                var importProjectItem = new FileProviderProjectItem(new TestFileInfo(), "", importFilePath);
+                var importProjectItem = new FileProviderRazorProjectItem(new TestFileInfo(), "", importFilePath);
 
                 imports.Add(importProjectItem);
             }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/CompilerCacheTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/CompilerCacheTest.cs
@@ -48,10 +48,18 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
         public void GetOrAdd_ReturnsFileNotFoundResult_IfFileIsNotFoundInFileSystem()
         {
             // Arrange
+            var item = new Mock<RazorProjectItem>();
+            item
+                .SetupGet(i => i.Path)
+                .Returns("/path");
+            item
+                .SetupGet(i => i.Exists)
+                .Returns(false);
+
             var fileProvider = new TestFileProvider();
             var cache = new CompilerCache(fileProvider);
             var compilerCacheContext = new CompilerCacheContext(
-                new NotFoundProjectItem("", "/path"),
+                item.Object,
                 Enumerable.Empty<RazorProjectItem>(),
                 _ => throw new Exception("Shouldn't be called."));
 
@@ -113,10 +121,20 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             // Arrange
             var fileProvider = new TestFileProvider();
             var fileInfo = fileProvider.AddFile(ViewPath, "some content");
+
+            var foundItem = new FileProviderProjectItem(fileInfo, "", ViewPath);
+
+            var notFoundItem = new Mock<RazorProjectItem>();
+            notFoundItem
+                .SetupGet(i => i.Path)
+                .Returns(ViewPath);
+            notFoundItem
+                .SetupGet(i => i.Exists)
+                .Returns(false);
+
             var cache = new CompilerCache(fileProvider);
             var expected = new CompilationResult(typeof(TestView));
-            var projectItem = new DefaultRazorProjectItem(fileInfo, "", ViewPath);
-            var cacheContext = new CompilerCacheContext(projectItem, Enumerable.Empty<RazorProjectItem>(), _ => expected);
+            var cacheContext = new CompilerCacheContext(foundItem, Enumerable.Empty<RazorProjectItem>(), _ => expected);
 
             // Act 1
             var result1 = cache.GetOrAdd(ViewPath, _ => cacheContext);
@@ -419,7 +437,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             {
                 return cache.GetOrAdd("/Views/Home/Index.cshtml", path =>
                 {
-                    var projectItem = new DefaultRazorProjectItem(new TestFileInfo(), "", path);
+                    var projectItem = new FileProviderProjectItem(new TestFileInfo(), "", path);
                     return new CompilerCacheContext(projectItem, Enumerable.Empty<RazorProjectItem>(), compile1);
                 });
             });
@@ -429,7 +447,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
                 // Event 4
                 return cache.GetOrAdd("/Views/Home/About.cshtml", path =>
                 {
-                    var projectItem = new DefaultRazorProjectItem(new TestFileInfo(), "", path);
+                    var projectItem = new FileProviderProjectItem(new TestFileInfo(), "", path);
                     return new CompilerCacheContext(projectItem, Enumerable.Empty<RazorProjectItem>(), compile2);
                 });
             });
@@ -472,7 +490,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             {
                 return cache.GetOrAdd(ViewPath, path =>
                 {
-                    var projectItem = new DefaultRazorProjectItem(new TestFileInfo(), "", path);
+                    var projectItem = new FileProviderProjectItem(new TestFileInfo(), "", path);
                     return new CompilerCacheContext(projectItem, Enumerable.Empty<RazorProjectItem>(), compile);
                 });
             });
@@ -607,7 +625,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
         private CompilerCacheContext ThrowsIfCalled(string path, Exception exception)
         {
             exception = exception ?? new Exception("Shouldn't be called");
-            var projectItem = new DefaultRazorProjectItem(new TestFileInfo(), "", path);
+            var projectItem = new FileProviderProjectItem(new TestFileInfo(), "", path);
 
             return new CompilerCacheContext(
                 projectItem,
@@ -622,12 +640,12 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
         private CompilerCacheContext CreateCacheContext(CompilationResult compile, string path = ViewPath)
         {
-            var projectItem = new DefaultRazorProjectItem(new TestFileInfo(), "", path);
+            var projectItem = new FileProviderProjectItem(new TestFileInfo(), "", path);
 
             var imports = new List<RazorProjectItem>();
             foreach (var importFilePath in _viewImportsPath)
             {
-                var importProjectItem = new DefaultRazorProjectItem(new TestFileInfo(), "", importFilePath);
+                var importProjectItem = new FileProviderProjectItem(new TestFileInfo(), "", importFilePath);
 
                 imports.Add(importProjectItem);
             }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/DefaultRazorPageFactoryProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/DefaultRazorPageFactoryProviderTest.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             return new RazorCompiler(
                 Mock.Of<ICompilationService>(),
                 compilerCacheProvider.Object,
-                new MvcRazorTemplateEngine(RazorEngine.Create(), new DefaultRazorProject(new TestFileProvider())));
+                new MvcRazorTemplateEngine(RazorEngine.Create(), new FileProviderRazorProject(new TestFileProvider())));
         }
 
         private class TestRazorPage : RazorPage

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/FileProviderRazorProjectTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/FileProviderRazorProjectTest.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 {
-    public class DefaultRazorProjectTest
+    public class FileProviderRazorProjectTest
     {
         [Fact]
         public void EnumerateFiles_ReturnsEmptySequenceIfNoCshtmlFilesArePresent()
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var file2 = fileProvider.AddFile("File2.js", "content");
             fileProvider.AddDirectoryContent("/", new IFileInfo[] { file1, file2 });
 
-            var razorProject = new DefaultRazorProject(fileProvider);
+            var razorProject = new FileProviderRazorProject(fileProvider);
 
             // Act
             var razorFiles = razorProject.EnumerateItems("/");
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var file3 = fileProvider.AddFile("File3.cshtml", "content");
             fileProvider.AddDirectoryContent("/", new IFileInfo[] { file1, file2, file3 });
 
-            var razorProject = new DefaultRazorProject(fileProvider);
+            var razorProject = new FileProviderRazorProject(fileProvider);
 
             // Act
             var razorFiles = razorProject.EnumerateItems("/");
@@ -75,7 +75,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var file5 = fileProvider.AddFile("Level1-Dir2/File5.cshtml", "content");
             fileProvider.AddDirectoryContent("/Level1-Dir2", new IFileInfo[] { file5 });
             fileProvider.AddDirectoryContent("/Level1/Level2", new IFileInfo[0]);
-            var razorProject = new DefaultRazorProject(fileProvider);
+
+            var razorProject = new FileProviderRazorProject(fileProvider);
 
             // Act
             var razorFiles = razorProject.EnumerateItems("/");
@@ -115,7 +116,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var file5 = fileProvider.AddFile("Level1-Dir2/File5.cshtml", "content");
             fileProvider.AddDirectoryContent("/Level1-Dir2", new IFileInfo[] { file5 });
             fileProvider.AddDirectoryContent("/Level1/Level2", new IFileInfo[0]);
-            var razorProject = new DefaultRazorProject(fileProvider);
+
+            var razorProject = new FileProviderRazorProject(fileProvider);
 
             // Act
             var razorFiles = razorProject.EnumerateItems("/Level1-Dir1");

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/RazorCompilerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/RazorCompilerTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var razorEngine = RazorEngine.Create();
             var fileProvider = new TestFileProvider();
             fileProvider.AddFile(viewPath, "<span name=\"@(User.Id\">");
-            var razorProject = new DefaultRazorProject(fileProvider);
+            var razorProject = new FileProviderRazorProject(fileProvider);
 
             var templateEngine = new MvcRazorTemplateEngine(razorEngine, razorProject);
             var compiler = new RazorCompiler(
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var fileProvider = new TestFileProvider();
             var file = fileProvider.AddFile(viewPath, "<span name=\"@(User.Id\">");
             file.PhysicalPath = physicalPath;
-            var razorProject = new DefaultRazorProject(fileProvider);
+            var razorProject = new FileProviderRazorProject(fileProvider);
 
             var templateEngine = new MvcRazorTemplateEngine(razorEngine, razorProject);
             var compiler = new RazorCompiler(
@@ -90,7 +90,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var razorEngine = RazorEngine.Create();
             var fileProvider = new TestFileProvider();
             fileProvider.AddFile(viewPath, fileContent);
-            var razorProject = new DefaultRazorProject(fileProvider);
+            var razorProject = new FileProviderRazorProject(fileProvider);
 
             var templateEngine = new MvcRazorTemplateEngine(razorEngine, razorProject);
             var compiler = new RazorCompiler(
@@ -122,7 +122,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             fileProvider.AddFile(viewPath, fileContent);
             var importsFile = fileProvider.AddFile("/Views/_MyImports.cshtml", importsContent);
             importsFile.PhysicalPath = importsFilePath;
-            var razorProject = new DefaultRazorProject(fileProvider);
+            var razorProject = new FileProviderRazorProject(fileProvider);
 
             var templateEngine = new MvcRazorTemplateEngine(razorEngine, razorProject)
             {
@@ -186,7 +186,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var compiler = new RazorCompiler(
                 Mock.Of<ICompilationService>(),
                 GetCompilerCacheProvider(fileProvider),
-                new MvcRazorTemplateEngine(RazorEngine.Create(), new DefaultRazorProject(fileProvider)));
+                new MvcRazorTemplateEngine(RazorEngine.Create(), new FileProviderRazorProject(fileProvider)));
 
             // Act
             var result = compiler.GetCompilationFailedResult(codeDocument, diagnostics);

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorViewEngineTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorViewEngineTest.cs
@@ -901,7 +901,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Test
                .Returns(new RazorPageFactoryResult(() => viewStart, new IChangeToken[0]));
 
             var fileProvider = new TestFileProvider();
-            var razorProject = new DefaultRazorProject(fileProvider);
+            var razorProject = new FileProviderRazorProject(fileProvider);
             var viewEngine = CreateViewEngine(pageFactory.Object, razorProject: razorProject);
             var context = GetActionContext(_controllerTestContext);
 
@@ -1349,7 +1349,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Test
                 Mock.Of<IRazorPageActivator>(),
                 new HtmlTestEncoder(),
                 GetOptionsAccessor(expanders: null),
-                new DefaultRazorProject(new TestFileProvider()),
+                new FileProviderRazorProject(new TestFileProvider()),
                 loggerFactory);
 
             // Act
@@ -1772,7 +1772,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Test
             pageFactory = pageFactory ?? Mock.Of<IRazorPageFactoryProvider>();
             if (razorProject == null)
             {
-                razorProject = new DefaultRazorProject(new TestFileProvider());
+                razorProject = new FileProviderRazorProject(new TestFileProvider());
             }
             return new TestableRazorViewEngine(pageFactory, GetOptionsAccessor(expanders), razorProject);
         }
@@ -1873,7 +1873,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Test
             public TestableRazorViewEngine(
                 IRazorPageFactoryProvider pageFactory,
                 IOptions<RazorViewEngineOptions> optionsAccessor)
-                : this(pageFactory, optionsAccessor, new DefaultRazorProject(new TestFileProvider()))
+                : this(pageFactory, optionsAccessor, new FileProviderRazorProject(new TestFileProvider()))
             {
             }
 

--- a/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Infrastructure/PageActionDescriptorProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Infrastructure/PageActionDescriptorProviderTest.cs
@@ -347,7 +347,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
                 Content = content,
             };
 
-            return new DefaultRazorProjectItem(testFileInfo, basePath, path);
+            return new FileProviderProjectItem(testFileInfo, basePath, path);
         }
 
         private class TestPageApplicationModelProvider : IPageApplicationModelProvider

--- a/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Infrastructure/PageActionDescriptorProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Infrastructure/PageActionDescriptorProviderTest.cs
@@ -347,7 +347,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
                 Content = content,
             };
 
-            return new FileProviderProjectItem(testFileInfo, basePath, path);
+            return new FileProviderRazorProjectItem(testFileInfo, basePath, path);
         }
 
         private class TestPageApplicationModelProvider : IPageApplicationModelProvider

--- a/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/PageActionInvokerProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/PageActionInvokerProviderTest.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using Microsoft.AspNetCore.Mvc.Razor;
+using Microsoft.AspNetCore.Mvc.Razor.Internal;
 using Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Mvc.ViewFeatures.Internal;
@@ -175,7 +176,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             fileProvider.AddFile("/Home/Path1/_ViewStart.cshtml", "content1");
             fileProvider.AddFile("/_ViewStart.cshtml", "content2");
 
-            var defaultRazorProject = new TestRazorProject(fileProvider);
+            var defaultRazorProject = new FileProviderRazorProject(fileProvider);
 
             var invokerProvider = CreateInvokerProvider(
                 loader.Object,

--- a/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/TestRazorProject.cs
+++ b/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/TestRazorProject.cs
@@ -7,7 +7,7 @@ using Moq;
 
 namespace Microsoft.AspNetCore.Mvc.RazorPages
 {
-    public class TestRazorProject : DefaultRazorProject
+    public class TestRazorProject : FileProviderRazorProject
     {
         public TestRazorProject(IFileProvider fileProvider)
             :base(GetAccessor(fileProvider))

--- a/test/WebSites/RazorPageExecutionInstrumentationWebSite/TestRazorCompilationService.cs
+++ b/test/WebSites/RazorPageExecutionInstrumentationWebSite/TestRazorCompilationService.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Razor.Language;
 
 namespace RazorPageExecutionInstrumentationWebSite
 {
-    public class TestRazorProject : DefaultRazorProject
+    public class TestRazorProject : FileProviderRazorProject
     {
         public TestRazorProject(IRazorViewEngineFileProviderAccessor fileProviderAccessor)
             : base(fileProviderAccessor)
@@ -17,13 +17,13 @@ namespace RazorPageExecutionInstrumentationWebSite
 
         public override RazorProjectItem GetItem(string path)
         {
-            var item = (DefaultRazorProjectItem)base.GetItem(path);
+            var item = (FileProviderRazorProjectItem)base.GetItem(path);
             return new TestRazorProjectItem(item);
         }
 
-        private class TestRazorProjectItem : DefaultRazorProjectItem
+        private class TestRazorProjectItem : FileProviderRazorProjectItem
         {
-            public TestRazorProjectItem(DefaultRazorProjectItem projectItem)
+            public TestRazorProjectItem(FileProviderRazorProjectItem projectItem)
                 : base(projectItem.FileInfo, projectItem.BasePath, projectItem.Path)
             {
             }


### PR DESCRIPTION
We're making this type internal in Razor, using a mock here is fine.

Also renamed some types with a generic name. The actual 'default'
RazorProject class lives in Razor and is internal.