### PR TITLE
Upgrade to xunit 2.3.0-beta4

### DIFF
--- a/Mvc.sln
+++ b/Mvc.sln
@@ -13,6 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{3BA657BF-2
 	ProjectSection(SolutionItems) = preProject
 		test\Directory.Build.props = test\Directory.Build.props
 		test\Directory.Build.targets = test\Directory.Build.targets
+		test\MvcTests.ruleset = test\MvcTests.ruleset
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Mvc", "src\Microsoft.AspNetCore.Mvc\Microsoft.AspNetCore.Mvc.csproj", "{079EFA1F-0B0A-4853-B27B-5780D111CD85}"

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -14,8 +14,9 @@
     <NETStandardLibraryNETFrameworkVersion>2.0.0-*</NETStandardLibraryNETFrameworkVersion>
     <RoslynVersion>2.3.1</RoslynVersion>
     <RuntimeFrameworkVersion Condition="'$(TargetFramework)'=='netcoreapp2.0'">2.0.0-*</RuntimeFrameworkVersion>
-    <TestSdkVersion>15.3.0-*</TestSdkVersion>
+    <TestSdkVersion>15.3.0</TestSdkVersion>
     <WebApiClientVersion>5.2.2</WebApiClientVersion>
-    <XunitVersion>2.3.0-beta2-*</XunitVersion>
+    <XunitVersion>2.3.0-beta4-build3742</XunitVersion>
+    <XunitAnalyzersVersion>0.6.1</XunitAnalyzersVersion>
   </PropertyGroup>
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,5 +3,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <WarningsNotAsErrors>xUnit1026:$(WarningsNotAsErrors)</WarningsNotAsErrors>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)MvcTests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 </Project>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.analyzers" Version="$(XunitAnalyzersVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.AspNetCore.Mvc.Abstractions.Test/ModelBinding/ModelStateDictionaryTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Abstractions.Test/ModelBinding/ModelStateDictionaryTest.cs
@@ -1037,13 +1037,13 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             dictionary.ClearValidationState("Property4");
 
             // Assert
-            Assert.Equal(0, dictionary["Property1"].Errors.Count);
+            Assert.Empty(dictionary["Property1"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["Property1"].ValidationState);
-            Assert.Equal(0, dictionary["Property2"].Errors.Count);
+            Assert.Empty(dictionary["Property2"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["Property2"].ValidationState);
-            Assert.Equal(1, dictionary["Property3"].Errors.Count);
+            Assert.Single(dictionary["Property3"].Errors);
             Assert.Equal(ModelValidationState.Invalid, dictionary["Property3"].ValidationState);
-            Assert.Equal(0, dictionary["Property4"].Errors.Count);
+            Assert.Empty(dictionary["Property4"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["Property4"].ValidationState);
         }
 
@@ -1064,19 +1064,19 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             dictionary.ClearValidationState("Product");
 
             // Assert
-            Assert.Equal(0, dictionary["Product"].Errors.Count);
+            Assert.Empty(dictionary["Product"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["Product"].ValidationState);
-            Assert.Equal(0, dictionary["Product.Detail1"].Errors.Count);
+            Assert.Empty(dictionary["Product.Detail1"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["Product.Detail1"].ValidationState);
-            Assert.Equal(0, dictionary["Product.Detail2[0]"].Errors.Count);
+            Assert.Empty(dictionary["Product.Detail2[0]"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["Product.Detail2[0]"].ValidationState);
-            Assert.Equal(0, dictionary["Product.Detail2[1]"].Errors.Count);
+            Assert.Empty(dictionary["Product.Detail2[1]"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["Product.Detail2[1]"].ValidationState);
-            Assert.Equal(0, dictionary["Product.Detail2[2]"].Errors.Count);
+            Assert.Empty(dictionary["Product.Detail2[2]"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["Product.Detail2[2]"].ValidationState);
-            Assert.Equal(0, dictionary["Product.Detail3"].Errors.Count);
+            Assert.Empty(dictionary["Product.Detail3"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["Product.Detail3"].ValidationState);
-            Assert.Equal(1, dictionary["ProductName"].Errors.Count);
+            Assert.Single(dictionary["ProductName"].Errors);
             Assert.Equal(ModelValidationState.Invalid, dictionary["ProductName"].ValidationState);
         }
 
@@ -1095,9 +1095,9 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 
             // Assert
             Assert.Equal(ModelValidationState.Valid, dictionary["Product"].ValidationState);
-            Assert.Equal(0, dictionary["Product.Detail1"].Errors.Count);
+            Assert.Empty(dictionary["Product.Detail1"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["Product.Detail1"].ValidationState);
-            Assert.Equal(0, dictionary["Product.Detail1.Name"].Errors.Count);
+            Assert.Empty(dictionary["Product.Detail1.Name"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["Product.Detail1.Name"].ValidationState);
             Assert.Equal(ModelValidationState.Skipped, dictionary["Product.Detail1Name"].ValidationState);
         }
@@ -1118,13 +1118,13 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             dictionary.ClearValidationState(modelKey);
 
             // Assert
-            Assert.Equal(0, dictionary["Property1"].Errors.Count);
+            Assert.Empty(dictionary["Property1"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["Property1"].ValidationState);
-            Assert.Equal(0, dictionary["Property2"].Errors.Count);
+            Assert.Empty(dictionary["Property2"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["Property2"].ValidationState);
-            Assert.Equal(0, dictionary["Property3"].Errors.Count);
+            Assert.Empty(dictionary["Property3"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["Property3"].ValidationState);
-            Assert.Equal(0, dictionary["Property4"].Errors.Count);
+            Assert.Empty(dictionary["Property4"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["Property4"].ValidationState);
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Authorization/AuthorizeFilterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Authorization/AuthorizeFilterTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Mvc.Authorization
         public void InvalidUser()
         {
             var authorizationContext = GetAuthorizationContext();
-            Assert.True(authorizationContext.HttpContext.User.Identities.Any(i => i.IsAuthenticated));
+            Assert.Contains(authorizationContext.HttpContext.User.Identities, i => i.IsAuthenticated);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/BadRequestObjectResultTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/BadRequestObjectResultTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Mvc
             // Assert
             Assert.Equal(StatusCodes.Status400BadRequest, badRequestObjecResult.StatusCode);
             var errors = Assert.IsType<SerializableError>(badRequestObjecResult.Value);
-            Assert.Equal(0, errors.Count);
+            Assert.Empty(errors);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ControllerBaseTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ControllerBaseTest.cs
@@ -1987,7 +1987,7 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
             Assert.IsType<BadRequestObjectResult>(result);
             Assert.Equal(StatusCodes.Status400BadRequest, result.StatusCode);
             var errors = Assert.IsType<SerializableError>(result.Value);
-            Assert.Equal(0, errors.Count);
+            Assert.Empty(errors);
         }
 
         [Theory]

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/FileResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/FileResultTest.cs
@@ -153,7 +153,7 @@ namespace Microsoft.AspNetCore.Mvc
             await result.ExecuteResultAsync(actionContext);
 
             // Assert
-            Assert.Equal(1, loggerSink.Writes.Count);
+            Assert.Single(loggerSink.Writes);
         }
 
         public static TheoryData<string, string> ContentDispositionData

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/FormatFilterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/FormatFilterTest.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
             // Assert
             var objectResult = Assert.IsType<ObjectResult>(resultExecutingContext.Result);
-            Assert.Equal(1, objectResult.ContentTypes.Count);
+            Assert.Single(objectResult.ContentTypes);
             MediaTypeAssert.Equal(mediaType, objectResult.ContentTypes[0]);
         }
 
@@ -100,7 +100,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
             // Assert
             var objectResult = Assert.IsType<ObjectResult>(resultExecutingContext.Result);
-            Assert.Equal(1, objectResult.ContentTypes.Count);
+            Assert.Single(objectResult.ContentTypes);
             MediaTypeAssert.Equal(mediaType, objectResult.ContentTypes[0]);
         }
 
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
             // Assert
             var objectResult = Assert.IsType<ObjectResult>(resultExecutingContext.Result);
-            Assert.Equal(1, objectResult.ContentTypes.Count);
+            Assert.Single(objectResult.ContentTypes);
             MediaTypeAssert.Equal(mediaType, objectResult.ContentTypes[0]);
         }
 
@@ -336,7 +336,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
             // Assert
             var result = Assert.IsType<ObjectResult>(resultExecutingContext.Result);
-            Assert.Equal(1, result.ContentTypes.Count);
+            Assert.Single(result.ContentTypes);
             MediaTypeAssert.Equal(mediaType, result.ContentTypes[0]);
         }
 
@@ -371,7 +371,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
             // Assert
             var result = Assert.IsType<ObjectResult>(resultExecutingContext.Result);
-            Assert.Equal(0, result.ContentTypes.Count);
+            Assert.Empty(result.ContentTypes);
         }
 
 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/FormatterCollectionTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/FormatterCollectionTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
             // Assert
             var formatter = Assert.Single(collection);
-            Assert.IsType(typeof(AnotherTestOutputFormatter), formatter);
+            Assert.IsType<AnotherTestOutputFormatter>(formatter);
         }
 
         [Fact]
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
             // Assert
             var formatter = Assert.Single(collection);
-            Assert.IsType(typeof(AnotherTestOutputFormatter), formatter);
+            Assert.IsType<AnotherTestOutputFormatter>(formatter);
         }
 
         private class TestOutputFormatter : TextOutputFormatter

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/MediaTypeTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/MediaTypeTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             Assert.Equal(new StringSegment("json"), result.SubType);
         }
 
-        public static IEnumerable<string[]> MediaTypesWithSuffixes
+        public static IEnumerable<object[]> MediaTypesWithSuffixes
         {
             get
             {
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         }
 
         [Theory]
-        [MemberData(nameof (MediaTypesWithSuffixes))]
+        [MemberData(nameof(MediaTypesWithSuffixes))]
         public void Constructor_CanParseSuffixedMediaTypes(
             string mediaType,
             string expectedSubTypeWithoutSuffix,

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/TextInputFormatterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/TextInputFormatterTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             // Assert
             Assert.True(result.HasError);
             Assert.True(context.ModelState.ContainsKey("something"));
-            Assert.Equal(1, context.ModelState["something"].Errors.Count);
+            Assert.Single(context.ModelState["something"].Errors);
 
             var error = context.ModelState["something"].Errors[0];
             Assert.IsType<UnsupportedContentTypeException>(error.Exception);

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerActionDescriptorProviderTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerActionDescriptorProviderTests.cs
@@ -1337,7 +1337,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             var actions = provider.GetDescriptors().Where(a => a.ActionName == actionName);
 
             // Assert
-            Assert.Equal(1, actions.Count());
+            Assert.Single(actions);
 
             var action = Assert.Single(actions, a => a.AttributeRouteInfo.Template == "A2");
             Assert.Equal(2, action.ActionConstraints.Count);

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerActionInvokerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerActionInvokerTest.cs
@@ -1103,7 +1103,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             await invoker.InvokeAsync();
 
             // Assert
-            Assert.IsType(typeof(EmptyResult), result);
+            Assert.IsType<EmptyResult>(result);
         }
 
         [Fact]
@@ -1131,8 +1131,8 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             await invoker.InvokeAsync();
 
             // Assert
-            Assert.IsType(typeof(ObjectResult), result);
-            Assert.IsType(typeof(int), ((ObjectResult)result).Value);
+            Assert.IsType<ObjectResult>(result);
+            Assert.IsType<int>(((ObjectResult)result).Value);
             Assert.Equal(1, ((ObjectResult)result).Value);
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerBinderDelegateProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerBinderDelegateProviderTest.cs
@@ -139,7 +139,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             await binderDelegate(controllerContext, controller, arguments);
 
             // Assert
-            Assert.Equal(1, arguments.Count);
+            Assert.Single(arguments);
             Assert.Equal(value, arguments["foo"]);
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/DefaultObjectValidatorTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/DefaultObjectValidatorTests.cs
@@ -1076,8 +1076,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             var model = new ThrowingProperty();
 
             // Act & Assert
-            Assert.Throws(
-                typeof(InvalidTimeZoneException),
+            Assert.Throws<InvalidTimeZoneException>(
                 () =>
                 {
                     validator.Validate(actionContext, validationState, string.Empty, model);

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/ComplexTypeModelBinderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/ComplexTypeModelBinderTest.cs
@@ -1024,7 +1024,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
 
             // Assert
             Assert.False(bindingContext.ModelState.IsValid);
-            Assert.Equal(1, bindingContext.ModelState["foo.NameNoAttribute"].Errors.Count);
+            Assert.Single(bindingContext.ModelState["foo.NameNoAttribute"].Errors);
             Assert.Equal("This is a different exception." + Environment.NewLine
                        + "Parameter name: value",
                          bindingContext.ModelState["foo.NameNoAttribute"].Errors[0].Exception.Message);

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Metadata/DefaultModelMetadataProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Metadata/DefaultModelMetadataProviderTest.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
             var metadata = provider.GetMetadataForProperties(typeof(ModelTypeWithIndexer)).ToArray();
 
             // Assert
-            Assert.Equal(1, metadata.Length);
+            Assert.Single(metadata);
             Assert.Single(metadata, m => m.PropertyName == "Property1");
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ModelBindingHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/ModelBindingHelperTest.cs
@@ -652,14 +652,14 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             ModelBindingHelper.ClearValidationStateForModel(modelMetadata, dictionary, modelKey);
 
             // Assert
-            Assert.Equal(0, dictionary["Name"].Errors.Count);
+            Assert.Empty(dictionary["Name"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["Name"].ValidationState);
-            Assert.Equal(0, dictionary["Id"].Errors.Count);
+            Assert.Empty(dictionary["Id"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["Id"].ValidationState);
-            Assert.Equal(0, dictionary["Category"].Errors.Count);
+            Assert.Empty(dictionary["Category"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["Category"].ValidationState);
 
-            Assert.Equal(1, dictionary["Unrelated"].Errors.Count);
+            Assert.Single(dictionary["Unrelated"].Errors);
             Assert.Equal(ModelValidationState.Invalid, dictionary["Unrelated"].ValidationState);
         }
 
@@ -681,10 +681,10 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             ModelBindingHelper.ClearValidationStateForModel(modelMetadata, dictionary, modelKey);
 
             // Assert
-            Assert.Equal(0, dictionary[string.Empty].Errors.Count);
+            Assert.Empty(dictionary[string.Empty].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary[string.Empty].ValidationState);
 
-            Assert.Equal(1, dictionary["Unrelated"].Errors.Count);
+            Assert.Single(dictionary["Unrelated"].Errors);
             Assert.Equal(ModelValidationState.Invalid, dictionary["Unrelated"].ValidationState);
         }
 
@@ -712,20 +712,20 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             ModelBindingHelper.ClearValidationStateForModel(modelMetadata, dictionary, modelKey);
 
             // Assert
-            Assert.Equal(0, dictionary["[0].Name"].Errors.Count);
+            Assert.Empty(dictionary["[0].Name"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["[0].Name"].ValidationState);
-            Assert.Equal(0, dictionary["[0].Id"].Errors.Count);
+            Assert.Empty(dictionary["[0].Id"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["[0].Id"].ValidationState);
-            Assert.Equal(0, dictionary["[0].Category"].Errors.Count);
+            Assert.Empty(dictionary["[0].Category"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["[0].Category"].ValidationState);
-            Assert.Equal(0, dictionary["[1].Name"].Errors.Count);
+            Assert.Empty(dictionary["[1].Name"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["[1].Name"].ValidationState);
-            Assert.Equal(0, dictionary["[1].Id"].Errors.Count);
+            Assert.Empty(dictionary["[1].Id"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["[1].Id"].ValidationState);
-            Assert.Equal(0, dictionary["[1].Category"].Errors.Count);
+            Assert.Empty(dictionary["[1].Category"].Errors);
             Assert.Equal(ModelValidationState.Unvalidated, dictionary["[1].Category"].ValidationState);
 
-            Assert.Equal(1, dictionary["Unrelated"].Errors.Count);
+            Assert.Single(dictionary["Unrelated"].Errors);
             Assert.Equal(ModelValidationState.Invalid, dictionary["Unrelated"].ValidationState);
         }
 
@@ -761,7 +761,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             {
                 if (entry.StartsWith(prefix))
                 {
-                    Assert.Equal(0, dictionary[entry].Errors.Count);
+                    Assert.Empty(dictionary[entry].Errors);
                     Assert.Equal(ModelValidationState.Unvalidated, dictionary[entry].ValidationState);
                 }
             }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ProducesAttributeTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ProducesAttributeTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Mvc.Test
 
             // Assert
             var objectResult = Assert.IsType<ObjectResult>(resultExecutingContext.Result);
-            Assert.Equal(1, objectResult.ContentTypes.Count);
+            Assert.Single(objectResult.ContentTypes);
         }
 
         [Fact]
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Mvc.Test
 
             // Assert
             var objectResult = Assert.IsType<ObjectResult>(resultExecutingContext.Result);
-            Assert.Equal(0, objectResult.ContentTypes.Count);
+            Assert.Empty(objectResult.ContentTypes);
         }
 
         [Theory]

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/SerializableErrorTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/SerializableErrorTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Mvc
             var serializableError = new SerializableError(modelState);
 
             // Assert
-            Assert.Equal(0, serializableError.Count);
+            Assert.Empty(serializableError);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Cors.Test/Internal/CorsApplicationModelProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Cors.Test/Internal/CorsApplicationModelProviderTest.cs
@@ -122,7 +122,7 @@ namespace Microsoft.AspNetCore.Mvc.Cors.Internal
             // Assert
             var controller = Assert.Single(context.Result.Controllers);
             var action = Assert.Single(controller.Actions);
-            Assert.True(action.Filters.Any(f => f is DisableCorsAuthorizationFilter));
+            Assert.Contains(action.Filters, f => f is DisableCorsAuthorizationFilter);
             var selector = Assert.Single(action.Selectors);
             var constraint = Assert.Single(selector.ActionConstraints, c => c is HttpMethodActionConstraint);
             Assert.IsType<CorsHttpMethodActionConstraint>(constraint);

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/Internal/EnumerableWrapperProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/Internal/EnumerableWrapperProviderTest.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
             Assert.NotNull(wrapped);
             var delegatingEnumerable = wrapped as DelegatingEnumerable<int, int>;
             Assert.NotNull(delegatingEnumerable);
-            Assert.Equal(0, delegatingEnumerable.Count());
+            Assert.Empty(delegatingEnumerable);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/Internal/SerializableErrorWrapperTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/Internal/SerializableErrorWrapperTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
             // Assert
             Assert.NotNull(wrapper.SerializableError);
             Assert.Same(serializableError, wrapper.SerializableError);
-            Assert.Equal(1, wrapper.SerializableError.Count);
+            Assert.Single(wrapper.SerializableError);
             Assert.True(wrapper.SerializableError.ContainsKey("key1"));
             Assert.Equal("key1-error", wrapper.SerializableError["key1"]);
         }

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlDataContractSerializerInputFormatterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlDataContractSerializerInputFormatterTest.cs
@@ -117,12 +117,10 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var formatter = new XmlDataContractSerializerInputFormatter();
 
             // Assert
-            Assert.True(formatter.SupportedMediaTypes
-                                 .Select(content => content.ToString())
-                                 .Contains("application/xml"));
-            Assert.True(formatter.SupportedMediaTypes
-                                 .Select(content => content.ToString())
-                                 .Contains("text/xml"));
+            Assert.Contains("application/xml", formatter.SupportedMediaTypes
+                                 .Select(content => content.ToString()));
+            Assert.Contains("text/xml", formatter.SupportedMediaTypes
+                                 .Select(content => content.ToString()));
         }
 
         [Fact]
@@ -132,8 +130,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var formatter = new XmlDataContractSerializerInputFormatter();
 
             // Assert
-            Assert.True(formatter.SupportedEncodings.Any(i => i.WebName == "utf-8"));
-            Assert.True(formatter.SupportedEncodings.Any(i => i.WebName == "utf-16"));
+            Assert.Contains(formatter.SupportedEncodings, i => i.WebName == "utf-8");
+            Assert.Contains(formatter.SupportedEncodings, i => i.WebName == "utf-16");
         }
 
         [Fact]
@@ -309,7 +307,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var context = GetInputFormatterContext(contentBytes, typeof(TestLevelTwo));
 
             // Act & Assert
-            await Assert.ThrowsAsync(typeof(SerializationException), async () => await formatter.ReadAsync(context));
+            await Assert.ThrowsAsync<SerializationException>(async () => await formatter.ReadAsync(context));
         }
 
         [Fact]
@@ -326,7 +324,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var context = GetInputFormatterContext(contentBytes, typeof(TestLevelTwo));
 
             // Act & Assert
-            await Assert.ThrowsAsync(typeof(SerializationException), async () => await formatter.ReadAsync(context));
+            await Assert.ThrowsAsync<SerializationException>(async () => await formatter.ReadAsync(context));
         }
 
         [Fact]
@@ -336,7 +334,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var formatter = new XmlDataContractSerializerInputFormatter();
 
             // Act & Assert
-            Assert.Throws(typeof(ArgumentException), () => formatter.MaxDepth = 0);
+            Assert.Throws<ArgumentException>(() => formatter.MaxDepth = 0);
         }
 
         [Fact]
@@ -498,7 +496,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var context = GetInputFormatterContext(contentBytes, typeof(DummyClass));
 
             // Act & Assert
-            await Assert.ThrowsAsync(typeof(SerializationException), async () => await formatter.ReadAsync(context));
+            await Assert.ThrowsAsync<SerializationException>(async () => await formatter.ReadAsync(context));
         }
 
         [Fact]
@@ -555,7 +553,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var context = GetInputFormatterContext(contentBytes, typeof(DummyClass));
 
             // Act & Assert
-            await Assert.ThrowsAsync(typeof(SerializationException), async () => await formatter.ReadAsync(context));
+            await Assert.ThrowsAsync<SerializationException>(async () => await formatter.ReadAsync(context));
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlDataContractSerializerOutputFormatterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlDataContractSerializerOutputFormatterTest.cs
@@ -471,8 +471,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var outputFormatterContext = GetOutputFormatterContext(sampleInput, typeof(DummyClass));
 
             // Act & Assert
-            await Assert.ThrowsAsync(typeof(SerializationException),
-                async () => await formatter.WriteAsync(outputFormatterContext));
+            await Assert.ThrowsAsync<SerializationException>(async () => await formatter.WriteAsync(outputFormatterContext));
         }
 
         [ConditionalFact]
@@ -489,8 +488,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var outputFormatterContext = GetOutputFormatterContext(parent, parent.GetType());
 
             // Act & Assert
-            await Assert.ThrowsAsync(typeof(SerializationException),
-                async () => await formatter.WriteAsync(outputFormatterContext));
+            await Assert.ThrowsAsync<SerializationException>(async () => await formatter.WriteAsync(outputFormatterContext));
         }
 
         [ConditionalFact]

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlSerializerInputFormatterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlSerializerInputFormatterTest.cs
@@ -215,12 +215,10 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var formatter = new XmlSerializerInputFormatter();
 
             // Assert
-            Assert.True(formatter.SupportedMediaTypes
-                                 .Select(content => content.ToString())
-                                 .Contains("application/xml"));
-            Assert.True(formatter.SupportedMediaTypes
-                                 .Select(content => content.ToString())
-                                 .Contains("text/xml"));
+            Assert.Contains("application/xml", formatter.SupportedMediaTypes
+                                 .Select(content => content.ToString()));
+            Assert.Contains("text/xml", formatter.SupportedMediaTypes
+                                 .Select(content => content.ToString()));
         }
 
         [Fact]
@@ -230,8 +228,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var formatter = new XmlSerializerInputFormatter();
 
             // Assert
-            Assert.True(formatter.SupportedEncodings.Any(i => i.WebName == "utf-8"));
-            Assert.True(formatter.SupportedEncodings.Any(i => i.WebName == "utf-16"));
+            Assert.Contains(formatter.SupportedEncodings, i => i.WebName == "utf-8");
+            Assert.Contains(formatter.SupportedEncodings, i => i.WebName == "utf-16");
         }
 
         [Fact]
@@ -342,7 +340,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var context = GetInputFormatterContext(contentBytes, typeof(TestLevelTwo));
 
             // Act & Assert
-            await Assert.ThrowsAsync(typeof(InvalidOperationException), () => formatter.ReadAsync(context));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => formatter.ReadAsync(context));
         }
 
         [ConditionalFact]
@@ -363,7 +361,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var context = GetInputFormatterContext(contentBytes, typeof(TestLevelTwo));
 
             // Act & Assert
-            await Assert.ThrowsAsync(typeof(InvalidOperationException), () => formatter.ReadAsync(context));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => formatter.ReadAsync(context));
         }
 
         [Fact]
@@ -373,7 +371,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var formatter = new XmlSerializerInputFormatter();
 
             // Act & Assert
-            Assert.Throws(typeof(ArgumentException), () => formatter.MaxDepth = 0);
+            Assert.Throws<ArgumentException>(() => formatter.MaxDepth = 0);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/BasicTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/BasicTests.cs
@@ -208,7 +208,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal(0, response.Content.Headers.ContentLength);
 
             var responseBytes = await response.Content.ReadAsByteArrayAsync();
-            Assert.Equal(0, responseBytes.Length);
+            Assert.Empty(responseBytes);
         }
 
         [Fact]
@@ -224,7 +224,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal(0, response.Content.Headers.ContentLength);
 
             var responseBytes = await response.Content.ReadAsByteArrayAsync();
-            Assert.Equal(0, responseBytes.Length);
+            Assert.Empty(responseBytes);
         }
 
         [Theory]

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/WebApiCompatShimBasicTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/WebApiCompatShimBasicTest.cs
@@ -145,7 +145,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
             // Assert
             var json = JsonConvert.DeserializeObject<Dictionary<string, string>>(response);
-            Assert.Equal(1, json.Count);
+            Assert.Single(json);
             Assert.Equal("The field ID must be between 0 and 100.", json["prefix.ID"]);
         }
 
@@ -167,7 +167,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
             // Assert
             var json = JsonConvert.DeserializeObject<Dictionary<string, string>>(response);
-            Assert.Equal(1, json.Count);
+            Assert.Single(json);
             Assert.Equal("The field ID must be between 0 and 100.", json["ID"]);
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/ActionParametersIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/ActionParametersIntegrationTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             // Model
             Assert.NotNull(modelBindingResult.Model);
             var boundModel = Assert.IsType<Person3>(modelBindingResult.Model);
-            Assert.Equal(1, boundModel.Address.Count);
+            Assert.Single(boundModel.Address);
             Assert.Equal("SomeStreet", boundModel.Address[0].Street);
 
             // ModelState
@@ -153,7 +153,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.NotNull(modelBindingResult.Model);
             var boundModel = Assert.IsType<Person4>(modelBindingResult.Model);
             Assert.NotNull(boundModel.Address);
-            Assert.Equal(1, boundModel.Address.Count());
+            Assert.Single(boundModel.Address);
             Assert.Equal("SomeStreet", boundModel.Address[0].Street);
 
             // ModelState
@@ -201,7 +201,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.NotNull(boundModel.Address);
 
             // Arrays should not be updated.
-            Assert.Equal(0, boundModel.Address.Count());
+            Assert.Empty(boundModel.Address);
 
             // ModelState
             Assert.True(modelState.IsValid);
@@ -239,7 +239,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             // Model
             Assert.NotNull(modelBindingResult.Model);
             var boundModel = Assert.IsType<Person3>(modelBindingResult.Model);
-            Assert.Equal(1, boundModel.Address.Count);
+            Assert.Single(boundModel.Address);
             Assert.Equal("SomeStreet", boundModel.Address[0].Street);
 
             // ModelState
@@ -330,7 +330,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             // Model
             Assert.NotNull(modelBindingResult.Model);
             var boundModel = Assert.IsType<Person4>(modelBindingResult.Model);
-            Assert.Equal(1, boundModel.Address.Count());
+            Assert.Single(boundModel.Address);
             Assert.Equal("SomeStreet", boundModel.Address[0].Street);
 
             // ModelState
@@ -377,7 +377,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             var boundModel = Assert.IsType<Person5>(modelBindingResult.Model);
 
             // Arrays should not be updated.
-            Assert.Equal(0, boundModel.Address.Count());
+            Assert.Empty(boundModel.Address);
 
             // ModelState
             Assert.True(modelState.IsValid);

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/CancellationTokenModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/CancellationTokenModelBinderIntegrationTest.cs
@@ -50,7 +50,9 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             // Model
             var boundPerson = Assert.IsType<Person>(modelBindingResult.Model);
             Assert.NotNull(boundPerson);
-            Assert.NotSame(default(CancellationToken), boundPerson.Token);
+            Assert.False(boundPerson.Token.IsCancellationRequested);
+            testContext.HttpContext.Abort();
+            Assert.True(boundPerson.Token.IsCancellationRequested);
 
             // ModelState
             Assert.True(modelState.IsValid);
@@ -84,7 +86,9 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             // Model
             var boundPerson = Assert.IsType<Person>(modelBindingResult.Model);
             Assert.NotNull(boundPerson);
-            Assert.NotSame(default(CancellationToken), boundPerson.Token);
+            Assert.False(boundPerson.Token.IsCancellationRequested);
+            testContext.HttpContext.Abort();
+            Assert.True(boundPerson.Token.IsCancellationRequested);
 
             // ModelState
             Assert.True(modelState.IsValid);
@@ -120,7 +124,9 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
 
             // Model
             var token = Assert.IsType<CancellationToken>(modelBindingResult.Model);
-            Assert.NotSame(default(CancellationToken), token);
+            Assert.False(token.IsCancellationRequested);
+            testContext.HttpContext.Abort();
+            Assert.True(token.IsCancellationRequested);
 
             // ModelState
             Assert.True(modelState.IsValid);

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/GenericModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/GenericModelBinderIntegrationTest.cs
@@ -216,7 +216,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.True(modelBindingResult.IsModelSet);
 
             var model = Assert.IsType<Address[]>(modelBindingResult.Model);
-            Assert.Equal(1, model.Length);
+            Assert.Single(model);
             Assert.NotNull(model[0]);
 
             Assert.Equal(0, modelState.Count);
@@ -250,7 +250,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.True(modelBindingResult.IsModelSet);
 
             var model = Assert.IsType<Address[]>(modelBindingResult.Model);
-            Assert.Equal(1, model.Length);
+            Assert.Single(model);
             Assert.Null(model[0]);
 
             Assert.Equal(0, modelState.Count);

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/ServicesModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/ServicesModelBinderIntegrationTest.cs
@@ -116,7 +116,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
 
             // Model
             var formatterArray = Assert.IsType<JsonOutputFormatter[]>(modelBindingResult.Model);
-            Assert.Equal(1, formatterArray.Length);
+            Assert.Single(formatterArray);
 
             // ModelState
             Assert.True(modelState.IsValid);
@@ -152,7 +152,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
 
             // Model
             var actionResultArray = Assert.IsType<IActionResult[]>(modelBindingResult.Model);
-            Assert.Equal(0, actionResultArray.Length);
+            Assert.Empty(actionResultArray);
 
             // ModelState
             Assert.True(modelState.IsValid);

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/SimpleTypeModelBinderIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/SimpleTypeModelBinderIntegrationTest.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             // ModelState
             Assert.True(modelState.IsValid);
 
-            Assert.Equal(1, modelState.Keys.Count());
+            Assert.Single(modelState.Keys);
             var key = Assert.Single(modelState.Keys, k => k == "CustomParameter.Address.Zip");
             Assert.Equal("1", modelState[key].AttemptedValue);
             Assert.Equal("1", modelState[key].RawValue);
@@ -101,7 +101,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             // ModelState
             Assert.True(modelState.IsValid);
 
-            Assert.Equal(1, modelState.Keys.Count());
+            Assert.Single(modelState.Keys);
             var key = Assert.Single(modelState.Keys, k => k == "Address.Zip");
             Assert.Equal("1", modelState[key].AttemptedValue);
             Assert.Equal("1", modelState[key].RawValue);
@@ -144,7 +144,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             // ModelState
             Assert.True(modelState.IsValid);
 
-            Assert.Equal(1, modelState.Keys.Count());
+            Assert.Single(modelState.Keys);
             var key = Assert.Single(modelState.Keys);
             Assert.Equal("Parameter1", key);
             Assert.Equal("someValue", modelState[key].AttemptedValue);
@@ -188,7 +188,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             // ModelState
             Assert.True(modelState.IsValid);
 
-            Assert.Equal(1, modelState.Keys.Count());
+            Assert.Single(modelState.Keys);
             var key = Assert.Single(modelState.Keys);
             Assert.Equal("Parameter1", key);
             Assert.Equal("32,000.99", modelState[key].AttemptedValue);
@@ -232,7 +232,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             // ModelState
             Assert.True(modelState.IsValid);
 
-            Assert.Equal(1, modelState.Keys.Count());
+            Assert.Single(modelState.Keys);
             var key = Assert.Single(modelState.Keys);
             Assert.Equal("Parameter1", key);
             Assert.Equal("someValue,otherValue", modelState[key].AttemptedValue);

--- a/test/Microsoft.AspNetCore.Mvc.IntegrationTests/TryUpdateModelIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.IntegrationTests/TryUpdateModelIntegrationTest.cs
@@ -234,7 +234,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
 
             // Model
             Assert.NotNull(model.Address);
-            Assert.Equal(1, model.Address.Count);
+            Assert.Single(model.Address);
             Assert.Equal("SomeStreet", model.Address[0].Street);
             Assert.Null(model.Address[0].City);
 
@@ -275,7 +275,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             // Model
             Assert.NotNull(model.Address);
             Assert.Same(collection, model.Address);
-            Assert.Equal(1, model.Address.Count);
+            Assert.Single(model.Address);
             Assert.Equal("SomeStreet", model.Address[0].Street);
             Assert.Null(model.Address[0].City);
 
@@ -336,7 +336,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
 
             // Model (collection is cleared and new members created from scratch).
             Assert.NotNull(model.Address);
-            Assert.Equal(1, model.Address.Count);
+            Assert.Single(model.Address);
             Assert.Equal("SomeStreet", model.Address[0].Street);
             Assert.Null(model.Address[0].City);
 
@@ -440,7 +440,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
 
             // Model
             Assert.NotNull(model.Address);
-            Assert.Equal(1, model.Address.Length);
+            Assert.Single(model.Address);
             Assert.Equal("SomeStreet", model.Address[0].Street);
             Assert.Null(model.Address[0].City);
 
@@ -488,7 +488,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             // Model
             Assert.NotNull(model.Address);
             Assert.NotSame(collection, model.Address);
-            Assert.Equal(1, model.Address.Length);
+            Assert.Single(model.Address);
             Assert.Equal("SomeStreet", model.Address[0].Street);
             Assert.Null(model.Address[0].City);
 
@@ -531,7 +531,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.NotNull(model.Address);
 
             // Arrays should not be updated.
-            Assert.Equal(0, model.Address.Length);
+            Assert.Empty(model.Address);
 
             // ModelState
             Assert.True(modelState.IsValid);
@@ -572,7 +572,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.NotNull(model.Address);
 
             // Arrays should not be updated.
-            Assert.Equal(1, model.Address.Count());
+            Assert.Single(model.Address);
             Assert.Collection(
                 model.Address,
                 (a) =>
@@ -619,7 +619,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.NotNull(model.Address);
 
             // Arrays should not be updated.
-            Assert.Equal(1, model.Address.Count());
+            Assert.Single(model.Address);
             Assert.Collection(
                 model.Address,
                 (a) =>
@@ -829,7 +829,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
 
             // Model
             Assert.NotNull(model.Address);
-            Assert.Equal(1, model.Address.Count);
+            Assert.Single(model.Address);
             Assert.Equal("SomeStreet", model.Address[0].Street);
             Assert.Null(model.Address[0].City);
 
@@ -870,7 +870,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             // Model
             Assert.NotNull(model.Address);
             Assert.Same(collection, model.Address);
-            Assert.Equal(1, model.Address.Count);
+            Assert.Single(model.Address);
             Assert.Equal("SomeStreet", model.Address[0].Street);
             Assert.Null(model.Address[0].City);
 
@@ -921,7 +921,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
 
             // Model (collection is cleared and new members created from scratch).
             Assert.NotNull(model.Address);
-            Assert.Equal(1, model.Address.Count);
+            Assert.Single(model.Address);
             Assert.Equal("SomeStreet", model.Address[0].Street);
             Assert.Null(model.Address[0].City);
 
@@ -957,7 +957,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
 
             // Model
             Assert.NotNull(model.Address);
-            Assert.Equal(1, model.Address.Length);
+            Assert.Single(model.Address);
             Assert.Equal("SomeStreet", model.Address[0].Street);
             Assert.Null(model.Address[0].City);
 
@@ -1005,7 +1005,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             // Model
             Assert.NotNull(model.Address);
             Assert.NotSame(collection, model.Address);
-            Assert.Equal(1, model.Address.Length);
+            Assert.Single(model.Address);
             Assert.Equal("SomeStreet", model.Address[0].Street);
             Assert.Null(model.Address[0].City);
 
@@ -1043,7 +1043,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.NotNull(model.Address);
 
             // Arrays should not be updated.
-            Assert.Equal(0, model.Address.Length);
+            Assert.Empty(model.Address);
 
             // ModelState
             Assert.True(modelState.IsValid);

--- a/test/Microsoft.AspNetCore.Mvc.Localization.Test/HtmlLocalizerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Localization.Test/HtmlLocalizerTest.cs
@@ -230,7 +230,7 @@ namespace Microsoft.AspNetCore.Mvc.Localization.Test
             var allLocalizedStrings = htmlLocalizer.GetAllStrings(includeParentCultures: false).ToList();
 
             //Assert
-            Assert.Equal(1, allLocalizedStrings.Count);
+            Assert.Single(allLocalizedStrings);
             Assert.Equal("World", allLocalizedStrings.First().Value);
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.Localization.Test/ViewLocalizerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Localization.Test/ViewLocalizerTest.cs
@@ -136,7 +136,7 @@ namespace Microsoft.AspNetCore.Mvc.Localization.Test
             var allLocalizedStrings = viewLocalizer.GetAllStrings(includeParentCultures: false).ToList();
 
             // Assert
-            Assert.Equal(1, allLocalizedStrings.Count);
+            Assert.Single(allLocalizedStrings);
             Assert.Equal("World", allLocalizedStrings.First().Value);
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorViewEngineTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorViewEngineTest.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Test
             {"page", "/Accounts/Index"},
         };
 
-        public static IEnumerable<string[]> AbsoluteViewPathData
+        public static IEnumerable<object[]> AbsoluteViewPathData
         {
             get
             {

--- a/test/Microsoft.AspNetCore.Mvc.Test/JsonPatchExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Test/JsonPatchExtensionsTest.cs
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Mvc
             // Assert
             Assert.Equal(1, modelState.ErrorCount);
             Assert.Equal(nameof(Customer), modelState.First().Key);
-            Assert.Equal(1, modelState.First().Value.Errors.Count);
+            Assert.Single(modelState.First().Value.Errors);
             Assert.Equal(error, modelState.First().Value.Errors.First().ErrorMessage);
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Internal/HtmlAttributePropertyHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Internal/HtmlAttributePropertyHelperTest.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             var helpers2 = HtmlAttributePropertyHelper.GetProperties(anonymous.GetType());
 
             // Assert
-            Assert.Equal(1, helpers1.Length);
+            Assert.Single(helpers1);
             Assert.Same(helpers1, helpers2);
             Assert.Same(helpers1[0], helpers2[0]);
         }
@@ -97,8 +97,8 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             var helpers2 = PropertyHelper.GetProperties(anonymous.GetType());
 
             // Assert
-            Assert.Equal(1, helpers1.Length);
-            Assert.Equal(1, helpers2.Length);
+            Assert.Single(helpers1);
+            Assert.Single(helpers2);
 
             Assert.NotEqual<PropertyHelper[]>(helpers1, helpers2);
             Assert.NotEqual<PropertyHelper>(helpers1[0], helpers2[0]);

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponents/DefaultViewComponentHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponents/DefaultViewComponentHelperTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
 
             // Assert
             Assert.Equal(0, argumentDictionary.Count);
-            Assert.IsType(typeof(Dictionary<string,object>),argumentDictionary);
+            Assert.IsType<Dictionary<string,object>>(argumentDictionary);
         }
 
         [Fact]
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
                 item =>
                 {
                     Assert.Equal("a", item.Key);
-                    Assert.IsType(typeof(int), item.Value);
+                    Assert.IsType<int>(item.Value);
                     Assert.Equal(0, item.Value);
                 });
         }
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
                 item =>
                 {
                     Assert.Equal("a", item.Key);
-                    Assert.IsType(typeof(int), item.Value);
+                    Assert.IsType<int>(item.Value);
                     Assert.Equal(0, item.Value);
                 });
         }
@@ -85,13 +85,13 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
                 item1 =>
                 {
                     Assert.Equal("a", item1.Key);
-                    Assert.IsType(typeof(int), item1.Value);
+                    Assert.IsType<int>(item1.Value);
                     Assert.Equal(0, item1.Value);
                 },
                 item2 =>
                 {
                     Assert.Equal("b", item2.Key);
-                    Assert.IsType(typeof(string), item2.Value);
+                    Assert.IsType<string>(item2.Value);
                     Assert.Equal("foo", item2.Value);
                 });
         }
@@ -112,7 +112,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
                 item =>
                 {
                     Assert.Equal("o", item.Key);
-                    Assert.IsType(typeof(object), item.Value);
+                    Assert.IsType<object>(item.Value);
                     Assert.Same(expectedValue, item.Value);
                 });
         }
@@ -136,7 +136,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
                 item =>
                 {
                     Assert.Equal("a", item.Key);
-                    Assert.IsType(typeof(int), item.Value);
+                    Assert.IsType<int>(item.Value);
                     Assert.Equal(10, item.Value);
                 });
         }

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/ModelExplorerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/ModelExplorerTest.cs
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             var properties = modelExplorer.Properties.ToArray();
 
             // Assert
-            Assert.Equal(1, properties.Length);
+            Assert.Single(properties);
 
             var baseProperty = Assert.Single(properties, p => p.Metadata.PropertyName == "Base1");
             Assert.Equal(typeof(int), baseProperty.Metadata.ModelType);

--- a/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/ApiControllerActionDiscoveryTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/ApiControllerActionDiscoveryTest.cs
@@ -281,7 +281,7 @@ namespace System.Web.Http
                 var parameter = Assert.Single(action.Parameters);
                 Assert.Equal((new FromUriAttribute()).BindingSource, parameter.BindingInfo.BindingSource);
                 var optionalParameters = (HashSet<string>)action.Properties["OptionalParameters"];
-                Assert.False(optionalParameters.Contains(parameter.Name));
+                Assert.DoesNotContain(parameter.Name, optionalParameters);
             }
         }
 
@@ -366,7 +366,7 @@ namespace System.Web.Http
                 var parameter = Assert.Single(action.Parameters);
                 Assert.Equal((new FromUriAttribute()).BindingSource, parameter.BindingInfo.BindingSource);
                 var optionalParameters = (HashSet<string>)action.Properties["OptionalParameters"];
-                Assert.True(optionalParameters.Contains(parameter.Name));
+                Assert.Contains(parameter.Name, optionalParameters);
             }
         }
 

--- a/test/MvcTests.ruleset
+++ b/test/MvcTests.ruleset
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Rules for MVC Tests" Description="Code analysis rules for MVC Tests" ToolsVersion="15.0">
+  <Rules AnalyzerId="xunit.analyzers" RuleNamespace="xunit.analyzers">
+    <!-- 
+      This code is produced when theory parameters that are unused. Normally, this is a warning which causes our build to fail.
+    -->
+    <Rule Id="xUnit1026" Action="Info" />
+  </Rules>
+</RuleSet>


### PR DESCRIPTION
The new version of the analyzers required lots of changes. 

I made most of them, with the exception of xunit1026 ("Not all theory parameters are used"). Fixing this would required refactoring some of the data collections used in MemberData. For now, I've reduced this to "info" across all projects. There are other approaches we could take, however, such as (1) doing that refactoring to ensure all parameters are actually used and (2) using `#pragma` around the specific parameters. Thoughts?