### PR TITLE
Fix logger category of FileStreamResultExecutor

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/FileStreamResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/FileStreamResultExecutor.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
     public class FileStreamResultExecutor : FileResultExecutorBase
     {
         public FileStreamResultExecutor(ILoggerFactory loggerFactory)
-            : base(CreateLogger<VirtualFileResultExecutor>(loggerFactory))
+            : base(CreateLogger<FileStreamResultExecutor>(loggerFactory))
         {
         }
 


### PR DESCRIPTION
FileStreamResultExecutor creates a logger for VirtualFileResultExecutor. I suspect this is a copy-and-paste error and creating one for FileStreamResultExecutor was intended instead.