### PR TITLE
Makes MediaType (MT) a wrapper around HttpAbstractions MediaTypeHeaderValue (MTHV)

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Formatters/MediaType.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Formatters/MediaType.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         /// <summary>
         /// Initializes a <see cref="MediaType"/> instance.
         /// </summary>
-        /// <param name="mediaType">The <see cref="string"/> with the media type.</param>
+        /// <param name="mediaType">The <see cref="StringSegment"/> with the media type.</param>
         /// <param name="offset">The offset in the <paramref name="mediaType"/> where the parsing starts.</param>
         /// <param name="length">The length of the media type to parse if provided.</param>
         public MediaType(StringSegment mediaType, int offset, int? length)

--- a/src/Microsoft.AspNetCore.Mvc.Core/Formatters/MediaType.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Formatters/MediaType.cs
@@ -34,6 +34,11 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         /// <param name="mediaType">The <see cref="StringSegment"/> with the media type.</param>
         public MediaType(StringSegment mediaType)
         {
+            if (mediaType == null)
+            {
+                throw new ArgumentNullException(nameof(mediaType));
+            }
+
             if (MediaTypeHeaderValue.TryParse(mediaType, out _mediaTypeHeaderValue))
             {
                 SubType = _mediaTypeHeaderValue.SubType;
@@ -49,13 +54,21 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 SubTypeWithoutSuffix = new StringSegment();
             }
         }
+
+        /// <summary>
+        /// Initializes a <see cref="MediaType"/> instance.
+        /// </summary>
+        /// <param name="mediaType">The <see cref="string"/> with the media type.</param>
+        /// <param name="offset">The offset in the <paramref name="mediaType"/> where the parsing starts.</param>
+        /// <param name="length">The length of the media type to parse if provided.</param>
         public MediaType(string mediaType, int offset, int? length)
             : this(new StringSegment(mediaType), offset, length)
-
         {
         }
 
-
+        /// <summary>
+        /// Initializes a <see cref="MediaType"/> instance.
+        /// </summary>
         /// <param name="mediaType">The <see cref="string"/> with the media type.</param>
         /// <param name="offset">The offset in the <paramref name="mediaType"/> where the parsing starts.</param>
         /// <param name="length">The length of the media type to parse if provided.</param>
@@ -249,7 +262,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                     return HeaderUtilities.RemoveQuotes(nameValue.Value);
                 }
             }
-            return null;
+            return new StringSegment();
         }
 
         /// <summary>
@@ -329,22 +342,11 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             }
 
             var quality = parsedMediaType._mediaTypeHeaderValue.Quality ?? 1.0;
-            //foreach (var nameValue in )
-            //{
-            //    if (nameValue.Name == QualityParameter)
-            //    {
-            //        // If media type contains two `q` values i.e. it's invalid in an uncommon way, pick last value.
-            //        quality = double.Parse(
-            //            nameValue.Value.Value, NumberStyles.AllowDecimalPoint,
-            //            NumberFormatInfo.InvariantInfo);
-            //    }
-            //}
 
             // We check if the parsed media type has a value at this stage when we have iterated
-            // over all the parameters and we know if the parsing was successful.
-
+            // over all the parameters and we know if the parsing was successful
             return new MediaTypeSegmentWithQuality(
-                parsedMediaType._mediaTypeHeaderValue.MediaType,
+                parsedMediaType._mediaTypeHeaderValue.ToString(),
                 quality);
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/Formatters/MediaType.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Formatters/MediaType.cs
@@ -241,9 +241,10 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             {
                 return null;
             }
+
             foreach (var nameValue in _mediaTypeHeaderValue.Parameters)
             {
-                if (nameValue.Name == parameterName)
+                if (nameValue.Name.Equals(parameterName, StringComparison.OrdinalIgnoreCase))
                 {
                     return nameValue.Value;
                 }
@@ -318,8 +319,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         /// <returns>The parsed media type with its associated quality.</returns>
         public static MediaTypeSegmentWithQuality CreateMediaTypeSegmentWithQuality(string mediaType, int start)
         {
-            // This method may be tough to recoup. This method can accept a list of MediaTypes, and it will parse 
-            // just the first one of the list (in place parsing). 
             var parsedMediaType = new MediaType(mediaType, start, length: null);
             // Short-circuit use of the MediaTypeParameterParser if constructor detected an invalid type or subtype.
             // Parser would set ParsingFailed==true in this case. But, we handle invalid parameters as a separate case.

--- a/src/Microsoft.AspNetCore.Mvc.Core/Formatters/MediaType.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Formatters/MediaType.cs
@@ -255,8 +255,9 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 return null;
             }
 
-            foreach (var nameValue in _mediaTypeHeaderValue.Parameters)
+            for (var i = 0; i < _mediaTypeHeaderValue.Parameters.Count; i++)
             {
+                var nameValue = _mediaTypeHeaderValue.Parameters[i];
                 if (nameValue.Name.Equals(parameterName, StringComparison.OrdinalIgnoreCase))
                 {
                     return HeaderUtilities.RemoveQuotes(nameValue.Value);
@@ -290,6 +291,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         {
             var parsedMediaType = new MediaType(mediaType);
             var charset = parsedMediaType.GetParameter("charset");
+
             if (charset.HasValue && charset.Equals(encoding.WebName, StringComparison.OrdinalIgnoreCase))
             {
                 return mediaType.Value;
@@ -320,6 +322,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         public static Encoding GetEncoding(StringSegment mediaType)
         {
             var parsedMediaType = new MediaType(mediaType);
+
             return parsedMediaType.Encoding;
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/Formatters/MediaType.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Formatters/MediaType.cs
@@ -246,7 +246,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             {
                 if (nameValue.Name.Equals(parameterName, StringComparison.OrdinalIgnoreCase))
                 {
-                    return nameValue.Value;
+                    return HeaderUtilities.RemoveQuotes(nameValue.Value);
                 }
             }
             return null;
@@ -328,17 +328,17 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 return default(MediaTypeSegmentWithQuality);
             }
 
-            var quality = 1.0d;
-            foreach (var nameValue in parsedMediaType._mediaTypeHeaderValue.Parameters)
-            {
-                if (nameValue.Name == QualityParameter)
-                {
-                    // If media type contains two `q` values i.e. it's invalid in an uncommon way, pick last value.
-                    quality = double.Parse(
-                        nameValue.Value.Value, NumberStyles.AllowDecimalPoint,
-                        NumberFormatInfo.InvariantInfo);
-                }
-            }
+            var quality = parsedMediaType._mediaTypeHeaderValue.Quality ?? 1.0;
+            //foreach (var nameValue in )
+            //{
+            //    if (nameValue.Name == QualityParameter)
+            //    {
+            //        // If media type contains two `q` values i.e. it's invalid in an uncommon way, pick last value.
+            //        quality = double.Parse(
+            //            nameValue.Value.Value, NumberStyles.AllowDecimalPoint,
+            //            NumberFormatInfo.InvariantInfo);
+            //    }
+            //}
 
             // We check if the parsed media type has a value at this stage when we have iterated
             // over all the parameters and we know if the parsing was successful.

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/AcceptHeaderParser.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/AcceptHeaderParser.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
 {
@@ -28,146 +29,15 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
             {
                 throw new ArgumentNullException(nameof(parsedValues));
             }
-            for (var i = 0; i < acceptHeaders.Count; i++)
-            {
-                var charIndex = 0;
-                var value = acceptHeaders[i];
 
-                while (!string.IsNullOrEmpty(value) && charIndex < value.Length)
+            if (MediaTypeHeaderValue.TryParseList(acceptHeaders, out var output))
+            {
+                for (int j = 0; j < output.Count; j++)
                 {
-                    var startCharIndex = charIndex;
-
-                    if (TryParseValue(value, ref charIndex, out var output))
-                    {
-                        // The entry may not contain an actual value, like Accept: application/json, , */*
-                        if (output.MediaType.HasValue)
-                        {
-                            parsedValues.Add(output);
-                        }
-                    }
-
-                    if (charIndex <= startCharIndex)
-                    {
-                        Debug.Fail("ParseAcceptHeader should advance charIndex, this is a bug.");
-                        break;
-                    }
+                    var mediaTypeHeaderValue = output[j];
+                    var mediaTypeWithQuality = new MediaTypeSegmentWithQuality(mediaTypeHeaderValue.MediaType, mediaTypeHeaderValue.Quality ?? 1.0);
+                    parsedValues.Add(mediaTypeWithQuality);
                 }
-            }
-        }
-
-        private static bool TryParseValue(string value, ref int index, out MediaTypeSegmentWithQuality parsedValue)
-        {
-            parsedValue = default(MediaTypeSegmentWithQuality);
-
-            // The accept header may be added multiple times to the request/response message. E.g.
-            // Accept: text/xml; q=1
-            // Accept:
-            // Accept: text/plain; q=0.2
-            // In this case, do not fail parsing in case one of the values is the empty string.
-            if (string.IsNullOrEmpty(value) || (index == value.Length))
-            {
-                return true;
-            }
-
-            var currentIndex = GetNextNonEmptyOrWhitespaceIndex(value, index, out var separatorFound);
-
-            if (currentIndex == value.Length)
-            {
-                index = currentIndex;
-                return true;
-            }
-
-            // We deliberately want to ignore media types that we are not capable of parsing.
-            // This is due to the fact that some browsers will send invalid media types like 
-            // ; q=0.9 or */;q=0.2, etc.
-            // In this scenario, our recovery action consists of advancing the pointer to the
-            // next separator and moving on.
-            // In case we don't find the next separator, we simply advance the cursor to the
-            // end of the string to signal that we are done parsing.
-            var result = default(MediaTypeSegmentWithQuality);
-            var length = 0;
-            try
-            {
-                length = GetMediaTypeWithQualityLength(value, currentIndex, out result);
-            }
-            catch
-            {
-                length = 0;
-            }
-
-            if (length == 0)
-            {
-                // The parsing failed.
-                currentIndex = value.IndexOf(',', currentIndex);
-                if (currentIndex == -1)
-                {
-                    index = value.Length;
-                    return false;
-                }
-                index = currentIndex;
-                return false;
-            }
-
-            currentIndex = currentIndex + length;
-            currentIndex = GetNextNonEmptyOrWhitespaceIndex(value, currentIndex, out separatorFound);
-
-            // If we've not reached the end of the string, then we must have a separator.
-            // E. g application/json, text/plain <- We must be at ',' otherwise, we've failed parsing.
-            if (!separatorFound && (currentIndex < value.Length))
-            {
-                index = currentIndex;
-                return false;
-            }
-
-            index = currentIndex;
-            parsedValue = result;
-            return true;
-        }
-
-        private static int GetNextNonEmptyOrWhitespaceIndex(
-            string input,
-            int startIndex,
-            out bool separatorFound)
-        {
-            Debug.Assert(input != null);
-            Debug.Assert(startIndex <= input.Length); // it's OK if index == value.Length.
-
-            separatorFound = false;
-            var current = startIndex + HttpTokenParsingRules.GetWhitespaceLength(input, startIndex);
-
-            if ((current == input.Length) || (input[current] != ','))
-            {
-                return current;
-            }
-
-            // If we have a separator, skip the separator and all following whitespaces, and
-            // continue until the current character is neither a separator nor a whitespace.
-            separatorFound = true;
-            current++; // skip delimiter.
-            current = current + HttpTokenParsingRules.GetWhitespaceLength(input, current);
-
-            while ((current < input.Length) && (input[current] == ','))
-            {
-                current++; // skip delimiter.
-                current = current + HttpTokenParsingRules.GetWhitespaceLength(input, current);
-            }
-
-            return current;
-        }
-
-        private static int GetMediaTypeWithQualityLength(
-            string input,
-            int start,
-            out MediaTypeSegmentWithQuality result)
-        {
-            result = MediaType.CreateMediaTypeSegmentWithQuality(input, start);
-            if (result.MediaType.HasValue)
-            {
-                return result.MediaType.Length;
-            }
-            else
-            {
-                return 0;
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/AcceptHeaderParser.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/AcceptHeaderParser.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
                 for (int j = 0; j < output.Count; j++)
                 {
                     var mediaTypeHeaderValue = output[j];
-                    var mediaTypeWithQuality = new MediaTypeSegmentWithQuality(mediaTypeHeaderValue.MediaType, mediaTypeHeaderValue.Quality ?? 1.0);
+                    var mediaTypeWithQuality = new MediaTypeSegmentWithQuality(mediaTypeHeaderValue.ToString(), mediaTypeHeaderValue.Quality ?? 1.0);
                     parsedValues.Add(mediaTypeWithQuality);
                 }
             }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/MediaTypeTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/MediaTypeTest.cs
@@ -56,6 +56,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             Assert.Equal(new StringSegment(expectedSubtypeSuffix), result.SubTypeSuffix);
         }
 
+        // These commented out tests fail because of quotes (MTHV has quotes, MT doesn't)
         public static TheoryData<string> MediaTypesWithParameters
         {
             get
@@ -63,7 +64,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 return new TheoryData<string>
                 {
                     "application/json+bson;format=pretty;charset=utf-8;q=0.8",
-                    "application/json+bson;format=pretty;charset=\"utf-8\";q=0.8",
+                    //"application/json+bson;format=pretty;charset=\"utf-8\";q=0.8",
                     "application/json+bson;format=pretty;charset=utf-8; q=0.8 ",
                     "application/json+bson;format=pretty;charset=utf-8 ; q=0.8 ",
                     "application/json+bson;format=pretty; charset=utf-8 ; q=0.8 ",
@@ -72,7 +73,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                     "application/json+bson; format=pretty ; charset=utf-8 ; q=  0.8 ",
                     "application/json+bson; format=pretty ; charset=utf-8 ; q  =  0.8 ",
                     " application /  json+bson; format =  pretty ; charset = utf-8 ; q  =  0.8 ",
-                    " application /  json+bson; format =  \"pretty\" ; charset = \"utf-8\" ; q  =  \"0.8\" ",
+                    //" application /  json+bson; format =  \"pretty\" ; charset = \"utf-8\" ; q  =  \"0.8\" ",
                 };
             }
         }
@@ -94,6 +95,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             Assert.Equal(new StringSegment("utf-8"), result.GetParameter("charset"));
         }
 
+        // MTHV doesn't parse this, MT does
         [Fact]
         public void Constructor_NullLength_IgnoresLength()
         {
@@ -331,13 +333,15 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             Assert.Equal(expectedReturnValue, result);
         }
 
+        // MT allows for wildcards as a parameter.
+        // Though it isn't by part of the media type spec, we should consider supporting it.
         [Theory]
         [InlineData("*/*", true)]
         [InlineData("text/*", true)]
         [InlineData("text/entity+*", false)] // We don't support wildcards on suffixes
         [InlineData("text/*+json", true)]
-        [InlineData("text/entity+json;*", true)]
-        [InlineData("text/entity+json;v=3;*", true)]
+        //[InlineData("text/entity+json;*", true)]
+        //[InlineData("text/entity+json;v=3;*", true)]
         [InlineData("text/entity+json;v=3;q=0.8", false)]
         [InlineData("text/json", false)]
         [InlineData("text/json;param=*", false)] // * is the literal value of the param

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/MediaTypeTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/MediaTypeTest.cs
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 return new TheoryData<string>
                 {
                     "application/json+bson;format=pretty;charset=utf-8;q=0.8",
-                    //"application/json+bson;format=pretty;charset=\"utf-8\";q=0.8",
+                    "application/json+bson;format=pretty;charset=\"utf-8\";q=0.8",
                     "application/json+bson;format=pretty;charset=utf-8; q=0.8 ",
                     "application/json+bson;format=pretty;charset=utf-8 ; q=0.8 ",
                     "application/json+bson;format=pretty; charset=utf-8 ; q=0.8 ",
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                     "application/json+bson; format=pretty ; charset=utf-8 ; q=  0.8 ",
                     "application/json+bson; format=pretty ; charset=utf-8 ; q  =  0.8 ",
                     " application /  json+bson; format =  pretty ; charset = utf-8 ; q  =  0.8 ",
-                    //" application /  json+bson; format =  \"pretty\" ; charset = \"utf-8\" ; q  =  \"0.8\" ",
+                    " application /  json+bson; format =  \"pretty\" ; charset = \"utf-8\" ; q  =  \"0.8\" ",
                 };
             }
         }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/MediaTypeTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/MediaTypeTest.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 return new TheoryData<string>
                 {
                     "application/json+bson;format=pretty;charset=utf-8;q=0.8",
-                    "application/json+bson;format=pretty;charset=\"utf-8\";q=0.8",
+                    "application/json+bson;format=pretty;charset=\"utf-8\";q=0.8", // MTHV will not remove quotes. 
                     "application/json+bson;format=pretty;charset=utf-8; q=0.8 ",
                     "application/json+bson;format=pretty;charset=utf-8 ; q=0.8 ",
                     "application/json+bson;format=pretty; charset=utf-8 ; q=0.8 ",
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                     "application/json+bson; format=pretty ; charset=utf-8 ; q=  0.8 ",
                     "application/json+bson; format=pretty ; charset=utf-8 ; q  =  0.8 ",
                     " application /  json+bson; format =  pretty ; charset = utf-8 ; q  =  0.8 ",
-                    " application /  json+bson; format =  \"pretty\" ; charset = \"utf-8\" ; q  =  \"0.8\" ",
+                    " application /  json+bson; format =  \"pretty\" ; charset = \"utf-8\" ; q  =  0.8 ", // Quality parameters are not allowed to be quoted.
                 };
             }
         }
@@ -101,10 +101,10 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         public void Constructor_NullLength_IgnoresLength()
         {
             // Arrange & Act
-            var result = new MediaType("mediaType", 1, length: null);
+            var result = new MediaType("application/json", 1, length: null);
 
             // Assert
-            Assert.Equal(new StringSegment("ediaType"), result.Type);
+            Assert.Equal(new StringSegment("pplication"), result.Type);
         }
 
         [Fact]
@@ -360,8 +360,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
         [Theory]
         [MemberData(nameof(MediaTypesWithParameters))]
-        [InlineData("application/json;format=pretty;q=0.9;charset=utf-8;q=0.8")]
-        [InlineData("application/json;format=pretty;q=0.9;charset=utf-8;q=0.8;version=3")]
+        //[InlineData("application/json;format=pretty;q=0.9;charset=utf-8;q=0.8")]
+        //[InlineData("application/json;format=pretty;q=0.9;charset=utf-8;q=0.8;version=3")]
         public void CreateMediaTypeSegmentWithQuality_FindsQValue(string value)
         {
             // Arrange & Act

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/MediaTypeTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/MediaTypeTest.cs
@@ -41,7 +41,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             }
         }
 
-
         [Theory]
         [MemberData(nameof(MediaTypesWithSuffixes))]
         public void Constructor_CanParseSuffixedMediaTypes(
@@ -57,7 +56,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             Assert.Equal(new StringSegment(expectedSubtypeSuffix), result.SubTypeSuffix);
         }
 
-        // These commented out tests fail because of quotes (MTHV has quotes, MT doesn't)
         public static TheoryData<string> MediaTypesWithParameters
         {
             get
@@ -65,7 +63,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 return new TheoryData<string>
                 {
                     "application/json+bson;format=pretty;charset=utf-8;q=0.8",
-                    "application/json+bson;format=pretty;charset=\"utf-8\";q=0.8", // MTHV will not remove quotes. 
+                    "application/json+bson;format=pretty;charset=\"utf-8\";q=0.8",
                     "application/json+bson;format=pretty;charset=utf-8; q=0.8 ",
                     "application/json+bson;format=pretty;charset=utf-8 ; q=0.8 ",
                     "application/json+bson;format=pretty; charset=utf-8 ; q=0.8 ",

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/MediaTypeTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/MediaTypeTest.cs
@@ -41,6 +41,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             }
         }
 
+
         [Theory]
         [MemberData(nameof(MediaTypesWithSuffixes))]
         public void Constructor_CanParseSuffixedMediaTypes(

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/OutputFormatterTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/OutputFormatterTests.cs
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/json"));
             formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("*/*"));
             formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("text/*"));
-            //formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("text/plain;*")); // The wild card is not counted here because it is invalid in MTHV
+            //formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("text/plain;*"));
             formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/xml"));
 
             // Act

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/OutputFormatterTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/OutputFormatterTests.cs
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/json"));
             formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("*/*"));
             formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("text/*"));
-            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("text/plain;*"));
+            //formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("text/plain;*")); // The wild card is not counted here because it is invalid in MTHV
             formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/xml"));
 
             // Act

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Infrastructure/ObjectResultExecutorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Infrastructure/ObjectResultExecutorTest.cs
@@ -515,7 +515,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
         [InlineData(new[] { "application/xml", "*/*", "application/json" }, "*/*")]
         [InlineData(new[] { "*/*", "application/json" }, "*/*")]
         [InlineData(new[] { "application/json", "application/*+json" }, "application/*+json")]
-        [InlineData(new[] { "application/entiy+json;*", "application/json" }, "application/entiy+json;*")]
+        //[InlineData(new[] { "application/entiy+json;*", "application/json" }, "application/entiy+json;*")]
         public async Task ExecuteAsync_MatchAllContentType_Throws(string[] contentTypes, string invalidContentType)
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
@@ -122,39 +122,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
             Assert.Equal(expected, parsed);
         }
 
-        // The text "*/*Content-Type" parses as a valid media type value. However it's followed
-        // by ':' instead of whitespace or a delimiter, which means that it's actually invalid.
-        //[Fact]
-        //public void ParseAcceptHeader_ValidMediaType_FollowedByNondelimiter()
-        //{
-        //    // Arrange
-        //    var expected = new MediaTypeSegmentWithQuality[0];
-
-        //    // This input is actually stricter than MTHV, MTHV will continue parsing a list 
-        //    var input = "*/*Content-Type:application/json";
-
-        //    // Act
-        //    var parsed = AcceptHeaderParser.ParseAcceptHeader(new List<string>() { input });
-
-        //    // Assert
-        //    Assert.Equal(expected, parsed);
-        //}
-
-        //[Fact]
-        //public void ParseAcceptHeader_ValidMediaType_FollowedBySemicolon()
-        //{
-        //    // Arrange
-        //    var expected = new MediaTypeSegmentWithQuality[0];
-
-        //    var input = "*/*Content-Type;application/json";
-
-        //    // Act
-        //    var parsed = AcceptHeaderParser.ParseAcceptHeader(new List<string>() { input });
-
-        //    // Assert
-        //    Assert.Equal(expected, parsed);
-        //}
-
         [Fact]
         public void ParseAcceptHeader_ValidMediaType_FollowedByComma()
         {

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
         public void ParseAcceptHeader_ParsesSimpleHeaderWithMultipleValues()
         {
             // Arrange
-            var header = "application/json, application/xml;q=0.8";
+            var header = "application/json, application/xml; q=0.8";
             var expected = new List<MediaTypeSegmentWithQuality>
             {
                 new MediaTypeSegmentWithQuality(new StringSegment("application/json"),1.0),
@@ -44,10 +44,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
 
             // Assert
             Assert.Equal(expected, parsed);
-            foreach (var mediaType in parsed)
-            {
-                Assert.Same(header, mediaType.MediaType.Buffer);
-            }
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
             var expected = new List<MediaTypeSegmentWithQuality>
             {
                 new MediaTypeSegmentWithQuality(new StringSegment("application/json"),1.0),
-                new MediaTypeSegmentWithQuality(new StringSegment("application/xml;q=0.8"),0.8)
+                new MediaTypeSegmentWithQuality(new StringSegment("application/xml"),0.8)
             };
 
             // Act
@@ -86,7 +86,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
                 { new [] { "img/png,/*;q=0.9,text/html" }, new string[] { "img/png", "text/html" } },
                 { new [] { "img/png, /;q=0.9" }, new string[] { "img/png", } },
                 { new [] { "img/png, */;q=0.9" }, new string[] { "img/png", } },
-                { new [] { "img/png;q=1.0, /*;q=0.9" }, new string[] { "img/png;q=1.0", } },
             };
 
         [Theory]
@@ -112,7 +111,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
             var expected = new List<MediaTypeSegmentWithQuality>
             {
                 new MediaTypeSegmentWithQuality(new StringSegment("application/json"), 1.0),
-                new MediaTypeSegmentWithQuality(new StringSegment("application/xml;q=0.8"), 0.8)
+                new MediaTypeSegmentWithQuality(new StringSegment("application/xml"), 0.8)
             };
 
             // Act
@@ -125,35 +124,36 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
 
         // The text "*/*Content-Type" parses as a valid media type value. However it's followed
         // by ':' instead of whitespace or a delimiter, which means that it's actually invalid.
-        [Fact]
-        public void ParseAcceptHeader_ValidMediaType_FollowedByNondelimiter()
-        {
-            // Arrange
-            var expected = new MediaTypeSegmentWithQuality[0];
+        //[Fact]
+        //public void ParseAcceptHeader_ValidMediaType_FollowedByNondelimiter()
+        //{
+        //    // Arrange
+        //    var expected = new MediaTypeSegmentWithQuality[0];
 
-            var input = "*/*Content-Type:application/json";
+        //    // This input is actually stricter than MTHV, MTHV will continue parsing a list 
+        //    var input = "*/*Content-Type:application/json";
 
-            // Act
-            var parsed = AcceptHeaderParser.ParseAcceptHeader(new List<string>() { input });
+        //    // Act
+        //    var parsed = AcceptHeaderParser.ParseAcceptHeader(new List<string>() { input });
 
-            // Assert
-            Assert.Equal(expected, parsed);
-        }
+        //    // Assert
+        //    Assert.Equal(expected, parsed);
+        //}
 
-        [Fact]
-        public void ParseAcceptHeader_ValidMediaType_FollowedBySemicolon()
-        {
-            // Arrange
-            var expected = new MediaTypeSegmentWithQuality[0];
+        //[Fact]
+        //public void ParseAcceptHeader_ValidMediaType_FollowedBySemicolon()
+        //{
+        //    // Arrange
+        //    var expected = new MediaTypeSegmentWithQuality[0];
 
-            var input = "*/*Content-Type;application/json";
+        //    var input = "*/*Content-Type;application/json";
 
-            // Act
-            var parsed = AcceptHeaderParser.ParseAcceptHeader(new List<string>() { input });
+        //    // Act
+        //    var parsed = AcceptHeaderParser.ParseAcceptHeader(new List<string>() { input });
 
-            // Assert
-            Assert.Equal(expected, parsed);
-        }
+        //    // Assert
+        //    Assert.Equal(expected, parsed);
+        //}
 
         [Fact]
         public void ParseAcceptHeader_ValidMediaType_FollowedByComma()

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AcceptHeaderParserTest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
             var expected = new List<MediaTypeSegmentWithQuality>
             {
                 new MediaTypeSegmentWithQuality(new StringSegment("application/json"),1.0),
-                new MediaTypeSegmentWithQuality(new StringSegment("application/xml"),0.8)
+                new MediaTypeSegmentWithQuality(new StringSegment("application/xml; q=0.8"),0.8)
             };
 
             // Act
@@ -86,6 +86,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
                 { new [] { "img/png,/*;q=0.9,text/html" }, new string[] { "img/png", "text/html" } },
                 { new [] { "img/png, /;q=0.9" }, new string[] { "img/png", } },
                 { new [] { "img/png, */;q=0.9" }, new string[] { "img/png", } },
+                { new [] { "img/png;q=1.0, /*;q=0.9" }, new string[] { "img/png; q=1.0", } }
             };
 
         [Theory]
@@ -111,12 +112,44 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Internal
             var expected = new List<MediaTypeSegmentWithQuality>
             {
                 new MediaTypeSegmentWithQuality(new StringSegment("application/json"), 1.0),
-                new MediaTypeSegmentWithQuality(new StringSegment("application/xml"), 0.8)
+                new MediaTypeSegmentWithQuality(new StringSegment("application/xml; q=0.8"), 0.8)
             };
 
             // Act
             var parsed = AcceptHeaderParser.ParseAcceptHeader(
                 new List<string> { "application/json", "", "application/xml;q=0.8" });
+
+            // Assert
+            Assert.Equal(expected, parsed);
+        }
+
+        // The text "*/*Content-Type" parses as a valid media type value. However it's followed
+        // by ':' instead of whitespace or a delimiter, which means that it's actually invalid.
+        [Fact]
+        public void ParseAcceptHeader_ValidMediaType_FollowedByNondelimiter()
+        {
+            // Arrange
+            var expected = new MediaTypeSegmentWithQuality[0];
+
+            var input = "*/*Content-Type:application/json";
+
+            // Act
+            var parsed = AcceptHeaderParser.ParseAcceptHeader(new List<string>() { input });
+
+            // Assert
+            Assert.Equal(expected, parsed);
+        }
+
+        [Fact]
+        public void ParseAcceptHeader_ValidMediaType_FollowedBySemicolon()
+        {
+            // Arrange
+            var expected = new MediaTypeSegmentWithQuality[0];
+
+            var input = "*/*Content-Type;application/json";
+
+            // Act
+            var parsed = AcceptHeaderParser.ParseAcceptHeader(new List<string>() { input });
 
             // Assert
             Assert.Equal(expected, parsed);

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ProducesAttributeTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ProducesAttributeTests.cs
@@ -112,12 +112,11 @@ namespace Microsoft.AspNetCore.Mvc.Test
         [InlineData("application/*", "application/*")]
         [InlineData("application/xml, application/*, application/json", "application/*")]
         [InlineData("application/*, application/json", "application/*")]
-
         [InlineData("*/*", "*/*")]
         [InlineData("application/xml, */*, application/json", "*/*")]
         [InlineData("*/*, application/json", "*/*")]
         [InlineData("application/*+json", "application/*+json")]
-        //[InlineData("application/json;v=1;*", "application/json;v=1;*")] // The wild card is not counted here because it is invalid in MTHV
+        //[InlineData("application/json;v=1;*", "application/json;v=1;*")]
         public void ProducesAttribute_InvalidContentType_Throws(string content, string invalidContentType)
         {
             // Act

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ProducesAttributeTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ProducesAttributeTests.cs
@@ -117,7 +117,7 @@ namespace Microsoft.AspNetCore.Mvc.Test
         [InlineData("application/xml, */*, application/json", "*/*")]
         [InlineData("*/*, application/json", "*/*")]
         [InlineData("application/*+json", "application/*+json")]
-        [InlineData("application/json;v=1;*", "application/json;v=1;*")]
+        //[InlineData("application/json;v=1;*", "application/json;v=1;*")] // The wild card is not counted here because it is invalid in MTHV
         public void ProducesAttribute_InvalidContentType_Throws(string content, string invalidContentType)
         {
             // Act


### PR DESCRIPTION
Making this PR to identify the current issues between MT and MTHV. Here are the differences I identified.

**MTHV is case sensitive and MT is case insensitive**
```c#
[Fact]
public void GetParameter_IsCaseInsensitive()
{
    // Arrange
    var mediaType = "application/json;charset=utf-8";
    var expectedParameter = new StringSegment("utf-8");

    var parsedMediaType = new MediaType(mediaType);

    // Act
    var result = parsedMediaType.GetParameter("CHARSET");

    // Assert
    Assert.Equal(expectedParameter, result);
}
```

**MT supports "*" for parameters, while MTHV says it is invalid.**
```csharp
[InlineData("text/entity+json;*", true)]
```
This will fail to parse in MTHV.

**MT removes quotes around values that don't require it, while MTHV keeps them**
This passes for MT because it removes quotes around utf-8.
```csharp
public static TheoryData<string> MediaTypesWithParameters
{
    get
    {
        return new TheoryData<string>
        {
            "application/json+bson;format=pretty;charset=utf-8;q=0.8",
            "application/json+bson;format=pretty;charset=\"utf-8\";q=0.8",
        };
    }
}

[Theory]
[MemberData(nameof(MediaTypesWithParameters))]
public void Constructor_CanParseMediaTypesWithParameters(string mediaType)
{
    // Arrange & Act
    var result = new MediaType(mediaType, 0, mediaType.Length);

    // Assert
    Assert.Equal(new StringSegment("application"), result.Type);
    Assert.Equal(new StringSegment("json+bson"), result.SubType);
    Assert.Equal(new StringSegment("json"), result.SubTypeWithoutSuffix);
    Assert.Equal(new StringSegment("bson"), result.SubTypeSuffix);
    Assert.Equal(new StringSegment("pretty"), result.GetParameter("format"));
    Assert.Equal(new StringSegment("0.8"), result.GetParameter("q"));
    Assert.Equal(new StringSegment("utf-8"), result.GetParameter("charset"));
}
```
**MT can take the full Accept header in the constructor, parse a single type, and not throw an exception.**
With MT, we can call
```csharp
var parsedMediaType = new MediaType("text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8", start, length: null);
```
and it would succeed, returning the first type in the list of MediaType, "text/html", in the MediaType struct. MTHV will fail to parse this. We can try to parse it as a list and take the first one, but that seems bad. 

cc/ @muratg @Eilon 