### PR TITLE
Update fsproj for FSharpWebSite. Fixes #6554

### DIFF
--- a/test/WebSites/FSharpWebSite/FSharpWebSite.fsproj
+++ b/test/WebSites/FSharpWebSite/FSharpWebSite.fsproj
@@ -1,19 +1,8 @@
-﻿<Project Sdk="FSharp.NET.Sdk; Microsoft.NET.Sdk.Web">
-  <Import Project="..\..\..\build\dependencies.props" />
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <!--
-      Signing is normally configured in common.props, but we can't import that into an F# project
-      because Internal.AspNetCore.Sdk doesn't support it.
-    -->
-    <AssemblyOriginatorKeyFile>..\..\..\build\Key.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
-    <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,9 +13,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Microsoft.AspNetCore.Mvc\Microsoft.AspNetCore.Mvc.csproj" />
-
-    <PackageReference Include="FSharp.Core" Version="$(FSharpCoreVersion)" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="$(FSharpNetSdkVersion)" PrivateAssets="All" />
 
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="$(AspNetCoreVersion)" />


### PR DESCRIPTION
Fix for #6554 

Currently this doesn't actually affect anything, because `FSharpWebSite.fsproj` is not included in the `.sln`, nor is it referenced from any other project. The functional tests for it were [deleted back in May](https://github.com/aspnet/Mvc/pull/6319/files#diff-21fce3789bdd5ad204ec410b088d7018) due to what looks like build system issues.

Eventually it would be best to reinstate the functional tests for our F# support but this can't be done at least until resolving https://github.com/aspnet/BuildTools/issues/414