### PR TITLE
Added Conflict result helper to ControllerBase

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/ConflictObjectResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ConflictObjectResult.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace Microsoft.AspNetCore.Mvc
+{
+    /// <summary>
+    /// A <see cref="StatusCodeResult"/> that when executed will produce a Conflict (409) response.
+    /// </summary>
+    public class ConflictObjectResult : ObjectResult
+    {
+        /// <summary>
+        /// Creates a new <see cref="ConflictObjectResult"/> instance.
+        /// </summary>
+        /// <param name="error">Contains the errors to be returned to the client.</param>
+        public ConflictObjectResult(object error) 
+            : base(error)
+        {
+            StatusCode = StatusCodes.Status409Conflict;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ConflictObjectResult"/> instance.
+        /// </summary>
+        /// <param name="modelState"><see cref="ModelStateDictionary"/> containing the validation errors.</param>
+        public ConflictObjectResult(ModelStateDictionary modelState)
+            : base(new SerializableError(modelState))
+        {
+            if (modelState == null)
+            {
+                throw new ArgumentNullException(nameof(modelState));
+            }
+
+            StatusCode = StatusCodes.Status409Conflict;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/ConflictResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ConflictResult.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Mvc
+{
+    /// <summary>
+    /// A <see cref="StatusCodeResult"/> that when executed will produce a Conflict (409) response.
+    /// </summary>
+    public class ConflictResult : StatusCodeResult
+    {
+        /// <summary>
+        /// Creates a new <see cref="ConflictResult"/> instance.
+        /// </summary>
+        public ConflictResult() 
+            : base(StatusCodes.Status409Conflict)
+        {
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
@@ -1499,6 +1499,32 @@ namespace Microsoft.AspNetCore.Mvc
         }
 
         /// <summary>
+        /// Creates an <see cref="ConflictResult"/> that produces a <see cref="StatusCodes.Status409Conflict"/> response.
+        /// </summary>
+        /// <returns>The created <see cref="ConflictResult"/> for the response.</returns>
+        [NonAction]
+        public virtual ConflictResult Conflict()
+            => new ConflictResult();
+
+        /// <summary>
+        /// Creates an <see cref="ConflictObjectResult"/> that produces a <see cref="StatusCodes.Status409Conflict"/> response.
+        /// </summary>
+        /// <param name="error">Contains errors to be returned to the client.</param>
+        /// <returns>The created <see cref="ConflictObjectResult"/> for the response.</returns>
+        [NonAction]
+        public virtual ConflictObjectResult Conflict(object error)
+            => new ConflictObjectResult(error);
+
+        /// <summary>
+        /// Creates an <see cref="ConflictObjectResult"/> that produces a <see cref="StatusCodes.Status409Conflict"/> response.
+        /// </summary>
+        /// <param name="modelState">The model state dictionary containing errors to be returned to the client.</param>
+        /// <returns>The created <see cref="ConflictObjectResult"/> for the response.</returns>
+        [NonAction]
+        public virtual ConflictObjectResult Conflict(ModelStateDictionary modelState)
+            => new ConflictObjectResult(modelState);
+
+        /// <summary>
         /// Creates an <see cref="BadRequestObjectResult"/> that produces a <see cref="StatusCodes.Status400BadRequest"/> response.
         /// </summary>
         /// <returns>The created <see cref="BadRequestObjectResult"/> for the response.</returns>

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/BadRequestObjectResultTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/BadRequestObjectResultTests.cs
@@ -14,22 +14,22 @@ namespace Microsoft.AspNetCore.Mvc
         {
             // Arrange & Act
             var obj = new object();
-            var badRequestObjecResult = new BadRequestObjectResult(obj);
+            var badRequestObjectResult = new BadRequestObjectResult(obj);
 
             // Assert
-            Assert.Equal(StatusCodes.Status400BadRequest, badRequestObjecResult.StatusCode);
-            Assert.Equal(obj, badRequestObjecResult.Value);
+            Assert.Equal(StatusCodes.Status400BadRequest, badRequestObjectResult.StatusCode);
+            Assert.Equal(obj, badRequestObjectResult.Value);
         }
 
         [Fact]
         public void BadRequestObjectResult_ModelState_SetsStatusCodeAndValue()
         {
             // Arrange & Act
-            var badRequestObjecResult = new BadRequestObjectResult(new ModelStateDictionary());
+            var badRequestObjectResult = new BadRequestObjectResult(new ModelStateDictionary());
 
             // Assert
-            Assert.Equal(StatusCodes.Status400BadRequest, badRequestObjecResult.StatusCode);
-            var errors = Assert.IsType<SerializableError>(badRequestObjecResult.Value);
+            Assert.Equal(StatusCodes.Status400BadRequest, badRequestObjectResult.StatusCode);
+            var errors = Assert.IsType<SerializableError>(badRequestObjectResult.Value);
             Assert.Empty(errors);
         }
     }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ConflictObjectResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ConflictObjectResultTest.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc
+{
+    public class ConflictObjectResultTest
+    {
+        [Fact]
+        public void ConflictObjectResult_SetsStatusCodeAndValue()
+        {
+            // Arrange & Act
+            var obj = new object();
+            var conflictObjectResult = new ConflictObjectResult(obj);
+
+            // Assert
+            Assert.Equal(StatusCodes.Status409Conflict, conflictObjectResult.StatusCode);
+            Assert.Equal(obj, conflictObjectResult.Value);
+        }
+
+        [Fact]
+        public void ConflictObjectResult_ModelState_SetsStatusCodeAndValue()
+        {
+            // Arrange & Act
+            var conflictObjectResult = new ConflictObjectResult(new ModelStateDictionary());
+
+            // Assert
+            Assert.Equal(StatusCodes.Status409Conflict, conflictObjectResult.StatusCode);
+            var errors = Assert.IsType<SerializableError>(conflictObjectResult.Value);
+            Assert.Empty(errors);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ConflictResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ConflictResultTest.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc
+{
+    public class ConflictResultTest
+    {
+        [Fact]
+        public void ConflictResult_InitializesStatusCode()
+        {
+            // Arrange & act
+            var conflictResult = new ConflictResult();
+
+            // Assert
+            Assert.Equal(StatusCodes.Status409Conflict, conflictResult.StatusCode);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ControllerBaseTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ControllerBaseTest.cs
@@ -1990,6 +1990,53 @@ namespace Microsoft.AspNetCore.Mvc.Core.Test
             Assert.Empty(errors);
         }
 
+        [Fact]
+        public void Conflict_SetsStatusCode()
+        {
+            // Arrange
+            var controller = new TestableController();
+            var obj = new object();
+
+            // Act
+            var result = controller.Conflict();
+
+            // Assert
+            Assert.IsType<ConflictResult>(result);
+            Assert.Equal(StatusCodes.Status409Conflict, result.StatusCode);
+        }
+
+        [Fact]
+        public void Conflict_SetsStatusCodeAndValue_Object()
+        {
+            // Arrange
+            var controller = new TestableController();
+            var obj = new object();
+
+            // Act
+            var result = controller.Conflict(obj);
+
+            // Assert
+            Assert.IsType<ConflictObjectResult>(result);
+            Assert.Equal(StatusCodes.Status409Conflict, result.StatusCode);
+            Assert.Equal(obj, result.Value);
+        }
+
+        [Fact]
+        public void Conflict_SetsStatusCodeAndValue_ModelState()
+        {
+            // Arrange
+            var controller = new TestableController();
+
+            // Act
+            var result = controller.Conflict(new ModelStateDictionary());
+
+            // Assert
+            Assert.IsType<ConflictObjectResult>(result);
+            Assert.Equal(StatusCodes.Status409Conflict, result.StatusCode);
+            var errors = Assert.IsType<SerializableError>(result.Value);
+            Assert.Empty(errors);
+        }
+
         [Theory]
         [MemberData(nameof(PublicNormalMethodsFromControllerBase))]
         public void NonActionAttribute_IsOnEveryPublicNormalMethodFromControllerBase(MethodInfo method)


### PR DESCRIPTION
- Added ConflictObjectResult and ConflictResult types.
- Conflict(), Conflict(object error), Conflict(ModelState modelState)
added to ControllerBase.cs.
- Tests added to ControllerBaseTest.cs.
- Added ConflictObjectResultTest.cs and ConflictResultTest.cs.
- Fixed spelling in BadRequestObjectResultTests.cs

Addresses #6172