### PR TITLE
Remove unused dependency and update corefx version

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AspNetCoreVersion>2.0.0-*</AspNetCoreVersion>
     <BenchmarkDotNetVersion>0.10.3</BenchmarkDotNetVersion>
-    <CoreFxVersion>4.3.0</CoreFxVersion>
+    <CoreFxVersion>4.4.0-*</CoreFxVersion>
     <DependencyModelVersion>2.0.0-*</DependencyModelVersion>
     <FSharpCoreVersion>4.1.0</FSharpCoreVersion>
     <FSharpNetSdkVersion>1.0.*</FSharpNetSdkVersion>

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Compilation/CompiledViewManfiest.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Compilation/CompiledViewManfiest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Reflection;
-using System.Runtime.Loader;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.Compilation

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Microsoft.AspNetCore.Mvc.Razor.csproj
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Microsoft.AspNetCore.Mvc.Razor.csproj
@@ -24,6 +24,5 @@
     <PackageReference Include="Microsoft.Extensions.HashCodeCombiner.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.PropertyActivator.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.PropertyHelper.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
-    <PackageReference Include="System.Runtime.Loader" Version="$(CoreFxVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Use corefx 4.4.0-* and remove the unused System.Runtime.Loader package