### PR TITLE
Make RazorReferenceManage public

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor/Compilation/RazorReferenceManager.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Compilation/RazorReferenceManager.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
+{
+    /// <summary>
+    /// Manages compilation references for Razor compilation.
+    /// </summary>
+    public abstract class RazorReferenceManager
+    {
+        /// <summary>
+        /// Gets the set of compilation references to be used for Razor compilation.
+        /// </summary>
+        public abstract IReadOnlyList<MetadataReference> CompilationReferences { get; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Razor/DependencyInjection/MvcRazorMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/DependencyInjection/MvcRazorMvcCoreBuilderExtensions.cs
@@ -132,8 +132,7 @@ namespace Microsoft.Extensions.DependencyInjection
         internal static void AddRazorViewEngineServices(IServiceCollection services)
         {
             services.TryAddSingleton<CSharpCompiler>();
-            services.TryAddSingleton<RazorReferenceManager>();
-            // This caches compilation related details that are valid across the lifetime of the application.
+            services.TryAddSingleton<RazorReferenceManager, DefaultRazorReferenceManager>();
 
             services.TryAddEnumerable(
                 ServiceDescriptor.Transient<IConfigureOptions<MvcViewOptions>, MvcRazorMvcViewOptionsSetup>());

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/CSharpCompiler.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/CSharpCompiler.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.AspNetCore.Mvc.Razor.Compilation;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Emit;

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/DefaultRazorReferenceManager.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/DefaultRazorReferenceManager.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 {
-    public class RazorReferenceManager
+    public class DefaultRazorReferenceManager : RazorReferenceManager
     {
         private readonly ApplicationPartManager _partManager;
         private readonly IList<MetadataReference> _additionalMetadataReferences;
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
         private bool _compilationReferencesInitialized;
         private IReadOnlyList<MetadataReference> _compilationReferences;
 
-        public RazorReferenceManager(
+        public DefaultRazorReferenceManager(
             ApplicationPartManager partManager,
             IOptions<RazorViewEngineOptions> optionsAccessor)
         {
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             _additionalMetadataReferences = optionsAccessor.Value.AdditionalCompilationReferences;
         }
 
-        public IReadOnlyList<MetadataReference> CompilationReferences
+        public override IReadOnlyList<MetadataReference> CompilationReferences
         {
             get
             {

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/LazyMetadataReferenceFeature.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/LazyMetadataReferenceFeature.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Mvc.Razor.Compilation;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/CSharpCompilerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/CSharpCompilerTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var define = "MY_CUSTOM_DEFINE";
             var options = new TestOptionsManager<RazorViewEngineOptions>();
             options.Value.ParseOptions = options.Value.ParseOptions.WithPreprocessorSymbols(define);
-            var razorReferenceManager = new RazorReferenceManager(GetApplicationPartManager(), options);
+            var razorReferenceManager = new DefaultRazorReferenceManager(GetApplicationPartManager(), options);
             var compiler = new CSharpCompiler(razorReferenceManager, options);
 
             // Act

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/DefaultRazorReferenceManagerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/DefaultRazorReferenceManagerTest.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.Test.Internal
 {
-    public class ReferenceManagerTest
+    public class DefaultRazorReferenceManagerTest
     {
         [Fact]
         public void GetCompilationReferences_CombinesApplicationPartAndOptionMetadataReferences()
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Test.Internal
             var expectedReferenceDisplays = partReferences
                 .Concat(new[] { objectAssemblyMetadataReference })
                 .Select(r => r.Display);
-            var referenceManager = new RazorReferenceManager(
+            var referenceManager = new DefaultRazorReferenceManager(
                 applicationPartManager,
                 new TestOptionsManager<RazorViewEngineOptions>(options));
 
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Test.Internal
         private static ApplicationPartManager GetApplicationPartManager()
         {
             var applicationPartManager = new ApplicationPartManager();
-            var assembly = typeof(ReferenceManagerTest).GetTypeInfo().Assembly;
+            var assembly = typeof(DefaultRazorReferenceManagerTest).GetTypeInfo().Assembly;
             applicationPartManager.ApplicationParts.Add(new AssemblyPart(assembly));
             applicationPartManager.FeatureProviders.Add(new MetadataReferenceFeatureProvider());
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/RazorViewCompilerProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/RazorViewCompilerProviderTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var accessor = new Mock<IRazorViewEngineFileProviderAccessor>();
             var applicationManager = new ApplicationPartManager();
             var options = new TestOptionsManager<RazorViewEngineOptions>();
-            var referenceManager = new RazorReferenceManager(applicationManager, options);
+            var referenceManager = new DefaultRazorReferenceManager(applicationManager, options);
             accessor.Setup(a => a.FileProvider).Returns(fileProvider);
             var provider = new RazorViewCompilerProvider(
                 applicationManager,

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/RazorViewCompilerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/RazorViewCompilerTest.cs
@@ -440,7 +440,7 @@ this should fail";
             };
 
             var applicationPartManager = new ApplicationPartManager();
-            var referenceManager = new RazorReferenceManager(
+            var referenceManager = new DefaultRazorReferenceManager(
                 applicationPartManager,
                 new TestOptionsManager<RazorViewEngineOptions>());
             var compiler = GetViewCompiler(
@@ -472,7 +472,7 @@ this should fail";
                 applicationPartManager.ApplicationParts.Add(new AssemblyPart(assembly));
                 applicationPartManager.FeatureProviders.Add(new MetadataReferenceFeatureProvider());
 
-                referenceManager = new RazorReferenceManager(applicationPartManager, options);
+                referenceManager = new DefaultRazorReferenceManager(applicationPartManager, options);
             }
 
             precompiledViews = precompiledViews ?? Array.Empty<CompiledViewDescriptor>();


### PR DESCRIPTION
Fix for #4938. This change makes the reference manager public and
documented so that it can be replaced.