### PR TITLE
Use Strict SameSite mode for temp data cookies

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/CookieTempDataProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/CookieTempDataProvider.cs
@@ -65,6 +65,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             {
                 Domain = string.IsNullOrEmpty(_options.Domain) ? null : _options.Domain,
                 HttpOnly = true,
+                SameSite = SameSiteMode.Strict,
                 Secure = context.Request.IsHttps,
             };
             SetCookiePath(context, cookieOptions);


### PR DESCRIPTION
Reacting to https://github.com/aspnet/HttpAbstractions/pull/843 Last time @rynowak and I spoke about this and it seemed that a Strict SameSite attribute is appropriate since we expect the usage to be initiated with only same-site requests. Will there be any scenarios where we would want to send this cookie along during a cross-site request?