### PR TITLE
Fix Xml formatters to taking in MvcOptions to take affect of options …

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/MvcXmlDataContractSerializerMvcOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/MvcXmlDataContractSerializerMvcOptionsSetup.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
             options.ModelMetadataDetailsProviders.Add(new DataMemberRequiredBindingMetadataProvider());
 
             options.OutputFormatters.Add(new XmlDataContractSerializerOutputFormatter());
-            options.InputFormatters.Add(new XmlDataContractSerializerInputFormatter(options.SuppressInputFormatterBuffering));
+            options.InputFormatters.Add(new XmlDataContractSerializerInputFormatter(options));
 
             options.ModelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider("System.Xml.Linq.XObject"));
             options.ModelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider("System.Xml.XmlNode"));

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/MvcXmlSerializerMvcOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/Internal/MvcXmlSerializerMvcOptionsSetup.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml.Internal
         public void Configure(MvcOptions options)
         {
             options.OutputFormatters.Add(new XmlSerializerOutputFormatter());
-            options.InputFormatters.Add(new XmlSerializerInputFormatter(options.SuppressInputFormatterBuffering));
+            options.InputFormatters.Add(new XmlSerializerInputFormatter(options));
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/XmlDataContractSerializerInputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/XmlDataContractSerializerInputFormatter.cs
@@ -28,11 +28,13 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         private readonly ConcurrentDictionary<Type, object> _serializerCache = new ConcurrentDictionary<Type, object>();
         private readonly XmlDictionaryReaderQuotas _readerQuotas = FormattingUtilities.GetDefaultXmlReaderQuotas();
         private readonly bool _suppressInputFormatterBuffering;
+        private readonly MvcOptions _options;
         private DataContractSerializerSettings _serializerSettings;
 
         /// <summary>
         /// Initializes a new instance of DataContractSerializerInputFormatter
         /// </summary>
+        [Obsolete("This constructor is obsolete and will be removed in a future version.")]
         public XmlDataContractSerializerInputFormatter() :
             this(suppressInputFormatterBuffering: false)
         {
@@ -42,9 +44,31 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         /// Initializes a new instance of DataContractSerializerInputFormatter
         /// </summary>
         /// <param name="suppressInputFormatterBuffering">Flag to buffer entire request body before deserializing it.</param>
+        [Obsolete("This constructor is obsolete and will be removed in a future version.")]
         public XmlDataContractSerializerInputFormatter(bool suppressInputFormatterBuffering)
         {
             _suppressInputFormatterBuffering = suppressInputFormatterBuffering;
+
+            SupportedEncodings.Add(UTF8EncodingWithoutBOM);
+            SupportedEncodings.Add(UTF16EncodingLittleEndian);
+
+            SupportedMediaTypes.Add(MediaTypeHeaderValues.ApplicationXml);
+            SupportedMediaTypes.Add(MediaTypeHeaderValues.TextXml);
+            SupportedMediaTypes.Add(MediaTypeHeaderValues.ApplicationAnyXmlSyntax);
+
+            _serializerSettings = new DataContractSerializerSettings();
+
+            WrapperProviderFactories = new List<IWrapperProviderFactory>();
+            WrapperProviderFactories.Add(new SerializableErrorWrapperProviderFactory());
+        }
+
+        /// <summary>
+        /// Initializes a new instance of DataContractSerializerInputFormatter
+        /// </summary>
+        /// <param name="options">The <see cref="MvcOptions"/>.</param>
+        public XmlDataContractSerializerInputFormatter(MvcOptions options)
+        {
+            _options = options;
 
             SupportedEncodings.Add(UTF8EncodingWithoutBOM);
             SupportedEncodings.Add(UTF16EncodingLittleEndian);
@@ -126,7 +150,9 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
             var request = context.HttpContext.Request;
 
-            if (!request.Body.CanSeek && !_suppressInputFormatterBuffering)
+            var suppressInputFormatterBuffering = _options?.SuppressInputFormatterBuffering ?? _suppressInputFormatterBuffering;
+            
+            if (!request.Body.CanSeek && !suppressInputFormatterBuffering)
             {
                 // XmlDataContractSerializer does synchronous reads. In order to avoid blocking on the stream, we asynchronously 
                 // read everything into a buffer, and then seek back to the beginning. 

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/XmlDataContractSerializerInputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/XmlDataContractSerializerInputFormatter.cs
@@ -37,8 +37,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         [Obsolete("This constructor is obsolete and will be removed in a future version.")]
         public XmlDataContractSerializerInputFormatter()
         {
-            _suppressInputFormatterBuffering = false;
-
             SupportedEncodings.Add(UTF8EncodingWithoutBOM);
             SupportedEncodings.Add(UTF16EncodingLittleEndian);
 
@@ -63,18 +61,18 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             _suppressInputFormatterBuffering = suppressInputFormatterBuffering;
         }
 
-#pragma warning disable CS0618
         /// <summary>
         /// Initializes a new instance of <see cref="XmlDataContractSerializerInputFormatter"/>.
         /// </summary>
         /// <param name="options">The <see cref="MvcOptions"/>.</param>
         public XmlDataContractSerializerInputFormatter(MvcOptions options)
+#pragma warning disable CS0618
             : this()
+#pragma warning restore CS0618
         {
             _options = options;
         }
-#pragma warning restore CS0618
-        
+
         /// <summary>
         /// Gets the list of <see cref="IWrapperProviderFactory"/> to
         /// provide the wrapping type for de-serialization.
@@ -143,7 +141,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             var request = context.HttpContext.Request;
 
             var suppressInputFormatterBuffering = _options?.SuppressInputFormatterBuffering ?? _suppressInputFormatterBuffering;
-            
+
             if (!request.Body.CanSeek && !suppressInputFormatterBuffering)
             {
                 // XmlDataContractSerializer does synchronous reads. In order to avoid blocking on the stream, we asynchronously 

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/XmlDataContractSerializerInputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/XmlDataContractSerializerInputFormatter.cs
@@ -32,57 +32,49 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         private DataContractSerializerSettings _serializerSettings;
 
         /// <summary>
-        /// Initializes a new instance of DataContractSerializerInputFormatter
+        /// Initializes a new instance of <see cref="XmlDataContractSerializerInputFormatter"/>.
         /// </summary>
         [Obsolete("This constructor is obsolete and will be removed in a future version.")]
-        public XmlDataContractSerializerInputFormatter() :
-            this(suppressInputFormatterBuffering: false)
+        public XmlDataContractSerializerInputFormatter()
         {
+            _suppressInputFormatterBuffering = false;
+
+            SupportedEncodings.Add(UTF8EncodingWithoutBOM);
+            SupportedEncodings.Add(UTF16EncodingLittleEndian);
+
+            SupportedMediaTypes.Add(MediaTypeHeaderValues.ApplicationXml);
+            SupportedMediaTypes.Add(MediaTypeHeaderValues.TextXml);
+            SupportedMediaTypes.Add(MediaTypeHeaderValues.ApplicationAnyXmlSyntax);
+
+            _serializerSettings = new DataContractSerializerSettings();
+
+            WrapperProviderFactories = new List<IWrapperProviderFactory>();
+            WrapperProviderFactories.Add(new SerializableErrorWrapperProviderFactory());
         }
 
         /// <summary>
-        /// Initializes a new instance of DataContractSerializerInputFormatter
+        /// Initializes a new instance of <see cref="XmlDataContractSerializerInputFormatter"/>.
         /// </summary>
         /// <param name="suppressInputFormatterBuffering">Flag to buffer entire request body before deserializing it.</param>
         [Obsolete("This constructor is obsolete and will be removed in a future version.")]
         public XmlDataContractSerializerInputFormatter(bool suppressInputFormatterBuffering)
+            : this()
         {
             _suppressInputFormatterBuffering = suppressInputFormatterBuffering;
-
-            SupportedEncodings.Add(UTF8EncodingWithoutBOM);
-            SupportedEncodings.Add(UTF16EncodingLittleEndian);
-
-            SupportedMediaTypes.Add(MediaTypeHeaderValues.ApplicationXml);
-            SupportedMediaTypes.Add(MediaTypeHeaderValues.TextXml);
-            SupportedMediaTypes.Add(MediaTypeHeaderValues.ApplicationAnyXmlSyntax);
-
-            _serializerSettings = new DataContractSerializerSettings();
-
-            WrapperProviderFactories = new List<IWrapperProviderFactory>();
-            WrapperProviderFactories.Add(new SerializableErrorWrapperProviderFactory());
         }
 
+#pragma warning disable CS0618
         /// <summary>
-        /// Initializes a new instance of DataContractSerializerInputFormatter
+        /// Initializes a new instance of <see cref="XmlDataContractSerializerInputFormatter"/>.
         /// </summary>
         /// <param name="options">The <see cref="MvcOptions"/>.</param>
         public XmlDataContractSerializerInputFormatter(MvcOptions options)
+            : this()
         {
             _options = options;
-
-            SupportedEncodings.Add(UTF8EncodingWithoutBOM);
-            SupportedEncodings.Add(UTF16EncodingLittleEndian);
-
-            SupportedMediaTypes.Add(MediaTypeHeaderValues.ApplicationXml);
-            SupportedMediaTypes.Add(MediaTypeHeaderValues.TextXml);
-            SupportedMediaTypes.Add(MediaTypeHeaderValues.ApplicationAnyXmlSyntax);
-
-            _serializerSettings = new DataContractSerializerSettings();
-
-            WrapperProviderFactories = new List<IWrapperProviderFactory>();
-            WrapperProviderFactories.Add(new SerializableErrorWrapperProviderFactory());
         }
-
+#pragma warning restore CS0618
+        
         /// <summary>
         /// Gets the list of <see cref="IWrapperProviderFactory"/> to
         /// provide the wrapping type for de-serialization.

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/XmlSerializerInputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/XmlSerializerInputFormatter.cs
@@ -36,8 +36,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         [Obsolete("This constructor is obsolete and will be removed in a future version.")]
         public XmlSerializerInputFormatter()
         {
-            _suppressInputFormatterBuffering = false;
-
             SupportedEncodings.Add(UTF8EncodingWithoutBOM);
             SupportedEncodings.Add(UTF16EncodingLittleEndian);
 
@@ -60,17 +58,17 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             _suppressInputFormatterBuffering = suppressInputFormatterBuffering;
         }
 
-#pragma warning disable CS0618
         /// <summary>
         /// Initializes a new instance of <see cref="XmlSerializerInputFormatter"/>.
         /// </summary>
         /// <param name="options">The <see cref="MvcOptions"/>.</param>
         public XmlSerializerInputFormatter(MvcOptions options)
+#pragma warning disable CS0618
             : this()
+#pragma warning restore CS0618
         {
             _options = options;
         }
-#pragma warning restore CS0618
 
         /// <summary>
         /// Gets the list of <see cref="IWrapperProviderFactory"/> to

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/XmlSerializerInputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/XmlSerializerInputFormatter.cs
@@ -35,48 +35,42 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         /// </summary>
         [Obsolete("This constructor is obsolete and will be removed in a future version.")]
         public XmlSerializerInputFormatter()
-            : this(suppressInputFormatterBuffering: false)
         {
+            _suppressInputFormatterBuffering = false;
+
+            SupportedEncodings.Add(UTF8EncodingWithoutBOM);
+            SupportedEncodings.Add(UTF16EncodingLittleEndian);
+
+            SupportedMediaTypes.Add(MediaTypeHeaderValues.ApplicationXml);
+            SupportedMediaTypes.Add(MediaTypeHeaderValues.TextXml);
+            SupportedMediaTypes.Add(MediaTypeHeaderValues.ApplicationAnyXmlSyntax);
+
+            WrapperProviderFactories = new List<IWrapperProviderFactory>();
+            WrapperProviderFactories.Add(new SerializableErrorWrapperProviderFactory());
         }
 
         /// <summary>
-        /// Initializes a new instance of XmlSerializerInputFormatter.
+        /// Initializes a new instance of <see cref="XmlSerializerInputFormatter"/>.
         /// </summary>
         /// <param name="suppressInputFormatterBuffering">Flag to buffer entire request body before deserializing it.</param>
         [Obsolete("This constructor is obsolete and will be removed in a future version.")]
         public XmlSerializerInputFormatter(bool suppressInputFormatterBuffering)
+            : this()
         {
             _suppressInputFormatterBuffering = suppressInputFormatterBuffering;
-
-            SupportedEncodings.Add(UTF8EncodingWithoutBOM);
-            SupportedEncodings.Add(UTF16EncodingLittleEndian);
-
-            SupportedMediaTypes.Add(MediaTypeHeaderValues.ApplicationXml);
-            SupportedMediaTypes.Add(MediaTypeHeaderValues.TextXml);
-            SupportedMediaTypes.Add(MediaTypeHeaderValues.ApplicationAnyXmlSyntax);
-
-            WrapperProviderFactories = new List<IWrapperProviderFactory>();
-            WrapperProviderFactories.Add(new SerializableErrorWrapperProviderFactory());
         }
 
+#pragma warning disable CS0618
         /// <summary>
-        /// Initializes a new instance of XmlSerializerInputFormatter.
+        /// Initializes a new instance of <see cref="XmlSerializerInputFormatter"/>.
         /// </summary>
         /// <param name="options">The <see cref="MvcOptions"/>.</param>
         public XmlSerializerInputFormatter(MvcOptions options)
+            : this()
         {
             _options = options;
-
-            SupportedEncodings.Add(UTF8EncodingWithoutBOM);
-            SupportedEncodings.Add(UTF16EncodingLittleEndian);
-
-            SupportedMediaTypes.Add(MediaTypeHeaderValues.ApplicationXml);
-            SupportedMediaTypes.Add(MediaTypeHeaderValues.TextXml);
-            SupportedMediaTypes.Add(MediaTypeHeaderValues.ApplicationAnyXmlSyntax);
-
-            WrapperProviderFactories = new List<IWrapperProviderFactory>();
-            WrapperProviderFactories.Add(new SerializableErrorWrapperProviderFactory());
         }
+#pragma warning restore CS0618
 
         /// <summary>
         /// Gets the list of <see cref="IWrapperProviderFactory"/> to

--- a/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/XmlSerializerInputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Formatters.Xml/XmlSerializerInputFormatter.cs
@@ -28,10 +28,12 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         private readonly ConcurrentDictionary<Type, object> _serializerCache = new ConcurrentDictionary<Type, object>();
         private readonly XmlDictionaryReaderQuotas _readerQuotas = FormattingUtilities.GetDefaultXmlReaderQuotas();
         private readonly bool _suppressInputFormatterBuffering;
+        private readonly MvcOptions _options;
 
         /// <summary>
         /// Initializes a new instance of XmlSerializerInputFormatter.
         /// </summary>
+        [Obsolete("This constructor is obsolete and will be removed in a future version.")]
         public XmlSerializerInputFormatter()
             : this(suppressInputFormatterBuffering: false)
         {
@@ -41,9 +43,29 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         /// Initializes a new instance of XmlSerializerInputFormatter.
         /// </summary>
         /// <param name="suppressInputFormatterBuffering">Flag to buffer entire request body before deserializing it.</param>
+        [Obsolete("This constructor is obsolete and will be removed in a future version.")]
         public XmlSerializerInputFormatter(bool suppressInputFormatterBuffering)
         {
             _suppressInputFormatterBuffering = suppressInputFormatterBuffering;
+
+            SupportedEncodings.Add(UTF8EncodingWithoutBOM);
+            SupportedEncodings.Add(UTF16EncodingLittleEndian);
+
+            SupportedMediaTypes.Add(MediaTypeHeaderValues.ApplicationXml);
+            SupportedMediaTypes.Add(MediaTypeHeaderValues.TextXml);
+            SupportedMediaTypes.Add(MediaTypeHeaderValues.ApplicationAnyXmlSyntax);
+
+            WrapperProviderFactories = new List<IWrapperProviderFactory>();
+            WrapperProviderFactories.Add(new SerializableErrorWrapperProviderFactory());
+        }
+
+        /// <summary>
+        /// Initializes a new instance of XmlSerializerInputFormatter.
+        /// </summary>
+        /// <param name="options">The <see cref="MvcOptions"/>.</param>
+        public XmlSerializerInputFormatter(MvcOptions options)
+        {
+            _options = options;
 
             SupportedEncodings.Add(UTF8EncodingWithoutBOM);
             SupportedEncodings.Add(UTF16EncodingLittleEndian);
@@ -107,7 +129,9 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
             var request = context.HttpContext.Request;
 
-            if (!request.Body.CanSeek && !_suppressInputFormatterBuffering)
+            var suppressInputFormatterBuffering = _options?.SuppressInputFormatterBuffering ?? _suppressInputFormatterBuffering;
+
+            if (!request.Body.CanSeek && !suppressInputFormatterBuffering)
             {
                 // XmlSerializer does synchronous reads. In order to avoid blocking on the stream, we asynchronously 
                 // read everything into a buffer, and then seek back to the beginning. 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/BodyModelBinderTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/BodyModelBinderTests.cs
@@ -820,8 +820,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         {
             private bool _throwNonInputFormatterException;
 
-            public TestableXmlSerializerInputFormatter(bool throwNonInputFormatterException) :
-                base(new MvcOptions())
+            public TestableXmlSerializerInputFormatter(bool throwNonInputFormatterException)
+                : base(new MvcOptions())
             {
                 _throwNonInputFormatterException = throwNonInputFormatterException;
             }
@@ -842,8 +842,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         {
             private bool _throwNonInputFormatterException;
 
-            public TestableXmlDataContractSerializerInputFormatter(bool throwNonInputFormatterException) :
-                base(new MvcOptions())
+            public TestableXmlDataContractSerializerInputFormatter(bool throwNonInputFormatterException)
+                : base(new MvcOptions())
             {
                 _throwNonInputFormatterException = throwNonInputFormatterException;
             }
@@ -886,8 +886,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         {
             private bool _throwNonInputFormatterException;
 
-            public DerivedXmlSerializerInputFormatter(bool throwNonInputFormatterException) :
-                base(new MvcOptions())
+            public DerivedXmlSerializerInputFormatter(bool throwNonInputFormatterException)
+                : base(new MvcOptions())
             {
                 _throwNonInputFormatterException = throwNonInputFormatterException;
             }
@@ -908,8 +908,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         {
             private bool _throwNonInputFormatterException;
 
-            public DerivedXmlDataContractSerializerInputFormatter(bool throwNonInputFormatterException) :
-                base(new MvcOptions())
+            public DerivedXmlDataContractSerializerInputFormatter(bool throwNonInputFormatterException)
+                : base(new MvcOptions())
             {
                 _throwNonInputFormatterException = throwNonInputFormatterException;
             }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/BodyModelBinderTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/BodyModelBinderTests.cs
@@ -243,10 +243,10 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             {
                 return new TheoryData<IInputFormatter, InputFormatterExceptionModelStatePolicy>()
                 {
-                    { new XmlSerializerInputFormatter(), InputFormatterExceptionModelStatePolicy.AllExceptions },
-                    { new XmlSerializerInputFormatter(), InputFormatterExceptionModelStatePolicy.MalformedInputExceptions },
-                    { new XmlDataContractSerializerInputFormatter(), InputFormatterExceptionModelStatePolicy.AllExceptions },
-                    { new XmlDataContractSerializerInputFormatter(), InputFormatterExceptionModelStatePolicy.MalformedInputExceptions },
+                    { new XmlSerializerInputFormatter(new MvcOptions()), InputFormatterExceptionModelStatePolicy.AllExceptions },
+                    { new XmlSerializerInputFormatter(new MvcOptions()), InputFormatterExceptionModelStatePolicy.MalformedInputExceptions },
+                    { new XmlDataContractSerializerInputFormatter(new MvcOptions()), InputFormatterExceptionModelStatePolicy.AllExceptions },
+                    { new XmlDataContractSerializerInputFormatter(new MvcOptions()), InputFormatterExceptionModelStatePolicy.MalformedInputExceptions },
                 };
             }
         }
@@ -820,7 +820,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         {
             private bool _throwNonInputFormatterException;
 
-            public TestableXmlSerializerInputFormatter(bool throwNonInputFormatterException)
+            public TestableXmlSerializerInputFormatter(bool throwNonInputFormatterException) :
+                base(new MvcOptions())
             {
                 _throwNonInputFormatterException = throwNonInputFormatterException;
             }
@@ -841,7 +842,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         {
             private bool _throwNonInputFormatterException;
 
-            public TestableXmlDataContractSerializerInputFormatter(bool throwNonInputFormatterException)
+            public TestableXmlDataContractSerializerInputFormatter(bool throwNonInputFormatterException) :
+                base(new MvcOptions())
             {
                 _throwNonInputFormatterException = throwNonInputFormatterException;
             }
@@ -884,7 +886,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         {
             private bool _throwNonInputFormatterException;
 
-            public DerivedXmlSerializerInputFormatter(bool throwNonInputFormatterException)
+            public DerivedXmlSerializerInputFormatter(bool throwNonInputFormatterException) :
+                base(new MvcOptions())
             {
                 _throwNonInputFormatterException = throwNonInputFormatterException;
             }
@@ -905,7 +908,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         {
             private bool _throwNonInputFormatterException;
 
-            public DerivedXmlDataContractSerializerInputFormatter(bool throwNonInputFormatterException)
+            public DerivedXmlDataContractSerializerInputFormatter(bool throwNonInputFormatterException) :
+                base(new MvcOptions())
             {
                 _throwNonInputFormatterException = throwNonInputFormatterException;
             }

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlDataContractSerializerInputFormatterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlDataContractSerializerInputFormatterTest.cs
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
         public void CanRead_ReturnsTrueForAnySupportedContentType(string requestContentType, bool expectedCanRead)
         {
             // Arrange
-            var formatter = new XmlDataContractSerializerInputFormatter();
+            var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
             var contentBytes = Encoding.UTF8.GetBytes("content");
 
             var modelState = new ModelStateDictionary();
@@ -114,7 +114,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
         public void HasProperSuppportedMediaTypes()
         {
             // Arrange & Act
-            var formatter = new XmlDataContractSerializerInputFormatter();
+            var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
 
             // Assert
             Assert.Contains("application/xml", formatter.SupportedMediaTypes
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
         public void HasProperSuppportedEncodings()
         {
             // Arrange & Act
-            var formatter = new XmlDataContractSerializerInputFormatter();
+            var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
 
             // Assert
             Assert.Contains(formatter.SupportedEncodings, i => i.WebName == "utf-8");
@@ -144,8 +144,10 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
                                 "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
                                 "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
-
+#pragma warning disable CS0618
             var formatter = new XmlDataContractSerializerInputFormatter();
+#pragma warning restore CS0618
+
             var contentBytes = Encoding.UTF8.GetBytes(input);
             var httpContext = new DefaultHttpContext();
             httpContext.Features.Set<IHttpResponseFeature>(new TestResponseFeature());
@@ -188,8 +190,88 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
                                 "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
                                 "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
-
+#pragma warning disable CS0618
             var formatter = new XmlDataContractSerializerInputFormatter(suppressInputFormatterBuffering: true);
+#pragma warning restore CS0618
+
+            var contentBytes = Encoding.UTF8.GetBytes(input);
+            var httpContext = new DefaultHttpContext();
+            httpContext.Features.Set<IHttpResponseFeature>(new TestResponseFeature());
+            httpContext.Request.Body = new NonSeekableReadStream(contentBytes);
+            httpContext.Request.ContentType = "application/xml";
+            var context = GetInputFormatterContext(httpContext, typeof(TestLevelOne));
+
+            // Act
+            var result = await formatter.ReadAsync(context);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.False(result.HasError);
+            var model = Assert.IsType<TestLevelOne>(result.Model);
+
+            Assert.Equal(expectedInt, model.SampleInt);
+            Assert.Equal(expectedString, model.sampleString);
+
+            // Reading again should fail as buffering request body is disabled
+            await Assert.ThrowsAsync<XmlException>(() => formatter.ReadAsync(context));
+        }
+
+        [Fact]
+        public async Task BuffersRequestBody_ByDefaultUsinMvcOptions()
+        {
+            // Arrange
+            var expectedInt = 10;
+            var expectedString = "TestString";
+
+            var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                                "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
+
+            var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
+            var contentBytes = Encoding.UTF8.GetBytes(input);
+            var httpContext = new DefaultHttpContext();
+            httpContext.Features.Set<IHttpResponseFeature>(new TestResponseFeature());
+            httpContext.Request.Body = new NonSeekableReadStream(contentBytes);
+            httpContext.Request.ContentType = "application/json";
+            var context = GetInputFormatterContext(httpContext, typeof(TestLevelOne));
+
+            // Act
+            var result = await formatter.ReadAsync(context);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.False(result.HasError);
+            var model = Assert.IsType<TestLevelOne>(result.Model);
+
+            Assert.Equal(expectedInt, model.SampleInt);
+            Assert.Equal(expectedString, model.sampleString);
+
+            Assert.True(httpContext.Request.Body.CanSeek);
+            httpContext.Request.Body.Seek(0L, SeekOrigin.Begin);
+
+            result = await formatter.ReadAsync(context);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.False(result.HasError);
+            model = Assert.IsType<TestLevelOne>(result.Model);
+
+            Assert.Equal(expectedInt, model.SampleInt);
+            Assert.Equal(expectedString, model.sampleString);
+        }
+
+        [Fact]
+        public async Task SuppressInputFormatterBufferingSetToTrue_DoesNotBufferRequestBody_UsingMvcOptions()
+        {
+            // Arrange
+            var expectedInt = 10;
+            var expectedString = "TestString";
+
+            var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                                "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
+
+            var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions() { SuppressInputFormatterBuffering = true });
             var contentBytes = Encoding.UTF8.GetBytes(input);
             var httpContext = new DefaultHttpContext();
             httpContext.Features.Set<IHttpResponseFeature>(new TestResponseFeature());
@@ -223,7 +305,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
                                 "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
                                 "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
 
-            var formatter = new XmlDataContractSerializerInputFormatter();
+            var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
             var contentBytes = Encoding.UTF8.GetBytes(input);
             var context = GetInputFormatterContext(contentBytes, typeof(TestLevelOne));
 
@@ -240,6 +322,43 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
         }
 
         [Fact]
+        public async Task SuppressInputFormatterBufferingSetToTrue_UsingMutatedOptions()
+        {
+            // Arrange
+            var expectedInt = 10;
+            var expectedString = "TestString";
+
+            var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                                "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
+
+            var mvcOptions = new MvcOptions() { SuppressInputFormatterBuffering = false };
+            var formatter = new XmlDataContractSerializerInputFormatter(mvcOptions);
+            var contentBytes = Encoding.UTF8.GetBytes(input);
+            var httpContext = new DefaultHttpContext();
+            httpContext.Features.Set<IHttpResponseFeature>(new TestResponseFeature());
+            httpContext.Request.Body = new NonSeekableReadStream(contentBytes);
+            httpContext.Request.ContentType = "application/xml";
+            var context = GetInputFormatterContext(httpContext, typeof(TestLevelOne));
+
+            // Act
+            // Mutate options after passing into the constructor to make sure that the value type is not store in the constructor
+            mvcOptions.SuppressInputFormatterBuffering = true;
+            var result = await formatter.ReadAsync(context);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.False(result.HasError);
+            var model = Assert.IsType<TestLevelOne>(result.Model);
+
+            Assert.Equal(expectedInt, model.SampleInt);
+            Assert.Equal(expectedString, model.sampleString);
+
+            // Reading again should fail as buffering request body is disabled
+            await Assert.ThrowsAsync<XmlException>(() => formatter.ReadAsync(context));
+        }
+
+        [Fact]
         public async Task ReadAsync_ReadsComplexTypes()
         {
             // Arrange
@@ -252,7 +371,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
                         "<TestOne><SampleInt>" + expectedInt + "</SampleInt>" +
                         "<sampleString>" + expectedString + "</sampleString></TestOne></TestLevelTwo>";
 
-            var formatter = new XmlDataContractSerializerInputFormatter();
+            var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
             var contentBytes = Encoding.UTF8.GetBytes(input);
             var context = GetInputFormatterContext(contentBytes, typeof(TestLevelTwo));
 
@@ -277,7 +396,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
 
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
                 "<DummyClass><SampleInt>" + expectedInt + "</SampleInt></DummyClass>";
-            var formatter = new XmlDataContractSerializerInputFormatter();
+            var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
             formatter.MaxDepth = 10;
             var contentBytes = Encoding.UTF8.GetBytes(input);
             var context = GetInputFormatterContext(contentBytes, typeof(DummyClass));
@@ -301,7 +420,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
                         "<TestLevelTwo><SampleString>test</SampleString>" +
                         "<TestOne><SampleInt>10</SampleInt>" +
                         "<sampleString>test</sampleString></TestOne></TestLevelTwo>";
-            var formatter = new XmlDataContractSerializerInputFormatter();
+            var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
             formatter.MaxDepth = 1;
             var contentBytes = Encoding.UTF8.GetBytes(input);
             var context = GetInputFormatterContext(contentBytes, typeof(TestLevelTwo));
@@ -318,7 +437,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
                         "<TestLevelTwo><SampleString>test</SampleString>" +
                         "<TestOne><SampleInt>10</SampleInt>" +
                         "<sampleString>test</sampleString></TestOne></TestLevelTwo>";
-            var formatter = new XmlDataContractSerializerInputFormatter();
+            var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
             formatter.XmlDictionaryReaderQuotas.MaxStringContentLength = 2;
             var contentBytes = Encoding.UTF8.GetBytes(input);
             var context = GetInputFormatterContext(contentBytes, typeof(TestLevelTwo));
@@ -331,7 +450,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
         public void SetMaxDepth_ThrowsWhenMaxDepthIsBelowOne()
         {
             // Arrange
-            var formatter = new XmlDataContractSerializerInputFormatter();
+            var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
 
             // Act & Assert
             Assert.Throws<ArgumentException>(() => formatter.MaxDepth = 0);
@@ -343,7 +462,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             // Arrange
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
                 "<DummyClass><SampleInt>10</SampleInt></DummyClass>";
-            var formatter = new XmlDataContractSerializerInputFormatter();
+            var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
             var contentBytes = Encoding.UTF8.GetBytes(input);
             var context = GetInputFormatterContext(contentBytes, typeof(DummyClass));
 
@@ -372,7 +491,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             Buffer.BlockCopy(inp, 0, contentBytes, inpStart.Length, inp.Length);
             Buffer.BlockCopy(inpEnd, 0, contentBytes, inpStart.Length + inp.Length, inpEnd.Length);
 
-            var formatter = new XmlDataContractSerializerInputFormatter();
+            var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
             var context = GetInputFormatterContext(contentBytes, typeof(TestLevelTwo));
 
             // Act
@@ -390,7 +509,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var inputBytes = Encoding.UTF8.GetBytes("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
                 "<DummyClass><SampleInt>1000</SampleInt></DummyClass>");
 
-            var formatter = new XmlDataContractSerializerInputFormatter();
+            var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
 
             var modelState = new ModelStateDictionary();
             var httpContext = GetHttpContext(inputBytes, contentType: "application/xml; charset=utf-16");
@@ -427,7 +546,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             Buffer.BlockCopy(bom, 0, contentBytes, inputStart.Length, bom.Length);
             Buffer.BlockCopy(inputEnd, 0, contentBytes, inputStart.Length + bom.Length, inputEnd.Length);
 
-            var formatter = new XmlDataContractSerializerInputFormatter();
+            var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
             var context = GetInputFormatterContext(contentBytes, typeof(TestLevelTwo));
 
             // Act
@@ -453,7 +572,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
                                 "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
                                 "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
 
-            var formatter = new XmlDataContractSerializerInputFormatter();
+            var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
             var contentBytes = Encoding.Unicode.GetBytes(input);
 
             var modelState = new ModelStateDictionary();
@@ -491,7 +610,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
                 "<{0} xmlns=\"{1}\"><SampleInt xmlns=\"\">1</SampleInt></{0}>",
                 SubstituteRootName,
                 SubstituteRootNamespace);
-            var formatter = new XmlDataContractSerializerInputFormatter();
+            var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
             var contentBytes = Encoding.UTF8.GetBytes(input);
             var context = GetInputFormatterContext(contentBytes, typeof(DummyClass));
 
@@ -519,7 +638,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
                 RootName = dictionary.Add(SubstituteRootName),
                 RootNamespace = dictionary.Add(SubstituteRootNamespace)
             };
-            var formatter = new XmlDataContractSerializerInputFormatter
+            var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions())
             {
                 SerializerSettings = settings
             };
@@ -548,7 +667,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
                     + "<SampleString>Some text</SampleString></DummyClass>",
                     KnownTypeName,
                     InstanceNamespace);
-            var formatter = new XmlDataContractSerializerInputFormatter();
+            var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
             var contentBytes = Encoding.UTF8.GetBytes(input);
             var context = GetInputFormatterContext(contentBytes, typeof(DummyClass));
 
@@ -576,7 +695,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             {
                 KnownTypes = new[] { typeof(SomeDummyClass) }
             };
-            var formatter = new XmlDataContractSerializerInputFormatter
+            var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions())
             {
                 SerializerSettings = settings
             };
@@ -631,6 +750,11 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
         private class TestXmlDataContractSerializerInputFormatter : XmlDataContractSerializerInputFormatter
         {
             public int createSerializerCalledCount = 0;
+
+            public TestXmlDataContractSerializerInputFormatter() :
+                base(new MvcOptions())
+            {
+            }
 
             protected override DataContractSerializer CreateSerializer(Type type)
             {

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlDataContractSerializerInputFormatterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlDataContractSerializerInputFormatterTest.cs
@@ -142,8 +142,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var expectedString = "TestString";
 
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                        "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
-                        "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
+                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
 
 #pragma warning disable CS0618
             var formatter = new XmlDataContractSerializerInputFormatter();
@@ -189,8 +189,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var expectedString = "TestString";
 
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                        "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
-                        "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
+                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
 
 #pragma warning disable CS0618
             var formatter = new XmlDataContractSerializerInputFormatter(suppressInputFormatterBuffering: true);
@@ -226,8 +226,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var expectedString = "TestString";
 
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                        "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
-                        "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
+                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
 
             var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
             var contentBytes = Encoding.UTF8.GetBytes(input);
@@ -270,8 +270,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var expectedString = "TestString";
 
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                        "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
-                        "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
+                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
 
             var formatter = new XmlDataContractSerializerInputFormatter(
                 new MvcOptions() { SuppressInputFormatterBuffering = true });
@@ -305,8 +305,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var expectedString = "TestString";
 
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
-                                "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
+                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
 
             var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
             var contentBytes = Encoding.UTF8.GetBytes(input);
@@ -332,8 +332,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var expectedString = "TestString";
 
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                        "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
-                        "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
+                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
 
             var mvcOptions = new MvcOptions() { SuppressInputFormatterBuffering = false };
             var formatter = new XmlDataContractSerializerInputFormatter(mvcOptions);
@@ -370,9 +370,9 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var expectedLevelTwoString = "102";
 
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                        "<TestLevelTwo><SampleString>" + expectedLevelTwoString + "</SampleString>" +
-                        "<TestOne><SampleInt>" + expectedInt + "</SampleInt>" +
-                        "<sampleString>" + expectedString + "</sampleString></TestOne></TestLevelTwo>";
+                "<TestLevelTwo><SampleString>" + expectedLevelTwoString + "</SampleString>" +
+                "<TestOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                "<sampleString>" + expectedString + "</sampleString></TestOne></TestLevelTwo>";
 
             var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
             var contentBytes = Encoding.UTF8.GetBytes(input);
@@ -420,9 +420,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
         {
             // Arrange
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                        "<TestLevelTwo><SampleString>test</SampleString>" +
-                        "<TestOne><SampleInt>10</SampleInt>" +
-                        "<sampleString>test</sampleString></TestOne></TestLevelTwo>";
+                "<TestLevelTwo><SampleString>test</SampleString>" +
+                "<TestOne><SampleInt>10</SampleInt><sampleString>test</sampleString></TestOne></TestLevelTwo>";
             var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
             formatter.MaxDepth = 1;
             var contentBytes = Encoding.UTF8.GetBytes(input);
@@ -437,9 +436,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
         {
             // Arrange
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                        "<TestLevelTwo><SampleString>test</SampleString>" +
-                        "<TestOne><SampleInt>10</SampleInt>" +
-                        "<sampleString>test</sampleString></TestOne></TestLevelTwo>";
+                "<TestLevelTwo><SampleString>test</SampleString><TestOne><SampleInt>10</SampleInt>" +
+                "<sampleString>test</sampleString></TestOne></TestLevelTwo>";
             var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
             formatter.XmlDictionaryReaderQuotas.MaxStringContentLength = 2;
             var contentBytes = Encoding.UTF8.GetBytes(input);

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlDataContractSerializerInputFormatterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlDataContractSerializerInputFormatterTest.cs
@@ -142,8 +142,9 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var expectedString = "TestString";
 
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
-                                "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
+                        "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                        "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
+
 #pragma warning disable CS0618
             var formatter = new XmlDataContractSerializerInputFormatter();
 #pragma warning restore CS0618
@@ -188,8 +189,9 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var expectedString = "TestString";
 
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
-                                "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
+                        "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                        "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
+
 #pragma warning disable CS0618
             var formatter = new XmlDataContractSerializerInputFormatter(suppressInputFormatterBuffering: true);
 #pragma warning restore CS0618
@@ -217,15 +219,15 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
         }
 
         [Fact]
-        public async Task BuffersRequestBody_ByDefaultUsinMvcOptions()
+        public async Task BuffersRequestBody_ByDefaultUsingMvcOptions()
         {
             // Arrange
             var expectedInt = 10;
             var expectedString = "TestString";
 
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
-                                "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
+                        "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                        "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
 
             var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
             var contentBytes = Encoding.UTF8.GetBytes(input);
@@ -268,10 +270,11 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var expectedString = "TestString";
 
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
-                                "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
+                        "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                        "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
 
-            var formatter = new XmlDataContractSerializerInputFormatter(new MvcOptions() { SuppressInputFormatterBuffering = true });
+            var formatter = new XmlDataContractSerializerInputFormatter(
+                new MvcOptions() { SuppressInputFormatterBuffering = true });
             var contentBytes = Encoding.UTF8.GetBytes(input);
             var httpContext = new DefaultHttpContext();
             httpContext.Features.Set<IHttpResponseFeature>(new TestResponseFeature());
@@ -329,8 +332,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var expectedString = "TestString";
 
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
-                                "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
+                        "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                        "<sampleString>" + expectedString + "</sampleString></TestLevelOne>";
 
             var mvcOptions = new MvcOptions() { SuppressInputFormatterBuffering = false };
             var formatter = new XmlDataContractSerializerInputFormatter(mvcOptions);
@@ -751,8 +754,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
         {
             public int createSerializerCalledCount = 0;
 
-            public TestXmlDataContractSerializerInputFormatter() :
-                base(new MvcOptions())
+            public TestXmlDataContractSerializerInputFormatter()
+                : base(new MvcOptions())
             {
             }
 

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlSerializerInputFormatterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlSerializerInputFormatterTest.cs
@@ -49,9 +49,10 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var expectedDateTime = XmlConvert.ToString(DateTime.UtcNow, XmlDateTimeSerializationMode.Utc);
 
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
-                                "<sampleString>" + expectedString + "</sampleString>" +
-                                "<SampleDate>" + expectedDateTime + "</SampleDate></TestLevelOne>";
+                        "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                        "<sampleString>" + expectedString + "</sampleString>" +
+                        "<SampleDate>" + expectedDateTime + "</SampleDate></TestLevelOne>";
+
 #pragma warning disable CS0618
             var formatter = new XmlSerializerInputFormatter();
 #pragma warning restore CS0618
@@ -103,9 +104,10 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var expectedDateTime = XmlConvert.ToString(DateTime.UtcNow, XmlDateTimeSerializationMode.Utc);
 
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
-                                "<sampleString>" + expectedString + "</sampleString>" +
-                                "<SampleDate>" + expectedDateTime + "</SampleDate></TestLevelOne>";
+                        "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                        "<sampleString>" + expectedString + "</sampleString>" +
+                        "<SampleDate>" + expectedDateTime + "</SampleDate></TestLevelOne>";
+
 #pragma warning disable CS0618
             var formatter = new XmlSerializerInputFormatter(suppressInputFormatterBuffering: true);
 #pragma warning restore CS0618
@@ -144,9 +146,9 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var expectedDateTime = XmlConvert.ToString(DateTime.UtcNow, XmlDateTimeSerializationMode.Utc);
 
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
-                                "<sampleString>" + expectedString + "</sampleString>" +
-                                "<SampleDate>" + expectedDateTime + "</SampleDate></TestLevelOne>";
+                        "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                        "<sampleString>" + expectedString + "</sampleString>" +
+                        "<SampleDate>" + expectedDateTime + "</SampleDate></TestLevelOne>";
 
             var formatter = new XmlSerializerInputFormatter(new MvcOptions());
             var contentBytes = Encoding.UTF8.GetBytes(input);
@@ -196,9 +198,9 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var expectedDateTime = XmlConvert.ToString(DateTime.UtcNow, XmlDateTimeSerializationMode.Utc);
 
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
-                                "<sampleString>" + expectedString + "</sampleString>" +
-                                "<SampleDate>" + expectedDateTime + "</SampleDate></TestLevelOne>";
+                        "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                        "<sampleString>" + expectedString + "</sampleString>" +
+                        "<SampleDate>" + expectedDateTime + "</SampleDate></TestLevelOne>";
 
             var formatter = new XmlSerializerInputFormatter(new MvcOptions() { SuppressInputFormatterBuffering = true });
             var contentBytes = Encoding.UTF8.GetBytes(input);
@@ -235,9 +237,9 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var expectedDateTime = XmlConvert.ToString(DateTime.UtcNow, XmlDateTimeSerializationMode.Utc);
 
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
-                                "<sampleString>" + expectedString + "</sampleString>" +
-                                "<SampleDate>" + expectedDateTime + "</SampleDate></TestLevelOne>";
+                        "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                        "<sampleString>" + expectedString + "</sampleString>" +
+                        "<SampleDate>" + expectedDateTime + "</SampleDate></TestLevelOne>";
 
             var mvcOptions = new MvcOptions();
             mvcOptions.SuppressInputFormatterBuffering = false;
@@ -699,8 +701,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
         {
             public int createSerializerCalledCount = 0;
 
-            public TestXmlSerializerInputFormatter():
-                base(new MvcOptions())
+            public TestXmlSerializerInputFormatter()
+                : base(new MvcOptions())
             {
             }
 

--- a/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlSerializerInputFormatterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Formatters.Xml.Test/XmlSerializerInputFormatterTest.cs
@@ -49,9 +49,9 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var expectedDateTime = XmlConvert.ToString(DateTime.UtcNow, XmlDateTimeSerializationMode.Utc);
 
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                        "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
-                        "<sampleString>" + expectedString + "</sampleString>" +
-                        "<SampleDate>" + expectedDateTime + "</SampleDate></TestLevelOne>";
+                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                "<sampleString>" + expectedString + "</sampleString>" +
+                "<SampleDate>" + expectedDateTime + "</SampleDate></TestLevelOne>";
 
 #pragma warning disable CS0618
             var formatter = new XmlSerializerInputFormatter();
@@ -104,9 +104,9 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var expectedDateTime = XmlConvert.ToString(DateTime.UtcNow, XmlDateTimeSerializationMode.Utc);
 
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                        "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
-                        "<sampleString>" + expectedString + "</sampleString>" +
-                        "<SampleDate>" + expectedDateTime + "</SampleDate></TestLevelOne>";
+                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                "<sampleString>" + expectedString + "</sampleString>" +
+                "<SampleDate>" + expectedDateTime + "</SampleDate></TestLevelOne>";
 
 #pragma warning disable CS0618
             var formatter = new XmlSerializerInputFormatter(suppressInputFormatterBuffering: true);
@@ -146,9 +146,9 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var expectedDateTime = XmlConvert.ToString(DateTime.UtcNow, XmlDateTimeSerializationMode.Utc);
 
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                        "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
-                        "<sampleString>" + expectedString + "</sampleString>" +
-                        "<SampleDate>" + expectedDateTime + "</SampleDate></TestLevelOne>";
+                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                "<sampleString>" + expectedString + "</sampleString>" +
+                "<SampleDate>" + expectedDateTime + "</SampleDate></TestLevelOne>";
 
             var formatter = new XmlSerializerInputFormatter(new MvcOptions());
             var contentBytes = Encoding.UTF8.GetBytes(input);
@@ -198,9 +198,9 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var expectedDateTime = XmlConvert.ToString(DateTime.UtcNow, XmlDateTimeSerializationMode.Utc);
 
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                        "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
-                        "<sampleString>" + expectedString + "</sampleString>" +
-                        "<SampleDate>" + expectedDateTime + "</SampleDate></TestLevelOne>";
+                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                "<sampleString>" + expectedString + "</sampleString>" +
+                "<SampleDate>" + expectedDateTime + "</SampleDate></TestLevelOne>";
 
             var formatter = new XmlSerializerInputFormatter(new MvcOptions() { SuppressInputFormatterBuffering = true });
             var contentBytes = Encoding.UTF8.GetBytes(input);
@@ -237,9 +237,9 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var expectedDateTime = XmlConvert.ToString(DateTime.UtcNow, XmlDateTimeSerializationMode.Utc);
 
             var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                        "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
-                        "<sampleString>" + expectedString + "</sampleString>" +
-                        "<SampleDate>" + expectedDateTime + "</SampleDate></TestLevelOne>";
+                "<TestLevelOne><SampleInt>" + expectedInt + "</SampleInt>" +
+                "<sampleString>" + expectedString + "</sampleString>" +
+                "<SampleDate>" + expectedDateTime + "</SampleDate></TestLevelOne>";
 
             var mvcOptions = new MvcOptions();
             mvcOptions.SuppressInputFormatterBuffering = false;

--- a/test/WebSites/XmlFormattersWebSite/Startup.cs
+++ b/test/WebSites/XmlFormattersWebSite/Startup.cs
@@ -30,7 +30,7 @@ namespace XmlFormattersWebSite
                 // request information (Ex: Accept header).
                 // So here we instead clear out the default supported media types and create new
                 // ones which are distinguishable between formatters.
-                var xmlSerializerInputFormatter = new XmlSerializerInputFormatter();
+                var xmlSerializerInputFormatter = new XmlSerializerInputFormatter(new MvcOptions());
                 xmlSerializerInputFormatter.SupportedMediaTypes.Clear();
                 xmlSerializerInputFormatter.SupportedMediaTypes.Add(
                     new MediaTypeHeaderValue("application/xml-xmlser"));
@@ -44,7 +44,7 @@ namespace XmlFormattersWebSite
                 xmlSerializerOutputFormatter.SupportedMediaTypes.Add(
                     new MediaTypeHeaderValue("text/xml-xmlser"));
 
-                var dcsInputFormatter = new XmlDataContractSerializerInputFormatter();
+                var dcsInputFormatter = new XmlDataContractSerializerInputFormatter(new MvcOptions());
                 dcsInputFormatter.SupportedMediaTypes.Clear();
                 dcsInputFormatter.SupportedMediaTypes.Add(new MediaTypeHeaderValue("application/xml-dcs"));
                 dcsInputFormatter.SupportedMediaTypes.Add(new MediaTypeHeaderValue("text/xml-dcs"));


### PR DESCRIPTION
…mutation

Related to issue [Fixes #6858] Changes to MvcOption's settings (SuppressInputFormatterBuffering & AllowBindingUndefinedValueToEnumType) are not taking affect

@dougbu @pranavkm I missed the xml formatters in my earlier PR and this fixes that.