### PR TITLE
Corrected xml-comment for the User-property

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
@@ -221,7 +221,7 @@ namespace Microsoft.AspNetCore.Mvc
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="ClaimsPrincipal"/> for user associated with the executing action.
+        /// Gets the <see cref="ClaimsPrincipal"/> for user associated with the executing action.
         /// </summary>
         public ClaimsPrincipal User
         {


### PR DESCRIPTION
Removed comment about setting the User. `User` property only supports `get`.

- Removed "or sets" in the xml-comment.