### PR TITLE
Upgrade test framework versions and fix test issues

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -10,8 +10,8 @@
     <MoqVersion>4.7.1</MoqVersion>
     <NETStandardImplicitPackageVersion>$(BundledNETStandardPackageVersion)</NETStandardImplicitPackageVersion>
     <RoslynVersion>2.0.0</RoslynVersion>
-    <TestSdkVersion>15.0.0</TestSdkVersion>
+    <TestSdkVersion>15.3.0-*</TestSdkVersion>
     <WebApiClientVersion>5.2.2</WebApiClientVersion>
-    <XunitVersion>2.2.0</XunitVersion>
+    <XunitVersion>2.3.0-beta2-*</XunitVersion>
   </PropertyGroup>
 </Project>

--- a/test/Microsoft.AspNetCore.Mvc.Abstractions.Test/Microsoft.AspNetCore.Mvc.Abstractions.Test.csproj
+++ b/test/Microsoft.AspNetCore.Mvc.Abstractions.Test/Microsoft.AspNetCore.Mvc.Abstractions.Test.csproj
@@ -15,8 +15,4 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.AspNetCore.Mvc.ApiExplorer.Test/Microsoft.AspNetCore.Mvc.ApiExplorer.Test.csproj
+++ b/test/Microsoft.AspNetCore.Mvc.ApiExplorer.Test/Microsoft.AspNetCore.Mvc.ApiExplorer.Test.csproj
@@ -13,8 +13,4 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
 </Project>

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Builder/MvcAreaRouteBuilderExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Builder/MvcAreaRouteBuilderExtensionsTest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Builder
                 route.Constraints.OrderBy(kvp => kvp.Key),
                 kvp =>
                 {
-                    Assert.Equal(kvp.Key, "area");
+                    Assert.Equal("area", kvp.Key);
                     Assert.IsType<StringRouteConstraint>(kvp.Value);
                 });
             Assert.Empty(route.DataTokens);
@@ -41,8 +41,8 @@ namespace Microsoft.AspNetCore.Builder
                 route.Defaults.OrderBy(kvp => kvp.Key),
                 kvp =>
                 {
-                    Assert.Equal(kvp.Key, "area");
-                    Assert.Equal(kvp.Value, "admin");
+                    Assert.Equal("area", kvp.Key);
+                    Assert.Equal("admin", kvp.Value);
                 });
         }
 
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Builder
                 route.Constraints.OrderBy(kvp => kvp.Key),
                 kvp =>
                 {
-                    Assert.Equal(kvp.Key, "area");
+                    Assert.Equal("area", kvp.Key);
                     Assert.IsType<StringRouteConstraint>(kvp.Value);
                 });
             Assert.Empty(route.DataTokens);
@@ -76,13 +76,13 @@ namespace Microsoft.AspNetCore.Builder
                 route.Defaults.OrderBy(kvp => kvp.Key),
                 kvp =>
                 {
-                    Assert.Equal(kvp.Key, "action");
-                    Assert.Equal(kvp.Value, "Home");
+                    Assert.Equal("action", kvp.Key);
+                    Assert.Equal("Home", kvp.Value);
                 },
                 kvp =>
                 {
-                    Assert.Equal(kvp.Key, "area");
-                    Assert.Equal(kvp.Value, "admin");
+                    Assert.Equal("area", kvp.Key);
+                    Assert.Equal("admin", kvp.Value);
                 });
         }
 
@@ -109,12 +109,12 @@ namespace Microsoft.AspNetCore.Builder
                 route.Constraints.OrderBy(kvp => kvp.Key),
                 kvp =>
                 {
-                    Assert.Equal(kvp.Key, "area");
+                    Assert.Equal("area", kvp.Key);
                     Assert.IsType<StringRouteConstraint>(kvp.Value);
                 },
                 kvp =>
                 {
-                    Assert.Equal(kvp.Key, "id");
+                    Assert.Equal("id", kvp.Key);
                     Assert.IsType<IntRouteConstraint>(kvp.Value);
                 });
             Assert.Empty(route.DataTokens);
@@ -122,13 +122,13 @@ namespace Microsoft.AspNetCore.Builder
                 route.Defaults.OrderBy(kvp => kvp.Key),
                 kvp =>
                 {
-                    Assert.Equal(kvp.Key, "action");
-                    Assert.Equal(kvp.Value, "Home");
+                    Assert.Equal("action", kvp.Key);
+                    Assert.Equal("Home", kvp.Value);
                 },
                 kvp =>
                 {
-                    Assert.Equal(kvp.Key, "area");
-                    Assert.Equal(kvp.Value, "admin");
+                    Assert.Equal("area", kvp.Key);
+                    Assert.Equal("admin", kvp.Value);
                 });
         }
 
@@ -156,32 +156,32 @@ namespace Microsoft.AspNetCore.Builder
                 route.Constraints.OrderBy(kvp => kvp.Key),
                 kvp =>
                 {
-                    Assert.Equal(kvp.Key, "area");
+                    Assert.Equal("area", kvp.Key);
                     Assert.IsType<StringRouteConstraint>(kvp.Value);
                 },
                 kvp =>
                 {
-                    Assert.Equal(kvp.Key, "id");
+                    Assert.Equal("id", kvp.Key);
                     Assert.IsType<IntRouteConstraint>(kvp.Value);
                 });
             Assert.Collection(
                 route.DataTokens.OrderBy(kvp => kvp.Key),
                 kvp =>
                 {
-                    Assert.Equal(kvp.Key, "some_token");
-                    Assert.Equal(kvp.Value, "hello");
+                    Assert.Equal("some_token", kvp.Key);
+                    Assert.Equal("hello", kvp.Value);
                 });
             Assert.Collection(
                 route.Defaults.OrderBy(kvp => kvp.Key),
                 kvp =>
                 {
-                    Assert.Equal(kvp.Key, "action");
-                    Assert.Equal(kvp.Value, "Home");
+                    Assert.Equal("action", kvp.Key);
+                    Assert.Equal("Home", kvp.Value);
                 },
                 kvp =>
                 {
-                    Assert.Equal(kvp.Key, "area");
-                    Assert.Equal(kvp.Value, "admin");
+                    Assert.Equal("area", kvp.Key);
+                    Assert.Equal("admin", kvp.Value);
                 });
         }
 
@@ -209,22 +209,22 @@ namespace Microsoft.AspNetCore.Builder
                 route.Constraints.OrderBy(kvp => kvp.Key),
                 kvp =>
                 {
-                    Assert.Equal(kvp.Key, "area");
+                    Assert.Equal("area", kvp.Key);
                     Assert.IsType<IntRouteConstraint>(kvp.Value);
                 });
             Assert.Collection(
                 route.DataTokens.OrderBy(kvp => kvp.Key),
                 kvp =>
                 {
-                    Assert.Equal(kvp.Key, "some_token");
-                    Assert.Equal(kvp.Value, "hello");
+                    Assert.Equal("some_token", kvp.Key);
+                    Assert.Equal("hello", kvp.Value);
                 });
             Assert.Collection(
                 route.Defaults.OrderBy(kvp => kvp.Key),
                 kvp =>
                 {
-                    Assert.Equal(kvp.Key, "area");
-                    Assert.Equal(kvp.Value, "Home");
+                    Assert.Equal("area", kvp.Key);
+                    Assert.Equal("Home", kvp.Value);
                 });
         }
 
@@ -247,7 +247,7 @@ namespace Microsoft.AspNetCore.Builder
                 route.Constraints.OrderBy(kvp => kvp.Key),
                 kvp =>
                 {
-                    Assert.Equal(kvp.Key, "area");
+                    Assert.Equal("area", kvp.Key);
                     Assert.IsType<StringRouteConstraint>(kvp.Value);
 
                     var values = new RouteValueDictionary(new { area = areaName });
@@ -265,7 +265,7 @@ namespace Microsoft.AspNetCore.Builder
                 route.Defaults.OrderBy(kvp => kvp.Key),
                 kvp =>
                 {
-                    Assert.Equal(kvp.Key, "area");
+                    Assert.Equal("area", kvp.Key);
                     Assert.Equal(kvp.Value, areaName);
                 });
         }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Controllers/DefaultControllerActivatorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Controllers/DefaultControllerActivatorTest.cs
@@ -57,9 +57,9 @@ namespace Microsoft.AspNetCore.Mvc.Controllers
             activator.Release(new ControllerContext(), controller);
 
             // Assert
-            Assert.Equal(true, controller.Disposed);
+            Assert.True(controller.Disposed);
         }
-                
+
         [Fact]
         public void DefaultControllerActivator_ReleasesNonIDisposableController()
         {

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/TextInputFormatterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/TextInputFormatterTest.cs
@@ -35,8 +35,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             var result = await formatter.ReadAsync(context);
 
             // Assert
-            Assert.Equal(true, result.HasError);
-            Assert.Equal(true, context.ModelState.ContainsKey("something"));
+            Assert.True(result.HasError);
+            Assert.True(context.ModelState.ContainsKey("something"));
             Assert.Equal(1, context.ModelState["something"].Errors.Count);
 
             var error = context.ModelState["something"].Errors[0];

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerActionDescriptorProviderTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerActionDescriptorProviderTests.cs
@@ -392,6 +392,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             Assert.Empty(showPeople.Selectors[0].ActionConstraints.OfType<HttpMethodActionConstraint>());
         }
 
+        [Fact]
         public void AttributeRouting_TokenReplacement_IsAfterReflectedModel()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerActionInvokerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerActionInvokerTest.cs
@@ -2448,6 +2448,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                     () => invoker.InvokeAsync());
         }
 
+        [Fact]
         public async Task InvokeAction_AsyncAction_WithExceptionsAfterAwait()
         {
             // Arrange
@@ -3549,7 +3550,6 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
             public void OnAuthorization(AuthorizationFilterContext context)
             {
-                Assert.NotNull(context.ModelState.MaxAllowedErrors);
                 Assert.Equal(_expectedMaxAllowedErrors, context.ModelState.MaxAllowedErrors);
             }
         }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/DefaultObjectValidatorTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/DefaultObjectValidatorTests.cs
@@ -846,15 +846,15 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             AssertKeysEqual(modelState, "items[0]", "items[1]", "items[2]");
 
             var entry = modelState["items[0]"];
-            Assert.Equal(entry.ValidationState, ModelValidationState.Valid);
+            Assert.Equal(ModelValidationState.Valid, entry.ValidationState);
             Assert.Empty(entry.Errors);
 
             entry = modelState["items[1]"];
-            Assert.Equal(entry.ValidationState, ModelValidationState.Valid);
+            Assert.Equal(ModelValidationState.Valid, entry.ValidationState);
             Assert.Empty(entry.Errors);
 
             entry = modelState["items[2]"];
-            Assert.Equal(entry.ValidationState, ModelValidationState.Valid);
+            Assert.Equal(ModelValidationState.Valid, entry.ValidationState);
             Assert.Empty(entry.Errors);
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/FilterFactoryTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/FilterFactoryTest.cs
@@ -12,6 +12,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 {
     public class FilterFactoryTest
     {
+        [Fact]
         public void GetAllFilters_ReturnsNoFilters_IfNoFiltersAreSpecified()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Microsoft.AspNetCore.Mvc.Core.Test.csproj
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Microsoft.AspNetCore.Mvc.Core.Test.csproj
@@ -24,8 +24,4 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
 </Project>

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/BodyModelBinderProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/BodyModelBinderProviderTest.cs
@@ -42,6 +42,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             Assert.Null(result);
         }
 
+        [Fact]
         public void GetBinder_WhenNoInputFormatters_Throws()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/EnumerableValueProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/EnumerableValueProviderTest.cs
@@ -167,7 +167,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             var result = valueProvider.GetValue("prefix.name");
 
             // Assert
-            Assert.NotNull(result);
             Assert.Equal("someOtherValue", (string)result);
             Assert.Equal(culture, result.Culture);
         }
@@ -183,7 +182,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             var result = valueProvider.GetValue("some");
 
             // Assert
-            Assert.NotNull(result);
             Assert.Equal(new[] { "someValue1", "someValue2" }, result.Values);
             Assert.Equal("someValue1,someValue2", (string)result);
             Assert.Equal(culture, result.Culture);

--- a/test/Microsoft.AspNetCore.Mvc.Cors.Test/Microsoft.AspNetCore.Mvc.Cors.Test.csproj
+++ b/test/Microsoft.AspNetCore.Mvc.Cors.Test/Microsoft.AspNetCore.Mvc.Cors.Test.csproj
@@ -16,8 +16,4 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/CompareAttributeAdapterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/CompareAttributeAdapterTest.cs
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
                 kvp =>
                 {
                     Assert.Equal("data-val-equalto-other", kvp.Key);
-                    Assert.Equal(kvp.Value, "*.OtherProperty");
+                    Assert.Equal("*.OtherProperty", kvp.Value);
                 });
         }
 
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
                 kvp =>
                 {
                     Assert.Equal("data-val-equalto-other", kvp.Key);
-                    Assert.Equal(kvp.Value, "*.OtherProperty");
+                    Assert.Equal("*.OtherProperty", kvp.Value);
                 });
         }
 
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
                 kvp =>
                 {
                     Assert.Equal("data-val-equalto-other", kvp.Key);
-                    Assert.Equal(kvp.Value, "*.OtherProperty");
+                    Assert.Equal("*.OtherProperty", kvp.Value);
                 });
         }
 
@@ -164,7 +164,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
                 kvp =>
                 {
                     Assert.Equal("data-val-equalto-other", kvp.Key);
-                    Assert.Equal(kvp.Value, "*.OtherProperty");
+                    Assert.Equal("*.OtherProperty", kvp.Value);
                 });
         }
 
@@ -204,7 +204,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
                 kvp =>
                 {
                     Assert.Equal("data-val-equalto-other", kvp.Key);
-                    Assert.Equal(kvp.Value, "*.OtherProperty");
+                    Assert.Equal("*.OtherProperty", kvp.Value);
                 });
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test.csproj
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test.csproj
@@ -17,8 +17,4 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Json.Test/Microsoft.AspNetCore.Mvc.Formatters.Json.Test.csproj
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Json.Test/Microsoft.AspNetCore.Mvc.Formatters.Json.Test.csproj
@@ -17,8 +17,4 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test.csproj
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test.csproj
@@ -15,8 +15,4 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ApiExplorerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ApiExplorerTest.cs
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
             // Assert
             var description = Assert.Single(result);
-            Assert.Equal(description.GroupName, "ApiExplorerNameSetByConvention");
+            Assert.Equal("ApiExplorerNameSetByConvention", description.GroupName);
         }
 
         [Fact]
@@ -101,7 +101,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
             // Assert
             var description = Assert.Single(result);
-            Assert.Equal(description.GroupName, "SetOnController");
+            Assert.Equal("SetOnController", description.GroupName);
         }
 
         [Fact]
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
             // Assert
             var description = Assert.Single(result);
-            Assert.Equal(description.GroupName, "SetOnAction");
+            Assert.Equal("SetOnAction", description.GroupName);
         }
 
         [Fact]
@@ -129,7 +129,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
             // Assert
             var description = Assert.Single(result);
-            Assert.Equal(description.RelativePath, "ApiExplorerRouteAndPathParametersInformation");
+            Assert.Equal("ApiExplorerRouteAndPathParametersInformation", description.RelativePath);
         }
 
         [Fact]
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
             // Assert
             var description = Assert.Single(result);
-            Assert.Equal(description.RelativePath, "ApiExplorerRouteAndPathParametersInformation/{id}");
+            Assert.Equal("ApiExplorerRouteAndPathParametersInformation/{id}", description.RelativePath);
 
             var parameter = Assert.Single(description.ParameterDescriptions);
             Assert.Equal("id", parameter.Name);

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ContentNegotiationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ContentNegotiationTest.cs
@@ -469,7 +469,7 @@ END:VCARD
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var body = await response.Content.ReadAsStringAsync();
-            Assert.Equal(body, "MethodWithFormatFilter");
+            Assert.Equal("MethodWithFormatFilter", body);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/Microsoft.AspNetCore.Mvc.FunctionalTests.csproj
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/Microsoft.AspNetCore.Mvc.FunctionalTests.csproj
@@ -57,10 +57,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
   <!--
     Work around https://github.com/NuGet/Home/issues/4412. MVC uses DependencyContext.Load() which looks next to a .dll
     for a .deps.json. Information isn't available elsewhere. Need the .deps.json file for all web site applications.

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RoutingTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RoutingTests.cs
@@ -861,7 +861,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal("GetEmployees", result.Action);
 
             Assert.Equal("/api/Company/5/Employees", result.ExpectedUrls.Single());
-            Assert.Equal(null, result.RouteName);
+            Assert.Null(result.RouteName);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/CancellationTokenModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/CancellationTokenModelBinderIntegrationTest.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             // Model
             var boundPerson = Assert.IsType<Person>(modelBindingResult.Model);
             Assert.NotNull(boundPerson);
-            Assert.NotNull(boundPerson.Token);
+            Assert.NotSame(default(CancellationToken), boundPerson.Token);
 
             // ModelState
             Assert.True(modelState.IsValid);
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             // Model
             var boundPerson = Assert.IsType<Person>(modelBindingResult.Model);
             Assert.NotNull(boundPerson);
-            Assert.NotNull(boundPerson.Token);
+            Assert.NotSame(default(CancellationToken), boundPerson.Token);
 
             // ModelState
             Assert.True(modelState.IsValid);
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
 
             // Model
             var token = Assert.IsType<CancellationToken>(modelBindingResult.Model);
-            Assert.NotNull(token);
+            Assert.NotSame(default(CancellationToken), token);
 
             // ModelState
             Assert.True(modelState.IsValid);

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/ComplexTypeModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/ComplexTypeModelBinderIntegrationTest.cs
@@ -2677,7 +2677,6 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             // Model
             var model = Assert.IsType<Photo>(modelBindingResult.Model);
             Assert.Equal("1", model.Id);
-            Assert.NotNull(model.Info);
             Assert.Equal("location1", model.Info.Key);
             Assert.NotNull(model.Info.Value);
             Assert.Equal("10,20", model.Info.Value.GpsCoordinates);

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/Microsoft.AspNetCore.Mvc.IntegrationTests.csproj
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/Microsoft.AspNetCore.Mvc.IntegrationTests.csproj
@@ -17,8 +17,4 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/SimpleTypeModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/SimpleTypeModelBinderIntegrationTest.cs
@@ -396,6 +396,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.Null(error.Exception);
         }
 
+        [Theory(Skip = "This test fails")]
         [InlineData(typeof(int?))]
         [InlineData(typeof(bool?))]
         [InlineData(typeof(string))]

--- a/test/Microsoft.AspNetCore.Mvc.Localization.Test/Microsoft.AspNetCore.Mvc.Localization.Test.csproj
+++ b/test/Microsoft.AspNetCore.Mvc.Localization.Test/Microsoft.AspNetCore.Mvc.Localization.Test.csproj
@@ -16,8 +16,4 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Microsoft.AspNetCore.Mvc.Razor.Test.csproj
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Microsoft.AspNetCore.Mvc.Razor.Test.csproj
@@ -26,8 +26,4 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorPageTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorPageTest.cs
@@ -553,7 +553,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             await page.ExecuteAsync();
 
             // Assert
-            Assert.Equal(false, actual);
+            Assert.False(actual);
         }
 
         [Fact]
@@ -577,7 +577,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             await page.ExecuteAsync();
 
             // Assert
-            Assert.Equal(true, actual);
+            Assert.True(actual);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/TagHelpers/UrlResolutionTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/TagHelpers/UrlResolutionTagHelperTest.cs
@@ -300,7 +300,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.TagHelpers
             // Assert
             var attribute = Assert.Single(tagHelperOutput.Attributes);
             Assert.Equal("href", attribute.Name, StringComparer.Ordinal);
-            Assert.Equal(true, attribute.Value);
+            Assert.True(Assert.IsType<bool>(attribute.Value));
             Assert.Equal(HtmlAttributeValueStyle.DoubleQuotes, attribute.ValueStyle);
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/DefaultPageHandlerMethodSelectorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/DefaultPageHandlerMethodSelectorTest.cs
@@ -537,11 +537,11 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             Assert.Equal(message, ex.Message);
         }
 
-        public void Post()
+        protected void Post()
         {
         }
 
-        public void PostAsync()
+        protected void PostAsync()
         {
         }
     }

--- a/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Microsoft.AspNetCore.Mvc.RazorPages.Test.csproj
+++ b/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Microsoft.AspNetCore.Mvc.RazorPages.Test.csproj
@@ -18,8 +18,4 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/Microsoft.AspNetCore.Mvc.TagHelpers.Test.csproj
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/Microsoft.AspNetCore.Mvc.TagHelpers.Test.csproj
@@ -20,8 +20,4 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/TagHelperOutputExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/TagHelperOutputExtensionsTest.cs
@@ -962,7 +962,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             tagHelperOutput.MergeAttributes(tagBuilder);
 
             // Assert
-            Assert.Equal(tagHelperOutput.Attributes.Count, 2);
+            Assert.Equal(2, tagHelperOutput.Attributes.Count);
             var attribute = Assert.Single(tagHelperOutput.Attributes, attr => attr.Name.Equals("class"));
             Assert.Equal(expectedOutputAttribute.Value, attribute.Value);
             attribute = Assert.Single(tagHelperOutput.Attributes, attr => attr.Name.Equals("for"));

--- a/test/Microsoft.AspNetCore.Mvc.Test/Microsoft.AspNetCore.Mvc.Test.csproj
+++ b/test/Microsoft.AspNetCore.Mvc.Test/Microsoft.AspNetCore.Mvc.Test.csproj
@@ -16,8 +16,4 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
 </Project>

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test.csproj
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test.csproj
@@ -16,8 +16,4 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
 </Project>

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/RemoteAttributeTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/RemoteAttributeTest.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Mvc
 
             // Assert
             var keyValuePair = Assert.Single(attribute.RouteData);
-            Assert.Equal(keyValuePair.Key, "controller");
+            Assert.Equal("controller", keyValuePair.Key);
         }
 
         [Fact]
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Mvc
 
             // Assert
             var keyValuePair = Assert.Single(attribute.RouteData);
-            Assert.Equal(keyValuePair.Key, "action");
+            Assert.Equal("action", keyValuePair.Key);
             Assert.Null(attribute.RouteName);
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponents/DefaultViewComponentFactoryTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponents/DefaultViewComponentFactoryTest.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
             factory.ReleaseViewComponent(context, component);
 
             // Assert
-            Assert.Equal(true, component.Disposed);
+            Assert.True(component.Disposed);
         }
     }
 

--- a/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/DefaultContentNegotiatorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/DefaultContentNegotiatorTest.cs
@@ -376,7 +376,7 @@ namespace System.Net.Http.Formatting
         }
 
         [Theory]
-        [MemberData("MatchAcceptHeaderData")]
+        [MemberData(nameof(MatchAcceptHeaderData))]
         public void MatchAcceptHeader_ReturnsMatch(string[] acceptHeaders, string[] supportedMediaTypes, string expectedMediaType, double expectedQuality, int ranking)
         {
             // Arrange
@@ -409,7 +409,7 @@ namespace System.Net.Http.Formatting
         }
 
         [Theory]
-        [MemberData("MatchRequestMediaTypeData")]
+        [MemberData(nameof(MatchRequestMediaTypeData))]
         public void MatchRequestMediaType_ReturnsMatch(string requestMediaType, string[] supportedMediaTypes, string expectedMediaType)
         {
             // Arrange
@@ -443,7 +443,7 @@ namespace System.Net.Http.Formatting
         }
 
         [Theory]
-        [MemberData("ShouldMatchOnTypeData")]
+        [MemberData(nameof(ShouldMatchOnTypeData))]
         public void ShouldMatchOnType_ReturnsExpectedResult(bool excludeMatchOnType, string[] acceptHeaders, bool expectedResult)
         {
             // Arrange
@@ -459,7 +459,7 @@ namespace System.Net.Http.Formatting
         }
 
         [Theory]
-        [MemberData("MatchTypeData")]
+        [MemberData(nameof(MatchTypeData))]
         public void MatchType_ReturnsMatch(string[] supportedMediaTypes, string expectedMediaType)
         {
             // Arrange
@@ -482,7 +482,7 @@ namespace System.Net.Http.Formatting
         }
 
         [Theory]
-        [MemberData("SelectResponseMediaTypeData")]
+        [MemberData(nameof(SelectResponseMediaTypeData))]
         public void SelectResponseMediaTypeFormatter_SelectsMediaType(ICollection<MediaTypeFormatterMatch> matches, MediaTypeFormatterMatch expectedWinner)
         {
             // Arrange
@@ -496,7 +496,7 @@ namespace System.Net.Http.Formatting
         }
 
         [Theory]
-        [MemberData("SelectResponseCharacterEncodingData")]
+        [MemberData(nameof(SelectResponseCharacterEncodingData))]
         public void SelectResponseCharacterEncoding_SelectsEncoding(string[] acceptCharsetHeaders, string requestEncoding, string[] supportedEncodings, string expectedEncoding)
         {
             // Arrange
@@ -664,7 +664,7 @@ namespace System.Net.Http.Formatting
         }
 
         [Theory]
-        [MemberData("UpdateBestMatchData")]
+        [MemberData(nameof(UpdateBestMatchData))]
         public void UpdateBestMatch_SelectsCorrectly(MediaTypeFormatterMatch current, MediaTypeFormatterMatch replacement, bool currentWins)
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest.csproj
+++ b/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest.csproj
@@ -19,8 +19,4 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Part of https://github.com/aspnet/Coherence-Signed/issues/497

Upgrade to xunit 2.3 and vstest 15.3.
Also, fix all issues as identified by xunit.analyzers. Most commons errors:

 - Order of args passed to Assert.Equal was aackward
 - Assert.NotNull on value types (they can't be null)
 - Not using "nameof" for MemberData
 - Not using Assert.True/False on boolean values

FYI - there were some tests missing Theory/Fact attributes. I've re-added these attributes, but in one case the test fails.

`SimpleTypeModelBinderIntegrationTest.BindParameter_WithEmptyData_BindsMutableAndNullableObjects`