### PR TITLE
JsonResultExecuter logs type of result.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Json/Internal/MvcJsonLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Json/Internal/MvcJsonLoggerExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Json.Internal
             _jsonResultExecuting = LoggerMessage.Define<string>(
                 LogLevel.Information,
                 1,
-                "Executing JsonResult, writing value {Value}.");
+                "Executing JsonResult, writing value type {Value}.");
         }
 
         public static void JsonInputException(this ILogger logger, Exception exception)
@@ -32,7 +32,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Json.Internal
 
         public static void JsonResultExecuting(this ILogger logger, object value)
         {
-            _jsonResultExecuting(logger, Convert.ToString(value), null);
+            var stringValue = value == null ? "null" : Convert.ToString(value.GetType());
+            _jsonResultExecuting(logger, stringValue, null);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Json.Test/Internal/JsonResultExecutorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Json.Test/Internal/JsonResultExecutorTest.cs
@@ -182,11 +182,45 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Json.Internal
             Assert.Equal(expected, written);
         }
 
-        private static JsonResultExecutor CreateExcutor()
+        [Fact]
+        public async Task ExecuteAsync_NonNullResult_LogsResultType()
+        {
+            // Arrange
+            var expected = "Executing JsonResult, writing value type System.String.";
+            var context = GetActionContext();
+            var logger = new StubLogger();
+            var executer = CreateExcutor(logger);
+            var result = new JsonResult("result_value");
+
+            // Act
+            await executer.ExecuteAsync(context, result);
+
+            // Assert
+            Assert.Equal(expected, logger.MostRecentMessage);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_NullResult_LogsNull()
+        {
+            // Arrange
+            var expected = "Executing JsonResult, writing value type null.";
+            var context = GetActionContext();
+            var logger = new StubLogger();
+            var executer = CreateExcutor(logger);
+            var result = new JsonResult(null);
+
+            // Act
+            await executer.ExecuteAsync(context, result);
+
+            // Assert
+            Assert.Equal(expected, logger.MostRecentMessage);
+        }
+
+        private static JsonResultExecutor CreateExcutor(ILogger<JsonResultExecutor> logger = null)
         {
             return new JsonResultExecutor(
                 new TestHttpResponseStreamWriterFactory(),
-                NullLogger<JsonResultExecutor>.Instance,
+                logger ?? NullLogger<JsonResultExecutor>.Instance,
                 new TestOptionsManager<MvcJsonOptions>(),
                 ArrayPool<char>.Shared);
         }
@@ -224,6 +258,20 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Json.Internal
                 {
                     throw new NotImplementedException($"Property {nameof(Age)} has not been implemented");
                 }
+            }
+        }
+
+        private class StubLogger : ILogger<JsonResultExecutor>
+        {
+            public string MostRecentMessage { get; private set; }
+
+            public IDisposable BeginScope<TState>(TState state) => throw new NotImplementedException();
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                MostRecentMessage = formatter(state, exception);
             }
         }
     }


### PR DESCRIPTION
- MvcJsonLoggerExtensions.JsonResultExecuting now logs result type instead of value
- Nulls handled more elegantly.
- Two tests added to JsonResultExecutorTests.cs.
Addresses #4604