### PR TITLE
Port fix for #6875: Only set Content-Length when serving body

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/FileResultExecutorBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/FileResultExecutorBase.cs
@@ -90,8 +90,11 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 // Assuming the request is not a range request, the Content-Length header is set to the length of the entire file. 
                 // If the request is a valid range request, this header is overwritten with the length of the range as part of the 
                 // range processing (see method SetContentLength).
-                response.ContentLength = fileLength.Value;
-
+                if (serveBody)
+                {
+                    response.ContentLength = fileLength.Value;
+                }
+                
                 if (enableRangeProcessing)
                 {
                     SetAcceptRangeHeader(context);

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/FileContentResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/FileContentResultTest.cs
@@ -376,7 +376,7 @@ namespace Microsoft.AspNetCore.Mvc
             var streamReader = new StreamReader(httpResponse.Body);
             var body = streamReader.ReadToEndAsync().Result;
             Assert.Equal(StatusCodes.Status412PreconditionFailed, httpResponse.StatusCode);
-            Assert.Equal(11, httpResponse.ContentLength);
+            Assert.Null(httpResponse.ContentLength);
             Assert.Empty(httpResponse.Headers[HeaderNames.ContentRange]);
             Assert.NotEmpty(httpResponse.Headers[HeaderNames.LastModified]);
             Assert.Empty(body);
@@ -417,7 +417,7 @@ namespace Microsoft.AspNetCore.Mvc
             var streamReader = new StreamReader(httpResponse.Body);
             var body = streamReader.ReadToEndAsync().Result;
             Assert.Equal(StatusCodes.Status304NotModified, httpResponse.StatusCode);
-            Assert.Equal(11, httpResponse.ContentLength);
+            Assert.Null(httpResponse.ContentLength);
             Assert.Empty(httpResponse.Headers[HeaderNames.ContentRange]);
             Assert.NotEmpty(httpResponse.Headers[HeaderNames.LastModified]);
             Assert.Empty(body);

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/FileStreamResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/FileStreamResultTest.cs
@@ -366,7 +366,7 @@ namespace Microsoft.AspNetCore.Mvc
             var streamReader = new StreamReader(httpResponse.Body);
             var body = streamReader.ReadToEndAsync().Result;
             Assert.Equal(StatusCodes.Status412PreconditionFailed, httpResponse.StatusCode);
-            Assert.Equal(11, httpResponse.ContentLength);
+            Assert.Null(httpResponse.ContentLength);
             Assert.Empty(httpResponse.Headers[HeaderNames.ContentRange]);
             Assert.NotEmpty(httpResponse.Headers[HeaderNames.LastModified]);
             Assert.Empty(body);
@@ -408,7 +408,7 @@ namespace Microsoft.AspNetCore.Mvc
             var streamReader = new StreamReader(httpResponse.Body);
             var body = streamReader.ReadToEndAsync().Result;
             Assert.Equal(StatusCodes.Status304NotModified, httpResponse.StatusCode);
-            Assert.Equal(11, httpResponse.ContentLength);
+            Assert.Null(httpResponse.ContentLength);
             Assert.Empty(httpResponse.Headers[HeaderNames.ContentRange]);
             Assert.NotEmpty(httpResponse.Headers[HeaderNames.LastModified]);
             Assert.Empty(body);

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/PhysicalFileResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/PhysicalFileResultTest.cs
@@ -241,7 +241,7 @@ namespace Microsoft.AspNetCore.Mvc
             var body = streamReader.ReadToEndAsync().Result;
             Assert.Equal(StatusCodes.Status412PreconditionFailed, httpResponse.StatusCode);
             Assert.Equal("bytes", httpResponse.Headers[HeaderNames.AcceptRanges]);
-            Assert.Equal(34, httpResponse.ContentLength);
+            Assert.Null(httpResponse.ContentLength);
             Assert.Empty(httpResponse.Headers[HeaderNames.ContentRange]);
             Assert.NotEmpty(httpResponse.Headers[HeaderNames.LastModified]);
             Assert.Empty(body);
@@ -271,7 +271,7 @@ namespace Microsoft.AspNetCore.Mvc
             var body = streamReader.ReadToEndAsync().Result;
             Assert.Equal(StatusCodes.Status304NotModified, httpResponse.StatusCode);
             Assert.Equal("bytes", httpResponse.Headers[HeaderNames.AcceptRanges]);
-            Assert.Equal(34, httpResponse.ContentLength);
+            Assert.Null(httpResponse.ContentLength);
             Assert.Empty(httpResponse.Headers[HeaderNames.ContentRange]);
             Assert.NotEmpty(httpResponse.Headers[HeaderNames.LastModified]);
             Assert.Empty(body);

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/VirtualFileResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/VirtualFileResultTest.cs
@@ -313,7 +313,7 @@ namespace Microsoft.AspNetCore.Mvc
             var body = streamReader.ReadToEndAsync().Result;
             Assert.Equal(StatusCodes.Status412PreconditionFailed, httpResponse.StatusCode);
             Assert.Equal("bytes", httpResponse.Headers[HeaderNames.AcceptRanges]);
-            Assert.Equal(33, httpResponse.ContentLength);
+            Assert.Null(httpResponse.ContentLength);
             Assert.Empty(httpResponse.Headers[HeaderNames.ContentRange]);
             Assert.NotEmpty(httpResponse.Headers[HeaderNames.LastModified]);
             Assert.Empty(body);
@@ -355,7 +355,7 @@ namespace Microsoft.AspNetCore.Mvc
             var body = streamReader.ReadToEndAsync().Result;
             Assert.Equal(StatusCodes.Status304NotModified, httpResponse.StatusCode);
             Assert.Equal("bytes", httpResponse.Headers[HeaderNames.AcceptRanges]);
-            Assert.Equal(33, httpResponse.ContentLength);
+            Assert.Null(httpResponse.ContentLength);
             Assert.Empty(httpResponse.Headers[HeaderNames.ContentRange]);
             Assert.NotEmpty(httpResponse.Headers[HeaderNames.LastModified]);
             Assert.Empty(body);


### PR DESCRIPTION
Addresses #6887 

cc @Tratcher 