### PR TITLE
Design extensibility for executors

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/ContentResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ContentResult.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -32,7 +33,7 @@ namespace Microsoft.AspNetCore.Mvc
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var executor = context.HttpContext.RequestServices.GetRequiredService<ContentResultExecutor>();
+            var executor = context.HttpContext.RequestServices.GetRequiredService<IActionResultExecutor<ContentResult>>();
             return executor.ExecuteAsync(context, this);
         }
     }

--- a/src/Microsoft.AspNetCore.Mvc.Core/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
@@ -250,17 +250,17 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddSingleton<IHttpResponseStreamWriterFactory, MemoryPoolHttpResponseStreamWriterFactory>();
             services.TryAddSingleton(ArrayPool<byte>.Shared);
             services.TryAddSingleton(ArrayPool<char>.Shared);
-            services.TryAddSingleton<ObjectResultExecutor>();
-            services.TryAddSingleton<PhysicalFileResultExecutor>();
-            services.TryAddSingleton<VirtualFileResultExecutor>();
-            services.TryAddSingleton<FileStreamResultExecutor>();
-            services.TryAddSingleton<FileContentResultExecutor>();
-            services.TryAddSingleton<RedirectResultExecutor>();
-            services.TryAddSingleton<LocalRedirectResultExecutor>();
-            services.TryAddSingleton<RedirectToActionResultExecutor>();
-            services.TryAddSingleton<RedirectToRouteResultExecutor>();
-            services.TryAddSingleton<RedirectToPageResultExecutor>();
-            services.TryAddSingleton<ContentResultExecutor>();
+            services.TryAddSingleton<IActionResultExecutor<ObjectResult>, ObjectResultExecutor>();
+            services.TryAddSingleton<IActionResultExecutor<PhysicalFileResult>, PhysicalFileResultExecutor>();
+            services.TryAddSingleton<IActionResultExecutor<VirtualFileResult>, VirtualFileResultExecutor>();
+            services.TryAddSingleton<IActionResultExecutor<FileStreamResult>, FileStreamResultExecutor>();
+            services.TryAddSingleton<IActionResultExecutor<FileContentResult>, FileContentResultExecutor>();
+            services.TryAddSingleton<IActionResultExecutor<RedirectResult>, RedirectResultExecutor>();
+            services.TryAddSingleton<IActionResultExecutor<LocalRedirectResult>, LocalRedirectResultExecutor>();
+            services.TryAddSingleton<IActionResultExecutor<RedirectToActionResult>, RedirectToActionResultExecutor>();
+            services.TryAddSingleton<IActionResultExecutor<RedirectToRouteResult>, RedirectToRouteResultExecutor>();
+            services.TryAddSingleton<IActionResultExecutor<RedirectToPageResult>, RedirectToPageResultExecutor>();
+            services.TryAddSingleton<IActionResultExecutor<ContentResult>, ContentResultExecutor>();
 
             //
             // Route Handlers

--- a/src/Microsoft.AspNetCore.Mvc.Core/FileContentResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/FileContentResult.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Net.Http.Headers;
@@ -76,7 +77,7 @@ namespace Microsoft.AspNetCore.Mvc
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var executor = context.HttpContext.RequestServices.GetRequiredService<FileContentResultExecutor>();
+            var executor = context.HttpContext.RequestServices.GetRequiredService<IActionResultExecutor<FileContentResult>>();
             return executor.ExecuteAsync(context, this);
         }
     }

--- a/src/Microsoft.AspNetCore.Mvc.Core/FileStreamResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/FileStreamResult.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Net.Http.Headers;
@@ -73,7 +74,7 @@ namespace Microsoft.AspNetCore.Mvc
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var executor = context.HttpContext.RequestServices.GetRequiredService<FileStreamResultExecutor>();
+            var executor = context.HttpContext.RequestServices.GetRequiredService<IActionResultExecutor<FileStreamResult>>();
             return executor.ExecuteAsync(context, this);
         }
     }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/ContentResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/ContentResultExecutor.cs
@@ -4,11 +4,12 @@
 using System;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.AspNetCore.Mvc.Internal
+namespace Microsoft.AspNetCore.Mvc.Infrastructure
 {
-    public class ContentResultExecutor
+    public class ContentResultExecutor : IActionResultExecutor<ContentResult>
     {
         private const string DefaultContentType = "text/plain; charset=utf-8";
         private readonly ILogger<ContentResultExecutor> _logger;
@@ -20,6 +21,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             _httpResponseStreamWriterFactory = httpResponseStreamWriterFactory;
         }
 
+        /// <inheritdoc />
         public virtual async Task ExecuteAsync(ActionContext context, ContentResult result)
         {
             if (context == null)

--- a/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/FileContentResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/FileContentResultExecutor.cs
@@ -7,15 +7,16 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
 
-namespace Microsoft.AspNetCore.Mvc.Internal
+namespace Microsoft.AspNetCore.Mvc.Infrastructure
 {
-    public class FileContentResultExecutor : FileResultExecutorBase
+    public class FileContentResultExecutor : FileResultExecutorBase, IActionResultExecutor<FileContentResult>
     {
         public FileContentResultExecutor(ILoggerFactory loggerFactory)
             : base(CreateLogger<FileContentResultExecutor>(loggerFactory))
         {
         }
 
+        /// <inheritdoc />
         public virtual Task ExecuteAsync(ActionContext context, FileContentResult result)
         {
             if (context == null)

--- a/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/FileResultExecutorBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/FileResultExecutorBase.cs
@@ -10,10 +10,11 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Http.Headers;
 using Microsoft.AspNetCore.Internal;
+using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
 
-namespace Microsoft.AspNetCore.Mvc.Internal
+namespace Microsoft.AspNetCore.Mvc.Infrastructure
 {
     public class FileResultExecutorBase
     {

--- a/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/FileStreamResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/FileStreamResultExecutor.cs
@@ -6,15 +6,16 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
 
-namespace Microsoft.AspNetCore.Mvc.Internal
+namespace Microsoft.AspNetCore.Mvc.Infrastructure
 {
-    public class FileStreamResultExecutor : FileResultExecutorBase
+    public class FileStreamResultExecutor : FileResultExecutorBase, IActionResultExecutor<FileStreamResult>
     {
         public FileStreamResultExecutor(ILoggerFactory loggerFactory)
             : base(CreateLogger<FileStreamResultExecutor>(loggerFactory))
         {
         }
 
+        /// <inheritdoc />
         public virtual Task ExecuteAsync(ActionContext context, FileStreamResult result)
         {
             if (context == null)

--- a/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/IActionResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/IActionResultExecutor.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Mvc.Infrastructure
+{
+    /// <summary>
+    /// Defines an interface for a service which can execute a particular kind of <see cref="IActionResult"/> by
+    /// manipulating the <see cref="HttpResponse"/>.
+    /// </summary>
+    /// <typeparam name="TResult">The type of <see cref="IActionResult"/>.</typeparam>
+    /// <remarks>
+    /// Implementions of <see cref="IActionResultExecutor{TResult}"/> are typically called by the
+    /// <see cref="IActionResult.ExecuteResultAsync(ActionContext)"/> method of the corresponding action result type.
+    /// Implementations should be registered as singleton services.
+    /// </remarks>
+    public interface IActionResultExecutor<in TResult> where TResult : IActionResult
+    {
+        /// <summary>
+        /// Asynchronously excecutes the action result, by modifying the <see cref="HttpResponse"/>.
+        /// </summary>
+        /// <param name="context">The <see cref="ActionContext"/> associated with the current request."/></param>
+        /// <param name="result">The action result to execute.</param>
+        /// <returns>A <see cref="Task"/> which represents the asynchronous operation.</returns>
+        Task ExecuteAsync(ActionContext context, TResult result);
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/ObjectResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/ObjectResultExecutor.cs
@@ -11,17 +11,18 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Core;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.Formatters.Internal;
+using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 
-namespace Microsoft.AspNetCore.Mvc.Internal
+namespace Microsoft.AspNetCore.Mvc.Infrastructure
 {
     /// <summary>
     /// Executes an <see cref="ObjectResult"/> to write to the response.
     /// </summary>
-    public class ObjectResultExecutor
+    public class ObjectResultExecutor : IActionResultExecutor<ObjectResult>
     {
         /// <summary>
         /// Creates a new <see cref="ObjectResultExecutor"/>.

--- a/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/PhysicalFileResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/PhysicalFileResultExecutor.cs
@@ -10,15 +10,16 @@ using Microsoft.AspNetCore.Mvc.Core;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
 
-namespace Microsoft.AspNetCore.Mvc.Internal
+namespace Microsoft.AspNetCore.Mvc.Infrastructure
 {
-    public class PhysicalFileResultExecutor : FileResultExecutorBase
+    public class PhysicalFileResultExecutor : FileResultExecutorBase, IActionResultExecutor<PhysicalFileResult>
     {
         public PhysicalFileResultExecutor(ILoggerFactory loggerFactory)
             : base(CreateLogger<PhysicalFileResultExecutor>(loggerFactory))
         {
         }
 
+        /// <inheritdoc />
         public virtual Task ExecuteAsync(ActionContext context, PhysicalFileResult result)
         {
             if (context == null)

--- a/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/RedirectToActionResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/RedirectToActionResultExecutor.cs
@@ -2,15 +2,17 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Core;
+using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
 
-namespace Microsoft.AspNetCore.Mvc.Internal
+namespace Microsoft.AspNetCore.Mvc.Infrastructure
 {
-    public class RedirectToActionResultExecutor
+    public class RedirectToActionResultExecutor : IActionResultExecutor<RedirectToActionResult>
     {
         private readonly ILogger _logger;
         private readonly IUrlHelperFactory _urlHelperFactory;
@@ -31,7 +33,8 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             _urlHelperFactory = urlHelperFactory;
         }
 
-        public virtual void Execute(ActionContext context, RedirectToActionResult result)
+        /// <inheritdoc />
+        public virtual Task ExecuteAsync(ActionContext context, RedirectToActionResult result)
         {
             if (context == null)
             {
@@ -69,6 +72,8 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             {
                 context.HttpContext.Response.Redirect(destinationUrl, result.Permanent);
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/RedirectToPageResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/RedirectToPageResultExecutor.cs
@@ -2,20 +2,22 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Core;
+using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
 
-namespace Microsoft.AspNetCore.Mvc.Internal
+namespace Microsoft.AspNetCore.Mvc.Infrastructure
 {
-    public class LocalRedirectResultExecutor
+    public class RedirectToPageResultExecutor : IActionResultExecutor<RedirectToPageResult>
     {
         private readonly ILogger _logger;
         private readonly IUrlHelperFactory _urlHelperFactory;
 
-        public LocalRedirectResultExecutor(ILoggerFactory loggerFactory, IUrlHelperFactory urlHelperFactory)
+        public RedirectToPageResultExecutor(ILoggerFactory loggerFactory, IUrlHelperFactory urlHelperFactory)
         {
             if (loggerFactory == null)
             {
@@ -27,11 +29,12 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 throw new ArgumentNullException(nameof(urlHelperFactory));
             }
 
-            _logger = loggerFactory.CreateLogger<LocalRedirectResultExecutor>();
+            _logger = loggerFactory.CreateLogger<RedirectToRouteResult>();
             _urlHelperFactory = urlHelperFactory;
         }
 
-        public virtual void Execute(ActionContext context, LocalRedirectResult result)
+        /// <inheritdoc />
+        public virtual Task ExecuteAsync(ActionContext context, RedirectToPageResult result)
         {
             if (context == null)
             {
@@ -44,15 +47,20 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             }
 
             var urlHelper = result.UrlHelper ?? _urlHelperFactory.GetUrlHelper(context);
+            var destinationUrl = urlHelper.Page(
+                result.PageName,
+                result.PageHandler,
+                result.RouteValues,
+                result.Protocol,
+                result.Host,
+                fragment: result.Fragment);
 
-            // IsLocalUrl is called to handle  Urls starting with '~/'.
-            if (!urlHelper.IsLocalUrl(result.Url))
+            if (string.IsNullOrEmpty(destinationUrl))
             {
-                throw new InvalidOperationException(Resources.UrlNotLocal);
+                throw new InvalidOperationException(Resources.FormatNoRoutesMatchedForPage(result.PageName));
             }
 
-            var destinationUrl = urlHelper.Content(result.Url);
-            _logger.LocalRedirectResultExecuting(destinationUrl);
+            _logger.RedirectToPageResultExecuting(result.PageName);
 
             if (result.PreserveMethod)
             {
@@ -64,6 +72,8 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             {
                 context.HttpContext.Response.Redirect(destinationUrl, result.Permanent);
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/VirtualFileResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/VirtualFileResultExecutor.cs
@@ -12,9 +12,9 @@ using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
 
-namespace Microsoft.AspNetCore.Mvc.Internal
+namespace Microsoft.AspNetCore.Mvc.Infrastructure
 {
-    public class VirtualFileResultExecutor : FileResultExecutorBase
+    public class VirtualFileResultExecutor : FileResultExecutorBase , IActionResultExecutor<VirtualFileResult>
     {
         private readonly IHostingEnvironment _hostingEnvironment;
 
@@ -29,6 +29,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             _hostingEnvironment = hostingEnvironment;
         }
 
+        /// <inheritdoc />
         public virtual Task ExecuteAsync(ActionContext context, VirtualFileResult result)
         {
             if (context == null)

--- a/src/Microsoft.AspNetCore.Mvc.Core/ObjectResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ObjectResult.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -33,10 +34,8 @@ namespace Microsoft.AspNetCore.Mvc
 
         public override Task ExecuteResultAsync(ActionContext context)
         {
-            var executor = context.HttpContext.RequestServices.GetRequiredService<ObjectResultExecutor>();
-            var result = executor.ExecuteAsync(context, this);
-
-            return result;
+            var executor = context.HttpContext.RequestServices.GetRequiredService<IActionResultExecutor<ObjectResult>>();
+            return executor.ExecuteAsync(context, this);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Mvc.Core/PhysicalFileResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/PhysicalFileResult.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Net.Http.Headers;
@@ -74,7 +75,7 @@ namespace Microsoft.AspNetCore.Mvc
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var executor = context.HttpContext.RequestServices.GetRequiredService<PhysicalFileResultExecutor>();
+            var executor = context.HttpContext.RequestServices.GetRequiredService<IActionResultExecutor<PhysicalFileResult>>();
             return executor.ExecuteAsync(context, this);
         }
     }

--- a/src/Microsoft.AspNetCore.Mvc.Core/RedirectToActionResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RedirectToActionResult.cs
@@ -2,10 +2,17 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Core;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Mvc
 {
@@ -165,6 +172,19 @@ namespace Microsoft.AspNetCore.Mvc
         public string Fragment { get; set; }
 
         /// <inheritdoc />
+        public override Task ExecuteResultAsync(ActionContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var executor = context.HttpContext.RequestServices.GetRequiredService<IActionResultExecutor<RedirectToActionResult>>();
+            return executor.ExecuteAsync(context, this);
+        }
+
+#pragma warning disable CS0809
+        [Obsolete("This implementation will be removed in a future release, use ExecuteResultAsync.")]
         public override void ExecuteResult(ActionContext context)
         {
             if (context == null)
@@ -172,8 +192,37 @@ namespace Microsoft.AspNetCore.Mvc
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var executor = context.HttpContext.RequestServices.GetRequiredService<RedirectToActionResultExecutor>();
-            executor.Execute(context, this);
+            var services = context.HttpContext.RequestServices;
+            var urlHelperFactory = services.GetRequiredService<IUrlHelperFactory>();
+            var logger = services.GetRequiredService<ILogger<RedirectToActionResultExecutor>>();
+
+            var urlHelper = UrlHelper ?? urlHelperFactory.GetUrlHelper(context);
+
+            var destinationUrl = urlHelper.Action(
+                ActionName,
+                ControllerName,
+                RouteValues,
+                protocol: null,
+                host: null,
+                fragment: Fragment);
+            if (string.IsNullOrEmpty(destinationUrl))
+            {
+                throw new InvalidOperationException(Resources.NoRoutesMatched);
+            }
+
+            logger.RedirectToActionResultExecuting(destinationUrl);
+
+            if (PreserveMethod)
+            {
+                context.HttpContext.Response.StatusCode = Permanent ?
+                    StatusCodes.Status308PermanentRedirect : StatusCodes.Status307TemporaryRedirect;
+                context.HttpContext.Response.Headers[HeaderNames.Location] = destinationUrl;
+            }
+            else
+            {
+                context.HttpContext.Response.Redirect(destinationUrl, Permanent);
+            }
         }
+#pragma warning restore CS0809
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/RedirectToPageResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RedirectToPageResult.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Routing;
@@ -204,15 +206,15 @@ namespace Microsoft.AspNetCore.Mvc
         public string Host { get; set; }
 
         /// <inheritdoc />
-        public override void ExecuteResult(ActionContext context)
+        public override Task ExecuteResultAsync(ActionContext context)
         {
             if (context == null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var executor = context.HttpContext.RequestServices.GetRequiredService<RedirectToPageResultExecutor>();
-            executor.Execute(context, this);
+            var executor = context.HttpContext.RequestServices.GetRequiredService<IActionResultExecutor<RedirectToPageResult>>();
+            return executor.ExecuteAsync(context, this);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/RedirectToRouteResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RedirectToRouteResult.cs
@@ -2,10 +2,17 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Core;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Mvc
 {
@@ -157,6 +164,19 @@ namespace Microsoft.AspNetCore.Mvc
         public string Fragment { get; set; }
 
         /// <inheritdoc />
+        public override Task ExecuteResultAsync(ActionContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var executor = context.HttpContext.RequestServices.GetRequiredService<IActionResultExecutor<RedirectToRouteResult>>();
+            return executor.ExecuteAsync(context, this);
+        }
+
+#pragma warning disable CS0809
+        [Obsolete("This implementation will be removed in a future release, use ExecuteResultAsync.")]
         public override void ExecuteResult(ActionContext context)
         {
             if (context == null)
@@ -164,8 +184,36 @@ namespace Microsoft.AspNetCore.Mvc
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var executor = context.HttpContext.RequestServices.GetRequiredService<RedirectToRouteResultExecutor>();
-            executor.Execute(context, this);
+            var services = context.HttpContext.RequestServices;
+            var urlHelperFactory = services.GetRequiredService<IUrlHelperFactory>();
+            var logger = services.GetRequiredService<ILogger<RedirectToRouteResult>>();
+
+            var urlHelper = UrlHelper ?? urlHelperFactory.GetUrlHelper(context);
+
+            var destinationUrl = urlHelper.RouteUrl(
+                RouteName,
+                RouteValues,
+                protocol: null,
+                host: null,
+                fragment: Fragment);
+            if (string.IsNullOrEmpty(destinationUrl))
+            {
+                throw new InvalidOperationException(Resources.NoRoutesMatched);
+            }
+
+            logger.RedirectToRouteResultExecuting(destinationUrl, RouteName);
+
+            if (PreserveMethod)
+            {
+                context.HttpContext.Response.StatusCode = Permanent ?
+                    StatusCodes.Status308PermanentRedirect : StatusCodes.Status307TemporaryRedirect;
+                context.HttpContext.Response.Headers[HeaderNames.Location] = destinationUrl;
+            }
+            else
+            {
+                context.HttpContext.Response.Redirect(destinationUrl, Permanent);
+            }
         }
+#pragma warning restore CS0809
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/VirtualFileResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/VirtualFileResult.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
@@ -84,7 +85,7 @@ namespace Microsoft.AspNetCore.Mvc
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var executor = context.HttpContext.RequestServices.GetRequiredService<VirtualFileResultExecutor>();
+            var executor = context.HttpContext.RequestServices.GetRequiredService<IActionResultExecutor<VirtualFileResult>>();
             return executor.ExecuteAsync(context, this);
         }
     }

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/DependencyInjection/MvcViewFeaturesMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/DependencyInjection/MvcViewFeaturesMvcCoreBuilderExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewComponents;
@@ -148,8 +149,8 @@ namespace Microsoft.Extensions.DependencyInjection
             // View Engine and related infrastructure
             //
             services.TryAddSingleton<ICompositeViewEngine, CompositeViewEngine>();
-            services.TryAddSingleton<ViewResultExecutor>();
-            services.TryAddSingleton<PartialViewResultExecutor>();
+            services.TryAddSingleton<IActionResultExecutor<ViewResult>, ViewResultExecutor>();
+            services.TryAddSingleton<IActionResultExecutor<PartialViewResult>, PartialViewResultExecutor>();
 
             // Support for activating ViewDataDictionary
             services.TryAddEnumerable(
@@ -188,7 +189,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddSingleton<
                 IViewComponentDescriptorCollectionProvider,
                 DefaultViewComponentDescriptorCollectionProvider>();
-            services.TryAddSingleton<ViewComponentResultExecutor>();
+            services.TryAddSingleton<IActionResultExecutor<ViewComponentResult>, ViewComponentResultExecutor>();
 
             services.TryAddSingleton<ViewComponentInvokerCache>();
             services.TryAddTransient<IViewComponentDescriptorProvider, DefaultViewComponentDescriptorProvider>();

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/PartialViewResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/PartialViewResult.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Mvc.ViewFeatures.Internal;
@@ -57,7 +58,7 @@ namespace Microsoft.AspNetCore.Mvc
         public string ContentType { get; set; }
 
         /// <inheritdoc />
-        public override async Task ExecuteResultAsync(ActionContext context)
+        public override Task ExecuteResultAsync(ActionContext context)
         {
             if (context == null)
             {
@@ -65,16 +66,8 @@ namespace Microsoft.AspNetCore.Mvc
             }
 
             var services = context.HttpContext.RequestServices;
-            var executor = services.GetRequiredService<PartialViewResultExecutor>();
-
-            var result = executor.FindView(context, this);
-            result.EnsureSuccessful(originalLocations: null);
-
-            var view = result.View;
-            using (view as IDisposable)
-            {
-                await executor.ExecuteAsync(context, view, this);
-            }
+            var executor = services.GetRequiredService<IActionResultExecutor<PartialViewResult>>();
+            return executor.ExecuteAsync(context, this);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponentResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponentResult.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Mvc.ViewFeatures.Internal;
 using Microsoft.Extensions.DependencyInjection;
@@ -64,7 +65,7 @@ namespace Microsoft.AspNetCore.Mvc
             }
 
             var services = context.HttpContext.RequestServices;
-            var executor = services.GetRequiredService<ViewComponentResultExecutor>();
+            var executor = services.GetRequiredService<IActionResultExecutor<ViewComponentResult>>();
             return executor.ExecuteAsync(context, this);
         }
     }

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewResult.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Mvc.ViewFeatures.Internal;
@@ -64,17 +65,8 @@ namespace Microsoft.AspNetCore.Mvc
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var services = context.HttpContext.RequestServices;
-            var executor = services.GetRequiredService<ViewResultExecutor>();
-
-            var result = executor.FindView(context, this);
-            result.EnsureSuccessful(originalLocations: null);
-
-            var view = result.View;
-            using (view as IDisposable)
-            {
-                await executor.ExecuteAsync(context, view, this);
-            }
+            var executor = context.HttpContext.RequestServices.GetRequiredService<IActionResultExecutor<ViewResult>>();
+            await executor.ExecuteAsync(context, this);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/AcceptedAtActionResultTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/AcceptedAtActionResultTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Routing;
@@ -273,7 +274,7 @@ namespace Microsoft.AspNetCore.Mvc
             var options = new TestOptionsManager<MvcOptions>();
             options.Value.OutputFormatters.Add(formatter.Object);
             var services = new ServiceCollection();
-            services.AddSingleton(new ObjectResultExecutor(
+            services.AddSingleton<IActionResultExecutor<ObjectResult>>(new ObjectResultExecutor(
                 options,
                 new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/AcceptedAtRouteResultTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/AcceptedAtRouteResultTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Testing;
@@ -182,7 +183,7 @@ namespace Microsoft.AspNetCore.Mvc
             var options = new TestOptionsManager<MvcOptions>();
             options.Value.OutputFormatters.Add(formatter.Object);
             var services = new ServiceCollection();
-            services.AddSingleton(new ObjectResultExecutor(
+            services.AddSingleton<IActionResultExecutor<ObjectResult>>(new ObjectResultExecutor(
                 options,
                 new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/AcceptedResultTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/AcceptedResultTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -138,7 +139,7 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
             var options = new TestOptionsManager<MvcOptions>();
             options.Value.OutputFormatters.Add(formatter.Object);
             var services = new ServiceCollection();
-            services.AddSingleton(new ObjectResultExecutor(
+            services.AddSingleton<IActionResultExecutor<ObjectResult>>(new ObjectResultExecutor(
                 options,
                 new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ContentResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ContentResultTest.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.TestCommon;
 using Microsoft.AspNetCore.Mvc.ViewComponents;
@@ -269,7 +270,7 @@ namespace Microsoft.AspNetCore.Mvc
                 .Returns(new char[DefaultCharacterChunkSize]);
 
             var services = new ServiceCollection();
-            services.AddSingleton(new ContentResultExecutor(
+            services.AddSingleton<IActionResultExecutor<ContentResult>>(new ContentResultExecutor(
                 new Logger<ContentResultExecutor>(NullLoggerFactory.Instance),
                 new MemoryPoolHttpResponseStreamWriterFactory(ArrayPool<byte>.Shared, charArrayPool.Object)));
             return services;

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/CreatedAtActionResultTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/CreatedAtActionResultTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Routing;
@@ -95,7 +96,7 @@ namespace Microsoft.AspNetCore.Mvc
                 ArrayPool<char>.Shared));
 
             var services = new ServiceCollection();
-            services.AddSingleton(new ObjectResultExecutor(
+            services.AddSingleton<IActionResultExecutor<ObjectResult>>(new ObjectResultExecutor(
                 options,
                 new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/CreatedAtRouteResultTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/CreatedAtRouteResultTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Testing;
@@ -110,7 +111,7 @@ namespace Microsoft.AspNetCore.Mvc
                 ArrayPool<char>.Shared));
 
             var services = new ServiceCollection();
-            services.AddSingleton(new ObjectResultExecutor(
+            services.AddSingleton<IActionResultExecutor<ObjectResult>>(new ObjectResultExecutor(
                 options,
                 new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/CreatedResultTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/CreatedResultTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -96,7 +97,7 @@ namespace Microsoft.AspNetCore.Mvc
                 ArrayPool<char>.Shared));
 
             var services = new ServiceCollection();
-            services.AddSingleton(new ObjectResultExecutor(
+            services.AddSingleton<IActionResultExecutor<ObjectResult>>(new ObjectResultExecutor(
                 options,
                 new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/FileContentResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/FileContentResultTest.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.TestCommon;
 using Microsoft.AspNetCore.Routing;
@@ -422,7 +423,7 @@ namespace Microsoft.AspNetCore.Mvc
         private static IServiceCollection CreateServices()
         {
             var services = new ServiceCollection();
-            services.AddSingleton<FileContentResultExecutor>();
+            services.AddSingleton<IActionResultExecutor<FileContentResult>, FileContentResultExecutor>();
             services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
 
             return services;

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/FileResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/FileResultTest.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/FileStreamResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/FileStreamResultTest.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.TestCommon;
 using Microsoft.AspNetCore.Routing;
@@ -527,7 +528,7 @@ namespace Microsoft.AspNetCore.Mvc
         private static IServiceCollection CreateServices()
         {
             var services = new ServiceCollection();
-            services.AddSingleton<FileStreamResultExecutor>();
+            services.AddSingleton<IActionResultExecutor<FileStreamResult>, FileStreamResultExecutor>();
             services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
             return services;
         }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/HttpNotFoundObjectResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/HttpNotFoundObjectResultTest.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -75,7 +76,7 @@ namespace Microsoft.AspNetCore.Mvc
                 ArrayPool<char>.Shared));
 
             var services = new ServiceCollection();
-            services.AddSingleton(new ObjectResultExecutor(
+            services.AddSingleton<IActionResultExecutor<ObjectResult>>(new ObjectResultExecutor(
                 options,
                 new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/HttpOkObjectResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/HttpOkObjectResultTest.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -76,7 +77,7 @@ namespace Microsoft.AspNetCore.Mvc
                 ArrayPool<char>.Shared));
 
             var services = new ServiceCollection();
-            services.AddSingleton(new ObjectResultExecutor(
+            services.AddSingleton<IActionResultExecutor<ObjectResult>>(new ObjectResultExecutor(
                 options,
                 new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Infrastructure/ObjectResultExecutorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Infrastructure/ObjectResultExecutorTest.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.TestCommon;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -16,7 +17,7 @@ using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Mvc.Internal
+namespace Microsoft.AspNetCore.Mvc.Infrastructure
 {
     public class ObjectResultExecutorTest
     {

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerActionInvokerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerActionInvokerTest.cs
@@ -1602,7 +1602,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             var services = new ServiceCollection();
             services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
             services.AddSingleton<IOptions<MvcOptions>>(mvcOptionsAccessor);
-            services.AddSingleton(new ObjectResultExecutor(
+            services.AddSingleton<IActionResultExecutor<ObjectResult>>(new ObjectResultExecutor(
                 mvcOptionsAccessor,
                 new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/LocalRedirectResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/LocalRedirectResultTest.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Routing;
@@ -63,7 +65,7 @@ namespace Microsoft.AspNetCore.Mvc
         }
 
         [Fact]
-        public void Execute_ReturnsExpectedValues()
+        public async Task Execute_ReturnsExpectedValues()
         {
             // Arrange
             var appRoot = "/";
@@ -78,7 +80,7 @@ namespace Microsoft.AspNetCore.Mvc
             var result = new LocalRedirectResult(contentPath);
 
             // Act
-            result.ExecuteResult(actionContext);
+            await result.ExecuteResultAsync(actionContext);
 
             // Assert
             httpResponse.Verify();
@@ -87,7 +89,7 @@ namespace Microsoft.AspNetCore.Mvc
         [Theory]
         [InlineData("", "Home/About", "/Home/About")]
         [InlineData("/myapproot", "http://www.example.com", "/test")]
-        public void Execute_Throws_ForNonLocalUrl(
+        public async Task Execute_Throws_ForNonLocalUrl(
             string appRoot,
             string contentPath,
             string expectedPath)
@@ -102,7 +104,7 @@ namespace Microsoft.AspNetCore.Mvc
             var result = new LocalRedirectResult(contentPath);
 
             // Act & Assert
-            var exception = Assert.Throws<InvalidOperationException>(() => result.ExecuteResult(actionContext));
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => result.ExecuteResultAsync(actionContext));
             Assert.Equal(
                 "The supplied URL is not local. A URL with an absolute path is considered local if it does not " +
                 "have a host/authority part. URLs using virtual paths ('~/') are also local.",
@@ -120,7 +122,7 @@ namespace Microsoft.AspNetCore.Mvc
         private static IServiceProvider GetServiceProvider()
         {
             var serviceCollection = new ServiceCollection();
-            serviceCollection.AddSingleton<LocalRedirectResultExecutor>();
+            serviceCollection.AddSingleton<IActionResultExecutor<LocalRedirectResult>, LocalRedirectResultExecutor>();
             serviceCollection.AddSingleton<IUrlHelperFactory, UrlHelperFactory>();
             serviceCollection.AddTransient<ILoggerFactory, LoggerFactory>();
             return serviceCollection.BuildServiceProvider();

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ObjectResultTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ObjectResultTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -63,7 +64,7 @@ namespace Microsoft.AspNetCore.Mvc
         private static IServiceProvider CreateServices()
         {
             var services = new ServiceCollection();
-            services.AddSingleton(new ObjectResultExecutor(
+            services.AddSingleton<IActionResultExecutor<ObjectResult>>(new ObjectResultExecutor(
                 new TestOptionsManager<MvcOptions>(),
                 new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/PhysicalFileResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/PhysicalFileResultTest.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.TestCommon;
 using Microsoft.AspNetCore.Routing;

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/RedirectResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/RedirectResultTest.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Routing;
@@ -65,7 +67,7 @@ namespace Microsoft.AspNetCore.Mvc
         [Theory]
         [InlineData("", "/Home/About", "/Home/About")]
         [InlineData("/myapproot", "/test", "/test")]
-        public void Execute_ReturnsContentPath_WhenItDoesNotStartWithTilde(
+        public async Task Execute_ReturnsContentPath_WhenItDoesNotStartWithTilde(
             string appRoot,
             string contentPath,
             string expectedPath)
@@ -80,7 +82,7 @@ namespace Microsoft.AspNetCore.Mvc
             var result = new RedirectResult(contentPath);
 
             // Act
-            result.ExecuteResult(actionContext);
+            await result.ExecuteResultAsync(actionContext);
 
             // Assert
             // Verifying if Redirect was called with the specific Url and parameter flag.
@@ -93,7 +95,7 @@ namespace Microsoft.AspNetCore.Mvc
         [InlineData("/", "~/", "/")]
         [InlineData("", "~/Home/About", "/Home/About")]
         [InlineData("/myapproot", "~/", "/myapproot/")]
-        public void Execute_ReturnsAppRelativePath_WhenItStartsWithTilde(
+        public async Task Execute_ReturnsAppRelativePath_WhenItStartsWithTilde(
             string appRoot,
             string contentPath,
             string expectedPath)
@@ -108,7 +110,7 @@ namespace Microsoft.AspNetCore.Mvc
             var result = new RedirectResult(contentPath);
 
             // Act
-            result.ExecuteResult(actionContext);
+            await result.ExecuteResultAsync(actionContext);
 
             // Assert
             // Verifying if Redirect was called with the specific Url and parameter flag.
@@ -128,7 +130,7 @@ namespace Microsoft.AspNetCore.Mvc
         private static IServiceProvider GetServiceProvider()
         {
             var serviceCollection = new ServiceCollection();
-            serviceCollection.AddSingleton<RedirectResultExecutor>();
+            serviceCollection.AddSingleton<IActionResultExecutor<RedirectResult>, RedirectResultExecutor>();
             serviceCollection.AddSingleton<IUrlHelperFactory, UrlHelperFactory>();
             serviceCollection.AddTransient<ILoggerFactory, LoggerFactory>();
             return serviceCollection.BuildServiceProvider();

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/RedirectToActionResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/RedirectToActionResultTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Routing;
@@ -150,7 +151,7 @@ namespace Microsoft.AspNetCore.Mvc
         private static IServiceCollection CreateServices()
         {
             var services = new ServiceCollection();
-            services.AddSingleton<RedirectToActionResultExecutor>();
+            services.AddSingleton<IActionResultExecutor<RedirectToActionResult>, RedirectToActionResultExecutor>();
             services.AddSingleton<IUrlHelperFactory, UrlHelperFactory>();
             services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
             return services;

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/RedirectToPageResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/RedirectToPageResultTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Routing;
@@ -297,7 +298,7 @@ namespace Microsoft.AspNetCore.Mvc
         private static IServiceProvider CreateServices(IUrlHelperFactory factory = null)
         {
             var services = new ServiceCollection();
-            services.AddSingleton<RedirectToPageResultExecutor>();
+            services.AddSingleton<IActionResultExecutor<RedirectToPageResult>, RedirectToPageResultExecutor>();
 
             if (factory != null)
             {

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/RedirectToRouteResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/RedirectToRouteResultTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Routing;
@@ -179,7 +180,7 @@ namespace Microsoft.AspNetCore.Mvc
         private static IServiceCollection CreateServices(IUrlHelperFactory factory = null)
         {
             var services = new ServiceCollection();
-            services.AddSingleton<RedirectToRouteResultExecutor>();
+            services.AddSingleton<IActionResultExecutor<RedirectToRouteResult>, RedirectToRouteResultExecutor>();
 
             if (factory != null)
             {

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/VirtualFileResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/VirtualFileResultTest.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.TestCommon;
 using Microsoft.AspNetCore.Routing;
@@ -73,7 +74,7 @@ namespace Microsoft.AspNetCore.Mvc
             httpContext.Response.Body = new MemoryStream();
             httpContext.RequestServices = new ServiceCollection()
                 .AddSingleton(appEnvironment.Object)
-                .AddTransient<TestVirtualFileResultExecutor>()
+                .AddTransient<IActionResultExecutor<VirtualFileResult>, TestVirtualFileResultExecutor>()
                 .AddTransient<ILoggerFactory, LoggerFactory>()
                 .BuildServiceProvider();
 
@@ -117,7 +118,7 @@ namespace Microsoft.AspNetCore.Mvc
             httpContext.Response.Body = new MemoryStream();
             httpContext.RequestServices = new ServiceCollection()
                 .AddSingleton(appEnvironment.Object)
-                .AddTransient<TestVirtualFileResultExecutor>()
+                .AddTransient<IActionResultExecutor<VirtualFileResult>, TestVirtualFileResultExecutor>()
                 .AddTransient<ILoggerFactory, LoggerFactory>()
                 .BuildServiceProvider();
 
@@ -162,7 +163,7 @@ namespace Microsoft.AspNetCore.Mvc
             httpContext.Response.Body = new MemoryStream();
             httpContext.RequestServices = new ServiceCollection()
                 .AddSingleton(appEnvironment.Object)
-                .AddTransient<TestVirtualFileResultExecutor>()
+                .AddTransient<IActionResultExecutor<VirtualFileResult>, TestVirtualFileResultExecutor>()
                 .AddTransient<ILoggerFactory, LoggerFactory>()
                 .BuildServiceProvider();
 
@@ -207,7 +208,7 @@ namespace Microsoft.AspNetCore.Mvc
             httpContext.Response.Body = new MemoryStream();
             httpContext.RequestServices = new ServiceCollection()
                     .AddSingleton(appEnvironment.Object)
-                    .AddTransient<TestVirtualFileResultExecutor>()
+                    .AddTransient<IActionResultExecutor<VirtualFileResult>, TestVirtualFileResultExecutor>()
                     .AddTransient<ILoggerFactory, LoggerFactory>()
                     .BuildServiceProvider();
 
@@ -250,7 +251,7 @@ namespace Microsoft.AspNetCore.Mvc
             httpContext.Response.Body = new MemoryStream();
             httpContext.RequestServices = new ServiceCollection()
                     .AddSingleton(appEnvironment.Object)
-                    .AddTransient<TestVirtualFileResultExecutor>()
+                    .AddTransient<IActionResultExecutor<VirtualFileResult>, TestVirtualFileResultExecutor>()
                     .AddTransient<ILoggerFactory, LoggerFactory>()
                     .BuildServiceProvider();
 
@@ -292,7 +293,7 @@ namespace Microsoft.AspNetCore.Mvc
             httpContext.Response.Body = new MemoryStream();
             httpContext.RequestServices = new ServiceCollection()
                 .AddSingleton(appEnvironment.Object)
-                .AddTransient<TestVirtualFileResultExecutor>()
+                .AddTransient<IActionResultExecutor<VirtualFileResult>, TestVirtualFileResultExecutor>()
                 .AddTransient<ILoggerFactory, LoggerFactory>()
                 .BuildServiceProvider();
 
@@ -334,7 +335,7 @@ namespace Microsoft.AspNetCore.Mvc
             httpContext.Response.Body = new MemoryStream();
             httpContext.RequestServices = new ServiceCollection()
                 .AddSingleton(appEnvironment.Object)
-                .AddTransient<TestVirtualFileResultExecutor>()
+                .AddTransient<IActionResultExecutor<VirtualFileResult>, TestVirtualFileResultExecutor>()
                 .AddTransient<ILoggerFactory, LoggerFactory>()
                 .BuildServiceProvider();
 
@@ -376,7 +377,7 @@ namespace Microsoft.AspNetCore.Mvc
             httpContext.Response.Body = new MemoryStream();
             httpContext.RequestServices = new ServiceCollection()
                 .AddSingleton(appEnvironment.Object)
-                .AddTransient<TestVirtualFileResultExecutor>()
+                .AddTransient<IActionResultExecutor<VirtualFileResult>, TestVirtualFileResultExecutor>()
                 .AddTransient<ILoggerFactory, LoggerFactory>()
                 .BuildServiceProvider();
             var context = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
@@ -464,7 +465,7 @@ namespace Microsoft.AspNetCore.Mvc
                 .Returns(GetFileProvider(path));
             httpContext.RequestServices = new ServiceCollection()
                 .AddSingleton(appEnvironment.Object)
-                .AddTransient<TestVirtualFileResultExecutor>()
+                .AddTransient<IActionResultExecutor<VirtualFileResult>, TestVirtualFileResultExecutor>()
                 .AddTransient<ILoggerFactory, LoggerFactory>()
                 .BuildServiceProvider();
 
@@ -665,7 +666,12 @@ namespace Microsoft.AspNetCore.Mvc
 
             var hostingEnvironment = new Mock<IHostingEnvironment>();
 
-            services.AddSingleton(executorType ?? typeof(TestVirtualFileResultExecutor));
+            services.AddSingleton<IActionResultExecutor<VirtualFileResult>, TestVirtualFileResultExecutor>();
+            if (executorType != null)
+            {
+                services.AddSingleton(typeof(IActionResultExecutor<VirtualFileResult>), executorType);
+            }
+
             services.AddSingleton<IHostingEnvironment>(hostingEnvironment.Object);
             services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
 
@@ -708,7 +714,7 @@ namespace Microsoft.AspNetCore.Mvc
 
             public override Task ExecuteResultAsync(ActionContext context)
             {
-                var executor = context.HttpContext.RequestServices.GetRequiredService<TestVirtualFileResultExecutor>();
+                var executor = (TestVirtualFileResultExecutor)context.HttpContext.RequestServices.GetRequiredService<IActionResultExecutor<VirtualFileResult>>();
                 executor.IsAscii = IsAscii;
                 return executor.ExecuteAsync(context, this);
             }

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/PartialViewResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/PartialViewResultTest.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
@@ -226,7 +227,7 @@ namespace Microsoft.AspNetCore.Mvc
                 new EmptyModelMetadataProvider());
 
             var services = new ServiceCollection();
-            services.AddSingleton(viewExecutor);
+            services.AddSingleton<IActionResultExecutor<PartialViewResult>>(viewExecutor);
 
             var httpContext = new DefaultHttpContext();
             httpContext.RequestServices = services.BuildServiceProvider();

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponentResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponentResultTest.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.TestCommon;
 using Microsoft.AspNetCore.Mvc.ViewComponents;
@@ -579,7 +580,7 @@ namespace Microsoft.AspNetCore.Mvc
             services.AddSingleton<ITempDataProvider, SessionStateTempDataProvider>();
             services.AddSingleton<HtmlEncoder, HtmlTestEncoder>();
             services.AddSingleton<IViewBufferScope, TestViewBufferScope>();
-            services.AddSingleton<ViewComponentResultExecutor>();
+            services.AddSingleton<IActionResultExecutor<ViewComponentResult>, ViewComponentResultExecutor>();
 
             return services;
         }

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/PartialViewResultExecutorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/PartialViewResultExecutorTest.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -16,7 +15,7 @@ using Microsoft.Net.Http.Headers;
 using Moq;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
+namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 {
     public class PartialViewResultExecutorTest
     {

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/ViewResultExecutorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/ViewResultExecutorTest.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
@@ -15,7 +14,7 @@ using Microsoft.Net.Http.Headers;
 using Moq;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
+namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 {
     public class ViewResultExecutorTest
     {
@@ -268,7 +267,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             };
 
             // Act
-            await executor.ExecuteAsync(context, Mock.Of<IView>(), viewResult);
+            await executor.ExecuteAsync(context, viewResult);
 
             // Assert
             Assert.Equal("application/x-my-content-type", context.HttpContext.Response.ContentType);
@@ -292,7 +291,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             };
 
             // Act
-            await executor.ExecuteAsync(context, Mock.Of<IView>(), viewResult);
+            await executor.ExecuteAsync(context, viewResult);
 
             // Assert
             Assert.Equal(404, context.HttpContext.Response.StatusCode);

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewResultTest.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
@@ -238,7 +239,7 @@ namespace Microsoft.AspNetCore.Mvc
                 new EmptyModelMetadataProvider());
 
             var services = new ServiceCollection();
-            services.AddSingleton(viewExecutor);
+            services.AddSingleton<IActionResultExecutor<ViewResult>>(viewExecutor);
 
             var httpContext = new DefaultHttpContext();
             httpContext.RequestServices = services.BuildServiceProvider();

--- a/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/BadRequestErrorMessageResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/BadRequestErrorMessageResultTest.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -74,7 +75,7 @@ namespace System.Web.Http
                 ArrayPool<char>.Shared));
 
             var services = new ServiceCollection();
-            services.AddSingleton(new ObjectResultExecutor(
+            services.AddSingleton<IActionResultExecutor<ObjectResult>>(new ObjectResultExecutor(
                 options,
                 new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));

--- a/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/ExceptionResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/ExceptionResultTest.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -74,7 +75,7 @@ namespace System.Web.Http
                 ArrayPool<char>.Shared));
 
             var services = new ServiceCollection();
-            services.AddSingleton(new ObjectResultExecutor(
+            services.AddSingleton<IActionResultExecutor<ObjectResult>>(new ObjectResultExecutor(
                 options,
                 new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));

--- a/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/InvalidModelStateResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/InvalidModelStateResultTest.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Routing;
@@ -87,7 +88,7 @@ namespace System.Web.Http
                 ArrayPool<char>.Shared));
 
             var services = new ServiceCollection();
-            services.AddSingleton(new ObjectResultExecutor(
+            services.AddSingleton<IActionResultExecutor<ObjectResult>>(new ObjectResultExecutor(
                 options,
                 new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));

--- a/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/NegotiatedContentResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.WebApiCompatShimTest/NegotiatedContentResultTest.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -75,7 +76,7 @@ namespace System.Web.Http
                 ArrayPool<char>.Shared));
 
             var services = new ServiceCollection();
-            services.AddSingleton(new ObjectResultExecutor(
+            services.AddSingleton<IActionResultExecutor<ObjectResult>>(new ObjectResultExecutor(
                 options,
                 new TestHttpResponseStreamWriterFactory(),
                 NullLoggerFactory.Instance));


### PR DESCRIPTION
We have all of these executors but they aren't really
documented/supported for extensibility today. This change introduces a
pattern for action result executors so we can make them extensible.