### PR TITLE
Fix #6210 - define semantics for pagemodels

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Infrastructure/PageModelAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Infrastructure/PageModelAttribute.cs
@@ -6,11 +6,11 @@ using System;
 namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
 {
     /// <summary>
-    /// An attribute for base classes for Pages and PageModels. Applying this attribute to a type
-    /// suppresses discovery of handler methods for that type.
+    /// An attribute for base classes for page models. Applying this attribute to a type
+    /// marks all subclasses of that type as page model types.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
-    public class PagesBaseClassAttribute : Attribute
+    public class PageModelAttribute : Attribute
     {
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Page.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Page.cs
@@ -1,14 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure;
-
 namespace Microsoft.AspNetCore.Mvc.RazorPages
 {
     /// <summary>
     /// A base class for a Razor page.
     /// </summary>
-    [PagesBaseClass]
     public abstract class Page : PageBase
     {
     }

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/PageBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/PageBase.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using Microsoft.AspNetCore.Mvc.Razor;
-using Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,7 +23,6 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages
     /// <summary>
     /// A base class for a Razor page.
     /// </summary>
-    [PagesBaseClass]
     public abstract class PageBase : RazorPageBase
     {
         private IObjectModelValidator _objectValidator;

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/PageModel.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/PageModel.cs
@@ -21,7 +21,7 @@ using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Mvc.RazorPages
 {
-    [PagesBaseClass]
+    [PageModelAttribute]
     public abstract class PageModel
     {
         private IModelMetadataProvider _metadataProvider;

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Properties/Resources.Designer.cs
@@ -136,6 +136,34 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages
         internal static string FormatAsyncPageFilter_InvalidShortCircuit(object p0, object p1, object p2, object p3)
             => string.Format(CultureInfo.CurrentCulture, GetString("AsyncPageFilter_InvalidShortCircuit"), p0, p1, p2, p3);
 
+        /// <summary>
+        /// The type '{0}' is not a valid page. A page must inherit from '{1}'.
+        /// </summary>
+        internal static string InvalidPageType_WrongBase
+        {
+            get => GetString("InvalidPageType_WrongBase");
+        }
+
+        /// <summary>
+        /// The type '{0}' is not a valid page. A page must inherit from '{1}'.
+        /// </summary>
+        internal static string FormatInvalidPageType_WrongBase(object p0, object p1)
+            => string.Format(CultureInfo.CurrentCulture, GetString("InvalidPageType_WrongBase"), p0, p1);
+
+        /// <summary>
+        /// The type '{0}' is not a valid page. A page must define a public, non-static '{1}' property.
+        /// </summary>
+        internal static string InvalidPageType_NoModelProperty
+        {
+            get => GetString("InvalidPageType_NoModelProperty");
+        }
+
+        /// <summary>
+        /// The type '{0}' is not a valid page. A page must define a public, non-static '{1}' property.
+        /// </summary>
+        internal static string FormatInvalidPageType_NoModelProperty(object p0, object p1)
+            => string.Format(CultureInfo.CurrentCulture, GetString("InvalidPageType_NoModelProperty"), p0, p1);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Resources.resx
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Resources.resx
@@ -144,4 +144,10 @@
   <data name="AsyncPageFilter_InvalidShortCircuit" xml:space="preserve">
     <value>If an {0} provides a result value by setting the {1} property of {2} to a non-null value, then it cannot call the next filter by invoking {3}.</value>
   </data>
+  <data name="InvalidPageType_WrongBase" xml:space="preserve">
+    <value>The type '{0}' is not a valid page. A page must inherit from '{1}'.</value>
+  </data>
+  <data name="InvalidPageType_NoModelProperty" xml:space="preserve">
+    <value>The type '{0}' is not a valid page. A page must define a public, non-static '{1}' property.</value>
+  </data>
 </root>


### PR DESCRIPTION
Now a pagemodel requires a [PageModel] somewhere in it's hierarchy. We
don't do a guess at whether or not your model class is a PageModel.