### PR TITLE
Remove [BindProperty] on class

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/BindPropertyAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/BindPropertyAttribute.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Microsoft.AspNetCore.Mvc
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public class BindPropertyAttribute : Attribute, IModelNameProvider, IBinderTypeProviderMetadata, IRequestPredicateProvider
     {
         private static readonly Func<ActionContext, bool> _supportsAllRequests = (c) => true;

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/DefaultPageLoader.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/DefaultPageLoader.cs
@@ -239,9 +239,6 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
         {
             var properties = PropertyHelper.GetVisibleProperties(type.AsType());
 
-            // If the type has a [BindPropertyAttribute] then we'll consider any and all public properties bindable.
-            var bindPropertyOnType = type.GetCustomAttribute<BindPropertyAttribute>();
-
             var results = new List<PageBoundPropertyDescriptor>();
             for (var i = 0; i < properties.Length; i++)
             {
@@ -249,23 +246,11 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                 var bindingInfo = BindingInfo.GetBindingInfo(property.Property.GetCustomAttributes());
 
                 // If there's no binding info then that means there are no model binding attributes on the
-                // property. So we won't bind this property unless there's a [BindProperty] on the type.
-                if (bindingInfo == null && bindPropertyOnType == null)
+                // property. So we won't bind this property.
+                if (bindingInfo == null)
                 {
                     continue;
                 }
-
-                // If this property is declared as part of a pages base class, then it's likely infrastructure,
-                // so skip it.
-                if (property.Property.DeclaringType.GetTypeInfo().IsDefined(typeof(PagesBaseClassAttribute)))
-                {
-                    continue;
-                }
-
-                bindingInfo = bindingInfo ?? new BindingInfo();
-
-                // Allow a predicate on the class to cascade if it wasn't set on the property.
-                bindingInfo.RequestPredicate = bindingInfo.RequestPredicate ?? ((IRequestPredicateProvider)bindPropertyOnType)?.RequestPredicate;
 
                 var descriptor = new PageBoundPropertyDescriptor()
                 {

--- a/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/DefaultPageLoaderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/DefaultPageLoaderTest.cs
@@ -537,31 +537,6 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             public int IgnoreMe { get; set; }
         }
 
-        // Additionally [BindProperty] on a property can opt-in a property
-        [Fact]
-        public void CreateBoundProperties_BindPropertyAttributeOnModel_OptsInAllProperties()
-        {
-            // Arrange
-            var type = typeof(ModelWithBindPropertyOnClass).GetTypeInfo();
-
-            // Act
-            var results = DefaultPageLoader.CreateBoundProperties(type);
-
-            // Assert
-            Assert.Collection(
-                results.OrderBy(p => p.Property.Name),
-                p =>
-                {
-                    Assert.Equal("Property", p.Property.Name);
-                });
-        }
-
-        [BindProperty]
-        private class ModelWithBindPropertyOnClass : EmptyPageModel
-        {
-            public int Property { get; set; }
-        }
-
         [Fact]
         public void CreateBoundProperties_SupportsGet_OnProperty()
         {
@@ -597,77 +572,6 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             public int Property { get; set; }
 
             public int IgnoreMe { get; set; }
-        }
-
-        [Fact]
-        public void CreateBoundProperties_SupportsGet_OnClass()
-        {
-            // Arrange
-            var type = typeof(ModelSupportsGetOnClass).GetTypeInfo();
-
-            // Act
-            var results = DefaultPageLoader.CreateBoundProperties(type);
-
-            // Assert
-            Assert.Collection(
-                results.OrderBy(p => p.Property.Name),
-                p =>
-                {
-                    Assert.Equal("Property", p.Property.Name);
-                    Assert.NotNull(p.BindingInfo.RequestPredicate);
-                    Assert.True(p.BindingInfo.RequestPredicate(new ActionContext()
-                    {
-                        HttpContext = new DefaultHttpContext()
-                        {
-                            Request =
-                            {
-                                Method ="GET",
-                            }
-                        }
-                    }));
-                });
-        }
-
-        [BindProperty(SupportsGet = true)]
-        private class ModelSupportsGetOnClass : EmptyPageModel
-        {
-            public int Property { get; set; }
-        }
-
-        [Fact]
-        public void CreateBoundProperties_SupportsGet_Override()
-        {
-            // Arrange
-            var type = typeof(ModelSupportsGetOverride).GetTypeInfo();
-
-            // Act
-            var results = DefaultPageLoader.CreateBoundProperties(type);
-
-            // Assert
-            Assert.Collection(
-                results.OrderBy(p => p.Property.Name),
-                p =>
-                {
-                    Assert.Equal("Property", p.Property.Name);
-                    Assert.NotNull(p.BindingInfo.RequestPredicate);
-                    Assert.False(p.BindingInfo.RequestPredicate(new ActionContext()
-                    {
-                        HttpContext = new DefaultHttpContext()
-                        {
-                            Request =
-                            {
-                                Method ="GET",
-                            }
-                        }
-                    }));
-                });
-        }
-
-        [BindProperty(SupportsGet = true)]
-        private class ModelSupportsGetOverride : EmptyPageModel
-        {
-            [BindProperty(SupportsGet = false)]
-            public int Property { get; set; }
         }
 
         [Theory]


### PR DESCRIPTION
This isn't a good fit with consistency with controllers. Discussed with
@DamianEdwards and we agreed to remove this for now and bring it back in
the future if there's a real need for it.