### PR TITLE
Switch to using new Authorization PolicyEvaluator

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Authorization/AuthorizeFilter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Authorization/AuthorizeFilter.cs
@@ -9,6 +9,7 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Policy;
 using Microsoft.AspNetCore.Mvc.Core;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Internal;
@@ -106,6 +107,11 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
                 throw new ArgumentNullException(nameof(context));
             }
 
+            if (context.Result != null)
+            {
+                return;
+            }
+
             var effectivePolicy = Policy;
             if (effectivePolicy == null)
             {
@@ -125,26 +131,9 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
                 return;
             }
 
-            // Build a ClaimsPrincipal with the Policy's required authentication types
-            if (effectivePolicy.AuthenticationSchemes != null && effectivePolicy.AuthenticationSchemes.Count > 0)
-            {
-                ClaimsPrincipal newPrincipal = null;
-                for (var i = 0; i < effectivePolicy.AuthenticationSchemes.Count; i++)
-                {
-                    var scheme = effectivePolicy.AuthenticationSchemes[i];
-                    var result = await context.HttpContext.AuthenticateAsync(scheme);
-                    if (result.Succeeded)
-                    {
-                        newPrincipal = SecurityHelper.MergeUserPrincipal(newPrincipal, result.Principal);
-                    }
-                }
-                // If all schemes failed authentication, provide a default identity anyways
-                if (newPrincipal == null)
-                {
-                    newPrincipal = new ClaimsPrincipal(new ClaimsIdentity());
-                }
-                context.HttpContext.User = newPrincipal;
-            }
+            var policyEvaluator = context.HttpContext.RequestServices.GetRequiredService<IPolicyEvaluator>();
+
+            var authenticateResult = await policyEvaluator.AuthenticateAsync(effectivePolicy, context.HttpContext);
 
             // Allow Anonymous skips all authorization
             if (context.Filters.Any(item => item is IAllowAnonymousFilter))
@@ -152,13 +141,15 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
                 return;
             }
 
-            var httpContext = context.HttpContext;
-            var authService = httpContext.RequestServices.GetRequiredService<IAuthorizationService>();
+            var authorizeResult = await policyEvaluator.AuthorizeAsync(effectivePolicy, authenticateResult, context.HttpContext);
 
-            // Note: Default Anonymous User is new ClaimsPrincipal(new ClaimsIdentity())
-            if (!await authService.AuthorizeAsync(httpContext.User, context, effectivePolicy))
+            if (authorizeResult.Challenged)
             {
                 context.Result = new ChallengeResult(effectivePolicy.AuthenticationSchemes.ToArray());
+            }
+            else if (authorizeResult.Forbidden)
+            {
+                context.Result = new ForbidResult(effectivePolicy.AuthenticationSchemes.ToArray());
             }
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/DependencyInjection/MvcCoreMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/DependencyInjection/MvcCoreMvcCoreBuilderExtensions.cs
@@ -92,6 +92,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             services.AddAuthenticationCore();
             services.AddAuthorization();
+            services.AddAuthorizationPolicyEvaluator();
 
             services.TryAddEnumerable(
                 ServiceDescriptor.Transient<IApplicationModelProvider, AuthorizationApplicationModelProvider>());

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Authorization/AuthorizeFilterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Authorization/AuthorizeFilterTest.cs
@@ -128,7 +128,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
         }
 
         [Fact]
-        public async Task Invoke_EmptyClaimsShouldRejectAnonymousUser()
+        public async Task Invoke_EmptyClaimsShouldChallengeAnonymousUser()
         {
             // Arrange
             var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build());
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
             await authorizeFilter.OnAuthorizationAsync(authorizationContext);
 
             // Assert
-            Assert.NotNull(authorizationContext.Result);
+            Assert.IsType<ChallengeResult>(authorizationContext.Result);
         }
 
         [Fact]
@@ -215,7 +215,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
             await authorizeFilter.OnAuthorizationAsync(authorizationContext);
 
             // Assert
-            Assert.NotNull(authorizationContext.Result);
+            Assert.IsType<ForbidResult>(authorizationContext.Result);
         }
 
         [Fact]
@@ -233,7 +233,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
         }
 
         [Fact]
-        public async Task Invoke_RequireUnknownRoleShouldFail()
+        public async Task Invoke_RequireUnknownRoleShouldForbid()
         {
             // Arrange
             var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder().RequireRole("Wut").Build());
@@ -243,11 +243,11 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
             await authorizeFilter.OnAuthorizationAsync(authorizationContext);
 
             // Assert
-            Assert.NotNull(authorizationContext.Result);
+            Assert.IsType<ForbidResult>(authorizationContext.Result);
         }
 
         [Fact]
-        public async Task Invoke_RequireAdminRoleButFailPolicyShouldFail()
+        public async Task Invoke_RequireAdminRoleButFailPolicyShouldForbid()
         {
             // Arrange
             var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder()
@@ -260,11 +260,11 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
             await authorizeFilter.OnAuthorizationAsync(authorizationContext);
 
             // Assert
-            Assert.NotNull(authorizationContext.Result);
+            Assert.IsType<ForbidResult>(authorizationContext.Result);
         }
 
         [Fact]
-        public async Task Invoke_InvalidClaimShouldFail()
+        public async Task Invoke_InvalidClaimShouldForbid()
         {
             // Arrange
             var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder()
@@ -276,7 +276,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
             await authorizeFilter.OnAuthorizationAsync(authorizationContext);
 
             // Assert
-            Assert.NotNull(authorizationContext.Result);
+            Assert.IsType<ForbidResult>(authorizationContext.Result);
         }
 
         [Fact]
@@ -307,7 +307,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
         }
 
         [Fact]
-        public async Task Invoke_FailWhenLookingForClaimInOtherIdentity()
+        public async Task Invoke_ForbidWhenLookingForClaimInOtherIdentity()
         {
             // Arrange
             var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder()
@@ -319,7 +319,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
             await authorizeFilter.OnAuthorizationAsync(authorizationContext);
 
             // Assert
-            Assert.NotNull(authorizationContext.Result);
+            Assert.IsType<ForbidResult>(authorizationContext.Result);
         }
 
         [Fact]
@@ -336,7 +336,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
             await authorizeFilter.OnAuthorizationAsync(authorizationContext);
 
             // Assert
-            Assert.NotNull(authorizationContext.Result);
+            Assert.IsType<ForbidResult>(authorizationContext.Result);
         }
 
         [Fact]
@@ -352,7 +352,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
             await authorizeFilter.OnAuthorizationAsync(authorizationContext);
 
             // Assert
-            Assert.NotNull(authorizationContext.Result);
+            Assert.IsType<ForbidResult>(authorizationContext.Result);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Authorization/AuthorizeFilterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Authorization/AuthorizeFilterTest.cs
@@ -202,58 +202,10 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
         }
 
         [Fact]
-        public async Task Invoke_RequireAdminRoleShouldFailWithNoHandlers()
-        {
-            // Arrange
-            var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder().RequireRole("Administrator").Build());
-            var authorizationContext = GetAuthorizationContext(anonymous: false, registerServices: services =>
-            {
-                services.Remove(services.Where(sd => sd.ServiceType == typeof(IAuthorizationHandler)).Single());
-            });
-
-            // Act
-            await authorizeFilter.OnAuthorizationAsync(authorizationContext);
-
-            // Assert
-            Assert.IsType<ForbidResult>(authorizationContext.Result);
-        }
-
-        [Fact]
-        public async Task Invoke_RequireAdminAndUserRoleWithNoPolicyShouldSucceed()
-        {
-            // Arrange
-            var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder().RequireRole("Administrator").Build());
-            var authorizationContext = GetAuthorizationContext();
-
-            // Act
-            await authorizeFilter.OnAuthorizationAsync(authorizationContext);
-
-            // Assert
-            Assert.Null(authorizationContext.Result);
-        }
-
-        [Fact]
         public async Task Invoke_RequireUnknownRoleShouldForbid()
         {
             // Arrange
             var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder().RequireRole("Wut").Build());
-            var authorizationContext = GetAuthorizationContext();
-
-            // Act
-            await authorizeFilter.OnAuthorizationAsync(authorizationContext);
-
-            // Assert
-            Assert.IsType<ForbidResult>(authorizationContext.Result);
-        }
-
-        [Fact]
-        public async Task Invoke_RequireAdminRoleButFailPolicyShouldForbid()
-        {
-            // Arrange
-            var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder()
-                .RequireRole("Administrator")
-                .RequireClaim("Permission", "CanViewComment")
-                .Build());
             var authorizationContext = GetAuthorizationContext();
 
             // Act
@@ -269,82 +221,6 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
             // Arrange
             var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder()
                 .RequireClaim("Permission", "CanViewComment")
-                .Build());
-            var authorizationContext = GetAuthorizationContext();
-
-            // Act
-            await authorizeFilter.OnAuthorizationAsync(authorizationContext);
-
-            // Assert
-            Assert.IsType<ForbidResult>(authorizationContext.Result);
-        }
-
-        [Fact]
-        public async Task Invoke_FailedContextShouldNotCheckPermission()
-        {
-            // Arrange
-            var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder()
-                .RequireClaim("Permission", "CanViewComment")
-                .Build());
-
-
-            var actionContext = new ActionContext(
-                new Mock<HttpContext>().Object,
-                new RouteData(),
-                new ActionDescriptor());
-
-            var authorizationContext = new Filters.AuthorizationFilterContext(
-                actionContext,
-                Enumerable.Empty<IFilterMetadata>().ToList()
-            );
-
-            authorizationContext.Result = new UnauthorizedResult();
-
-            // Act
-            await authorizeFilter.OnAuthorizationAsync(authorizationContext);
-
-            // Assert that no exception was thrown (skips trying to resolve IPolicyEvaluator)
-        }
-
-        [Fact]
-        public async Task Invoke_ForbidWhenLookingForClaimInOtherIdentity()
-        {
-            // Arrange
-            var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder()
-                .RequireClaim("Permission", "CanViewComment")
-                .Build());
-            var authorizationContext = GetAuthorizationContext();
-
-            // Act
-            await authorizeFilter.OnAuthorizationAsync(authorizationContext);
-
-            // Assert
-            Assert.IsType<ForbidResult>(authorizationContext.Result);
-        }
-
-        [Fact]
-        public async Task Invoke_CanLookingForClaimsInMultipleIdentities()
-        {
-            // Arrange
-            var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder("Basic", "Bearer")
-                .RequireClaim("Permission", "CanViewComment")
-                .RequireClaim("Permission", "CupBearer")
-                .Build());
-            var authorizationContext = GetAuthorizationContext();
-
-            // Act
-            await authorizeFilter.OnAuthorizationAsync(authorizationContext);
-
-            // Assert
-            Assert.IsType<ForbidResult>(authorizationContext.Result);
-        }
-
-        [Fact]
-        public async Task Invoke_CanFilterToOnlyBearerScheme()
-        {
-            // Arrange
-            var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder("Bearer")
-                .RequireClaim("Permission", "CanViewPage")
                 .Build());
             var authorizationContext = GetAuthorizationContext();
 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Authorization/AuthorizeFilterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Authorization/AuthorizeFilterTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
         [Fact]
         public void InvalidUser()
         {
-            var authorizationContext = GetAuthorizationContext(services => services.AddAuthorization());
+            var authorizationContext = GetAuthorizationContext();
             Assert.True(authorizationContext.HttpContext.User.Identities.Any(i => i.IsAuthenticated));
         }
 
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
         {
             // Arrange
             var authorizeFilter = new AuthorizeFilter(new[] { new AuthorizeAttribute() });
-            var authorizationContext = GetAuthorizationContext(services => services.AddAuthorization());
+            var authorizationContext = GetAuthorizationContext();
             var expected = "An AuthorizationPolicy cannot be created without a valid instance of " +
                 "IAuthorizationPolicyProvider.";
 
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
         {
             // Arrange
             var authorizeFilter = new AuthorizeFilter(new[] { new AuthorizeAttribute() });
-            var authorizationContext = GetAuthorizationContext(services => services.AddAuthorization());
+            var authorizationContext = GetAuthorizationContext();
             var expected = "An AuthorizationPolicy cannot be created without a valid instance of " +
                 "IAuthorizationPolicyProvider.";
 
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
         {
             // Arrange
             var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder().RequireAssertion(_ => true).Build());
-            var authorizationContext = GetAuthorizationContext(services => services.AddAuthorization(), anonymous: true);
+            var authorizationContext = GetAuthorizationContext(anonymous: true);
             authorizationContext.HttpContext.User = new ClaimsPrincipal();
 
             // Act
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
             policyProvider.Setup(p => p.GetPolicyAsync(It.IsAny<string>())).ReturnsAsync(new AuthorizationPolicyBuilder().RequireAssertion(_ => true).Build())
                 .Callback(() => getPolicyCount++);
             var authorizeFilter = new AuthorizeFilter(policyProvider.Object, new AuthorizeAttribute[] { new AuthorizeAttribute("whatever") });
-            var authorizationContext = GetAuthorizationContext(services => services.AddAuthorization());
+            var authorizationContext = GetAuthorizationContext();
 
             // Act & Assert
             await authorizeFilter.OnAuthorizationAsync(authorizationContext);
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
         {
             // Arrange
             var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder().RequireAssertion(_ => true).Build());
-            var authorizationContext = GetAuthorizationContext(services => services.AddAuthorization(), anonymous: true);
+            var authorizationContext = GetAuthorizationContext(anonymous: true);
 
             // Act
             await authorizeFilter.OnAuthorizationAsync(authorizationContext);
@@ -118,7 +118,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
         {
             // Arrange
             var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder().RequireClaim("Permission", "CanViewPage").Build());
-            var authorizationContext = GetAuthorizationContext(services => services.AddAuthorization());
+            var authorizationContext = GetAuthorizationContext();
 
             // Act
             await authorizeFilter.OnAuthorizationAsync(authorizationContext);
@@ -132,9 +132,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
         {
             // Arrange
             var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build());
-            var authorizationContext = GetAuthorizationContext(services =>
-                services.AddAuthorization(),
-                anonymous: true);
+            var authorizationContext = GetAuthorizationContext(anonymous: true);
 
             // Act
             await authorizeFilter.OnAuthorizationAsync(authorizationContext);
@@ -148,8 +146,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
         {
             // Arrange
             var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build());
-            var authorizationContext = GetAuthorizationContext(services => services.AddAuthorization(),
-                anonymous: true);
+            var authorizationContext = GetAuthorizationContext(anonymous: true);
 
             authorizationContext.Filters.Add(new AllowAnonymousFilter());
 
@@ -165,7 +162,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
         {
             // Arrange
             var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build());
-            var authorizationContext = GetAuthorizationContext(services => services.AddAuthorization());
+            var authorizationContext = GetAuthorizationContext();
 
             // Act
             await authorizeFilter.OnAuthorizationAsync(authorizationContext);
@@ -181,7 +178,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
             var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder("Fails")
                 .RequireAuthenticatedUser()
                 .Build());
-            var authorizationContext = GetAuthorizationContext(services => services.AddAuthorization());
+            var authorizationContext = GetAuthorizationContext();
 
             // Act
             await authorizeFilter.OnAuthorizationAsync(authorizationContext);
@@ -195,7 +192,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
         {
             // Arrange
             var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder().RequireClaim("Permission", "CanViewComment", "CanViewPage").Build());
-            var authorizationContext = GetAuthorizationContext(services => services.AddAuthorization());
+            var authorizationContext = GetAuthorizationContext();
 
             // Act
             await authorizeFilter.OnAuthorizationAsync(authorizationContext);
@@ -209,11 +206,8 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
         {
             // Arrange
             var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder().RequireRole("Administrator").Build());
-            var authorizationContext = GetAuthorizationContext(services =>
+            var authorizationContext = GetAuthorizationContext(anonymous: false, registerServices: services =>
             {
-                services.AddOptions();
-                services.AddAuthorization();
-
                 services.Remove(services.Where(sd => sd.ServiceType == typeof(IAuthorizationHandler)).Single());
             });
 
@@ -229,7 +223,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
         {
             // Arrange
             var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder().RequireRole("Administrator").Build());
-            var authorizationContext = GetAuthorizationContext(services => services.AddAuthorization());
+            var authorizationContext = GetAuthorizationContext();
 
             // Act
             await authorizeFilter.OnAuthorizationAsync(authorizationContext);
@@ -243,7 +237,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
         {
             // Arrange
             var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder().RequireRole("Wut").Build());
-            var authorizationContext = GetAuthorizationContext(services => services.AddAuthorization());
+            var authorizationContext = GetAuthorizationContext();
 
             // Act
             await authorizeFilter.OnAuthorizationAsync(authorizationContext);
@@ -260,7 +254,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
                 .RequireRole("Administrator")
                 .RequireClaim("Permission", "CanViewComment")
                 .Build());
-            var authorizationContext = GetAuthorizationContext(services => services.AddAuthorization());
+            var authorizationContext = GetAuthorizationContext();
 
             // Act
             await authorizeFilter.OnAuthorizationAsync(authorizationContext);
@@ -276,7 +270,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
             var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder()
                 .RequireClaim("Permission", "CanViewComment")
                 .Build());
-            var authorizationContext = GetAuthorizationContext(services => services.AddAuthorization());
+            var authorizationContext = GetAuthorizationContext();
 
             // Act
             await authorizeFilter.OnAuthorizationAsync(authorizationContext);
@@ -289,29 +283,27 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
         public async Task Invoke_FailedContextShouldNotCheckPermission()
         {
             // Arrange
-            bool authorizationServiceIsCalled = false;
-            var authorizationService = new Mock<IAuthorizationService>();
-            authorizationService
-                .Setup(x => x.AuthorizeAsync(null, null, "CanViewComment"))
-                .Returns(() =>
-                {
-                    authorizationServiceIsCalled = true;
-                    return Task.FromResult(true);
-                });
-
             var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder()
                 .RequireClaim("Permission", "CanViewComment")
                 .Build());
-            var authorizationContext = GetAuthorizationContext(services =>
-                services.AddSingleton(authorizationService.Object));
+
+
+            var actionContext = new ActionContext(
+                new Mock<HttpContext>().Object,
+                new RouteData(),
+                new ActionDescriptor());
+
+            var authorizationContext = new Filters.AuthorizationFilterContext(
+                actionContext,
+                Enumerable.Empty<IFilterMetadata>().ToList()
+            );
 
             authorizationContext.Result = new UnauthorizedResult();
 
             // Act
             await authorizeFilter.OnAuthorizationAsync(authorizationContext);
 
-            // Assert
-            Assert.False(authorizationServiceIsCalled);
+            // Assert that no exception was thrown (skips trying to resolve IPolicyEvaluator)
         }
 
         [Fact]
@@ -321,7 +313,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
             var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder()
                 .RequireClaim("Permission", "CanViewComment")
                 .Build());
-            var authorizationContext = GetAuthorizationContext(services => services.AddAuthorization());
+            var authorizationContext = GetAuthorizationContext();
 
             // Act
             await authorizeFilter.OnAuthorizationAsync(authorizationContext);
@@ -338,7 +330,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
                 .RequireClaim("Permission", "CanViewComment")
                 .RequireClaim("Permission", "CupBearer")
                 .Build());
-            var authorizationContext = GetAuthorizationContext(services => services.AddAuthorization());
+            var authorizationContext = GetAuthorizationContext();
 
             // Act
             await authorizeFilter.OnAuthorizationAsync(authorizationContext);
@@ -354,7 +346,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
             var authorizeFilter = new AuthorizeFilter(new AuthorizationPolicyBuilder("Bearer")
                 .RequireClaim("Permission", "CanViewPage")
                 .Build());
-            var authorizationContext = GetAuthorizationContext(services => services.AddAuthorization());
+            var authorizationContext = GetAuthorizationContext();
 
             // Act
             await authorizeFilter.OnAuthorizationAsync(authorizationContext);
@@ -455,8 +447,8 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
         }
 
         private AuthorizationFilterContext GetAuthorizationContext(
-            Action<ServiceCollection> registerServices,
-            bool anonymous = false)
+            bool anonymous = false,
+            Action<IServiceCollection> registerServices = null)
         {
             var basicPrincipal = new ClaimsPrincipal(
                 new ClaimsIdentity(
@@ -482,12 +474,16 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
 
             // ServiceProvider
             var serviceCollection = new ServiceCollection();
+
             var auth = new Mock<IAuthenticationService>();
+
+            serviceCollection.AddOptions();
+            serviceCollection.AddLogging();
+            serviceCollection.AddSingleton(auth.Object);
+            serviceCollection.AddAuthorization();
+            serviceCollection.AddAuthorizationPolicyEvaluator();
             if (registerServices != null)
             {
-                serviceCollection.AddOptions();
-                serviceCollection.AddLogging();
-                serviceCollection.AddSingleton(auth.Object);
                 registerServices(serviceCollection);
             }
 
@@ -495,15 +491,15 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
 
             // HttpContext
             var httpContext = new Mock<HttpContext>();
+            auth.Setup(c => c.AuthenticateAsync(httpContext.Object, "Bearer")).ReturnsAsync(AuthenticateResult.Success(new AuthenticationTicket(bearerPrincipal, "Bearer")));
+            auth.Setup(c => c.AuthenticateAsync(httpContext.Object, "Basic")).ReturnsAsync(AuthenticateResult.Success(new AuthenticationTicket(basicPrincipal, "Basic")));
+            auth.Setup(c => c.AuthenticateAsync(httpContext.Object, "Fails")).ReturnsAsync(AuthenticateResult.Fail("Fails"));
             httpContext.SetupProperty(c => c.User);
             if (!anonymous)
             {
                 httpContext.Object.User = validUser;
             }
             httpContext.SetupGet(c => c.RequestServices).Returns(serviceProvider);
-            auth.Setup(c => c.AuthenticateAsync(httpContext.Object, "Bearer")).ReturnsAsync(AuthenticateResult.Success(new AuthenticationTicket(bearerPrincipal, "Bearer")));
-            auth.Setup(c => c.AuthenticateAsync(httpContext.Object, "Basic")).ReturnsAsync(AuthenticateResult.Success(new AuthenticationTicket(basicPrincipal, "Basic")));
-            auth.Setup(c => c.AuthenticateAsync(httpContext.Object, "Fails")).ReturnsAsync(AuthenticateResult.Fail("Fails"));
 
             // AuthorizationFilterContext
             var actionContext = new ActionContext(


### PR DESCRIPTION
Depends on: https://github.com/aspnet/Security/pull/1193

Also fixes a bug where AuthorizeFilter wasn't short circuiting if the result was set.

@rynowak @Tratcher 