### PR TITLE
Create custom collections for several MVC types

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/Formatters/FormatterCollection.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/Formatters/FormatterCollection.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
@@ -35,10 +36,19 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         /// <typeparam name="T">The type to remove.</typeparam>
         public void RemoveType<T>() where T : TFormatter
         {
+            RemoveType(typeof(T));
+        }
+
+        /// <summary>
+        /// Removes all formatters of the specified type.
+        /// </summary>
+        /// <param name="modelBinderType">The type to remove.</param>
+        public void RemoveType(Type modelBinderType)
+        {
             for (var i = Count - 1; i >= 0; i--)
             {
-                var formatter = this[i];
-                if (formatter is T)
+                var modelBinder = this[i];
+                if (modelBinder.GetType() == modelBinderType)
                 {
                     RemoveAt(i);
                 }

--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/Formatters/FormatterCollection.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/Formatters/FormatterCollection.cs
@@ -42,13 +42,13 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         /// <summary>
         /// Removes all formatters of the specified type.
         /// </summary>
-        /// <param name="modelBinderType">The type to remove.</param>
-        public void RemoveType(Type modelBinderType)
+        /// <param name="formatterType">The type to remove.</param>
+        public void RemoveType(Type formatterType)
         {
             for (var i = Count - 1; i >= 0; i--)
             {
-                var modelBinder = this[i];
-                if (modelBinder.GetType() == modelBinderType)
+                var formatter = this[i];
+                if (formatter.GetType() == formatterType)
                 {
                     RemoveAt(i);
                 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ApplicationModels/ApplicationModelConventionCollection.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ApplicationModels/ApplicationModelConventionCollection.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Microsoft.AspNetCore.Mvc.ApplicationModels
+{
+    /// <summary>
+    /// Represents a collection of model binder providers.
+    /// </summary>
+    public class ApplicationModelConventionCollection : Collection<IApplicationModelConvention>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApplicationModelConventionCollection"/> class that is empty.
+        /// </summary>
+        public ApplicationModelConventionCollection()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApplicationModelConventionCollection"/> class
+        /// as a wrapper for the specified list.
+        /// </summary>
+        /// <param name="applicationModelConventions">The list that is wrapped by the new collection.</param>
+        public ApplicationModelConventionCollection(IList<IApplicationModelConvention> applicationModelConventions)
+            : base(applicationModelConventions)
+        {
+        }
+
+        /// <summary>
+        /// Removes all application model conventions of the specified type.
+        /// </summary>
+        /// <typeparam name="TApplicationModelConvention">The type to remove.</typeparam>
+        public void RemoveType<TApplicationModelConvention>() where TApplicationModelConvention : IApplicationModelConvention
+        {
+            RemoveType(typeof(TApplicationModelConvention));
+        }
+
+        /// <summary>
+        /// Removes all application model conventions of the specified type.
+        /// </summary>
+        /// <param name="valueProviderFactoryType">The type to remove.</param>
+        public void RemoveType(Type valueProviderFactoryType)
+        {
+            for (var i = Count - 1; i >= 0; i--)
+            {
+                var valueProviderFactory = this[i];
+                if (valueProviderFactory.GetType() == valueProviderFactoryType)
+                {
+                    RemoveAt(i);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/ApplicationModels/ApplicationModelConventionCollection.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ApplicationModels/ApplicationModelConventionCollection.cs
@@ -8,7 +8,7 @@ using System.Collections.ObjectModel;
 namespace Microsoft.AspNetCore.Mvc.ApplicationModels
 {
     /// <summary>
-    /// Represents a collection of model binder providers.
+    /// Represents a collection of application model conventions.
     /// </summary>
     public class ApplicationModelConventionCollection : Collection<IApplicationModelConvention>
     {
@@ -41,13 +41,13 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
         /// <summary>
         /// Removes all application model conventions of the specified type.
         /// </summary>
-        /// <param name="valueProviderFactoryType">The type to remove.</param>
-        public void RemoveType(Type valueProviderFactoryType)
+        /// <param name="applicationModelConventionType">The type to remove.</param>
+        public void RemoveType(Type applicationModelConventionType)
         {
             for (var i = Count - 1; i >= 0; i--)
             {
-                var valueProviderFactory = this[i];
-                if (valueProviderFactory.GetType() == valueProviderFactoryType)
+                var applicationModelConvention = this[i];
+                if (applicationModelConvention.GetType() == applicationModelConventionType)
                 {
                     RemoveAt(i);
                 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Metadata/MetadataDetailsProviderCollection.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Metadata/MetadataDetailsProviderCollection.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
+{
+    /// <summary>
+    /// Represents a collection of metadata details providers.
+    /// </summary>
+    public class MetadataDetailsProviderCollection : Collection<IMetadataDetailsProvider>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MetadataDetailsProviderCollection"/> class that is empty.
+        /// </summary>
+        public MetadataDetailsProviderCollection()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MetadataDetailsProviderCollection"/> class
+        /// as a wrapper for the specified list.
+        /// </summary>
+        /// <param name="metadataDetailsProviders">The list that is wrapped by the new collection.</param>
+        public MetadataDetailsProviderCollection(IList<IMetadataDetailsProvider> metadataDetailsProviders)
+            : base(metadataDetailsProviders)
+        {
+        }
+
+        /// <summary>
+        /// Removes all metadata details providers of the specified type.
+        /// </summary>
+        /// <typeparam name="TMetadataDetailsProvider">The type to remove.</typeparam>
+        public void RemoveType<TMetadataDetailsProvider>() where TMetadataDetailsProvider : IMetadataDetailsProvider
+        {
+            RemoveType(typeof(TMetadataDetailsProvider));
+        }
+
+        /// <summary>
+        /// Removes all metadata details providers of the specified type.
+        /// </summary>
+        /// <param name="metadataDetailsProviderType">The type to remove.</param>
+        public void RemoveType(Type metadataDetailsProviderType)
+        {
+            for (var i = Count - 1; i >= 0; i--)
+            {
+                var metadataDetailsProvider = this[i];
+                if (metadataDetailsProvider.GetType() == metadataDetailsProviderType)
+                {
+                    RemoveAt(i);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/ModelBinderProviderCollection.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/ModelBinderProviderCollection.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding
+{
+    /// <summary>
+    /// Represents a collection of model binder providers.
+    /// </summary>
+    public class ModelBinderProviderCollection : Collection<IModelBinderProvider>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModelBinderProviderCollection"/> class that is empty.
+        /// </summary>
+        public ModelBinderProviderCollection()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModelBinderProviderCollection"/> class
+        /// as a wrapper for the specified list.
+        /// </summary>
+        /// <param name="modelBinderProviders">The list that is wrapped by the new collection.</param>
+        public ModelBinderProviderCollection(IList<IModelBinderProvider> modelBinderProviders)
+            : base(modelBinderProviders)
+        {
+        }
+
+        /// <summary>
+        /// Removes all model binder providers of the specified type.
+        /// </summary>
+        /// <typeparam name="TModelBinderProvider">The type to remove.</typeparam>
+        public void RemoveType<TModelBinderProvider>() where TModelBinderProvider : IModelBinderProvider
+        {
+            RemoveType(typeof(TModelBinderProvider));
+        }
+
+        /// <summary>
+        /// Removes all model binder providers of the specified type.
+        /// </summary>
+        /// <param name="modelBinderType">The type to remove.</param>
+        public void RemoveType(Type modelBinderType)
+        {
+            for (var i = Count - 1; i >= 0; i--)
+            {
+                var modelBinder = this[i];
+                if (modelBinder.GetType() == modelBinderType)
+                {
+                    RemoveAt(i);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/ModelBinderProviderCollection.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/ModelBinderProviderCollection.cs
@@ -41,13 +41,13 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         /// <summary>
         /// Removes all model binder providers of the specified type.
         /// </summary>
-        /// <param name="modelBinderType">The type to remove.</param>
-        public void RemoveType(Type modelBinderType)
+        /// <param name="modelBinderProviderType">The type to remove.</param>
+        public void RemoveType(Type modelBinderProviderType)
         {
             for (var i = Count - 1; i >= 0; i--)
             {
-                var modelBinder = this[i];
-                if (modelBinder.GetType() == modelBinderType)
+                var modelBinderProvider = this[i];
+                if (modelBinderProvider.GetType() == modelBinderProviderType)
                 {
                     RemoveAt(i);
                 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Validation/ModelValidatorProviderCollection.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Validation/ModelValidatorProviderCollection.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
+{
+    /// <summary>
+    /// Represents a collection of model validator providers.
+    /// </summary>
+    public class ModelValidatorProviderCollection : Collection<IModelValidatorProvider>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModelValidatorProviderCollection"/> class that is empty.
+        /// </summary>
+        public ModelValidatorProviderCollection()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModelValidatorProviderCollection"/> class
+        /// as a wrapper for the specified list.
+        /// </summary>
+        /// <param name="modelValidatorProviders">The list that is wrapped by the new collection.</param>
+        public ModelValidatorProviderCollection(IList<IModelValidatorProvider> modelValidatorProviders)
+            : base(modelValidatorProviders)
+        {
+        }
+
+        /// <summary>
+        /// Removes all model validator providers of the specified type.
+        /// </summary>
+        /// <typeparam name="TModelValidatorProvider">The type to remove.</typeparam>
+        public void RemoveType<TModelValidatorProvider>() where TModelValidatorProvider : IModelValidatorProvider
+        {
+            RemoveType(typeof(TModelValidatorProvider));
+        }
+
+        /// <summary>
+        /// Removes all model validator providers of the specified type.
+        /// </summary>
+        /// <param name="modelValidatorProviderType">The type to remove.</param>
+        public void RemoveType(Type modelValidatorProviderType)
+        {
+            for (var i = Count - 1; i >= 0; i--)
+            {
+                var modelValidatorProvider = this[i];
+                if (modelValidatorProvider.GetType() == modelValidatorProviderType)
+                {
+                    RemoveAt(i);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/ValueProviderFactoryCollection.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/ValueProviderFactoryCollection.cs
@@ -8,7 +8,7 @@ using System.Collections.ObjectModel;
 namespace Microsoft.AspNetCore.Mvc.ModelBinding
 {
     /// <summary>
-    /// Represents a collection of model binder providers.
+    /// Represents a collection of value provider factories.
     /// </summary>
     public class ValueProviderFactoryCollection : Collection<IValueProviderFactory>
     {

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/ValueProviderFactoryCollection.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/ValueProviderFactoryCollection.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding
+{
+    /// <summary>
+    /// Represents a collection of model binder providers.
+    /// </summary>
+    public class ValueProviderFactoryCollection : Collection<IValueProviderFactory>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueProviderFactoryCollection"/> class that is empty.
+        /// </summary>
+        public ValueProviderFactoryCollection()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueProviderFactoryCollection"/> class
+        /// as a wrapper for the specified list.
+        /// </summary>
+        /// <param name="valueProviderFactories">The list that is wrapped by the new collection.</param>
+        public ValueProviderFactoryCollection(IList<IValueProviderFactory> valueProviderFactories)
+            : base(valueProviderFactories)
+        {
+        }
+
+        /// <summary>
+        /// Removes all value provider factories of the specified type.
+        /// </summary>
+        /// <typeparam name="TValueProviderFactory">The type to remove.</typeparam>
+        public void RemoveType<TValueProviderFactory>() where TValueProviderFactory : IValueProviderFactory
+        {
+            RemoveType(typeof(TValueProviderFactory));
+        }
+
+        /// <summary>
+        /// Removes all value provider factories of the specified type.
+        /// </summary>
+        /// <param name="valueProviderFactoryType">The type to remove.</param>
+        public void RemoveType(Type valueProviderFactoryType)
+        {
+            for (var i = Count - 1; i >= 0; i--)
+            {
+                var valueProviderFactory = this[i];
+                if (valueProviderFactory.GetType() == valueProviderFactoryType)
+                {
+                    RemoveAt(i);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Mvc
             ModelBinderProviders = new ModelBinderProviderCollection();
             ModelBindingMessageProvider = new DefaultModelBindingMessageProvider();
             ModelMetadataDetailsProviders = new MetadataDetailsProviderCollection();
-            ModelValidatorProviders = new List<IModelValidatorProvider>();
+            ModelValidatorProviders = new ModelValidatorProviderCollection();
             ValueProviderFactories = new List<IValueProviderFactory>();
         }
 
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.Mvc
         /// <summary>
         /// Gets a list of <see cref="IModelValidatorProvider"/>s used by this application.
         /// </summary>
-        public IList<IModelValidatorProvider> ModelValidatorProviders { get; }
+        public ModelValidatorProviderCollection ModelValidatorProviders { get; }
 
         /// <summary>
         /// Gets a list of <see cref="IOutputFormatter"/>s that are used by this application.

--- a/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Mvc
             FormatterMappings = new FormatterMappings();
             InputFormatters = new FormatterCollection<IInputFormatter>();
             OutputFormatters = new FormatterCollection<IOutputFormatter>();
-            ModelBinderProviders = new List<IModelBinderProvider>();
+            ModelBinderProviders = new ModelBinderProviderCollection();
             ModelBindingMessageProvider = new DefaultModelBindingMessageProvider();
             ModelMetadataDetailsProviders = new List<IMetadataDetailsProvider>();
             ModelValidatorProviders = new List<IModelValidatorProvider>();
@@ -100,7 +100,7 @@ namespace Microsoft.AspNetCore.Mvc
         /// <summary>
         /// Gets a list of <see cref="IModelBinderProvider"/>s used by this application.
         /// </summary>
-        public IList<IModelBinderProvider> ModelBinderProviders { get; }
+        public ModelBinderProviderCollection ModelBinderProviders { get; }
 
         /// <summary>
         /// Gets the default <see cref="ModelBinding.Metadata.ModelBindingMessageProvider"/>. Changes here are copied to the

--- a/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Mvc
         public MvcOptions()
         {
             CacheProfiles = new Dictionary<string, CacheProfile>(StringComparer.OrdinalIgnoreCase);
-            Conventions = new List<IApplicationModelConvention>();
+            Conventions = new ApplicationModelConventionCollection();
             Filters = new FilterCollection();
             FormatterMappings = new FormatterMappings();
             InputFormatters = new FormatterCollection<IInputFormatter>();
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Mvc
         /// Gets a list of <see cref="IApplicationModelConvention"/> instances that will be applied to
         /// the <see cref="ApplicationModel"/> when discovering actions.
         /// </summary>
-        public IList<IApplicationModelConvention> Conventions { get; }
+        public ApplicationModelConventionCollection Conventions { get; }
 
         /// <summary>
         /// Gets a collection of <see cref="IFilterMetadata"/> which are used to construct filters that

--- a/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Mvc
             ModelBindingMessageProvider = new DefaultModelBindingMessageProvider();
             ModelMetadataDetailsProviders = new MetadataDetailsProviderCollection();
             ModelValidatorProviders = new ModelValidatorProviderCollection();
-            ValueProviderFactories = new List<IValueProviderFactory>();
+            ValueProviderFactories = new ValueProviderFactoryCollection();
         }
 
         /// <summary>
@@ -150,7 +150,7 @@ namespace Microsoft.AspNetCore.Mvc
         /// <summary>
         /// Gets a list of <see cref="IValueProviderFactory"/> used by this application.
         /// </summary>
-        public IList<IValueProviderFactory> ValueProviderFactories { get; }
+        public ValueProviderFactoryCollection ValueProviderFactories { get; }
 
         /// <summary>
         /// Gets or sets the SSL port that is used by this application when <see cref="RequireHttpsAttribute"/>

--- a/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Mvc
             OutputFormatters = new FormatterCollection<IOutputFormatter>();
             ModelBinderProviders = new ModelBinderProviderCollection();
             ModelBindingMessageProvider = new DefaultModelBindingMessageProvider();
-            ModelMetadataDetailsProviders = new List<IMetadataDetailsProvider>();
+            ModelMetadataDetailsProviders = new MetadataDetailsProviderCollection();
             ModelValidatorProviders = new List<IModelValidatorProvider>();
             ValueProviderFactories = new List<IValueProviderFactory>();
         }
@@ -122,7 +122,7 @@ namespace Microsoft.AspNetCore.Mvc
         /// <li><see cref="IValidationMetadataProvider"/></li>
         /// </ul>
         /// </remarks>
-        public IList<IMetadataDetailsProvider> ModelMetadataDetailsProviders { get; }
+        public MetadataDetailsProviderCollection ModelMetadataDetailsProviders { get; }
 
         /// <summary>
         /// Gets a list of <see cref="IModelValidatorProvider"/>s used by this application.

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ApplicationModel/ApplicationModelConventionCollectionTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ApplicationModel/ApplicationModelConventionCollectionTests.cs
@@ -24,8 +24,8 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
             collection.RemoveType(typeof(FooApplicationModelConvention));
 
             // Assert
-            var formatter = Assert.Single(collection);
-            Assert.IsType<BarApplicationModelConvention>(formatter);
+            var convention = Assert.Single(collection);
+            Assert.IsType<BarApplicationModelConvention>(convention);
         }
 
         [Fact]
@@ -43,8 +43,8 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
             collection.RemoveType<FooApplicationModelConvention>();
 
             // Assert
-            var formatter = Assert.Single(collection);
-            Assert.IsType<BarApplicationModelConvention>(formatter);
+            var convention = Assert.Single(collection);
+            Assert.IsType<BarApplicationModelConvention>(convention);
         }
 
         private class FooApplicationModelConvention : IApplicationModelConvention

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ApplicationModel/ApplicationModelConventionCollectionTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ApplicationModel/ApplicationModelConventionCollectionTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.ApplicationModels
+{
+    public class ApplicationModelConventionCollectionTests
+    {
+        [Fact]
+        public void RemoveType_RemovesAllOfType()
+        {
+            // Arrange
+            var collection = new ApplicationModelConventionCollection
+            {
+                new FooApplicationModelConvention(),
+                new BarApplicationModelConvention(),
+                new FooApplicationModelConvention()
+            };
+
+            // Act
+            collection.RemoveType(typeof(FooApplicationModelConvention));
+
+            // Assert
+            var formatter = Assert.Single(collection);
+            Assert.IsType<BarApplicationModelConvention>(formatter);
+        }
+
+        [Fact]
+        public void GenericRemoveType_RemovesAllOfType()
+        {
+            // Arrange
+            var collection = new ApplicationModelConventionCollection
+            {
+                new FooApplicationModelConvention(),
+                new BarApplicationModelConvention(),
+                new FooApplicationModelConvention()
+            };
+
+            // Act
+            collection.RemoveType<FooApplicationModelConvention>();
+
+            // Assert
+            var formatter = Assert.Single(collection);
+            Assert.IsType<BarApplicationModelConvention>(formatter);
+        }
+
+        private class FooApplicationModelConvention : IApplicationModelConvention
+        {
+            public void Apply(ApplicationModel application)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class BarApplicationModelConvention : IApplicationModelConvention
+        {
+            public void Apply(ApplicationModel application)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/FormatterCollectionTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/FormatterCollectionTest.cs
@@ -11,6 +11,25 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
     public class FormatterCollectionTest
     {
         [Fact]
+        public void NonGenericRemoveType_RemovesAllOfType()
+        {
+            // Arrange
+            var collection = new FormatterCollection<IOutputFormatter>
+            {
+                new TestOutputFormatter(),
+                new AnotherTestOutputFormatter(),
+                new TestOutputFormatter()
+            };
+
+            // Act
+            collection.RemoveType(typeof(TestOutputFormatter));
+
+            // Assert
+            var formatter = Assert.Single(collection);
+            Assert.IsType(typeof(AnotherTestOutputFormatter), formatter);
+        }
+
+        [Fact]
         public void RemoveType_RemovesAllOfType()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Metadata/MetadataDetailsProviderCollectionTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Metadata/MetadataDetailsProviderCollectionTests.cs
@@ -23,8 +23,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
             collection.RemoveType(typeof(FooMetadataDetailsProvider));
 
             // Assert
-            var formatter = Assert.Single(collection);
-            Assert.IsType<BarMetadataDetailsProvider>(formatter);
+            var provider = Assert.Single(collection);
+            Assert.IsType<BarMetadataDetailsProvider>(provider);
         }
 
         [Fact]
@@ -42,8 +42,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
             collection.RemoveType<FooMetadataDetailsProvider>();
 
             // Assert
-            var formatter = Assert.Single(collection);
-            Assert.IsType<BarMetadataDetailsProvider>(formatter);
+            var provider = Assert.Single(collection);
+            Assert.IsType<BarMetadataDetailsProvider>(provider);
         }
 
         private class FooMetadataDetailsProvider : IMetadataDetailsProvider

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Metadata/MetadataDetailsProviderCollectionTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Metadata/MetadataDetailsProviderCollectionTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
+{
+    public class MetadataDetailsProviderCollectionTests
+    {
+        [Fact]
+        public void RemoveType_RemovesAllOfType()
+        {
+            // Arrange
+            var collection = new MetadataDetailsProviderCollection
+            {
+                new FooMetadataDetailsProvider(),
+                new BarMetadataDetailsProvider(),
+                new FooMetadataDetailsProvider()
+            };
+
+            // Act
+            collection.RemoveType(typeof(FooMetadataDetailsProvider));
+
+            // Assert
+            var formatter = Assert.Single(collection);
+            Assert.IsType<BarMetadataDetailsProvider>(formatter);
+        }
+
+        [Fact]
+        public void GenericRemoveType_RemovesAllOfType()
+        {
+            // Arrange
+            var collection = new MetadataDetailsProviderCollection
+            {
+                new FooMetadataDetailsProvider(),
+                new BarMetadataDetailsProvider(),
+                new FooMetadataDetailsProvider()
+            };
+
+            // Act
+            collection.RemoveType<FooMetadataDetailsProvider>();
+
+            // Assert
+            var formatter = Assert.Single(collection);
+            Assert.IsType<BarMetadataDetailsProvider>(formatter);
+        }
+
+        private class FooMetadataDetailsProvider : IMetadataDetailsProvider
+        {
+        }
+
+        private class BarMetadataDetailsProvider : IMetadataDetailsProvider
+        {
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ModelBinderProviderCollectionTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ModelBinderProviderCollectionTests.cs
@@ -23,8 +23,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             collection.RemoveType(typeof(FooModelBinderProvider));
 
             // Assert
-            var formatter = Assert.Single(collection);
-            Assert.IsType<BarModelBinderProvider>(formatter);
+            var provider = Assert.Single(collection);
+            Assert.IsType<BarModelBinderProvider>(provider);
         }
 
         [Fact]
@@ -42,8 +42,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             collection.RemoveType<FooModelBinderProvider>();
 
             // Assert
-            var formatter = Assert.Single(collection);
-            Assert.IsType<BarModelBinderProvider>(formatter);
+            var provider = Assert.Single(collection);
+            Assert.IsType<BarModelBinderProvider>(provider);
         }
 
         private class FooModelBinderProvider : IModelBinderProvider

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ModelBinderProviderCollectionTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ModelBinderProviderCollectionTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding
+{
+    public class ModelBinderProviderCollectionTests
+    {
+        [Fact]
+        public void RemoveType_RemovesAllOfType()
+        {
+            // Arrange
+            var collection = new ModelBinderProviderCollection
+            {
+                new FooModelBinderProvider(),
+                new BarModelBinderProvider(),
+                new FooModelBinderProvider()
+            };
+
+            // Act
+            collection.RemoveType(typeof(FooModelBinderProvider));
+
+            // Assert
+            var formatter = Assert.Single(collection);
+            Assert.IsType<BarModelBinderProvider>(formatter);
+        }
+
+        [Fact]
+        public void GenericRemoveType_RemovesAllOfType()
+        {
+            // Arrange
+            var collection = new ModelBinderProviderCollection
+            {
+                new FooModelBinderProvider(),
+                new BarModelBinderProvider(),
+                new FooModelBinderProvider()
+            };
+
+            // Act
+            collection.RemoveType<FooModelBinderProvider>();
+
+            // Assert
+            var formatter = Assert.Single(collection);
+            Assert.IsType<BarModelBinderProvider>(formatter);
+        }
+
+        private class FooModelBinderProvider : IModelBinderProvider
+        {
+            public IModelBinder GetBinder(ModelBinderProviderContext context)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class BarModelBinderProvider : IModelBinderProvider
+        {
+            public IModelBinder GetBinder(ModelBinderProviderContext context)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Validation/ModelValidatorProviderCollectionTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Validation/ModelValidatorProviderCollectionTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
+{
+    public class ModelValidatorProviderCollectionTests
+    {
+        [Fact]
+        public void RemoveType_RemovesAllOfType()
+        {
+            // Arrange
+            var collection = new ModelValidatorProviderCollection
+            {
+                new FooModelValidatorProvider(),
+                new BarModelValidatorProvider(),
+                new FooModelValidatorProvider()
+            };
+
+            // Act
+            collection.RemoveType(typeof(FooModelValidatorProvider));
+
+            // Assert
+            var formatter = Assert.Single(collection);
+            Assert.IsType<BarModelValidatorProvider>(formatter);
+        }
+
+        [Fact]
+        public void GenericRemoveType_RemovesAllOfType()
+        {
+            // Arrange
+            var collection = new ModelValidatorProviderCollection
+            {
+                new FooModelValidatorProvider(),
+                new BarModelValidatorProvider(),
+                new FooModelValidatorProvider()
+            };
+
+            // Act
+            collection.RemoveType<FooModelValidatorProvider>();
+
+            // Assert
+            var formatter = Assert.Single(collection);
+            Assert.IsType<BarModelValidatorProvider>(formatter);
+        }
+
+        private class FooModelValidatorProvider : IModelValidatorProvider
+        {
+            public void CreateValidators(ModelValidatorProviderContext context)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class BarModelValidatorProvider : IModelValidatorProvider
+        {
+            public void CreateValidators(ModelValidatorProviderContext context)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Validation/ModelValidatorProviderCollectionTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Validation/ModelValidatorProviderCollectionTests.cs
@@ -23,8 +23,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
             collection.RemoveType(typeof(FooModelValidatorProvider));
 
             // Assert
-            var formatter = Assert.Single(collection);
-            Assert.IsType<BarModelValidatorProvider>(formatter);
+            var provider = Assert.Single(collection);
+            Assert.IsType<BarModelValidatorProvider>(provider);
         }
 
         [Fact]
@@ -42,8 +42,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
             collection.RemoveType<FooModelValidatorProvider>();
 
             // Assert
-            var formatter = Assert.Single(collection);
-            Assert.IsType<BarModelValidatorProvider>(formatter);
+            var provider = Assert.Single(collection);
+            Assert.IsType<BarModelValidatorProvider>(provider);
         }
 
         private class FooModelValidatorProvider : IModelValidatorProvider

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ValueProviderFactoryCollectionTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ValueProviderFactoryCollectionTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding
+{
+    public class ValueProviderFactoryCollectionTests
+    {
+        [Fact]
+        public void RemoveType_RemovesAllOfType()
+        {
+            // Arrange
+            var collection = new ValueProviderFactoryCollection
+            {
+                new FooValueProviderFactory(),
+                new BarValueProviderFactory(),
+                new FooValueProviderFactory()
+            };
+
+            // Act
+            collection.RemoveType(typeof(FooValueProviderFactory));
+
+            // Assert
+            var formatter = Assert.Single(collection);
+            Assert.IsType<BarValueProviderFactory>(formatter);
+        }
+
+        [Fact]
+        public void GenericRemoveType_RemovesAllOfType()
+        {
+            // Arrange
+            var collection = new ValueProviderFactoryCollection
+            {
+                new FooValueProviderFactory(),
+                new BarValueProviderFactory(),
+                new FooValueProviderFactory()
+            };
+
+            // Act
+            collection.RemoveType<FooValueProviderFactory>();
+
+            // Assert
+            var formatter = Assert.Single(collection);
+            Assert.IsType<BarValueProviderFactory>(formatter);
+        }
+
+        private class FooValueProviderFactory : IValueProviderFactory
+        {
+            public Task CreateValueProviderAsync(ValueProviderFactoryContext context)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class BarValueProviderFactory : IValueProviderFactory
+        {
+            public Task CreateValueProviderAsync(ValueProviderFactoryContext context)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ValueProviderFactoryCollectionTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ValueProviderFactoryCollectionTests.cs
@@ -24,8 +24,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             collection.RemoveType(typeof(FooValueProviderFactory));
 
             // Assert
-            var formatter = Assert.Single(collection);
-            Assert.IsType<BarValueProviderFactory>(formatter);
+            var factory = Assert.Single(collection);
+            Assert.IsType<BarValueProviderFactory>(factory);
         }
 
         [Fact]
@@ -43,8 +43,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             collection.RemoveType<FooValueProviderFactory>();
 
             // Assert
-            var formatter = Assert.Single(collection);
-            Assert.IsType<BarValueProviderFactory>(formatter);
+            var factory = Assert.Single(collection);
+            Assert.IsType<BarValueProviderFactory>(factory);
         }
 
         private class FooValueProviderFactory : IValueProviderFactory


### PR DESCRIPTION
Resolves #6161.

- [X] Conventions
- [X] ModelBinderProviders
- [X] ModelMetadataDetailsProviders
- [X] ModelValidatorProviders
- [X] ValueProviderFactories
- [X] Update `FormatterCollection` to include a non-generic `RemoveType(Type)` overload.
- [ ] Review duplicate code
- [ ] Review breaking changes (and update JSON file?)