### PR TITLE
Make our executor methods virtual

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ContentResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ContentResultExecutor.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             _httpResponseStreamWriterFactory = httpResponseStreamWriterFactory;
         }
 
-        public async Task ExecuteAsync(ActionContext context, ContentResult result)
+        public virtual async Task ExecuteAsync(ActionContext context, ContentResult result)
         {
             if (context == null)
             {

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/FileContentResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/FileContentResultExecutor.cs
@@ -13,13 +13,13 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         {
         }
 
-        public Task ExecuteAsync(ActionContext context, FileContentResult result)
+        public virtual Task ExecuteAsync(ActionContext context, FileContentResult result)
         {
             SetHeadersAndLog(context, result);
             return WriteFileAsync(context, result);
         }
 
-        private static Task WriteFileAsync(ActionContext context, FileContentResult result)
+        protected virtual Task WriteFileAsync(ActionContext context, FileContentResult result)
         {
             var response = context.HttpContext.Response;
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/FileContentResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/FileContentResultExecutor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -15,12 +16,32 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
         public virtual Task ExecuteAsync(ActionContext context, FileContentResult result)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (result == null)
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
             SetHeadersAndLog(context, result);
             return WriteFileAsync(context, result);
         }
 
         protected virtual Task WriteFileAsync(ActionContext context, FileContentResult result)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (result == null)
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
             var response = context.HttpContext.Response;
 
             return response.Body.WriteAsync(result.FileContents, offset: 0, count: result.FileContents.Length);

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/FileResultExecutorBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/FileResultExecutorBase.cs
@@ -18,6 +18,16 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
         protected virtual void SetHeadersAndLog(ActionContext context, FileResult result)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (result == null)
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
             SetContentType(context, result);
             SetContentDispositionHeader(context, result);
             Logger.FileResultExecuting(result.FileDownloadName);

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/FileResultExecutorBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/FileResultExecutorBase.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
         protected ILogger Logger { get; }
 
-        protected void SetHeadersAndLog(ActionContext context, FileResult result)
+        protected virtual void SetHeadersAndLog(ActionContext context, FileResult result)
         {
             SetContentType(context, result);
             SetContentDispositionHeader(context, result);

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/FileStreamResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/FileStreamResultExecutor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -18,12 +19,32 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
         public virtual Task ExecuteAsync(ActionContext context, FileStreamResult result)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (result == null)
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
             SetHeadersAndLog(context, result);
             return WriteFileAsync(context, result);
         }
 
         protected virtual async Task WriteFileAsync(ActionContext context, FileStreamResult result)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (result == null)
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
             var response = context.HttpContext.Response;
             var outputStream = response.Body;
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/FileStreamResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/FileStreamResultExecutor.cs
@@ -16,13 +16,13 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         {
         }
 
-        public Task ExecuteAsync(ActionContext context, FileStreamResult result)
+        public virtual Task ExecuteAsync(ActionContext context, FileStreamResult result)
         {
             SetHeadersAndLog(context, result);
             return WriteFileAsync(context, result);
         }
 
-        private static async Task WriteFileAsync(ActionContext context, FileStreamResult result)
+        protected virtual async Task WriteFileAsync(ActionContext context, FileStreamResult result)
         {
             var response = context.HttpContext.Response;
             var outputStream = response.Body;

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/LocalRedirectResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/LocalRedirectResultExecutor.cs
@@ -33,6 +33,16 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
         public virtual void Execute(ActionContext context, LocalRedirectResult result)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (result == null)
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
             var urlHelper = result.UrlHelper ?? _urlHelperFactory.GetUrlHelper(context);
 
             // IsLocalUrl is called to handle  Urls starting with '~/'.

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/LocalRedirectResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/LocalRedirectResultExecutor.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             _urlHelperFactory = urlHelperFactory;
         }
 
-        public void Execute(ActionContext context, LocalRedirectResult result)
+        public virtual void Execute(ActionContext context, LocalRedirectResult result)
         {
             var urlHelper = result.UrlHelper ?? _urlHelperFactory.GetUrlHelper(context);
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/PhysicalFileResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/PhysicalFileResultExecutor.cs
@@ -20,13 +20,13 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         {
         }
 
-        public Task ExecuteAsync(ActionContext context, PhysicalFileResult result)
+        public virtual Task ExecuteAsync(ActionContext context, PhysicalFileResult result)
         {
             SetHeadersAndLog(context, result);
             return WriteFileAsync(context, result);
         }
 
-        private async Task WriteFileAsync(ActionContext context, PhysicalFileResult result)
+        protected virtual async Task WriteFileAsync(ActionContext context, PhysicalFileResult result)
         {
             var response = context.HttpContext.Response;
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/PhysicalFileResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/PhysicalFileResultExecutor.cs
@@ -22,12 +22,32 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
         public virtual Task ExecuteAsync(ActionContext context, PhysicalFileResult result)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (result == null)
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
             SetHeadersAndLog(context, result);
             return WriteFileAsync(context, result);
         }
 
         protected virtual async Task WriteFileAsync(ActionContext context, PhysicalFileResult result)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (result == null)
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
             var response = context.HttpContext.Response;
 
             if (!Path.IsPathRooted(result.FileName))

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/RedirectResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/RedirectResultExecutor.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             _urlHelperFactory = urlHelperFactory;
         }
 
-        public void Execute(ActionContext context, RedirectResult result)
+        public virtual void Execute(ActionContext context, RedirectResult result)
         {
             var urlHelper = result.UrlHelper ?? _urlHelperFactory.GetUrlHelper(context);
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/RedirectResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/RedirectResultExecutor.cs
@@ -32,6 +32,16 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
         public virtual void Execute(ActionContext context, RedirectResult result)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (result == null)
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
             var urlHelper = result.UrlHelper ?? _urlHelperFactory.GetUrlHelper(context);
 
             // IsLocalUrl is called to handle URLs starting with '~/'.

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/RedirectToActionResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/RedirectToActionResultExecutor.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             _urlHelperFactory = urlHelperFactory;
         }
 
-        public void Execute(ActionContext context, RedirectToActionResult result)
+        public virtual void Execute(ActionContext context, RedirectToActionResult result)
         {
             var urlHelper = result.UrlHelper ?? _urlHelperFactory.GetUrlHelper(context);
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/RedirectToActionResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/RedirectToActionResultExecutor.cs
@@ -33,6 +33,16 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
         public virtual void Execute(ActionContext context, RedirectToActionResult result)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (result == null)
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
             var urlHelper = result.UrlHelper ?? _urlHelperFactory.GetUrlHelper(context);
 
             var destinationUrl = urlHelper.Action(

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/RedirectToPageResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/RedirectToPageResultExecutor.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             _urlHelperFactory = urlHelperFactory;
         }
 
-        public void Execute(ActionContext context, RedirectToPageResult result)
+        public virtual void Execute(ActionContext context, RedirectToPageResult result)
         {
             var urlHelper = result.UrlHelper ?? _urlHelperFactory.GetUrlHelper(context);
             var destinationUrl = urlHelper.Page(

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/RedirectToPageResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/RedirectToPageResultExecutor.cs
@@ -33,6 +33,16 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
         public virtual void Execute(ActionContext context, RedirectToPageResult result)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (result == null)
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
             var urlHelper = result.UrlHelper ?? _urlHelperFactory.GetUrlHelper(context);
             var destinationUrl = urlHelper.Page(
                 result.PageName,

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/VirtualFileResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/VirtualFileResultExecutor.cs
@@ -31,12 +31,32 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
         public virtual Task ExecuteAsync(ActionContext context, VirtualFileResult result)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (result == null)
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
             SetHeadersAndLog(context, result);
             return WriteFileAsync(context, result);
         }
 
         protected virtual async Task WriteFileAsync(ActionContext context, VirtualFileResult result)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (result == null)
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
             var response = context.HttpContext.Response;
             var fileProvider = GetFileProvider(result);
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/VirtualFileResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/VirtualFileResultExecutor.cs
@@ -29,13 +29,13 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             _hostingEnvironment = hostingEnvironment;
         }
 
-        public Task ExecuteAsync(ActionContext context, VirtualFileResult result)
+        public virtual Task ExecuteAsync(ActionContext context, VirtualFileResult result)
         {
             SetHeadersAndLog(context, result);
             return WriteFileAsync(context, result);
         }
 
-        private async Task WriteFileAsync(ActionContext context, VirtualFileResult result)
+        protected virtual async Task WriteFileAsync(ActionContext context, VirtualFileResult result)
         {
             var response = context.HttpContext.Response;
             var fileProvider = GetFileProvider(result);

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Json/Internal/JsonResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Json/Internal/JsonResultExecutor.cs
@@ -85,7 +85,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Json.Internal
         /// <param name="context">The <see cref="ActionContext"/>.</param>
         /// <param name="result">The <see cref="JsonResult"/>.</param>
         /// <returns>A <see cref="Task"/> which will complete when writing has completed.</returns>
-        public Task ExecuteAsync(ActionContext context, JsonResult result)
+        public virtual Task ExecuteAsync(ActionContext context, JsonResult result)
         {
             if (context == null)
             {

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Infrastructure/PageResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Infrastructure/PageResultExecutor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
@@ -49,6 +50,16 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
         /// </summary>
         public virtual Task ExecuteAsync(PageContext pageContext, PageResult result)
         {
+            if (pageContext == null)
+            {
+                throw new ArgumentNullException(nameof(pageContext));
+            }
+
+            if (result == null)
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
             if (result.Model != null)
             {
                 pageContext.ViewData.Model = result.Model;

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/PartialViewResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/PartialViewResultExecutor.cs
@@ -3,14 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
-using Microsoft.AspNetCore.Mvc.ViewFeatures.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ViewComponentResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ViewComponentResultExecutor.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             _tempDataDictionaryFactory = tempDataDictionaryFactory;
         }
 
-        public async Task ExecuteAsync(ActionContext context, ViewComponentResult viewComponentResult)
+        public virtual async Task ExecuteAsync(ActionContext context, ViewComponentResult viewComponentResult)
         {
             var response = context.HttpContext.Response;
 

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ViewComponentResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ViewComponentResultExecutor.cs
@@ -65,6 +65,16 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
 
         public virtual async Task ExecuteAsync(ActionContext context, ViewComponentResult viewComponentResult)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (viewComponentResult == null)
+            {
+                throw new ArgumentNullException(nameof(viewComponentResult));
+            }
+
             var response = context.HttpContext.Response;
 
             var viewData = viewComponentResult.ViewData;


### PR DESCRIPTION
Fixes #5874 - we are marking these methods virtual just in case someone
wants to customize the executors. These are in the 'public internal'
namespace but can't really be replaced because they aren't sufficiently
virtual.