### PR TITLE
Added new extension methods to configure all MVC localization services

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Localization/DependencyInjection/MvcLocalizationMvcBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Localization/DependencyInjection/MvcLocalizationMvcBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.Mvc.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.Localization.Internal;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.Extensions.Localization;
@@ -9,12 +10,12 @@ using Microsoft.Extensions.Localization;
 namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
-    /// Extension methods for configuring MVC view localization.
+    /// Extension methods for configuring MVC view and data annotations localization services.
     /// </summary>
     public static class MvcLocalizationMvcBuilderExtensions
     {
         /// <summary>
-        /// Adds MVC view localization to the application.
+        /// Adds MVC view localization services to the application.
         /// </summary>
         /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
         /// <returns>The <see cref="IMvcBuilder"/>.</returns>
@@ -29,7 +30,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        ///  Adds MVC view localization to the application.
+        ///  Adds MVC view localization services to the application.
         /// </summary>
         /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
         /// <param name="format">The view format for localized views.</param>
@@ -48,7 +49,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        ///  Adds MVC view localization to the application.
+        ///  Adds MVC view localization services to the application.
         /// </summary>
         /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
         /// <param name="setupAction">An action to configure the <see cref="LocalizationOptions"/>.</param>
@@ -67,7 +68,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        ///  Adds MVC view localization to the application.
+        ///  Adds MVC view localization services to the application.
         /// </summary>
         /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
         /// <param name="format">The view format for localized views.</param>
@@ -85,6 +86,234 @@ namespace Microsoft.Extensions.DependencyInjection
 
             MvcLocalizationServices.AddLocalizationServices(builder.Services, format, setupAction);
             return builder;
+        }
+
+        /// <summary>
+        /// Adds MVC view and data annotations localization services to the application.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
+        /// <returns>The <see cref="IMvcBuilder"/>.</returns>
+        /// <remarks>
+        /// Adding localization also adds support for views via
+        /// <see cref="MvcViewFeaturesMvcCoreBuilderExtensions.AddViews(IMvcCoreBuilder)"/> and the Razor view engine
+        /// via <see cref="MvcRazorMvcCoreBuilderExtensions.AddRazorViewEngine(IMvcCoreBuilder)"/>.
+        /// </remarks>
+        public static IMvcBuilder AddMvcLocalization(this IMvcBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return AddMvcLocalization(
+                builder,
+                localizationOptionsSetupAction: null,
+                format: LanguageViewLocationExpanderFormat.Suffix,
+                dataAnnotationsLocalizationOptionsSetupAction: null);
+        }
+
+        /// <summary>
+        /// Adds MVC view and data annotations localization services to the application.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
+        /// <param name="localizationOptionsSetupAction">An action to configure the <see cref="LocalizationOptions"/>.</param>
+        /// <returns>The <see cref="IMvcBuilder"/>.</returns>
+        /// <remarks>
+        /// Adding localization also adds support for views via
+        /// <see cref="MvcViewFeaturesMvcCoreBuilderExtensions.AddViews(IMvcCoreBuilder)"/> and the Razor view engine
+        /// via <see cref="MvcRazorMvcCoreBuilderExtensions.AddRazorViewEngine(IMvcCoreBuilder)"/>.
+        /// </remarks>
+        public static IMvcBuilder AddMvcLocalization(
+            this IMvcBuilder builder,
+            Action<LocalizationOptions> localizationOptionsSetupAction)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return AddMvcLocalization(
+                builder,
+                localizationOptionsSetupAction,
+                LanguageViewLocationExpanderFormat.Suffix,
+                dataAnnotationsLocalizationOptionsSetupAction: null);
+        }
+
+        /// <summary>
+        /// Adds MVC view and data annotations localization services to the application.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
+        /// <param name="format">The view format for localized views.</param>
+        /// <returns>The <see cref="IMvcBuilder"/>.</returns>
+        /// <remarks>
+        /// Adding localization also adds support for views via
+        /// <see cref="MvcViewFeaturesMvcCoreBuilderExtensions.AddViews(IMvcCoreBuilder)"/> and the Razor view engine
+        /// via <see cref="MvcRazorMvcCoreBuilderExtensions.AddRazorViewEngine(IMvcCoreBuilder)"/>.
+        /// </remarks>
+        public static IMvcBuilder AddMvcLocalization(
+            this IMvcBuilder builder,
+            LanguageViewLocationExpanderFormat format)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return AddMvcLocalization(
+                builder,
+                localizationOptionsSetupAction: null,
+                format: format,
+                dataAnnotationsLocalizationOptionsSetupAction: null);
+        }
+
+        /// <summary>
+        /// Adds MVC view and data annotations localization services to the application.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
+        /// <param name="localizationOptionsSetupAction">An action to configure the
+        /// <see cref="LocalizationOptions"/>.</param>
+        /// <param name="format">The view format for localized views.</param>
+        /// <returns>The <see cref="IMvcBuilder"/>.</returns>
+        /// <remarks>
+        /// Adding localization also adds support for views via
+        /// <see cref="MvcViewFeaturesMvcCoreBuilderExtensions.AddViews(IMvcCoreBuilder)"/> and the Razor view engine
+        /// via <see cref="MvcRazorMvcCoreBuilderExtensions.AddRazorViewEngine(IMvcCoreBuilder)"/>.
+        /// </remarks>
+        public static IMvcBuilder AddMvcLocalization(
+            this IMvcBuilder builder,
+            Action<LocalizationOptions> localizationOptionsSetupAction,
+            LanguageViewLocationExpanderFormat format)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return AddMvcLocalization(
+                builder,
+                localizationOptionsSetupAction: localizationOptionsSetupAction,
+                format: format,
+                dataAnnotationsLocalizationOptionsSetupAction: null);
+        }
+
+        /// <summary>
+        /// Adds MVC view and data annotations localization services to the application.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
+        /// <param name="dataAnnotationsLocalizationOptionsSetupAction">An action to configure the
+        /// <see cref="MvcDataAnnotationsLocalizationOptions"/>.</param>
+        /// <returns>The <see cref="IMvcBuilder"/>.</returns>
+        /// <remarks>
+        /// Adding localization also adds support for views via
+        /// <see cref="MvcViewFeaturesMvcCoreBuilderExtensions.AddViews(IMvcCoreBuilder)"/> and the Razor view engine
+        /// via <see cref="MvcRazorMvcCoreBuilderExtensions.AddRazorViewEngine(IMvcCoreBuilder)"/>.
+        /// </remarks>
+        public static IMvcBuilder AddMvcLocalization(
+            this IMvcBuilder builder,
+            Action<MvcDataAnnotationsLocalizationOptions> dataAnnotationsLocalizationOptionsSetupAction)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return AddMvcLocalization(
+                builder,
+                localizationOptionsSetupAction: null,
+                format: LanguageViewLocationExpanderFormat.Suffix,
+                dataAnnotationsLocalizationOptionsSetupAction: dataAnnotationsLocalizationOptionsSetupAction);
+        }
+
+        /// <summary>
+        /// Adds MVC view and data annotations localization services to the application.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
+        /// <param name="localizationOptionsSetupAction">An action to configure the
+        /// <see cref="LocalizationOptions"/>.</param>
+        /// <param name="dataAnnotationsLocalizationOptionsSetupAction">An action to configure the
+        /// <see cref="MvcDataAnnotationsLocalizationOptions"/>.</param>
+        /// <returns>The <see cref="IMvcBuilder"/>.</returns>
+        /// <remarks>
+        /// Adding localization also adds support for views via
+        /// <see cref="MvcViewFeaturesMvcCoreBuilderExtensions.AddViews(IMvcCoreBuilder)"/> and the Razor view engine
+        /// via <see cref="MvcRazorMvcCoreBuilderExtensions.AddRazorViewEngine(IMvcCoreBuilder)"/>.
+        /// </remarks>
+        public static IMvcBuilder AddMvcLocalization(
+            this IMvcBuilder builder,
+            Action<LocalizationOptions> localizationOptionsSetupAction,
+            Action<MvcDataAnnotationsLocalizationOptions> dataAnnotationsLocalizationOptionsSetupAction)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return AddMvcLocalization(
+                builder,
+                localizationOptionsSetupAction: localizationOptionsSetupAction,
+                format: LanguageViewLocationExpanderFormat.Suffix,
+                dataAnnotationsLocalizationOptionsSetupAction: dataAnnotationsLocalizationOptionsSetupAction);
+        }
+
+        /// <summary>
+        /// Adds MVC view and data annotations localization services to the application.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
+        /// <param name="format">The view format for localized views.</param>
+        /// <param name="dataAnnotationsLocalizationOptionsSetupAction">An action to configure the
+        /// <see cref="MvcDataAnnotationsLocalizationOptions"/>.</param>
+        /// <returns>The <see cref="IMvcBuilder"/>.</returns>
+        /// <remarks>
+        /// Adding localization also adds support for views via
+        /// <see cref="MvcViewFeaturesMvcCoreBuilderExtensions.AddViews(IMvcCoreBuilder)"/> and the Razor view engine
+        /// via <see cref="MvcRazorMvcCoreBuilderExtensions.AddRazorViewEngine(IMvcCoreBuilder)"/>.
+        /// </remarks>
+        public static IMvcBuilder AddMvcLocalization(
+            this IMvcBuilder builder,
+            LanguageViewLocationExpanderFormat format,
+            Action<MvcDataAnnotationsLocalizationOptions> dataAnnotationsLocalizationOptionsSetupAction)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return AddMvcLocalization(
+                builder,
+                localizationOptionsSetupAction: null,
+                format: format,
+                dataAnnotationsLocalizationOptionsSetupAction: dataAnnotationsLocalizationOptionsSetupAction);
+        }
+
+        /// <summary>
+        /// Adds MVC view and data annotations localization services to the application.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
+        /// <param name="localizationOptionsSetupAction">An action to configure the <see cref="LocalizationOptions"/>.
+        /// Can be <c>null</c>.</param>
+        /// <param name="format">The view format for localized views.</param>
+        /// <param name="dataAnnotationsLocalizationOptionsSetupAction">An action to configure 
+        /// the <see cref="MvcDataAnnotationsLocalizationOptions"/>. Can be <c>null</c>.</param>
+        /// <returns>The <see cref="IMvcBuilder"/>.</returns>
+        /// <remarks>
+        /// Adding localization also adds support for views via
+        /// <see cref="MvcViewFeaturesMvcCoreBuilderExtensions.AddViews(IMvcCoreBuilder)"/> and the Razor view engine
+        /// via <see cref="MvcRazorMvcCoreBuilderExtensions.AddRazorViewEngine(IMvcCoreBuilder)"/>.
+        /// </remarks>
+        public static IMvcBuilder AddMvcLocalization(
+            this IMvcBuilder builder,
+            Action<LocalizationOptions> localizationOptionsSetupAction,
+            LanguageViewLocationExpanderFormat format,
+            Action<MvcDataAnnotationsLocalizationOptions> dataAnnotationsLocalizationOptionsSetupAction)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return builder
+                .AddViewLocalization(format, localizationOptionsSetupAction)
+                .AddDataAnnotationsLocalization(dataAnnotationsLocalizationOptionsSetupAction);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Localization/DependencyInjection/MvcLocalizationMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Localization/DependencyInjection/MvcLocalizationMvcCoreBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.Mvc.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.Localization.Internal;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.Extensions.Localization;
@@ -9,15 +10,15 @@ using Microsoft.Extensions.Localization;
 namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
-    /// Extension methods for configuring MVC view localization.
+    /// Extension methods for configuring MVC view and data annotations localization services.
     /// </summary>
     public static class MvcLocalizationMvcCoreBuilderExtensions
     {
         /// <summary>
-        /// Adds MVC localization to the application.
+        /// Adds MVC view localization services to the application.
         /// </summary>
-        /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
-        /// <returns>The <see cref="IMvcBuilder"/>.</returns>
+        /// <param name="builder">The <see cref="IMvcCoreBuilder"/>.</param>
+        /// <returns>The <see cref="IMvcCoreBuilder"/>.</returns>
         /// <remarks>
         /// Adding localization also adds support for views via
         /// <see cref="MvcViewFeaturesMvcCoreBuilderExtensions.AddViews(IMvcCoreBuilder)"/> and the Razor view engine
@@ -34,11 +35,11 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        ///  Adds MVC localization to the application.
+        ///  Adds MVC view localization services to the application.
         /// </summary>
-        /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
+        /// <param name="builder">The <see cref="IMvcCoreBuilder"/>.</param>
         /// <param name="format">The view format for localized views.</param>
-        /// <returns>The <see cref="IMvcBuilder"/>.</returns>
+        /// <returns>The <see cref="IMvcCoreBuilder"/>.</returns>
         /// <remarks>
         /// Adding localization also adds support for views via
         /// <see cref="MvcViewFeaturesMvcCoreBuilderExtensions.AddViews(IMvcCoreBuilder)"/> and the Razor view engine
@@ -61,11 +62,11 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Adds MVC localization to the application.
+        /// Adds MVC view localization services to the application.
         /// </summary>
-        /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
+        /// <param name="builder">The <see cref="IMvcCoreBuilder"/>.</param>
         /// <param name="setupAction">An action to configure the <see cref="LocalizationOptions"/>.</param>
-        /// <returns>The <see cref="IMvcBuilder"/>.</returns>
+        /// <returns>The <see cref="IMvcCoreBuilder"/>.</returns>
         /// <remarks>
         /// Adding localization also adds support for views via
         /// <see cref="MvcViewFeaturesMvcCoreBuilderExtensions.AddViews(IMvcCoreBuilder)"/> and the Razor view engine
@@ -84,12 +85,12 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        ///  Adds MVC localization to the application.
+        ///  Adds MVC view localization services to the application.
         /// </summary>
-        /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
+        /// <param name="builder">The <see cref="IMvcCoreBuilder"/>.</param>
         /// <param name="format">The view format for localized views.</param>
         /// <param name="setupAction">An action to configure the <see cref="LocalizationOptions"/>.</param>
-        /// <returns>The <see cref="IMvcBuilder"/>.</returns>
+        /// <returns>The <see cref="IMvcCoreBuilder"/>.</returns>
         /// <remarks>
         /// Adding localization also adds support for views via
         /// <see cref="MvcViewFeaturesMvcCoreBuilderExtensions.AddViews(IMvcCoreBuilder)"/> and the Razor view engine
@@ -110,6 +111,234 @@ namespace Microsoft.Extensions.DependencyInjection
 
             MvcLocalizationServices.AddLocalizationServices(builder.Services, format, setupAction);
             return builder;
+        }
+
+        /// <summary>
+        /// Adds MVC view and data annotations localization services to the application.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcCoreBuilder"/>.</param>
+        /// <returns>The <see cref="IMvcCoreBuilder"/>.</returns>
+        /// <remarks>
+        /// Adding localization also adds support for views via
+        /// <see cref="MvcViewFeaturesMvcCoreBuilderExtensions.AddViews(IMvcCoreBuilder)"/> and the Razor view engine
+        /// via <see cref="MvcRazorMvcCoreBuilderExtensions.AddRazorViewEngine(IMvcCoreBuilder)"/>.
+        /// </remarks>
+        public static IMvcCoreBuilder AddMvcLocalization(this IMvcCoreBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return AddMvcLocalization(
+                builder,
+                localizationOptionsSetupAction: null,
+                format: LanguageViewLocationExpanderFormat.Suffix,
+                dataAnnotationsLocalizationOptionsSetupAction: null);
+        }
+
+        /// <summary>
+        /// Adds MVC view and data annotations localization services to the application.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcCoreBuilder"/>.</param>
+        /// <param name="localizationOptionsSetupAction">An action to configure the <see cref="LocalizationOptions"/>.</param>
+        /// <returns>The <see cref="IMvcCoreBuilder"/>.</returns>
+        /// <remarks>
+        /// Adding localization also adds support for views via
+        /// <see cref="MvcViewFeaturesMvcCoreBuilderExtensions.AddViews(IMvcCoreBuilder)"/> and the Razor view engine
+        /// via <see cref="MvcRazorMvcCoreBuilderExtensions.AddRazorViewEngine(IMvcCoreBuilder)"/>.
+        /// </remarks>
+        public static IMvcCoreBuilder AddMvcLocalization(
+            this IMvcCoreBuilder builder,
+            Action<LocalizationOptions> localizationOptionsSetupAction)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return AddMvcLocalization(
+                builder,
+                localizationOptionsSetupAction,
+                LanguageViewLocationExpanderFormat.Suffix,
+                dataAnnotationsLocalizationOptionsSetupAction: null);
+        }
+
+        /// <summary>
+        /// Adds MVC view and data annotations localization services to the application.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcCoreBuilder"/>.</param>
+        /// <param name="format">The view format for localized views.</param>
+        /// <returns>The <see cref="IMvcCoreBuilder"/>.</returns>
+        /// <remarks>
+        /// Adding localization also adds support for views via
+        /// <see cref="MvcViewFeaturesMvcCoreBuilderExtensions.AddViews(IMvcCoreBuilder)"/> and the Razor view engine
+        /// via <see cref="MvcRazorMvcCoreBuilderExtensions.AddRazorViewEngine(IMvcCoreBuilder)"/>.
+        /// </remarks>
+        public static IMvcCoreBuilder AddMvcLocalization(
+            this IMvcCoreBuilder builder,
+            LanguageViewLocationExpanderFormat format)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return AddMvcLocalization(
+                builder,
+                localizationOptionsSetupAction: null,
+                format: format,
+                dataAnnotationsLocalizationOptionsSetupAction: null);
+        }
+
+        /// <summary>
+        /// Adds MVC view and data annotations localization services to the application.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcCoreBuilder"/>.</param>
+        /// <param name="localizationOptionsSetupAction">An action to configure the
+        /// <see cref="LocalizationOptions"/>.</param>
+        /// <param name="format">The view format for localized views.</param>
+        /// <returns>The <see cref="IMvcCoreBuilder"/>.</returns>
+        /// <remarks>
+        /// Adding localization also adds support for views via
+        /// <see cref="MvcViewFeaturesMvcCoreBuilderExtensions.AddViews(IMvcCoreBuilder)"/> and the Razor view engine
+        /// via <see cref="MvcRazorMvcCoreBuilderExtensions.AddRazorViewEngine(IMvcCoreBuilder)"/>.
+        /// </remarks>
+        public static IMvcCoreBuilder AddMvcLocalization(
+            this IMvcCoreBuilder builder,
+            Action<LocalizationOptions> localizationOptionsSetupAction,
+            LanguageViewLocationExpanderFormat format)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return AddMvcLocalization(
+                builder,
+                localizationOptionsSetupAction: localizationOptionsSetupAction,
+                format: format,
+                dataAnnotationsLocalizationOptionsSetupAction: null);
+        }
+
+        /// <summary>
+        /// Adds MVC view and data annotations localization services to the application.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcCoreBuilder"/>.</param>
+        /// <param name="dataAnnotationsLocalizationOptionsSetupAction">An action to configure
+        /// the <see cref="MvcDataAnnotationsLocalizationOptions"/>.</param>
+        /// <returns>The <see cref="IMvcCoreBuilder"/>.</returns>
+        /// <remarks>
+        /// Adding localization also adds support for views via
+        /// <see cref="MvcViewFeaturesMvcCoreBuilderExtensions.AddViews(IMvcCoreBuilder)"/> and the Razor view engine
+        /// via <see cref="MvcRazorMvcCoreBuilderExtensions.AddRazorViewEngine(IMvcCoreBuilder)"/>.
+        /// </remarks>
+        public static IMvcCoreBuilder AddMvcLocalization(
+            this IMvcCoreBuilder builder,
+            Action<MvcDataAnnotationsLocalizationOptions> dataAnnotationsLocalizationOptionsSetupAction)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return AddMvcLocalization(
+                builder,
+                localizationOptionsSetupAction: null,
+                format: LanguageViewLocationExpanderFormat.Suffix,
+                dataAnnotationsLocalizationOptionsSetupAction: dataAnnotationsLocalizationOptionsSetupAction);
+        }
+
+        /// <summary>
+        /// Adds MVC view and data annotations localization services to the application.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcCoreBuilder"/>.</param>
+        /// <param name="localizationOptionsSetupAction">An action to configure the
+        /// <see cref="LocalizationOptions"/>.</param>
+        /// <param name="dataAnnotationsLocalizationOptionsSetupAction">An action to configure the
+        /// <see cref="MvcDataAnnotationsLocalizationOptions"/>.</param>
+        /// <returns>The <see cref="IMvcCoreBuilder"/>.</returns>
+        /// <remarks>
+        /// Adding localization also adds support for views via
+        /// <see cref="MvcViewFeaturesMvcCoreBuilderExtensions.AddViews(IMvcCoreBuilder)"/> and the Razor view engine
+        /// via <see cref="MvcRazorMvcCoreBuilderExtensions.AddRazorViewEngine(IMvcCoreBuilder)"/>.
+        /// </remarks>
+        public static IMvcCoreBuilder AddMvcLocalization(
+            this IMvcCoreBuilder builder,
+            Action<LocalizationOptions> localizationOptionsSetupAction,
+            Action<MvcDataAnnotationsLocalizationOptions> dataAnnotationsLocalizationOptionsSetupAction)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return AddMvcLocalization(
+                builder,
+                localizationOptionsSetupAction: localizationOptionsSetupAction,
+                format: LanguageViewLocationExpanderFormat.Suffix,
+                dataAnnotationsLocalizationOptionsSetupAction: dataAnnotationsLocalizationOptionsSetupAction);
+        }
+
+        /// <summary>
+        /// Adds MVC view and data annotations localization services to the application.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcCoreBuilder"/>.</param>
+        /// <param name="format">The view format for localized views.</param>
+        /// <param name="dataAnnotationsLocalizationOptionsSetupAction">An action to configure the
+        /// <see cref="MvcDataAnnotationsLocalizationOptions"/>.</param>
+        /// <returns>The <see cref="IMvcCoreBuilder"/>.</returns>
+        /// <remarks>
+        /// Adding localization also adds support for views via
+        /// <see cref="MvcViewFeaturesMvcCoreBuilderExtensions.AddViews(IMvcCoreBuilder)"/> and the Razor view engine
+        /// via <see cref="MvcRazorMvcCoreBuilderExtensions.AddRazorViewEngine(IMvcCoreBuilder)"/>.
+        /// </remarks>
+        public static IMvcCoreBuilder AddMvcLocalization(
+            this IMvcCoreBuilder builder,
+            LanguageViewLocationExpanderFormat format,
+            Action<MvcDataAnnotationsLocalizationOptions> dataAnnotationsLocalizationOptionsSetupAction)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return AddMvcLocalization(
+                builder,
+                localizationOptionsSetupAction: null,
+                format: format,
+                dataAnnotationsLocalizationOptionsSetupAction: dataAnnotationsLocalizationOptionsSetupAction);
+        }
+
+        /// <summary>
+        /// Adds MVC view and data annotations localization services to the application.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcCoreBuilder"/>.</param>
+        /// <param name="localizationOptionsSetupAction">An action to configure
+        /// the <see cref="LocalizationOptions"/>. Can be <c>null</c>.</param>
+        /// <param name="format">The view format for localized views.</param>
+        /// <param name="dataAnnotationsLocalizationOptionsSetupAction">An action to configure
+        /// the <see cref="MvcDataAnnotationsLocalizationOptions"/>. Can be <c>null</c>.</param>
+        /// <returns>The <see cref="IMvcCoreBuilder"/>.</returns>
+        /// <remarks>
+        /// Adding localization also adds support for views via
+        /// <see cref="MvcViewFeaturesMvcCoreBuilderExtensions.AddViews(IMvcCoreBuilder)"/> and the Razor view engine
+        /// via <see cref="MvcRazorMvcCoreBuilderExtensions.AddRazorViewEngine(IMvcCoreBuilder)"/>.
+        /// </remarks>
+        public static IMvcCoreBuilder AddMvcLocalization(
+            this IMvcCoreBuilder builder,
+            Action<LocalizationOptions> localizationOptionsSetupAction,
+            LanguageViewLocationExpanderFormat format,
+            Action<MvcDataAnnotationsLocalizationOptions> dataAnnotationsLocalizationOptionsSetupAction)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return builder
+                .AddViewLocalization(format, localizationOptionsSetupAction)
+                .AddDataAnnotationsLocalization(dataAnnotationsLocalizationOptionsSetupAction);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Localization/Internal/MvcLocalizationServices.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Localization/Internal/MvcLocalizationServices.cs
@@ -16,8 +16,8 @@ namespace Microsoft.AspNetCore.Mvc.Localization.Internal
             LanguageViewLocationExpanderFormat format,
             Action<LocalizationOptions> setupAction)
         {
-            AddMvcLocalizationServices(services, format, setupAction);
-            
+            AddMvcViewLocalizationServices(services, format, setupAction);
+
             if (setupAction == null)
             {
                 services.AddLocalization();
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Mvc.Localization.Internal
         }
 
         // To enable unit testing only 'MVC' specific services
-        public static void AddMvcLocalizationServices(
+        public static void AddMvcViewLocalizationServices(
             IServiceCollection services,
             LanguageViewLocationExpanderFormat format,
             Action<LocalizationOptions> setupAction)

--- a/test/Microsoft.AspNetCore.Mvc.Localization.Test/Internal/MvcLocalizationServiceCollectionExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Localization.Test/Internal/MvcLocalizationServiceCollectionExtensionsTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Mvc.Localization.Internal
             var collection = new ServiceCollection();
 
             // Act
-            MvcLocalizationServices.AddMvcLocalizationServices(
+            MvcLocalizationServices.AddMvcViewLocalizationServices(
                 collection,
                 LanguageViewLocationExpanderFormat.Suffix,
                 setupAction: null);
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Mvc.Localization.Internal
             collection.Add(ServiceDescriptor.Transient(typeof(IViewLocalizer), typeof(TestViewLocalizer)));
             collection.Add(ServiceDescriptor.Singleton(typeof(HtmlEncoder), testEncoder));
 
-            MvcLocalizationServices.AddMvcLocalizationServices(
+            MvcLocalizationServices.AddMvcViewLocalizationServices(
                 collection,
                 LanguageViewLocationExpanderFormat.Suffix,
                 setupAction: null);
@@ -119,7 +119,7 @@ namespace Microsoft.AspNetCore.Mvc.Localization.Internal
             });
 
             // Act
-            MvcLocalizationServices.AddMvcLocalizationServices(
+            MvcLocalizationServices.AddMvcViewLocalizationServices(
                 collection,
                 LanguageViewLocationExpanderFormat.Suffix,
                 setupAction: null);
@@ -186,7 +186,7 @@ namespace Microsoft.AspNetCore.Mvc.Localization.Internal
             var collection = new ServiceCollection();
 
             // Act
-            MvcLocalizationServices.AddMvcLocalizationServices(
+            MvcLocalizationServices.AddMvcViewLocalizationServices(
                 collection,
                 LanguageViewLocationExpanderFormat.Suffix,
                 options => options.ResourcesPath = "Resources");

--- a/test/Microsoft.AspNetCore.Mvc.Localization.Test/MvcLocalizationMvcBuilderExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Localization.Test/MvcLocalizationMvcBuilderExtensionsTest.cs
@@ -1,0 +1,146 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.AspNetCore.Mvc.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.Razor;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.Localization.Test
+{
+    public class MvcLocalizationMvcBuilderExtensionsTest
+    {
+        public static TheoryData<IMvcBuilder> MvcBuilderExtensionsData()
+        {
+            var builder1 = new TestMvcBuilder();
+            builder1.AddMvcLocalization();
+
+            var builder2 = new TestMvcBuilder();
+            builder2.AddMvcLocalization(LanguageViewLocationExpanderFormat.SubFolder);
+
+            var builder3 = new TestMvcBuilder();
+            builder3.AddMvcLocalization(localizationOptionsSetupAction: l => l.ResourcesPath = "Resources");
+
+            var builder4 = new TestMvcBuilder();
+            builder4.AddMvcLocalization(
+                localizationOptionsSetupAction: l => l.ResourcesPath = "Resources",
+                format: LanguageViewLocationExpanderFormat.SubFolder);
+
+            return new TheoryData<IMvcBuilder>()
+            {
+                builder1, builder2, builder3, builder4
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(MvcBuilderExtensionsData))]
+        public void AddsRequiredServices(IMvcBuilder mvcBuilder)
+        {
+            // Assert
+            var services = mvcBuilder.Services;
+            // Base localization services
+            var service = services.FirstOrDefault(
+                sd => sd.ServiceType == typeof(IStringLocalizerFactory));
+            Assert.NotNull(service);
+            Assert.Equal(ServiceLifetime.Singleton, service.Lifetime);
+            Assert.Equal(typeof(ResourceManagerStringLocalizerFactory), service.ImplementationType);
+
+            service = services.FirstOrDefault(
+                sd => sd.ServiceType == typeof(IStringLocalizer<>));
+            Assert.NotNull(service);
+            Assert.Equal(ServiceLifetime.Transient, service.Lifetime);
+            Assert.Equal(typeof(StringLocalizer<>), service.ImplementationType);
+
+            // View localization services
+            service = services.FirstOrDefault(
+                sd => sd.ServiceType == typeof(IConfigureOptions<MvcDataAnnotationsLocalizationOptions>));
+            Assert.NotNull(service);
+            Assert.Equal(ServiceLifetime.Transient, service.Lifetime);
+
+            service = services.FirstOrDefault(
+                sd => sd.ServiceType == typeof(IConfigureOptions<RazorViewEngineOptions>));
+            Assert.NotNull(service);
+            Assert.Equal(ServiceLifetime.Singleton, service.Lifetime);
+
+            service = services.FirstOrDefault(sd => sd.ServiceType == typeof(IHtmlLocalizerFactory));
+            Assert.NotNull(service);
+            Assert.Equal(typeof(HtmlLocalizerFactory), service.ImplementationType);
+            Assert.Equal(ServiceLifetime.Singleton, service.Lifetime);
+
+            service = services.FirstOrDefault(sd => sd.ServiceType == typeof(IHtmlLocalizer<>));
+            Assert.NotNull(service);
+            Assert.Equal(typeof(HtmlLocalizer<>), service.ImplementationType);
+            Assert.Equal(ServiceLifetime.Transient, service.Lifetime);
+
+            service = services.FirstOrDefault(sd => sd.ServiceType == typeof(IViewLocalizer));
+            Assert.NotNull(service);
+            Assert.Equal(typeof(ViewLocalizer), service.ImplementationType);
+            Assert.Equal(ServiceLifetime.Transient, service.Lifetime);
+        }
+
+        [Fact]
+        public void SetsLocalizationOptions_AsExpected()
+        {
+            // Arrange
+            var builder = new TestMvcBuilder();
+
+            // Act
+            builder.AddMvcLocalization(
+                localizationOptionsSetupAction: options => options.ResourcesPath = "TestResources");
+
+            // Assert
+            var serviceProvider = builder.Services.BuildServiceProvider();
+            var actualOptions = serviceProvider.GetRequiredService<IOptions<LocalizationOptions>>();
+            Assert.Equal("TestResources", actualOptions.Value.ResourcesPath);
+        }
+
+        [Fact]
+        public void SetsDataAnnotationsOptions_AsExpected()
+        {
+            // Arrange
+            var builder = new TestMvcBuilder();
+            var dataAnnotationLocalizerProvider = new Func<Type, IStringLocalizerFactory, IStringLocalizer>((type, factory) =>
+            {
+                return null;
+            });
+
+            // Act
+            builder.AddMvcLocalization(
+                dataAnnotationsLocalizationOptionsSetupAction: options
+                => options.DataAnnotationLocalizerProvider = dataAnnotationLocalizerProvider);
+
+            // Assert
+            var serviceProvider = builder.Services.BuildServiceProvider();
+            var actualOptions = serviceProvider.GetRequiredService<IOptions<MvcDataAnnotationsLocalizationOptions>>();
+            Assert.Same(dataAnnotationLocalizerProvider, actualOptions.Value.DataAnnotationLocalizerProvider);
+        }
+
+        private ServiceDescriptor GetService(IServiceCollection services, Type serviceType)
+        {
+            return services.FirstOrDefault(sd => sd.ServiceType == serviceType);
+        }
+
+        private class TestMvcBuilder : IMvcBuilder
+        {
+            IServiceCollection _services;
+            public IServiceCollection Services
+            {
+                get
+                {
+                    if (_services == null)
+                    {
+                        _services = new ServiceCollection();
+                    }
+                    return _services;
+                }
+            }
+
+            public ApplicationPartManager PartManager => new ApplicationPartManager();
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.Localization.Test/MvcLocalizationMvcCoreBuilderExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Localization.Test/MvcLocalizationMvcCoreBuilderExtensionsTest.cs
@@ -1,0 +1,146 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.AspNetCore.Mvc.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.Razor;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.Localization.Test
+{
+    public class MvcLocalizationMvcCoreBuilderExtensionsTest
+    {
+        public static TheoryData<IMvcCoreBuilder> MvcCoreBuilderExtensionsData()
+        {
+            var builder1 = new TestMvcCoreBuilder();
+            builder1.AddMvcLocalization();
+
+            var builder2 = new TestMvcCoreBuilder();
+            builder2.AddMvcLocalization(LanguageViewLocationExpanderFormat.SubFolder);
+
+            var builder3 = new TestMvcCoreBuilder();
+            builder3.AddMvcLocalization(localizationOptionsSetupAction: l => l.ResourcesPath = "Resources");
+
+            var builder4 = new TestMvcCoreBuilder();
+            builder4.AddMvcLocalization(
+                localizationOptionsSetupAction: l => l.ResourcesPath = "Resources",
+                format: LanguageViewLocationExpanderFormat.SubFolder);
+
+            return new TheoryData<IMvcCoreBuilder>()
+            {
+                builder1, builder2, builder3, builder4
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(MvcCoreBuilderExtensionsData))]
+        public void AddsRequiredServices(IMvcCoreBuilder mvcCoreBuilder)
+        {
+            // Assert
+            var services = mvcCoreBuilder.Services;
+            // Base localization services
+            var service = services.FirstOrDefault(
+                sd => sd.ServiceType == typeof(IStringLocalizerFactory));
+            Assert.NotNull(service);
+            Assert.Equal(ServiceLifetime.Singleton, service.Lifetime);
+            Assert.Equal(typeof(ResourceManagerStringLocalizerFactory), service.ImplementationType);
+
+            service = services.FirstOrDefault(
+                sd => sd.ServiceType == typeof(IStringLocalizer<>));
+            Assert.NotNull(service);
+            Assert.Equal(ServiceLifetime.Transient, service.Lifetime);
+            Assert.Equal(typeof(StringLocalizer<>), service.ImplementationType);
+
+            // View localization services
+            service = services.FirstOrDefault(
+                sd => sd.ServiceType == typeof(IConfigureOptions<MvcDataAnnotationsLocalizationOptions>));
+            Assert.NotNull(service);
+            Assert.Equal(ServiceLifetime.Transient, service.Lifetime);
+
+            service = services.FirstOrDefault(
+                sd => sd.ServiceType == typeof(IConfigureOptions<RazorViewEngineOptions>));
+            Assert.NotNull(service);
+            Assert.Equal(ServiceLifetime.Transient, service.Lifetime);
+
+            service = services.FirstOrDefault(sd => sd.ServiceType == typeof(IHtmlLocalizerFactory));
+            Assert.NotNull(service);
+            Assert.Equal(typeof(HtmlLocalizerFactory), service.ImplementationType);
+            Assert.Equal(ServiceLifetime.Singleton, service.Lifetime);
+
+            service = services.FirstOrDefault(sd => sd.ServiceType == typeof(IHtmlLocalizer<>));
+            Assert.NotNull(service);
+            Assert.Equal(typeof(HtmlLocalizer<>), service.ImplementationType);
+            Assert.Equal(ServiceLifetime.Transient, service.Lifetime);
+
+            service = services.FirstOrDefault(sd => sd.ServiceType == typeof(IViewLocalizer));
+            Assert.NotNull(service);
+            Assert.Equal(typeof(ViewLocalizer), service.ImplementationType);
+            Assert.Equal(ServiceLifetime.Transient, service.Lifetime);
+        }
+
+        [Fact]
+        public void SetsLocalizationOptions_AsExpected()
+        {
+            // Arrange
+            var builder = new TestMvcCoreBuilder();
+
+            // Act
+            builder.AddMvcLocalization(
+                localizationOptionsSetupAction: options => options.ResourcesPath = "TestResources");
+
+            // Assert
+            var serviceProvider = builder.Services.BuildServiceProvider();
+            var actualOptions = serviceProvider.GetRequiredService<IOptions<LocalizationOptions>>();
+            Assert.Equal("TestResources", actualOptions.Value.ResourcesPath);
+        }
+
+        [Fact]
+        public void SetsDataAnnotationsOptions_AsExpected()
+        {
+            // Arrange
+            var builder = new TestMvcCoreBuilder();
+            var dataAnnotationLocalizerProvider = new Func<Type, IStringLocalizerFactory, IStringLocalizer>((type, factory) =>
+            {
+                return null;
+            });
+
+            // Act
+            builder.AddMvcLocalization(
+                dataAnnotationsLocalizationOptionsSetupAction: options
+                => options.DataAnnotationLocalizerProvider = dataAnnotationLocalizerProvider);
+
+            // Assert
+            var serviceProvider = builder.Services.BuildServiceProvider();
+            var actualOptions = serviceProvider.GetRequiredService<IOptions<MvcDataAnnotationsLocalizationOptions>>();
+            Assert.Same(dataAnnotationLocalizerProvider, actualOptions.Value.DataAnnotationLocalizerProvider);
+        }
+
+        private ServiceDescriptor GetService(IServiceCollection services, Type serviceType)
+        {
+            return services.FirstOrDefault(sd => sd.ServiceType == serviceType);
+        }
+
+        private class TestMvcCoreBuilder : IMvcCoreBuilder
+        {
+            IServiceCollection _services;
+            public IServiceCollection Services
+            {
+                get
+                {
+                    if (_services == null)
+                    {
+                        _services = new ServiceCollection();
+                    }
+                    return _services;
+                }
+            }
+
+            public ApplicationPartManager PartManager => new ApplicationPartManager();
+        }
+    }
+}

--- a/test/WebSites/RazorPagesWebSite/Startup.cs
+++ b/test/WebSites/RazorPagesWebSite/Startup.cs
@@ -14,7 +14,7 @@ namespace RazorPagesWebSite
         {
             services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme).AddCookie(options => options.LoginPath = "/Login");
             services.AddMvc()
-                .AddViewLocalization()
+                .AddMvcLocalization()
                 .AddRazorPagesOptions(options =>
                 {
                     options.Conventions.AuthorizePage("/HelloWorldWithAuth");

--- a/test/WebSites/RazorWebSite/Startup.cs
+++ b/test/WebSites/RazorWebSite/Startup.cs
@@ -43,7 +43,7 @@ namespace RazorWebSite
                     options.HtmlHelperOptions.ValidationMessageElement = "validationMessageElement";
                     options.HtmlHelperOptions.ValidationSummaryMessageElement = "validationSummaryElement";
                 })
-                .AddViewLocalization(LanguageViewLocationExpanderFormat.SubFolder);
+                .AddMvcLocalization(LanguageViewLocationExpanderFormat.SubFolder);
 
             services.AddTransient<InjectedHelper>();
             services.AddTransient<TaskReturningService>();


### PR DESCRIPTION
[Fixes #5436] Must call `AddViewLocalization()` to use `IStringLocalizer<T>` in an application