### PR TITLE
[Fixes #6274] Fix and re-enable skipped test

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/SimpleTypeModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/SimpleTypeModelBinderIntegrationTest.cs
@@ -396,13 +396,11 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.Null(error.Exception);
         }
 
-        [Theory(Skip = "This test fails")]
+        [Theory]
         [InlineData(typeof(int?))]
         [InlineData(typeof(bool?))]
         [InlineData(typeof(string))]
-        [InlineData(typeof(object))]
-        [InlineData(typeof(IEnumerable))]
-        public async Task BindParameter_WithEmptyData_BindsMutableAndNullableObjects(Type parameterType)
+        public async Task BindParameter_WithEmptyData_BindsReferenceAndNullableObjects(Type parameterType)
         {
             // Arrange
             var parameterBinder = ModelBindingTestHelper.GetParameterBinder();
@@ -435,7 +433,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             var key = Assert.Single(modelState.Keys);
             Assert.Equal("Parameter1", key);
             Assert.Equal(string.Empty, modelState[key].AttemptedValue);
-            Assert.Equal(new string[] { string.Empty }, modelState[key].RawValue);
+            Assert.Equal(string.Empty, modelState[key].RawValue);
             Assert.Empty(modelState[key].Errors);
         }
 


### PR DESCRIPTION
The current version of the original code impacted by this test is the following:

https://github.com/aspnet/Mvc/blob/dev/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Binders/SimpleTypeModelBinder.cs#L78

The two test data instances removed don't make sense (you can't bind object nor IEnumerable)

The old version from the original PR is here
https://github.com/aspnet/Mvc/blob/fc2019c973e84c8b7faa99793cba56412e032c70/src/Microsoft.AspNet.Mvc.Core/ModelBinding/TypeConverterModelBinder.cs#L44

The remaining tests still maintaing the coverage as they are for a nullable value type and for a reference type.