### PR TITLE
Making Pages Binding Consistent

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/BindingInfo.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/BindingInfo.cs
@@ -34,6 +34,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             BinderModelName = other.BinderModelName;
             BinderType = other.BinderType;
             PropertyFilterProvider = other.PropertyFilterProvider;
+            RequestPredicate = other.RequestPredicate;
         }
 
         /// <summary>
@@ -55,6 +56,12 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         /// Gets or sets the <see cref="ModelBinding.IPropertyFilterProvider"/>.
         /// </summary>
         public IPropertyFilterProvider PropertyFilterProvider { get; set; }
+
+        /// <summary>
+        /// Gets or sets a predicate which determines whether or not the model should be bound based on state
+        /// from the current request.
+        /// </summary>
+        public Func<ActionContext, bool> RequestPredicate { get; set; }
 
         /// <summary>
         /// Constructs a new instance of <see cref="BindingInfo"/> from the given <paramref name="attributes"/>.
@@ -111,6 +118,17 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             {
                 isBindingInfoPresent = true;
                 bindingInfo.PropertyFilterProvider = new CompositePropertyFilterProvider(propertyFilterProviders);
+            }
+
+            // RequestPredicate
+            foreach (var requestPredicateProvider in attributes.OfType<IRequestPredicateProvider>())
+            {
+                isBindingInfoPresent = true;
+                if (requestPredicateProvider.RequestPredicate != null)
+                {
+                    bindingInfo.RequestPredicate = requestPredicateProvider.RequestPredicate;
+                    break;
+                }
             }
 
             return isBindingInfoPresent ? bindingInfo : null;

--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/IRequestPredicateProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/IRequestPredicateProvider.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding
+{
+    /// <summary>
+    /// An interface that allows a top-level model to be bound or not bound based on state associated
+    /// with the current request.
+    /// </summary>
+    public interface IRequestPredicateProvider
+    {
+        /// <summary>
+        /// Gets a function which determines whether or not the model object should be bound based
+        /// on the current request.
+        /// </summary>
+        Func<ActionContext, bool> RequestPredicate { get; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/ParameterBinder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/ParameterBinder.cs
@@ -152,6 +152,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 throw new ArgumentNullException(nameof(metadata));
             }
 
+            if (parameter.BindingInfo?.RequestPredicate?.Invoke(actionContext) == false)
+            {
+                return ModelBindingResult.Failed();
+            }
+
             var modelBindingContext = DefaultModelBindingContext.CreateBindingContext(
                 actionContext,
                 valueProvider,

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Infrastructure/PageBoundPropertyDescriptor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Infrastructure/PageBoundPropertyDescriptor.cs
@@ -9,7 +9,5 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
     public class PageBoundPropertyDescriptor : ParameterDescriptor
     {
         public PropertyInfo Property { get; set; }
-
-        public bool SupportsGet { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/PagePropertyBinderFactory.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/PagePropertyBinderFactory.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure;
 
 namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 {
@@ -56,16 +55,9 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             IList<ParameterDescriptor> properties,
             IList<ModelMetadata> metadata)
         {
-            var isGet = string.Equals("GET", pageContext.HttpContext.Request.Method, StringComparison.OrdinalIgnoreCase);
-
             var valueProvider = await CompositeValueProvider.CreateAsync(pageContext, pageContext.ValueProviderFactories);
             for (var i = 0; i < properties.Count; i++)
             {
-                if (isGet && !((PageBoundPropertyDescriptor)properties[i]).SupportsGet)
-                {
-                    continue;
-                }
-
                 var result = await parameterBinder.BindModelAsync(pageContext, valueProvider, properties[i]);
                 if (result.IsModelSet)
                 {

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RazorPagesTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RazorPagesTest.cs
@@ -728,7 +728,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
         public async Task PagePropertiesAreNotBoundInGetRequests()
         {
             // Arrange
-            var expected = "Id = 11, Name = , Age =";
+            var expected = "Id = 11, Name = Test-Name, Age =";
             var validationError = "The Name field is required.";
             var request = new HttpRequestMessage(HttpMethod.Get, "Pages/PropertyBinding/PageWithPropertyAndArgumentBinding?id=11")
             {

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/BindPropertyIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/BindPropertyIntegrationTest.cs
@@ -1,0 +1,101 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.IntegrationTests
+{
+    // Integration tests for binding top level models with [BindProperty]
+    public class BindPropertyIntegrationTest
+    {
+        private class Person
+        {
+            public string Name { get; set; }
+        }
+
+        [Fact]
+        public async Task BindModelAsync_WithBindProperty_BindsModel_WhenRequestIsNotGet()
+        {
+            // Arrange
+            var parameterBinder = ModelBindingTestHelper.GetParameterBinder();
+            var parameter = new ParameterDescriptor()
+            {
+                Name = "parameter",
+                ParameterType = typeof(Person),
+                BindingInfo = BindingInfo.GetBindingInfo(new[] { new BindPropertyAttribute() }),
+            };
+
+            var testContext = ModelBindingTestHelper.GetTestContext(request =>
+            {
+                request.Method = "POST";
+                request.QueryString = new QueryString("?parameter.Name=Joey");
+            });
+
+            // Act
+            var result = await parameterBinder.BindModelAsync(parameter, testContext);
+
+            // Assert
+            Assert.True(result.IsModelSet);
+
+            Assert.Equal("Joey", Assert.IsType<Person>(result.Model).Name);
+        }
+
+        [Fact]
+        public async Task BindModelAsync_WithBindProperty_SupportsGet_BindsModel_WhenRequestIsGet()
+        {
+            // Arrange
+            var parameterBinder = ModelBindingTestHelper.GetParameterBinder();
+            var parameter = new ParameterDescriptor()
+            {
+                Name = "parameter",
+                ParameterType = typeof(Person),
+                BindingInfo = BindingInfo.GetBindingInfo(new[] { new BindPropertyAttribute() { SupportsGet = true } }),
+            };
+
+            var testContext = ModelBindingTestHelper.GetTestContext(request =>
+            {
+                request.Method = "GET";
+                request.QueryString = new QueryString("?parameter.Name=Joey");
+            });
+
+            // Act
+            var result = await parameterBinder.BindModelAsync(parameter, testContext);
+
+            // Assert
+            Assert.True(result.IsModelSet);
+
+            Assert.Equal("Joey", Assert.IsType<Person>(result.Model).Name);
+        }
+
+        [Fact]
+        public async Task BindModelAsync_WithBindProperty_DoesNotBindModel_WhenRequestIsGet()
+        {
+            // Arrange
+            var parameterBinder = ModelBindingTestHelper.GetParameterBinder();
+            var parameter = new ParameterDescriptor()
+            {
+                Name = "parameter",
+                ParameterType = typeof(Person),
+                BindingInfo = BindingInfo.GetBindingInfo(new[] { new BindPropertyAttribute() }),
+            };
+
+            var testContext = ModelBindingTestHelper.GetTestContext(request =>
+            {
+                request.Method = "GET";
+                request.QueryString = new QueryString("?parameter.Name=Joey");
+            });
+
+            // Act
+            var result = await parameterBinder.BindModelAsync(parameter, testContext);
+
+            // Assert
+            Assert.False(result.IsModelSet);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/DefaultPageLoaderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/DefaultPageLoaderTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ActionConstraints;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure;
@@ -576,7 +577,17 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                 p =>
                 {
                     Assert.Equal("Property", p.Property.Name);
-                    Assert.True(p.SupportsGet);
+                    Assert.NotNull(p.BindingInfo.RequestPredicate);
+                    Assert.True(p.BindingInfo.RequestPredicate(new ActionContext()
+                    {
+                        HttpContext = new DefaultHttpContext()
+                        {
+                            Request =
+                            {
+                                Method ="GET",
+                            }
+                        }
+                    }));
                 });
         }
 
@@ -603,7 +614,17 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                 p =>
                 {
                     Assert.Equal("Property", p.Property.Name);
-                    Assert.True(p.SupportsGet);
+                    Assert.NotNull(p.BindingInfo.RequestPredicate);
+                    Assert.True(p.BindingInfo.RequestPredicate(new ActionContext()
+                    {
+                        HttpContext = new DefaultHttpContext()
+                        {
+                            Request =
+                            {
+                                Method ="GET",
+                            }
+                        }
+                    }));
                 });
         }
 
@@ -628,7 +649,17 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                 p =>
                 {
                     Assert.Equal("Property", p.Property.Name);
-                    Assert.False(p.SupportsGet);
+                    Assert.NotNull(p.BindingInfo.RequestPredicate);
+                    Assert.False(p.BindingInfo.RequestPredicate(new ActionContext()
+                    {
+                        HttpContext = new DefaultHttpContext()
+                        {
+                            Request =
+                            {
+                                Method ="GET",
+                            }
+                        }
+                    }));
                 });
         }
 


### PR DESCRIPTION
This changeset reckonciles the binding work we did for pages with
controllers.

A quick summary:
- Moves [BindProperty] to the MVC namespace (#6401)
- Makes [FromRoute] and friends behave consistently (#6402)
- Makes [BindProperty] work with controllers (untracked)