### PR TITLE
Add back support for AddTagHelpersAsServices

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor/DependencyInjection/MvcRazorMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/DependencyInjection/MvcRazorMvcCoreBuilderExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.Mvc.Razor.Compilation;
 using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 using Microsoft.AspNetCore.Mvc.Razor.Internal;
+using Microsoft.AspNetCore.Mvc.Razor.TagHelpers;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.TagHelpers;
@@ -64,6 +65,11 @@ namespace Microsoft.Extensions.DependencyInjection
             if (!builder.PartManager.FeatureProviders.OfType<MetadataReferenceFeatureProvider>().Any())
             {
                 builder.PartManager.FeatureProviders.Add(new MetadataReferenceFeatureProvider());
+            }
+
+            if (!builder.PartManager.FeatureProviders.OfType<TagHelperFeatureProvider>().Any())
+            {
+                builder.PartManager.FeatureProviders.Add(new TagHelperFeatureProvider());
             }
 
             if (!builder.PartManager.FeatureProviders.OfType<ViewsFeatureProvider>().Any())

--- a/src/Microsoft.AspNetCore.Mvc.Razor/TagHelpers/TagHelperFeatureProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/TagHelpers/TagHelperFeatureProvider.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Microsoft.AspNetCore.Mvc.Razor.TagHelpers
+{
+    public class TagHelperFeatureProvider : IApplicationFeatureProvider<TagHelperFeature>
+    {
+        public void PopulateFeature(IEnumerable<ApplicationPart> parts, TagHelperFeature feature)
+        {
+            foreach (var part in parts)
+            {
+                if (IncludePart(part) && part is IApplicationPartTypeProvider typeProvider)
+                {
+                    foreach (var type in typeProvider.Types)
+                    {
+                        var typeInfo = type.GetTypeInfo();
+                        if (IncludeType(typeInfo) && !feature.TagHelpers.Contains(typeInfo))
+                        {
+                            feature.TagHelpers.Add(typeInfo);
+                        }
+                    }
+                }
+            }
+        }
+
+        protected virtual bool IncludePart(ApplicationPart part) => true;
+
+        protected virtual bool IncludeType(TypeInfo type)
+        {
+            // We don't need to check visibility here, that's handled by the type provider.
+            return
+                typeof(ITagHelper).GetTypeInfo().IsAssignableFrom(type) &&
+                !type.IsAbstract &&
+                !type.IsGenericType;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/TagHelpersFromServicesTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/TagHelpersFromServicesTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
         public HttpClient Client { get; }
 
-        [Fact(Skip = "Workaround for https://github.com/aspnet/Mvc/issues/5768.")]
+        [Fact]
         public async Task TagHelpersWithConstructorInjectionAreCreatedAndActivated()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/DependencyInjection/MvcRazorMvcBuilderExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/DependencyInjection/MvcRazorMvcBuilderExtensionsTest.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Test.DependencyInjection
                 typeof(TestTagHelperOne),
                 typeof(TestTagHelperTwo)));
 
-            manager.FeatureProviders.Add(new TestFeatureProvider());
+            manager.FeatureProviders.Add(new TagHelperFeatureProvider());
 
             var builder = new MvcBuilder(services, manager);
 
@@ -77,17 +77,6 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Test.DependencyInjection
 
         private class TestTagHelperTwo : TagHelper
         {
-        }
-
-        private class TestFeatureProvider : IApplicationFeatureProvider<TagHelperFeature>
-        {
-            public void PopulateFeature(IEnumerable<ApplicationPart> parts, TagHelperFeature feature)
-            {
-                foreach (var type in parts.OfType<IApplicationPartTypeProvider>().SelectMany(tp => tp.Types))
-                {
-                    feature.TagHelpers.Add(type);
-                }
-            }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/DependencyInjection/MvcRazorMvcCoreBuilderExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/DependencyInjection/MvcRazorMvcCoreBuilderExtensionsTest.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.Razor.Compilation;
 using Microsoft.AspNetCore.Mvc.Razor.Internal;
 using Microsoft.AspNetCore.Mvc.Razor.TagHelpers;
-using Microsoft.AspNetCore.Razor.Runtime.TagHelpers;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;

--- a/test/Microsoft.AspNetCore.Mvc.Test/MvcServiceCollectionExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Test/MvcServiceCollectionExtensionsTest.cs
@@ -214,6 +214,7 @@ namespace Microsoft.AspNetCore.Mvc
                 feature => Assert.IsType<ControllerFeatureProvider>(feature),
                 feature => Assert.IsType<ViewComponentFeatureProvider>(feature),
                 feature => Assert.IsType<MetadataReferenceFeatureProvider>(feature),
+                feature => Assert.IsType<TagHelperFeatureProvider>(feature),
                 feature => Assert.IsType<ViewsFeatureProvider>(feature),
                 feature => Assert.IsType<CompiledPageFeatureProvider>(feature));
         }


### PR DESCRIPTION
This doesn't go through the Razor tag helper discovery pipeline because
this can really only ever work for ITagHelper based taghelpers. So
there's really no point in reusing that logic, which would be hard
anyway.