### PR TITLE
Make SHA256 algorithm creation FIPS compliant.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/Cache/CacheTagKey.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/Cache/CacheTagKey.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Security.Cryptography;
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.TagHelpers.Internal;
@@ -152,7 +151,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers.Cache
             // The key is typically too long to be useful, so we use a cryptographic hash
             // as the actual key (better randomization and key distribution, so small vary
             // values will generate dramatically different keys).
-            using (var sha256 = SHA256.Create())
+            using (var sha256 = CryptographyAlgorithms.CreateSHA256())
             {
                 var contentBytes = Encoding.UTF8.GetBytes(key);
                 var hashedBytes = sha256.ComputeHash(contentBytes);

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/Internal/CryptographyAlgorithms.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/Internal/CryptographyAlgorithms.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Security.Cryptography;
+
+namespace Microsoft.AspNetCore.Mvc.TagHelpers.Internal
+{
+    public static class CryptographyAlgorithms
+    {
+        public static SHA256 CreateSHA256()
+        {
+            try
+            {
+                return SHA256.Create();
+            }
+            // SHA256.Create is documented to throw this exception on FIPS compliant machines.
+            // See: https://msdn.microsoft.com/en-us/library/z08hz7ad%28v=vs.110%29.aspx?f=255&MSPPError=-2147217396
+            catch (System.Reflection.TargetInvocationException)
+            {
+                // Fallback to a FIPS compliant SHA256 algorithm.
+                return new SHA256CryptoServiceProvider();
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/Internal/FileVersionProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/Internal/FileVersionProvider.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Security.Cryptography;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Caching.Memory;
@@ -111,7 +110,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers.Internal
 
         private static string GetHashForFile(IFileInfo fileInfo)
         {
-            using (var sha256 = SHA256.Create())
+            using (var sha256 = CryptographyAlgorithms.CreateSHA256())
             {
                 using (var readStream = fileInfo.CreateReadStream())
                 {


### PR DESCRIPTION
- Tested this on a Windows 8.1 FIPS compliant machine with a net461 targeted application with/without my fix.

#6354 
