### PR TITLE
Introduce [ApiController]

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/ApiControllerAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ApiControllerAttribute.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Mvc.Internal;
+
+namespace Microsoft.AspNetCore.Mvc
+{
+    /// <summary>
+    /// Indicates that a type and all derived types are used to serve HTTP API responses. The presense of
+    /// this attribute can be used to target conventions, filters and other behaviors based on the purpose
+    /// of the controller.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public class ApiControllerAttribute : ControllerAttribute , IApiBehaviorMetadata
+    {
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/IApiBehaviorMetadata.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/IApiBehaviorMetadata.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Microsoft.AspNetCore.Mvc.Internal
+{
+    /// <summary>
+    /// An <see cref="IFilterMetadata"/> interface for <see cref="ApiControllerAttribute"/>. See 
+    /// <see cref="ApiControllerAttribute"/> for details.
+    /// </summary>
+    public interface IApiBehaviorMetadata : IFilterMetadata
+    {
+    }
+}


### PR DESCRIPTION
This puts a de-facto metadata approach in the box to declare
unambiguously 'Hey, I am an API!'.

I think this is worth us doing at this point because I haven't really
seen anyone in the community running with targeting conventions at
equivalence classes of controllers.

Now that we're putting API-specific, opinionated behaviors in the box,
we need to away to make it opt-in and declarative.