### PR TITLE
Port to 2.0.1: Input fields don't emit (and thus round-trip) offset value when binding against DateTimeOffset fields

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/InputTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/InputTagHelper.cs
@@ -34,6 +34,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 { "Date", "date" },
                 { "DateTime", "datetime-local" },
                 { "DateTime-local", "datetime-local" },
+                { nameof(DateTimeOffset), "text" },
                 { "Time", "time" },
                 { nameof(Byte), "number" },
                 { nameof(SByte), "number" },
@@ -234,8 +235,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         {
             foreach (var hint in GetInputTypeHints(modelExplorer))
             {
-                string inputType;
-                if (_defaultInputTypes.TryGetValue(hint, out inputType))
+                if (_defaultInputTypes.TryGetValue(hint, out var inputType))
                 {
                     inputTypeHint = hint;
                     return inputType;
@@ -252,8 +252,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             {
                 if (modelExplorer.Model != null)
                 {
-                    bool potentialBool;
-                    if (!bool.TryParse(modelExplorer.Model.ToString(), out potentialBool))
+                    if (!bool.TryParse(modelExplorer.Model.ToString(), out var potentialBool))
                     {
                         throw new InvalidOperationException(Resources.FormatInputTagHelper_InvalidStringResult(
                             ForAttributeName,
@@ -353,8 +352,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         private TagBuilder GenerateHidden(ModelExplorer modelExplorer)
         {
             var value = For.Model;
-            var byteArrayValue = value as byte[];
-            if (byteArrayValue != null)
+            if (value is byte[] byteArrayValue)
             {
                 value = Convert.ToBase64String(byteArrayValue);
             }
@@ -380,7 +378,6 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         private string GetFormat(ModelExplorer modelExplorer, string inputTypeHint, string inputType)
         {
             string format;
-            string rfc3339Format;
             if (string.Equals("decimal", inputTypeHint, StringComparison.OrdinalIgnoreCase) &&
                 string.Equals("text", inputType, StringComparison.Ordinal) &&
                 string.IsNullOrEmpty(modelExplorer.Metadata.EditFormatString))
@@ -389,14 +386,30 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 // EditFormatString has precedence over this fall-back format.
                 format = "{0:0.00}";
             }
-            else if (_rfc3339Formats.TryGetValue(inputType, out rfc3339Format) &&
-                ViewContext.Html5DateRenderingMode == Html5DateRenderingMode.Rfc3339 &&
+            else if (ViewContext.Html5DateRenderingMode == Html5DateRenderingMode.Rfc3339 &&
                 !modelExplorer.Metadata.HasNonDefaultEditFormat &&
-                (typeof(DateTime) == modelExplorer.Metadata.UnderlyingOrModelType || typeof(DateTimeOffset) == modelExplorer.Metadata.UnderlyingOrModelType))
+                (typeof(DateTime) == modelExplorer.Metadata.UnderlyingOrModelType ||
+                 typeof(DateTimeOffset) == modelExplorer.Metadata.UnderlyingOrModelType))
             {
-                // Rfc3339 mode _may_ override EditFormatString in a limited number of cases e.g. EditFormatString
-                // must be a default format (i.e. came from a built-in [DataType] attribute).
-                format = rfc3339Format;
+                // Rfc3339 mode _may_ override EditFormatString in a limited number of cases. Happens only when
+                // EditFormatString has a default format i.e. came from a [DataType] attribute.
+                if (string.Equals("text", inputType) &&
+                    string.Equals(nameof(DateTimeOffset), inputTypeHint, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Auto-select a format that round-trips Offset and sub-Second values in a DateTimeOffset. Not
+                    // done if user chose the "text" type in .cshtml file or with data annotations i.e. when
+                    // inputTypeHint==null or "text".
+                    format = _rfc3339Formats["datetime"];
+                }
+                else if (_rfc3339Formats.TryGetValue(inputType, out var rfc3339Format))
+                {
+                    format = rfc3339Format;
+                }
+                else
+                {
+                    // Otherwise use default EditFormatString.
+                    format = modelExplorer.Metadata.EditFormatString;
+                }
             }
             else
             {
@@ -428,7 +441,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 fieldType = modelExplorer.Metadata.UnderlyingOrModelType;
             }
 
-            foreach (string typeName in TemplateRenderer.GetTypeNames(modelExplorer.Metadata, fieldType))
+            foreach (var typeName in TemplateRenderer.GetTypeNames(modelExplorer.Metadata, fieldType))
             {
                 yield return typeName;
             }

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/DefaultEditorTemplates.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/DefaultEditorTemplates.cs
@@ -197,8 +197,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
         {
             var htmlAttributes = HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributesObject);
 
-            object htmlClassObject;
-            if (htmlAttributes.TryGetValue("class", out htmlClassObject))
+            if (htmlAttributes.TryGetValue("class", out var htmlClassObject))
             {
                 var htmlClassName = htmlClassObject + " " + className;
                 htmlAttributes["class"] = htmlClassName;
@@ -347,10 +346,10 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             return GenerateTextBox(htmlHelper, inputType: "email");
         }
 
-        public static IHtmlContent DateTimeInputTemplate(IHtmlHelper htmlHelper)
+        public static IHtmlContent DateTimeOffsetTemplate(IHtmlHelper htmlHelper)
         {
             ApplyRfc3339DateFormattingIfNeeded(htmlHelper, "{0:yyyy-MM-ddTHH:mm:ss.fffK}");
-            return GenerateTextBox(htmlHelper, inputType: "datetime");
+            return GenerateTextBox(htmlHelper, inputType: "text");
         }
 
         public static IHtmlContent DateTimeLocalInputTemplate(IHtmlHelper htmlHelper)

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/TemplateRenderer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/TemplateRenderer.cs
@@ -17,9 +17,10 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
 {
     public class TemplateRenderer
     {
+        public const string IEnumerableOfIFormFileName = "IEnumerable`" + nameof(IFormFile);
+        internal const string UseDateTimeLocalTypeForDateTimeOffsetSwitch = "Switch.Microsoft.AspNetCore.Mvc.UseDateTimeLocalTypeForDateTimeOffset";
         private const string DisplayTemplateViewPath = "DisplayTemplates";
         private const string EditorTemplateViewPath = "EditorTemplates";
-        public const string IEnumerableOfIFormFileName = "IEnumerable`" + nameof(IFormFile);
 
         private static readonly Dictionary<string, Func<IHtmlHelper, IHtmlContent>> _defaultDisplayActions =
             new Dictionary<string, Func<IHtmlHelper, IHtmlContent>>(StringComparer.OrdinalIgnoreCase)
@@ -74,6 +75,14 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
         private readonly ViewDataDictionary _viewData;
         private readonly string _templateName;
         private readonly bool _readOnly;
+
+        static TemplateRenderer()
+        {
+            if (AppContext.TryGetSwitch(UseDateTimeLocalTypeForDateTimeOffsetSwitch, out var enabled) && enabled)
+            {
+                _defaultEditorActions.Remove(nameof(DateTimeOffset));
+            }
+        }
 
         public TemplateRenderer(
             IViewEngine viewEngine,

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/TemplateRenderer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/TemplateRenderer.cs
@@ -50,6 +50,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
                 { "Date", DefaultEditorTemplates.DateInputTemplate },
                 { "DateTime", DefaultEditorTemplates.DateTimeLocalInputTemplate },
                 { "DateTime-local", DefaultEditorTemplates.DateTimeLocalInputTemplate },
+                { nameof(DateTimeOffset), DefaultEditorTemplates.DateTimeOffsetTemplate },
                 { "Time", DefaultEditorTemplates.TimeInputTemplate },
                 { typeof(byte).Name, DefaultEditorTemplates.NumberInputTemplate },
                 { typeof(sbyte).Name, DefaultEditorTemplates.NumberInputTemplate },
@@ -115,7 +116,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             var defaultActions = GetDefaultActions();
             var modeViewPath = _readOnly ? DisplayTemplateViewPath : EditorTemplateViewPath;
 
-            foreach (string viewName in GetViewNames())
+            foreach (var viewName in GetViewNames())
             {
                 var viewEngineResult = _viewEngine.GetView(_viewContext.ExecutingFilePath, viewName, isMainPage: false);
                 if (!viewEngineResult.Success)
@@ -141,8 +142,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
                     }
                 }
 
-                Func<IHtmlHelper, IHtmlContent> defaultAction;
-                if (defaultActions.TryGetValue(viewName, out defaultAction))
+                if (defaultActions.TryGetValue(viewName, out var defaultAction))
                 {
                     return defaultAction(MakeHtmlHelper(_viewContext, _viewData));
                 }
@@ -255,8 +255,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
         {
             var newHelper = viewContext.HttpContext.RequestServices.GetRequiredService<IHtmlHelper>();
 
-            var contextable = newHelper as IViewContextAware;
-            if (contextable != null)
+            if (newHelper is IViewContextAware contextable)
             {
                 var newViewContext = new ViewContext(viewContext, viewContext.View, viewData, viewContext.Writer);
                 contextable.Contextualize(newViewContext);

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/HtmlHelperOptionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/HtmlHelperOptionsTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 <validationMessageElement class=""field-validation-error"">An error occurred.</validationMessageElement>
 <input id=""Prefix!Property1"" name=""Prefix.Property1"" type=""text"" value="""" />
 <div class=""editor-label""><label for=""MyDate"">MyDate</label></div>
-<div class=""editor-field""><input class=""text-box single-line"" id=""MyDate"" name=""MyDate"" type=""datetime-local"" value=""2000-01-02T03:04:05.060"" /> </div>
+<div class=""editor-field""><input class=""text-box single-line"" id=""MyDate"" name=""MyDate"" type=""text"" value=""2000-01-02T03:04:05.060&#x2B;00:00"" /> </div>
 
 <div class=""validation-summary-errors""><validationSummaryElement>MySummary</validationSummaryElement>
 <ul><li>A model error occurred.</li>
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 <validationMessageElement class=""field-validation-error"">An error occurred.</validationMessageElement>
 <input id=""Prefix!Property1"" name=""Prefix.Property1"" type=""text"" value="""" />
 <div class=""editor-label""><label for=""MyDate"">MyDate</label></div>
-<div class=""editor-field""><input class=""text-box single-line"" id=""MyDate"" name=""MyDate"" type=""datetime-local"" value=""2000-01-02T03:04:05.060"" /> </div>
+<div class=""editor-field""><input class=""text-box single-line"" id=""MyDate"" name=""MyDate"" type=""text"" value=""2000-01-02T03:04:05.060&#x2B;00:00"" /> </div>
 
 False";
 
@@ -59,7 +59,7 @@ False";
 <ValidationInView class=""field-validation-error"" data-valmsg-for=""Error"" data-valmsg-replace=""true"">An error occurred.</ValidationInView>
 <input id=""Prefix!Property1"" name=""Prefix.Property1"" type=""text"" value="""" />
 <div class=""editor-label""><label for=""MyDate"">MyDate</label></div>
-<div class=""editor-field""><input class=""text-box single-line"" data-val=""true"" data-val-required=""The MyDate field is required."" id=""MyDate"" name=""MyDate"" type=""datetime-local"" value=""02/01/2000 03:04:05 &#x2B;00:00"" /> <ValidationInView class=""field-validation-valid"" data-valmsg-for=""MyDate"" data-valmsg-replace=""true""></ValidationInView></div>
+<div class=""editor-field""><input class=""text-box single-line"" data-val=""true"" data-val-required=""The MyDate field is required."" id=""MyDate"" name=""MyDate"" type=""text"" value=""02/01/2000 03:04:05 &#x2B;00:00"" /> <ValidationInView class=""field-validation-valid"" data-valmsg-for=""MyDate"" data-valmsg-replace=""true""></ValidationInView></div>
 
 True
 <div class=""validation-summary-errors""><ValidationSummaryInPartialView>MySummary</ValidationSummaryInPartialView>
@@ -68,7 +68,7 @@ True
 <ValidationInPartialView class=""field-validation-error"" data-valmsg-for=""Error"" data-valmsg-replace=""true"">An error occurred.</ValidationInPartialView>
 <input id=""Prefix!Property1"" name=""Prefix.Property1"" type=""text"" value="""" />
 <div class=""editor-label""><label for=""MyDate"">MyDate</label></div>
-<div class=""editor-field""><input class=""text-box single-line"" id=""MyDate"" name=""MyDate"" type=""datetime-local"" value=""02/01/2000 03:04:05 &#x2B;00:00"" /> <ValidationInPartialView class=""field-validation-valid"" data-valmsg-for=""MyDate"" data-valmsg-replace=""true""></ValidationInPartialView></div>
+<div class=""editor-field""><input class=""text-box single-line"" id=""MyDate"" name=""MyDate"" type=""text"" value=""02/01/2000 03:04:05 &#x2B;00:00"" /> <ValidationInPartialView class=""field-validation-valid"" data-valmsg-for=""MyDate"" data-valmsg-replace=""true""></ValidationInPartialView></div>
 
 True";
 

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/HtmlHelperOptionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/HtmlHelperOptionsTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Testing;
@@ -10,6 +11,8 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 {
     public class HtmlHelperOptionsTest : IClassFixture<MvcTestFixture<RazorWebSite.Startup>>
     {
+        private const string UseDateTimeLocalTypeForDateTimeOffsetSwitch = "Switch.Microsoft.AspNetCore.Mvc.UseDateTimeLocalTypeForDateTimeOffset";
+
         public HtmlHelperOptionsTest(MvcTestFixture<RazorWebSite.Startup> fixture)
         {
             Client = fixture.Client;
@@ -21,14 +24,17 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
         public async Task AppWideDefaultsInViewAndPartialView()
         {
             // Arrange
+            AppContext.TryGetSwitch(UseDateTimeLocalTypeForDateTimeOffsetSwitch, out var enabled);
+            var expectedType = enabled ? "datetime-local" : "text";
+            var expectedOffset = enabled ? string.Empty : "&#x2B;00:00";
             var expected =
-@"<div class=""validation-summary-errors""><validationSummaryElement>MySummary</validationSummaryElement>
+$@"<div class=""validation-summary-errors""><validationSummaryElement>MySummary</validationSummaryElement>
 <ul><li>A model error occurred.</li>
 </ul></div>
 <validationMessageElement class=""field-validation-error"">An error occurred.</validationMessageElement>
 <input id=""Prefix!Property1"" name=""Prefix.Property1"" type=""text"" value="""" />
 <div class=""editor-label""><label for=""MyDate"">MyDate</label></div>
-<div class=""editor-field""><input class=""text-box single-line"" id=""MyDate"" name=""MyDate"" type=""text"" value=""2000-01-02T03:04:05.060&#x2B;00:00"" /> </div>
+<div class=""editor-field""><input class=""text-box single-line"" id=""MyDate"" name=""MyDate"" type=""{expectedType}"" value=""2000-01-02T03:04:05.060{expectedOffset}"" /> </div>
 
 <div class=""validation-summary-errors""><validationSummaryElement>MySummary</validationSummaryElement>
 <ul><li>A model error occurred.</li>
@@ -36,7 +42,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 <validationMessageElement class=""field-validation-error"">An error occurred.</validationMessageElement>
 <input id=""Prefix!Property1"" name=""Prefix.Property1"" type=""text"" value="""" />
 <div class=""editor-label""><label for=""MyDate"">MyDate</label></div>
-<div class=""editor-field""><input class=""text-box single-line"" id=""MyDate"" name=""MyDate"" type=""text"" value=""2000-01-02T03:04:05.060&#x2B;00:00"" /> </div>
+<div class=""editor-field""><input class=""text-box single-line"" id=""MyDate"" name=""MyDate"" type=""{expectedType}"" value=""2000-01-02T03:04:05.060{expectedOffset}"" /> </div>
 
 False";
 
@@ -52,14 +58,16 @@ False";
         public async Task OverrideAppWideDefaultsInViewAndPartialView()
         {
             // Arrange
+            AppContext.TryGetSwitch(UseDateTimeLocalTypeForDateTimeOffsetSwitch, out var enabled);
+            var expectedType = enabled ? "datetime-local" : "text";
             var expected =
-@"<div class=""validation-summary-errors""><ValidationSummaryInView>MySummary</ValidationSummaryInView>
+$@"<div class=""validation-summary-errors""><ValidationSummaryInView>MySummary</ValidationSummaryInView>
 <ul><li>A model error occurred.</li>
 </ul></div>
 <ValidationInView class=""field-validation-error"" data-valmsg-for=""Error"" data-valmsg-replace=""true"">An error occurred.</ValidationInView>
 <input id=""Prefix!Property1"" name=""Prefix.Property1"" type=""text"" value="""" />
 <div class=""editor-label""><label for=""MyDate"">MyDate</label></div>
-<div class=""editor-field""><input class=""text-box single-line"" data-val=""true"" data-val-required=""The MyDate field is required."" id=""MyDate"" name=""MyDate"" type=""text"" value=""02/01/2000 03:04:05 &#x2B;00:00"" /> <ValidationInView class=""field-validation-valid"" data-valmsg-for=""MyDate"" data-valmsg-replace=""true""></ValidationInView></div>
+<div class=""editor-field""><input class=""text-box single-line"" data-val=""true"" data-val-required=""The MyDate field is required."" id=""MyDate"" name=""MyDate"" type=""{expectedType}"" value=""02/01/2000 03:04:05 &#x2B;00:00"" /> <ValidationInView class=""field-validation-valid"" data-valmsg-for=""MyDate"" data-valmsg-replace=""true""></ValidationInView></div>
 
 True
 <div class=""validation-summary-errors""><ValidationSummaryInPartialView>MySummary</ValidationSummaryInPartialView>
@@ -68,7 +76,7 @@ True
 <ValidationInPartialView class=""field-validation-error"" data-valmsg-for=""Error"" data-valmsg-replace=""true"">An error occurred.</ValidationInPartialView>
 <input id=""Prefix!Property1"" name=""Prefix.Property1"" type=""text"" value="""" />
 <div class=""editor-label""><label for=""MyDate"">MyDate</label></div>
-<div class=""editor-field""><input class=""text-box single-line"" id=""MyDate"" name=""MyDate"" type=""text"" value=""02/01/2000 03:04:05 &#x2B;00:00"" /> <ValidationInPartialView class=""field-validation-valid"" data-valmsg-for=""MyDate"" data-valmsg-replace=""true""></ValidationInPartialView></div>
+<div class=""editor-field""><input class=""text-box single-line"" id=""MyDate"" name=""MyDate"" type=""{expectedType}"" value=""02/01/2000 03:04:05 &#x2B;00:00"" /> <ValidationInPartialView class=""field-validation-valid"" data-valmsg-for=""MyDate"" data-valmsg-replace=""true""></ValidationInPartialView></div>
 
 True";
 


### PR DESCRIPTION
Commits include cherry-pick of the original (dev) fix and enabling a new quirks mode for the patch. Have run all tests with new switch enabled and disabled.