### PR TITLE
[Design] Add 'profiles' for ApiDescription

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ApiExplorer/ApiDescription.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ApiExplorer/ApiDescription.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
         /// Gets a list of <see cref="ApiParameterDescription"/> for this api.
         /// </summary>
         public IList<ApiParameterDescription> ParameterDescriptions { get; } = new List<ApiParameterDescription>();
-
+        
         /// <summary>
         /// Gets arbitrary metadata properties associated with the <see cref="ApiDescription"/>.
         /// </summary>

--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ApiExplorer/ApiDescriptionProfile.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ApiExplorer/ApiDescriptionProfile.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.ApiExplorer
+{
+    public abstract class ApiDescriptionProfile
+    {
+        public abstract string DisplayName { get; }
+
+        public abstract bool IsMatch(ApiDescription description);
+
+        public abstract void ApplyTo(ApiDescription description);
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/ApiBehaviorOptions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ApiBehaviorOptions.cs
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Microsoft.AspNetCore.Mvc
@@ -33,5 +36,11 @@ namespace Microsoft.AspNetCore.Mvc
         /// <seealso cref="InvalidModelStateResponseFactory"/>.
         /// </summary>
         public bool EnableModelStateInvalidFilter { get; set; } = true;
+
+        /// <summary>
+        /// Gets a collection of <see cref="ApiDescriptionProfile"/> that can be applied to enhance 
+        /// <see cref="ApiDescription"/> objects produced for actions attributed with <see cref="ApiControllerAttribute"/>.
+        /// </summary>
+        public IList<ApiDescriptionProfile> ApiDescriptionProfiles { get; } = new List<ApiDescriptionProfile>();
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ApiExplorer/DefaultApiDescriptionProfile.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ApiExplorer/DefaultApiDescriptionProfile.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Mvc.ApiExplorer
+{
+    public abstract class DefaultApiDescriptionProfile : ApiDescriptionProfile
+    {
+        public IList<ApiResponseType> ResponseTypes { get; } = new List<ApiResponseType>();
+
+        public override void ApplyTo(ApiDescription description)
+        {
+            if (description == null)
+            {
+                throw new ArgumentNullException(nameof(description));
+            }
+
+            for (var i = 0; i < ResponseTypes.Count; i++)
+            {
+                description.SupportedResponseTypes.Add(ResponseTypes[i]);
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/ApiExplorer/FindAllApiDescriptionProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ApiExplorer/FindAllApiDescriptionProvider.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Mvc.ApiExplorer
+{
+    public class FindAllApiDescriptionProvider : DefaultApiDescriptionProfile
+    {
+        public FindAllApiDescriptionProvider()
+        {
+            ResponseTypes.Add(new ApiResponseType()
+            {
+                Type = typeof(ProblemDetails),
+                StatusCode = 400,
+            });
+            ResponseTypes.Add(new ApiResponseType()
+            {
+                Type = typeof(ProblemDetails),
+                IsDefaultResponse = true,
+            });
+        }
+
+        public override string DisplayName => "FindAll";
+
+        public override bool IsMatch(ApiDescription description)
+        {
+            if (description == null)
+            {
+                throw new ArgumentNullException(nameof(description));
+            }
+
+            // Example
+            //
+            // [HttpGet]
+            // public ActionResult<IEnumerable<Product>> FindProducts(string name, decimal price, ...)
+            if (string.Equals("GET", description.HttpMethod, StringComparison.OrdinalIgnoreCase) &&
+                description.ParameterDescriptions.Count > 0 &&
+                description.SupportedResponseTypes.Count == 1 &&
+                description.SupportedResponseTypes[0].ModelMetadata.IsCollectionType)
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/ApiExplorer/FindSingleApiDescriptionProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ApiExplorer/FindSingleApiDescriptionProvider.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Mvc.ApiExplorer
+{
+    public class FindSingleApiDescriptionProvider : DefaultApiDescriptionProfile
+    {
+        public FindSingleApiDescriptionProvider()
+        {
+            ResponseTypes.Add(new ApiResponseType()
+            {
+                Type = typeof(ProblemDetails),
+                StatusCode = 400,
+            });
+            ResponseTypes.Add(new ApiResponseType()
+            {
+                Type = typeof(ProblemDetails),
+                IsDefaultResponse = true,
+            });
+        }
+
+        public override string DisplayName => "FindSingle";
+
+        public override bool IsMatch(ApiDescription description)
+        {
+            if (description == null)
+            {
+                throw new ArgumentNullException(nameof(description));
+            }
+
+            // Example
+            //
+            // [HttpGet]
+            // public ActionResult<IEnumerable<Product>> GetProducts()
+            if (string.Equals("GET", description.HttpMethod, StringComparison.OrdinalIgnoreCase) &&
+                description.ParameterDescriptions.Count > 0 &&
+                description.SupportedResponseTypes.Count == 1 &&
+                !description.SupportedResponseTypes[0].ModelMetadata.IsCollectionType)
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/ApiExplorer/GetAllApiDescriptionProfile.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ApiExplorer/GetAllApiDescriptionProfile.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Mvc.ApiExplorer
+{
+    public class GetAllApiDescriptionProfile : DefaultApiDescriptionProfile
+    {
+        public GetAllApiDescriptionProfile()
+        {
+            ResponseTypes.Add(new ApiResponseType()
+            {
+                Type = typeof(ProblemDetails),
+                IsDefaultResponse = true,
+            });
+        }
+
+        public override string DisplayName => "GetAll";
+
+        public override bool IsMatch(ApiDescription description)
+        {
+            if (description == null)
+            {
+                throw new ArgumentNullException(nameof(description));
+            }
+
+            // Example
+            //
+            // [HttpGet]
+            // public ActionResult<IEnumerable<Product>> GetProducts()
+            if (string.Equals("GET", description.HttpMethod, StringComparison.OrdinalIgnoreCase) &&
+                description.ParameterDescriptions.Count == 0 &&
+                description.SupportedResponseTypes.Count == 1 &&
+                description.SupportedResponseTypes[0].ModelMetadata.IsCollectionType)
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/ApiExplorer/GetByIdApiDescriptionProfile.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ApiExplorer/GetByIdApiDescriptionProfile.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Mvc.Internal;
+
+namespace Microsoft.AspNetCore.Mvc.ApiExplorer
+{
+    public class GetByIdApiDescriptionProfile : DefaultApiDescriptionProfile
+    {
+        public GetByIdApiDescriptionProfile()
+        {
+            ResponseTypes.Add(new ApiResponseType()
+            {
+                Type = typeof(ProblemDetails),
+                StatusCode = 404,
+            });
+            ResponseTypes.Add(new ApiResponseType()
+            {
+                Type = typeof(ProblemDetails),
+                StatusCode = 400,
+            });
+            ResponseTypes.Add(new ApiResponseType()
+            {
+                Type = typeof(ProblemDetails),
+                IsDefaultResponse = true,
+            });
+        }
+
+        public override string DisplayName => "GetById";
+
+        public override bool IsMatch(ApiDescription description)
+        {
+            if (description == null)
+            {
+                throw new ArgumentNullException(nameof(description));
+            }
+            
+            // Example
+            //
+            // [HttpGet]
+            // public ActionResult<Product> GetProduct(int productId)
+            if (string.Equals("GET", description.HttpMethod, StringComparison.OrdinalIgnoreCase) &&
+                description.ParameterDescriptions.Count == 1 &&
+                IdParameter.IsIdParameter(description.ParameterDescriptions[0]) &&
+                description.SupportedResponseTypes.Count == 1 &&
+                !description.SupportedResponseTypes[0].ModelMetadata.IsCollectionType)
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/ApiExplorer/UnknownApiDescriptionProfile.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ApiExplorer/UnknownApiDescriptionProfile.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Mvc.ApiExplorer
+{
+    public class UnknownApiDescriptionProfile : DefaultApiDescriptionProfile
+    {
+        public UnknownApiDescriptionProfile()
+        {
+            ResponseTypes.Add(new ApiResponseType()
+            {
+                Type = typeof(ProblemDetails),
+                IsDefaultResponse = true,
+            });
+        }
+
+        public override string DisplayName => "Unknown";
+
+        public override bool IsMatch(ApiDescription description)
+        {
+            if (description == null)
+            {
+                throw new ArgumentNullException(nameof(description));
+            }
+
+            // Example
+            //
+            // (Anything)
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -214,6 +215,15 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddSingleton<IErrorDescriptionFactory, DefaultErrorDescriptorFactory>();
 
             //
+            // Formatters
+            //
+            services.TryAddSingleton<IHttpRequestStreamReaderFactory, MemoryPoolHttpRequestStreamReaderFactory>();
+            services.TryAddSingleton<IHttpResponseStreamWriterFactory, MemoryPoolHttpResponseStreamWriterFactory>();
+            services.TryAddSingleton(ArrayPool<byte>.Shared);
+            services.TryAddSingleton(ArrayPool<char>.Shared);
+            services.TryAddSingleton<MediaTypeRegistry, DefaultMediaTypeRegistry>();
+
+            //
             // ModelBinding, Validation
             //
             // The DefaultModelMetadataProvider does significant caching and should be a singleton.
@@ -241,15 +251,8 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
             //
-            // Random Infrastructure
+            // Action Result executors
             //
-            services.TryAddSingleton<MvcMarkerService, MvcMarkerService>();
-            services.TryAddSingleton<ITypeActivatorCache, TypeActivatorCache>();
-            services.TryAddSingleton<IUrlHelperFactory, UrlHelperFactory>();
-            services.TryAddSingleton<IHttpRequestStreamReaderFactory, MemoryPoolHttpRequestStreamReaderFactory>();
-            services.TryAddSingleton<IHttpResponseStreamWriterFactory, MemoryPoolHttpResponseStreamWriterFactory>();
-            services.TryAddSingleton(ArrayPool<byte>.Shared);
-            services.TryAddSingleton(ArrayPool<char>.Shared);
             services.TryAddSingleton<IActionResultExecutor<ObjectResult>, ObjectResultExecutor>();
             services.TryAddSingleton<IActionResultExecutor<PhysicalFileResult>, PhysicalFileResultExecutor>();
             services.TryAddSingleton<IActionResultExecutor<VirtualFileResult>, VirtualFileResultExecutor>();
@@ -261,6 +264,13 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddSingleton<IActionResultExecutor<RedirectToRouteResult>, RedirectToRouteResultExecutor>();
             services.TryAddSingleton<IActionResultExecutor<RedirectToPageResult>, RedirectToPageResultExecutor>();
             services.TryAddSingleton<IActionResultExecutor<ContentResult>, ContentResultExecutor>();
+
+            //
+            // Random Infrastructure
+            //
+            services.TryAddSingleton<MvcMarkerService, MvcMarkerService>();
+            services.TryAddSingleton<ITypeActivatorCache, TypeActivatorCache>();
+            services.TryAddSingleton<IUrlHelperFactory, UrlHelperFactory>();
 
             //
             // Route Handlers

--- a/src/Microsoft.AspNetCore.Mvc.Core/Formatters/DefaultMediaTypeRegistry.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Formatters/DefaultMediaTypeRegistry.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Mvc.Formatters
+{
+    /// <summary>
+    /// A default implementation of <see cref="MediaTypeRegistry"/>.
+    /// </summary>
+    public class DefaultMediaTypeRegistry : MediaTypeRegistry
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="DefaultMediaTypeRegistry"/>.
+        /// </summary>
+        public DefaultMediaTypeRegistry()
+        {
+            KnownMappings = new Dictionary<Type, string[]>
+            {
+                { typeof(ProblemDetails), new string[]{ "application/problem+json", "application/problem+xml", } },
+            };
+        }
+
+        /// <summary>
+        /// Gets a dictionary of known mappings between types and media types.
+        /// </summary>
+        /// <remarks>
+        /// This property is not thread-safe. Consumers should not mutate this property while requests are served.
+        /// </remarks>
+        public IDictionary<Type, string[]> KnownMappings { get; }
+
+        /// <summary>
+        /// Gets a list of media types that used as default media types when a <see cref="Type"/> does not have
+        /// a specific mapping.
+        /// </summary>
+        /// <remarks>
+        /// This property is not thread-safe. Consumers should not mutate this property while requests are served.
+        /// </remarks>
+        public string[] FallbackMediaTypes { get; set; }
+
+        /// <inheritdoc />
+        public sealed override IReadOnlyList<string> GetMediaTypes(Type type)
+        {
+            if (type == null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            if (KnownMappings.TryGetValue(type, out var mediaTypes))
+            {
+                return mediaTypes;
+            }
+
+            return FallbackMediaTypes;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/Formatters/IMediaTypeRegistry.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Formatters/IMediaTypeRegistry.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Mvc.Formatters
+{
+    /// <summary>
+    /// A service which provides mappings from a <see cref="Type"/> representing a data type to serialize
+    /// to a set of possible media types.
+    /// </summary>
+    /// <remarks>
+    /// This service is registered as a singleton, and implementations should cache results to improve
+    /// performance.
+    /// </remarks>
+    public abstract class MediaTypeRegistry
+    {
+        /// <summary>
+        /// Gets a list of applicable media types to which a <see cref="Type"/> can be serialized.
+        /// </summary>
+        /// <param name="type">The data type.</param>
+        /// <returns>A list of applicable media types.</returns>
+        public abstract IReadOnlyList<string> GetMediaTypes(Type type);
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ApiBehaviorOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ApiBehaviorOptionsSetup.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.Options;
 
@@ -40,6 +41,17 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                     },
                 };
             }
+
+            // These are somewhat highly sensitive to order, so be careful.
+            //
+            // [HttpGet]
+            options.ApiDescriptionProfiles.Add(new GetAllApiDescriptionProfile());
+            options.ApiDescriptionProfiles.Add(new GetByIdApiDescriptionProfile());
+            options.ApiDescriptionProfiles.Add(new FindAllApiDescriptionProvider());
+            options.ApiDescriptionProfiles.Add(new FindSingleApiDescriptionProvider());
+
+            // Fallback
+            options.ApiDescriptionProfiles.Add(new UnknownApiDescriptionProfile());
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/IdParameter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/IdParameter.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+
+namespace Microsoft.AspNetCore.Mvc.Internal
+{
+    public static class IdParameter
+    {
+        // Check if the parameter is named "id" (e.g. int id) or ends in Id (e.g. personId)
+        public static bool IsIdParameter(ApiParameterDescription parameter)
+        {
+            if (parameter == null)
+            {
+                throw new ArgumentNullException(nameof(parameter));
+            }
+
+            return IsIdParameter(parameter.Name);
+        }
+
+        // Check if the parameter is named "id" (e.g. int id) or ends in Id (e.g. personId)
+        public static bool IsIdParameter(ParameterDescriptor parameter)
+        {
+            if (parameter == null)
+            {
+                throw new ArgumentNullException(nameof(parameter));
+            }
+
+            return IsIdParameter(parameter.Name);
+        }
+
+        private static bool IsIdParameter(string name)
+        {
+            if (name == null)
+            {
+                return false;
+            }
+
+            if (string.Equals("id", name, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            // We're looking for a name ending with Id, but preceded by a lower case letter. This should match
+            // the normal PascalCase naming conventions.
+            if (name.Length >= 3 &&
+                name.EndsWith("Id", StringComparison.Ordinal) &&
+                char.IsLower(name, name.Length - 3))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/ModelMetadataProviderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/ModelMetadataProviderExtensions.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Reflection;
+using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Core;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding

--- a/test/Microsoft.AspNetCore.Mvc.ApiExplorer.Test/ApiBehaviorApiDescriptionProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ApiExplorer.Test/ApiBehaviorApiDescriptionProviderTest.cs
@@ -3,10 +3,13 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -14,6 +17,72 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
 {
     public class ApiBehaviorApiDescriptionProviderTest
     {
+        public ApiBehaviorApiDescriptionProviderTest()
+        {
+            var profile = new Mock<DefaultApiDescriptionProfile>() { CallBase = true, };
+            profile
+                .Setup(p => p.IsMatch(It.Is<ApiDescription>(d => d.HttpMethod == "GET")))
+                .Returns(true);
+
+            GetProfile = profile.Object;
+            GetProfile.ResponseTypes.Add(new ApiResponseType()
+            {
+                Type = typeof(ProblemDetails),
+                StatusCode = 404,
+            });
+            GetProfile.ResponseTypes.Add(new ApiResponseType()
+            {
+                Type = typeof(ProblemDetails),
+                IsDefaultResponse = true,
+            });
+
+            profile = new Mock<DefaultApiDescriptionProfile>() { CallBase = true, };
+            profile
+                .Setup(p => p.IsMatch(It.Is<ApiDescription>(d => d.HttpMethod == "POST")))
+                .Returns(true);
+            PostProfile = profile.Object;
+            PostProfile.ResponseTypes.Add(new ApiResponseType()
+            {
+                Type = typeof(ProblemDetails),
+                StatusCode = 400,
+            });
+            PostProfile.ResponseTypes.Add(new ApiResponseType()
+            {
+                Type = typeof(ProblemDetails),
+                IsDefaultResponse = true,
+            });
+
+            var mockFormatter = new Mock<TextOutputFormatter>() { CallBase = true };
+            mockFormatter.Object.SupportedEncodings.Add(Encoding.UTF8);
+            mockFormatter.Object.SupportedMediaTypes.Add("application/json");
+            mockFormatter.Object.SupportedMediaTypes.Add("application/*+json");
+
+            Provider = new ApiBehaviorApiDescriptionProvider(
+                Options.Create(new MvcOptions()
+                {
+                    OutputFormatters =
+                    {
+                        mockFormatter.Object,
+                    },
+                }),
+                Options.Create(new ApiBehaviorOptions()
+                {
+                    ApiDescriptionProfiles =
+                    {
+                        GetProfile,
+                        PostProfile,
+                    },
+                }),
+                new EmptyModelMetadataProvider(),
+                new DefaultMediaTypeRegistry());
+        }
+
+        protected DefaultApiDescriptionProfile GetProfile { get; }
+
+        protected DefaultApiDescriptionProfile PostProfile { get; }
+
+        protected ApiBehaviorApiDescriptionProvider Provider { get; }
+
         [Fact]
         public void AppliesTo_ActionWithoutApiBehavior_ReturnsFalse()
         {
@@ -27,10 +96,8 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                 ActionDescriptor = action,
             };
 
-            var provider = new ApiBehaviorApiDescriptionProvider(new EmptyModelMetadataProvider());
-
             // Act
-            var result = provider.AppliesTo(description);
+            var result = Provider.AppliesTo(description);
 
             // Assert
             Assert.False(result);
@@ -52,63 +119,15 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                 ActionDescriptor = action,
             };
 
-            var provider = new ApiBehaviorApiDescriptionProvider(new EmptyModelMetadataProvider());
-
             // Act
-            var result = provider.AppliesTo(description);
+            var result = Provider.AppliesTo(description);
 
             // Assert
             Assert.True(result);
         }
 
-        [Theory]
-        [InlineData("id")]
-        [InlineData("personId")]
-        [InlineData("üId")]
-        public void IsIdParameter_ParameterNameMatchesConvention_ReturnsTrue(string name)
-        {
-            var parameter = new ParameterDescriptor()
-            {
-                Name = name,
-            };
-
-            var provider = new ApiBehaviorApiDescriptionProvider(new EmptyModelMetadataProvider());
-
-            // Act
-            var result = provider.IsIdParameter(parameter);
-
-            // Assert
-            Assert.True(result);
-        }
-
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("i")]
-        [InlineData("Id")]
-        [InlineData("iD")]
-        [InlineData("persoNId")]
-        [InlineData("personid")]
-        [InlineData("ü Id")]
-        [InlineData("ÜId")]
-        public void IsIdParameter_ParameterNameDoesNotMatchConvention_ReturnsFalse(string name)
-        {
-            var parameter = new ParameterDescriptor()
-            {
-                Name = name,
-            };
-
-            var provider = new ApiBehaviorApiDescriptionProvider(new EmptyModelMetadataProvider());
-
-            // Act
-            var result = provider.IsIdParameter(parameter);
-
-            // Assert
-            Assert.False(result);
-        }
-
-        [Fact]
-        public void CreateProblemResponseTypes_NoParameters_IncludesDefaultResponse()
+        [Fact] // This is more like an integration test
+        public void ApplyProfile_MatchesGetProfile_AddsApiResponseDescriptions()
         {
             // Arrange
             var action = new ActionDescriptor()
@@ -123,117 +142,64 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             var description = new ApiDescription()
             {
                 ActionDescriptor = action,
+                HttpMethod = "GET",
             };
 
-            var provider = new ApiBehaviorApiDescriptionProvider(new EmptyModelMetadataProvider());
-
             // Act
-            var results = provider.CreateProblemResponseTypes(description);
+            Provider.ApplyProfile(description);
 
             // Assert
             Assert.Collection(
-                results.OrderBy(r => r.StatusCode),
+                description.SupportedResponseTypes.OrderBy(r => r.StatusCode),
                 r =>
                 {
                     Assert.Equal(typeof(ProblemDetails), r.Type);
                     Assert.Equal(0, r.StatusCode);
                     Assert.True(r.IsDefaultResponse);
-                });
-        }
-
-        [Fact]
-        public void CreateProblemResponseTypes_WithBoundProperty_Includes400Response()
-        {
-            // Arrange
-            var action = new ActionDescriptor()
-            {
-                FilterDescriptors = new List<FilterDescriptor>()
-                {
-                    new FilterDescriptor(Mock.Of<IApiBehaviorMetadata>(), FilterScope.Global),
-                },
-                BoundProperties = new List<ParameterDescriptor>()
-                {
-                    new ParameterDescriptor()
-                },
-                Parameters = new List<ParameterDescriptor>(),
-            };
-            var description = new ApiDescription()
-            {
-                ActionDescriptor = action,
-            };
-
-            var provider = new ApiBehaviorApiDescriptionProvider(new EmptyModelMetadataProvider());
-
-            // Act
-            var results = provider.CreateProblemResponseTypes(description);
-
-            // Assert
-            Assert.Collection(
-                results.OrderBy(r => r.StatusCode),
-                r =>
-                {
-                    Assert.Equal(typeof(ProblemDetails), r.Type);
-                    Assert.Equal(0, r.StatusCode);
-                    Assert.True(r.IsDefaultResponse);
-                },
-                r =>
-                {
-                    Assert.Equal(typeof(ProblemDetails), r.Type);
-                    Assert.Equal(400, r.StatusCode);
-                    Assert.False(r.IsDefaultResponse);
-                });
-        }
-
-        [Fact]
-        public void CreateProblemResponseTypes_WithIdParameter_Includes404Response()
-        {
-            // Arrange
-            var action = new ActionDescriptor()
-            {
-                FilterDescriptors = new List<FilterDescriptor>()
-                {
-                    new FilterDescriptor(Mock.Of<IApiBehaviorMetadata>(), FilterScope.Global),
-                },
-                BoundProperties = new List<ParameterDescriptor>()
-                {
-                },
-                Parameters = new List<ParameterDescriptor>()
-                {
-                    new ParameterDescriptor()
-                    {
-                        Name = "customerId",
-                    }
-                },
-            };
-            var description = new ApiDescription()
-            {
-                ActionDescriptor = action,
-            };
-
-            var provider = new ApiBehaviorApiDescriptionProvider(new EmptyModelMetadataProvider());
-
-            // Act
-            var results = provider.CreateProblemResponseTypes(description);
-
-            // Assert
-            Assert.Collection(
-                results.OrderBy(r => r.StatusCode),
-                r =>
-                {
-                    Assert.Equal(typeof(ProblemDetails), r.Type);
-                    Assert.Equal(0, r.StatusCode);
-                    Assert.True(r.IsDefaultResponse);
-                },
-                r =>
-                {
-                    Assert.Equal(typeof(ProblemDetails), r.Type);
-                    Assert.Equal(400, r.StatusCode);
-                    Assert.False(r.IsDefaultResponse);
                 },
                 r =>
                 {
                     Assert.Equal(typeof(ProblemDetails), r.Type);
                     Assert.Equal(404, r.StatusCode);
+                    Assert.False(r.IsDefaultResponse);
+                });
+        }
+
+        [Fact] // This is more like an integration test
+        public void ApplyProfile_MatchesPostProfile_AddsApiResponseDescriptions()
+        {
+            // Arrange
+            var action = new ActionDescriptor()
+            {
+                FilterDescriptors = new List<FilterDescriptor>()
+                {
+                    new FilterDescriptor(Mock.Of<IApiBehaviorMetadata>(), FilterScope.Global),
+                },
+                BoundProperties = new List<ParameterDescriptor>(),
+                Parameters = new List<ParameterDescriptor>(),
+            };
+            var description = new ApiDescription()
+            {
+                ActionDescriptor = action,
+                HttpMethod = "POST",
+            };
+
+            // Act
+            Provider.ApplyProfile(description);
+
+            // Assert
+            Assert.Collection(
+                description.SupportedResponseTypes.OrderBy(r => r.StatusCode),
+                r =>
+                {
+                    Assert.Equal(typeof(ProblemDetails), r.Type);
+                    Assert.Equal(0, r.StatusCode);
+                    Assert.True(r.IsDefaultResponse);
+                },
+                r =>
+                {
+                    Assert.Equal(typeof(ProblemDetails), r.Type);
+                    Assert.Equal(400, r.StatusCode);
                     Assert.False(r.IsDefaultResponse);
                 });
         }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/IdParameterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/IdParameterTest.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.Internal
+{
+    public class IdParameterTest
+    {
+        [Theory]
+        [InlineData("id")]
+        [InlineData("personId")]
+        [InlineData("üId")]
+        public void IsIdParameter_ParameterNameMatchesConvention_ReturnsTrue(string name)
+        {
+            var parameter = new ParameterDescriptor()
+            {
+                Name = name,
+            };
+
+            // Act
+            var result = IdParameter.IsIdParameter(parameter);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("i")]
+        [InlineData("Id")]
+        [InlineData("iD")]
+        [InlineData("persoNId")]
+        [InlineData("personid")]
+        [InlineData("ü Id")]
+        [InlineData("ÜId")]
+        public void IsIdParameter_ParameterNameDoesNotMatchConvention_ReturnsFalse(string name)
+        {
+            var parameter = new ParameterDescriptor()
+            {
+                Name = name,
+            };
+
+            // Act
+            var result = IdParameter.IsIdParameter(parameter);
+
+            // Assert
+            Assert.False(result);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds infrastructure for 'profiles' that can be matched against
ApiDescriptions. Once a profile matches an action/description, it can
modify the description to fit the application's common practices and
conventions.

The idea is that each 'profile' corresponds to a kind of logical
operation (look at the examples) like 'get-by-id' - and will update the
ApiDescription to include the kind of things this operation would
normally need to declare.

This should make it easier to customize if you have your own set of
opinionated behaviors, such as using 202-accepted for 'create' operations.

This is a design PR, thus I'm looking for feedback on the design and
layering of the approach. (yes, I know about the functional test
failures, I haven't updated those yet).