### PR TITLE
Fix #6480

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/MvcViewFeaturesLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/MvcViewFeaturesLoggerExtensions.cs
@@ -30,6 +30,10 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
         private static readonly Action<ILogger, string, Exception> _viewFound;
         private static readonly Action<ILogger, string, IEnumerable<string>, Exception> _viewNotFound;
 
+        private static readonly Action<ILogger, string, Exception> _tempDataCookieNotFound;
+        private static readonly Action<ILogger, string, Exception> _tempDataCookieLoadSuccess;
+        private static readonly Action<ILogger, string, Exception> _tempDataCookieLoadFailure;
+
         static MvcViewFeaturesLoggerExtensions()
         {
             _viewComponentExecuting = LoggerMessage.Define<string, string[]>(
@@ -82,6 +86,21 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
                 LogLevel.Error,
                 3,
                 "The view '{ViewName}' was not found. Searched locations: {SearchedViewLocations}");
+
+            _tempDataCookieNotFound = LoggerMessage.Define<string>(
+                LogLevel.Debug,
+                1,
+                "The temp data cookie {CookieName} was not found.");
+
+            _tempDataCookieLoadSuccess = LoggerMessage.Define<string>(
+                LogLevel.Debug,
+                2,
+                "The temp data cookie {CookieName} was used to successfully load temp data.");
+
+            _tempDataCookieLoadFailure = LoggerMessage.Define<string>(
+                LogLevel.Warning,
+                3,
+                "The temp data cookie {CookieName} could not be loaded.");
         }
 
         public static IDisposable ViewComponentScope(this ILogger logger, ViewComponentContext context)
@@ -190,6 +209,21 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             IEnumerable<string> searchedLocations)
         {
             _viewNotFound(logger, viewName, searchedLocations, null);
+        }
+
+        public static void TempDataCookieNotFound(this ILogger logger, string cookieName)
+        {
+            _tempDataCookieNotFound(logger, cookieName, null);
+        }
+
+        public static void TempDataCookieLoadSuccess(this ILogger logger, string cookieName)
+        {
+            _tempDataCookieLoadSuccess(logger, cookieName, null);
+        }
+
+        public static void TempDataCookieLoadFailure(this ILogger logger, string cookieName, Exception exception)
+        {
+            _tempDataCookieLoadFailure(logger, cookieName, exception);
         }
 
         private class ViewComponentLogScope : IReadOnlyList<KeyValuePair<string, object>>

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/CookieTempDataProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/CookieTempDataProviderTest.cs
@@ -9,7 +9,9 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Mvc.ViewFeatures.Internal;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
 using Moq;
 using Xunit;
 
@@ -64,6 +66,41 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             // Assert
             Assert.NotNull(tempDataDictionary);
             Assert.Empty(tempDataDictionary);
+        }
+
+        [Fact]
+        public void LoadTempData_ReturnsEmptyDictionary_AndClearsCookie_WhenDataIsInvalid()
+        {
+            // Arrange
+            var dataProtector = new Mock<IDataProtector>(MockBehavior.Strict);
+            dataProtector
+                .Setup(d => d.Unprotect(It.IsAny<byte[]>()))
+                .Throws(new Exception());
+
+            var tempDataProvider = GetProvider(dataProtector.Object);
+
+            var inputData = new Dictionary<string, object>();
+            inputData.Add("int", 10);
+            var tempDataProviderSerializer = new TempDataSerializer();
+            var expectedDataToUnprotect = tempDataProviderSerializer.Serialize(inputData);
+            var base64AndUrlEncodedDataInCookie = Base64UrlTextEncoder.Encode(expectedDataToUnprotect);
+
+            var context = new DefaultHttpContext();
+            context.Request.Cookies = new RequestCookieCollection(new Dictionary<string, string>()
+            {
+                { CookieTempDataProvider.CookieName, base64AndUrlEncodedDataInCookie }
+            });
+
+            // Act
+            var tempDataDictionary = tempDataProvider.LoadTempData(context);
+
+            // Assert
+            Assert.Empty(tempDataDictionary);
+
+            var setCookieHeader = SetCookieHeaderValue.Parse(context.Response.Headers["Set-Cookie"].ToString());
+            Assert.Equal(CookieTempDataProvider.CookieName, setCookieHeader.Name.ToString());
+            Assert.Equal(string.Empty, setCookieHeader.Value.ToString());
+
         }
 
         [Fact]
@@ -219,7 +256,11 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         [InlineData("/", "/vdir1", ".abc.com", "/vdir1", ".abc.com")]
         [InlineData("/vdir1", "/", ".abc.com", "/", ".abc.com")]
         public void SaveTempData_CustomProviderOptions_SetsCookie_WithAppropriateCookieOptions(
-            string requestPathBase, string optionsPath, string optionsDomain, string expectedCookiePath, string expectedDomain)
+            string requestPathBase,
+            string optionsPath,
+            string optionsDomain,
+            string expectedCookiePath,
+            string expectedDomain)
         {
             // Arrange
             var values = new Dictionary<string, object>();
@@ -637,7 +678,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             var testOptions = new Mock<IOptions<CookieTempDataProviderOptions>>();
             testOptions.SetupGet(o => o.Value).Returns(options);
 
-            return new CookieTempDataProvider(new PassThroughDataProtectionProvider(dataProtector), testOptions.Object);
+            return new CookieTempDataProvider(new PassThroughDataProtectionProvider(dataProtector), NullLoggerFactory.Instance, testOptions.Object);
         }
 
         private class PassThroughDataProtectionProvider : IDataProtectionProvider


### PR DESCRIPTION
This change logs when we encounter and exception reading temp data from a
cookie and swallows the exception. Additionally, we clear the cookie so
that this won't happen on subsequent requests.

This will handle cases where data protection is misconfigured, or a
request just has general garbage in the cookies.