### PR TITLE
Generate full pdbs for views on desktop and re-enable runtime error tests

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/CSharpCompiler.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/CSharpCompiler.cs
@@ -15,7 +15,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
         private readonly CSharpCompilationOptions _compilationOptions;
         private readonly CSharpParseOptions _parseOptions;
         private readonly RazorReferenceManager _referenceManager;
-        private readonly DebugInformationFormat _pdbFormat = DebugInformationFormat.PortablePdb;
+        private readonly DebugInformationFormat _pdbFormat = SymbolsUtility.SupportsFullPdbGeneration() ?
+            DebugInformationFormat.Pdb :
+            DebugInformationFormat.PortablePdb;
 
         public CSharpCompiler(RazorReferenceManager manager, IOptions<RazorViewEngineOptions> optionsAccessor)
         {

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/SymbolsUtility.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/SymbolsUtility.cs
@@ -1,0 +1,51 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.AspNetCore.Mvc.Razor.Internal
+{
+    /// <summary>
+    /// Utility type for determining if a platform supports full pdb file generation.
+    /// </summary>
+    public class SymbolsUtility
+    {
+        private const string SymWriterGuid = "0AE2DEB0-F901-478b-BB9F-881EE8066788";
+
+        /// <summary>
+        /// Determines if the current platform supports full pdb generation.
+        /// </summary>
+        /// <returns><c>true</c> if full pdb generation is supported; <c>false</c> otherwise.</returns>
+        public static bool SupportsFullPdbGeneration()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // Cross-plat always produce portable pdbs.
+                return false;
+            }
+
+            if (Type.GetType("Mono.Runtime") != null)
+            {
+                return false;
+            }
+
+            try
+            {
+                // Check for the pdb writer component that roslyn uses to generate pdbs
+                var type = Marshal.GetTypeFromCLSID(new Guid(SymWriterGuid));
+                if (type != null)
+                {
+                    // This line will throw if pdb generation is not supported.
+                    Activator.CreateInstance(type);
+                    return true;
+                }
+            }
+            catch
+            {
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/SymbolsUtility.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/SymbolsUtility.cs
@@ -9,8 +9,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
     /// <summary>
     /// Utility type for determining if a platform supports full pdb file generation.
     /// </summary>
-    public class SymbolsUtility
+    internal static class SymbolsUtility
     {
+        // Native pdb writer's CLSID
         private const string SymWriterGuid = "0AE2DEB0-F901-478b-BB9F-881EE8066788";
 
         /// <summary>

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ErrorPageTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ErrorPageTests.cs
@@ -7,7 +7,6 @@ using System.Net.Http.Headers;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Razor.Internal;
-using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests
@@ -92,12 +91,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Contains(expectedCompilationContent, content);
         }
 
-        [ConditionalFact]
-        // MVC Generates portable PDBs when compiling Razor views. NET461 does not understand portable PDBs
-        // so line and file information cannot be determined. This is blocked until one of these issues are fixed:
-        // https://github.com/aspnet/Common/issues/235
-        // https://github.com/aspnet/Mvc/issues/6356
-        [FrameworkSkipCondition(RuntimeFrameworks.CLR)]
+        [Fact]
         public async Task RuntimeErrorAreListedByErrorPageMiddleware()
         {
             // Arrange


### PR DESCRIPTION
StackTraceHelper \ PortablePdbReader used by Diagnostics is only useful for
reading portable pdbs on disk. However pdbs produced by views are entirely
in memory and therefore cannot be read. Consequently
we choose to generate full pdbs for views on Windows (when possible).