### PR TITLE
[WIP] Add a default sliding expiration of 30 seconds on Memory and Distributed Cache Tag Helpers.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/CacheTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/CacheTagHelper.cs
@@ -153,25 +153,34 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         // Internal for unit testing
         internal MemoryCacheEntryOptions GetMemoryCacheEntryOptions()
         {
+            var hasEvictionCriteria = false;
             var options = new MemoryCacheEntryOptions();
             if (ExpiresOn != null)
             {
+                hasEvictionCriteria = true;
                 options.SetAbsoluteExpiration(ExpiresOn.Value);
             }
 
             if (ExpiresAfter != null)
             {
+                hasEvictionCriteria = true;
                 options.SetAbsoluteExpiration(ExpiresAfter.Value);
             }
 
             if (ExpiresSliding != null)
             {
+                hasEvictionCriteria = true;
                 options.SetSlidingExpiration(ExpiresSliding.Value);
             }
 
             if (Priority != null)
             {
                 options.SetPriority(Priority.Value);
+            }
+
+            if (!hasEvictionCriteria)
+            {
+                options.SetSlidingExpiration(DefaultExpiration);
             }
 
             return options;

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/CacheTagHelperBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/CacheTagHelperBase.cs
@@ -26,6 +26,13 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         private const string EnabledAttributeName = "enabled";
 
         /// <summary>
+        /// The default duration, from the time the cache entry was added, when it should be evicted.
+        /// This default duration will only be used if no other expiration criteria is specified.
+        /// The default expiration time is a sliding expiration of 30 seconds.
+        /// </summary>
+        public static readonly TimeSpan DefaultExpiration = TimeSpan.FromSeconds(30);
+
+        /// <summary>
         /// Creates a new <see cref="CacheTagHelperBase"/>.
         /// </summary>
         /// <param name="htmlEncoder">The <see cref="HtmlEncoder"/> to use.</param>
@@ -109,6 +116,5 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         /// </summary>
         [HtmlAttributeName(EnabledAttributeName)]
         public bool Enabled { get; set; } = true;
-
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/DistributedCacheTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/DistributedCacheTagHelper.cs
@@ -85,24 +85,32 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         // Internal for unit testing
         internal DistributedCacheEntryOptions GetDistributedCacheEntryOptions()
         {
+            var hasEvictionCriteria = false;
             var options = new DistributedCacheEntryOptions();
             if (ExpiresOn != null)
             {
+                hasEvictionCriteria = true;
                 options.SetAbsoluteExpiration(ExpiresOn.Value);
             }
 
             if (ExpiresAfter != null)
             {
+                hasEvictionCriteria = true;
                 options.SetAbsoluteExpiration(ExpiresAfter.Value);
             }
 
             if (ExpiresSliding != null)
             {
+                hasEvictionCriteria = true;
                 options.SetSlidingExpiration(ExpiresSliding.Value);
+            }
+
+            if (!hasEvictionCriteria)
+            {
+                options.SetSlidingExpiration(DefaultExpiration);
             }
 
             return options;
         }
-
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/CacheTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/CacheTagHelperTest.cs
@@ -211,6 +211,21 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         }
 
         [Fact]
+        public void UpdateCacheEntryOptions_DefaultsTo30SecondsSliding_IfNoEvictionCriteriaIsProvided()
+        {
+            // Arrange
+            var slidingExpiresIn = TimeSpan.FromSeconds(30);
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var cacheTagHelper = new CacheTagHelper(cache, new HtmlTestEncoder());
+
+            // Act
+            var cacheEntryOptions = cacheTagHelper.GetMemoryCacheEntryOptions();
+
+            // Assert
+            Assert.Equal(slidingExpiresIn, cacheEntryOptions.SlidingExpiration);
+        }
+
+        [Fact]
         public void UpdateCacheEntryOptions_SetsAbsoluteExpiration_IfExpiresAfterIsSet()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/DistributedCacheTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/DistributedCacheTagHelperTest.cs
@@ -272,6 +272,29 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         }
 
         [Fact]
+        public void UpdateCacheEntryOptions_DefaultsTo30SecondsSliding_IfNoEvictionCriteriaIsProvided()
+        {
+            // Arrange
+            var slidingExpiresIn = TimeSpan.FromSeconds(30);
+            var storage = GetStorage();
+            var service = new DistributedCacheTagHelperService(
+                storage,
+                Mock.Of<IDistributedCacheTagHelperFormatter>(),
+                new HtmlTestEncoder(),
+                NullLoggerFactory.Instance
+                );
+            var cacheTagHelper = new DistributedCacheTagHelper(
+                service,
+                new HtmlTestEncoder());
+
+            // Act
+            var cacheEntryOptions = cacheTagHelper.GetDistributedCacheEntryOptions();
+
+            // Assert
+            Assert.Equal(slidingExpiresIn, cacheEntryOptions.SlidingExpiration);
+        }
+
+        [Fact]
         public void UpdateCacheEntryOptions_SetsAbsoluteExpiration_IfExpiresAfterIsSet()
         {
             // Arrange


### PR DESCRIPTION
Adds a default sliding expiration for the cache tag helpers and creates a private memorycache instance to use with CacheTagHelper