### PR TITLE
Use previous version of Appveyor image to avoid dotnet bug

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,4 +16,4 @@ environment:
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
 test: off
 deploy: off
-os: Visual Studio 2017
+image: Previous Visual Studio 2017


### PR DESCRIPTION
This is a WIP to see if we can avoid problems on Appveyor, I will update it when I'm ready for actual review.