### PR TITLE
Improve logging - filter pipeline execution 

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionInvoker.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionInvoker.cs
@@ -115,6 +115,10 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                         var actionExecutingContext = _actionExecutingContext;
 
                         _diagnosticSource.BeforeOnActionExecution(actionExecutingContext, filter);
+                        _logger.BeforeExecutingMethodOnFilter(
+                            MvcCoreLoggerExtensions.ActionFilter,
+                            nameof(IAsyncActionFilter.OnActionExecutionAsync),
+                            filter);
 
                         var task = filter.OnActionExecutionAsync(actionExecutingContext, InvokeNextActionFilterAwaitedAsync);
                         if (task.Status != TaskStatus.RanToCompletion)
@@ -149,6 +153,10 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                         }
 
                         _diagnosticSource.AfterOnActionExecution(_actionExecutedContext, filter);
+                        _logger.AfterExecutingMethodOnFilter(
+                            MvcCoreLoggerExtensions.ActionFilter,
+                            nameof(IAsyncActionFilter.OnActionExecutionAsync),
+                            filter);
 
                         goto case State.ActionEnd;
                     }
@@ -162,10 +170,18 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                         var actionExecutingContext = _actionExecutingContext;
 
                         _diagnosticSource.BeforeOnActionExecuting(actionExecutingContext, filter);
+                        _logger.BeforeExecutingMethodOnFilter(
+                            MvcCoreLoggerExtensions.ActionFilter,
+                            nameof(IActionFilter.OnActionExecuting),
+                            filter);
 
                         filter.OnActionExecuting(actionExecutingContext);
 
                         _diagnosticSource.AfterOnActionExecuting(actionExecutingContext, filter);
+                        _logger.AfterExecutingMethodOnFilter(
+                            MvcCoreLoggerExtensions.ActionFilter,
+                            nameof(IActionFilter.OnActionExecuting),
+                            filter);
 
                         if (actionExecutingContext.Result != null)
                         {
@@ -204,10 +220,18 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                         var actionExecutedContext = _actionExecutedContext;
 
                         _diagnosticSource.BeforeOnActionExecuted(actionExecutedContext, filter);
+                        _logger.BeforeExecutingMethodOnFilter(
+                            MvcCoreLoggerExtensions.ActionFilter,
+                            nameof(IActionFilter.OnActionExecuted),
+                            filter);
 
                         filter.OnActionExecuted(actionExecutedContext);
 
                         _diagnosticSource.AfterOnActionExecuted(actionExecutedContext, filter);
+                        _logger.AfterExecutingMethodOnFilter(
+                            MvcCoreLoggerExtensions.ActionFilter,
+                            nameof(IActionFilter.OnActionExecuted),
+                            filter);
 
                         goto case State.ActionEnd;
                     }

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/PageActionInvoker.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/PageActionInvoker.cs
@@ -88,7 +88,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                 await Next(ref next, ref scope, ref state, ref isCompleted);
             }
         }
-        
+
         protected override void ReleaseResources()
         {
             if (_pageModel != null && CacheEntry.ReleaseModel != null)
@@ -163,7 +163,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             {
                 return;
             }
-            
+
             var valueProvider = await CompositeValueProvider.CreateAsync(_pageContext, _pageContext.ValueProviderFactories);
 
             for (var i = 0; i < _handler.Parameters.Count; i++)
@@ -232,7 +232,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                         break;
                     }
                 }
-                
+
                 _diagnosticSource.BeforeHandlerMethod(_pageContext, handler, _arguments, _instance);
                 _logger.ExecutingHandlerMethod(_pageContext, handler, arguments);
 
@@ -342,6 +342,10 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                         var handlerSelectedContext = _handlerSelectedContext;
 
                         _diagnosticSource.BeforeOnPageHandlerSelection(handlerSelectedContext, filter);
+                        _logger.BeforeExecutingMethodOnFilter(
+                            PageLoggerExtensions.PageFilter,
+                            nameof(IAsyncPageFilter.OnPageHandlerSelectionAsync),
+                            filter);
 
                         var task = filter.OnPageHandlerSelectionAsync(handlerSelectedContext);
                         if (task.Status != TaskStatus.RanToCompletion)
@@ -361,6 +365,10 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                         var filter = (IAsyncPageFilter)state;
 
                         _diagnosticSource.AfterOnPageHandlerSelection(_handlerSelectedContext, filter);
+                        _logger.AfterExecutingMethodOnFilter(
+                            PageLoggerExtensions.PageFilter,
+                            nameof(IAsyncPageFilter.OnPageHandlerSelectionAsync),
+                            filter);
 
                         goto case State.PageSelectHandlerNext;
                     }
@@ -374,6 +382,10 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                         var handlerSelectedContext = _handlerSelectedContext;
 
                         _diagnosticSource.BeforeOnPageHandlerSelected(handlerSelectedContext, filter);
+                        _logger.BeforeExecutingMethodOnFilter(
+                            PageLoggerExtensions.PageFilter,
+                            nameof(IPageFilter.OnPageHandlerSelected),
+                            filter);
 
                         filter.OnPageHandlerSelected(handlerSelectedContext);
 
@@ -420,7 +432,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                         {
                             if (_handlerExecutingContext == null)
                             {
-                                _handlerExecutingContext = new PageHandlerExecutingContext(_pageContext, _filters,_handler, _arguments, _instance);
+                                _handlerExecutingContext = new PageHandlerExecutingContext(_pageContext, _filters, _handler, _arguments, _instance);
                             }
 
                             state = current.Filter;
@@ -441,6 +453,10 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                         var handlerExecutingContext = _handlerExecutingContext;
 
                         _diagnosticSource.BeforeOnPageHandlerExecution(handlerExecutingContext, filter);
+                        _logger.BeforeExecutingMethodOnFilter(
+                            PageLoggerExtensions.PageFilter,
+                            nameof(IAsyncPageFilter.OnPageHandlerExecutionAsync),
+                            filter);
 
                         var task = filter.OnPageHandlerExecutionAsync(handlerExecutingContext, InvokeNextPageFilterAwaitedAsync);
                         if (task.Status != TaskStatus.RanToCompletion)
@@ -476,6 +492,10 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                         }
 
                         _diagnosticSource.AfterOnPageHandlerExecution(_handlerExecutedContext, filter);
+                        _logger.AfterExecutingMethodOnFilter(
+                           PageLoggerExtensions.PageFilter,
+                           nameof(IAsyncPageFilter.OnPageHandlerExecutionAsync),
+                           filter);
 
                         goto case State.PageEnd;
                     }
@@ -489,10 +509,18 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                         var handlerExecutingContext = _handlerExecutingContext;
 
                         _diagnosticSource.BeforeOnPageHandlerExecuting(handlerExecutingContext, filter);
+                        _logger.BeforeExecutingMethodOnFilter(
+                           PageLoggerExtensions.PageFilter,
+                           nameof(IPageFilter.OnPageHandlerExecuting),
+                           filter);
 
                         filter.OnPageHandlerExecuting(handlerExecutingContext);
 
                         _diagnosticSource.AfterOnPageHandlerExecuting(handlerExecutingContext, filter);
+                        _logger.AfterExecutingMethodOnFilter(
+                           PageLoggerExtensions.PageFilter,
+                           nameof(IPageFilter.OnPageHandlerExecuting),
+                           filter);
 
                         if (handlerExecutingContext.Result != null)
                         {
@@ -532,10 +560,18 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                         var handlerExecutedContext = _handlerExecutedContext;
 
                         _diagnosticSource.BeforeOnPageHandlerExecuted(handlerExecutedContext, filter);
+                        _logger.BeforeExecutingMethodOnFilter(
+                           PageLoggerExtensions.PageFilter,
+                           nameof(IPageFilter.OnPageHandlerExecuted),
+                           filter);
 
                         filter.OnPageHandlerExecuted(handlerExecutedContext);
 
                         _diagnosticSource.AfterOnPageHandlerExecuted(handlerExecutedContext, filter);
+                        _logger.AfterExecutingMethodOnFilter(
+                           PageLoggerExtensions.PageFilter,
+                           nameof(IPageFilter.OnPageHandlerExecuted),
+                           filter);
 
                         goto case State.PageEnd;
                     }

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/PageLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/PageLoggerExtensions.cs
@@ -13,10 +13,14 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 {
     internal static class PageLoggerExtensions
     {
+        public const string PageFilter = "Page Filter";
+
         private static readonly Action<ILogger, string, string[], ModelValidationState, Exception> _handlerMethodExecuting;
         private static readonly Action<ILogger, string, string, Exception> _handlerMethodExecuted;
         private static readonly Action<ILogger, object, Exception> _pageFilterShortCircuit;
         private static readonly Action<ILogger, string, string[], Exception> _malformedPageDirective;
+        private static readonly Action<ILogger, string, string, string, Exception> _beforeExecutingMethodOnFilter;
+        private static readonly Action<ILogger, string, string, string, Exception> _afterExecutingMethodOnFilter;
 
         static PageLoggerExtensions()
         {
@@ -41,6 +45,16 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                 LogLevel.Warning,
                 104,
                 "The page directive at '{FilePath}' is malformed. Please fix the following issues: {Diagnostics}");
+
+            _beforeExecutingMethodOnFilter = LoggerMessage.Define<string, string, string>(
+                LogLevel.Trace,
+                1,
+                "{FilterType}: Before executing {Method} on filter {Filter}.");
+
+            _afterExecutingMethodOnFilter = LoggerMessage.Define<string, string, string>(
+                LogLevel.Trace,
+                2,
+                "{FilterType}: After executing {Method} on filter {Filter}.");
         }
 
         public static void ExecutingHandlerMethod(this ILogger logger, PageContext context, HandlerMethodDescriptor handler, object[] arguments)
@@ -76,6 +90,16 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                 var handlerName = handler.MethodInfo.Name;
                 _handlerMethodExecuted(logger, handlerName, Convert.ToString(result), null);
             }
+        }
+
+        public static void BeforeExecutingMethodOnFilter(this ILogger logger, string filterType, string methodName, IFilterMetadata filter)
+        {
+            _beforeExecutingMethodOnFilter(logger, filterType, methodName, filter.GetType().ToString(), null);
+        }
+
+        public static void AfterExecutingMethodOnFilter(this ILogger logger, string filterType, string methodName, IFilterMetadata filter)
+        {
+            _afterExecutingMethodOnFilter(logger, filterType, methodName, filter.GetType().ToString(), null);
         }
 
         public static void PageFilterShortCircuited(

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerActionInvokerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ControllerActionInvokerTest.cs
@@ -34,44 +34,6 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         #region Diagnostics
 
         [Fact]
-        public async Task Invoke_Success_LogsCorrectValues()
-        {
-            // Arrange
-            var sink = new TestSink();
-            var loggerFactory = new TestLoggerFactory(sink, enabled: true);
-            var logger = loggerFactory.CreateLogger<ControllerActionInvoker>();
-
-            var displayName = "A.B.C";
-            var actionDescriptor = Mock.Of<ControllerActionDescriptor>(a => a.DisplayName == displayName);
-            actionDescriptor.MethodInfo = typeof(TestController).GetMethod(nameof(TestController.ActionMethod));
-            actionDescriptor.ControllerTypeInfo = typeof(TestController).GetTypeInfo();
-            actionDescriptor.FilterDescriptors = new List<FilterDescriptor>();
-            actionDescriptor.Parameters = new List<ParameterDescriptor>();
-            actionDescriptor.BoundProperties = new List<ParameterDescriptor>();
-
-            var filter = Mock.Of<IFilterMetadata>();
-            var invoker = CreateInvoker(
-                new[] { filter },
-                actionDescriptor,
-                controller: new TestController(),
-                logger: logger);
-
-            // Act
-            await invoker.InvokeAsync();
-
-            // Assert
-            Assert.Single(sink.Scopes);
-            Assert.Equal(displayName, sink.Scopes[0].Scope?.ToString());
-
-            Assert.Equal(4, sink.Writes.Count);
-            Assert.Equal($"Executing action {displayName}", sink.Writes[0].State?.ToString());
-            Assert.Equal($"Executing action method {displayName} with arguments ((null)) - ModelState is Valid", sink.Writes[1].State?.ToString());
-            Assert.Equal($"Executed action method {displayName}, returned result {Result.GetType().FullName}.", sink.Writes[2].State?.ToString());
-            // This message has the execution time embedded, which we don't want to verify.
-            Assert.StartsWith($"Executed action {displayName} ", sink.Writes[3].State?.ToString());
-        }
-
-        [Fact]
         public async Task Invoke_WritesDiagnostic_ActionSelected()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/MvcCoreLoggerExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/MvcCoreLoggerExtensionsTest.cs
@@ -1,0 +1,300 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Logging.Testing;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.Internal
+{
+    public class MvcCoreLoggerExtensionsTest
+    {
+        [Fact]
+        public void LogsFilters_OnlyWhenLogger_IsEnabled()
+        {
+            // Arrange
+            var authFilter = Mock.Of<IAuthorizationFilter>();
+            var asyncAuthFilter = Mock.Of<IAsyncAuthorizationFilter>();
+            var actionFilter = Mock.Of<IActionFilter>();
+            var asyncActionFilter = Mock.Of<IAsyncActionFilter>();
+            var exceptionFilter = Mock.Of<IExceptionFilter>();
+            var asyncExceptionFilter = Mock.Of<IAsyncExceptionFilter>();
+            var resultFilter = Mock.Of<IResultFilter>();
+            var asyncResultFilter = Mock.Of<IAsyncResultFilter>();
+            var resourceFilter = Mock.Of<IResourceFilter>();
+            var asyncResourceFilter = Mock.Of<IAsyncResourceFilter>();
+            var filters = new IFilterMetadata[]
+            {
+                actionFilter,
+                asyncActionFilter,
+                authFilter,
+                asyncAuthFilter,
+                exceptionFilter,
+                asyncExceptionFilter,
+                resultFilter,
+                asyncResultFilter,
+                resourceFilter,
+                asyncResourceFilter
+            };
+            var testSink = new TestSink();
+            var loggerFactory = new TestLoggerFactory(testSink, enabled: false);
+            var logger = loggerFactory.CreateLogger("test");
+
+            // Act
+            logger.AuthorizationFiltersExecutionPlan(filters);
+            logger.ResourceFiltersExecutionPlan(filters);
+            logger.ActionFiltersExecutionPlan(filters);
+            logger.ExceptionFiltersExecutionPlan(filters);
+            logger.ResultFiltersExecutionPlan(filters);
+
+            // Assert
+            Assert.Empty(testSink.Writes);
+        }
+
+        [Fact]
+        public void LogsListOfAuthorizationFilters()
+        {
+            // Arrange
+            var authFilter = Mock.Of<IAuthorizationFilter>();
+            var asyncAuthFilter = Mock.Of<IAsyncAuthorizationFilter>();
+            var orderedAuthFilterMock = new Mock<IOrderedAuthorizeFilter>();
+            orderedAuthFilterMock.SetupGet(f => f.Order).Returns(-100);
+            var orderedAuthFilter = orderedAuthFilterMock.Object;
+            var actionFilter = Mock.Of<IActionFilter>();
+            var asyncActionFilter = Mock.Of<IAsyncActionFilter>();
+            var exceptionFilter = Mock.Of<IExceptionFilter>();
+            var asyncExceptionFilter = Mock.Of<IAsyncExceptionFilter>();
+            var resultFilter = Mock.Of<IResultFilter>();
+            var asyncResultFilter = Mock.Of<IAsyncResultFilter>();
+            var resourceFilter = Mock.Of<IResourceFilter>();
+            var asyncResourceFilter = Mock.Of<IAsyncResourceFilter>();
+            var filters = new IFilterMetadata[]
+            {
+                actionFilter,
+                asyncActionFilter,
+                authFilter,
+                asyncAuthFilter,
+                orderedAuthFilter,
+                exceptionFilter,
+                asyncExceptionFilter,
+                resultFilter,
+                asyncResultFilter,
+                resourceFilter,
+                asyncResourceFilter
+            };
+            var testSink = new TestSink();
+            var loggerFactory = new TestLoggerFactory(testSink, enabled: true);
+            var logger = loggerFactory.CreateLogger("test");
+
+            // Act
+            logger.AuthorizationFiltersExecutionPlan(filters);
+
+            // Assert
+            Assert.Single(testSink.Writes);
+            var write = testSink.Writes[0];
+            Assert.Equal(
+                "Execution plan of authorization filters (in the following order): " +
+                $"{authFilter.GetType()}, {asyncAuthFilter.GetType()}, {orderedAuthFilter.GetType()} (Order: -100)",
+                write.State.ToString());
+        }
+
+        [Fact]
+        public void LogsListOfResourceFilters()
+        {
+            // Arrange
+            var authFilter = Mock.Of<IAuthorizationFilter>();
+            var asyncAuthFilter = Mock.Of<IAsyncAuthorizationFilter>();
+            var actionFilter = Mock.Of<IActionFilter>();
+            var asyncActionFilter = Mock.Of<IAsyncActionFilter>();
+            var exceptionFilter = Mock.Of<IExceptionFilter>();
+            var asyncExceptionFilter = Mock.Of<IAsyncExceptionFilter>();
+            var resultFilter = Mock.Of<IResultFilter>();
+            var asyncResultFilter = Mock.Of<IAsyncResultFilter>();
+            var resourceFilter = Mock.Of<IResourceFilter>();
+            var asyncResourceFilter = Mock.Of<IAsyncResourceFilter>();
+            var orderedresourceFilterMock = new Mock<IOrderedResourceFilter>();
+            orderedresourceFilterMock.SetupGet(f => f.Order).Returns(-100);
+            var orderedResourceFilter = orderedresourceFilterMock.Object;
+            var filters = new IFilterMetadata[]
+            {
+                actionFilter,
+                asyncActionFilter,
+                authFilter,
+                asyncAuthFilter,
+                exceptionFilter,
+                asyncExceptionFilter,
+                resultFilter,
+                asyncResultFilter,
+                resourceFilter,
+                asyncResourceFilter,
+                orderedResourceFilter,
+            };
+            var testSink = new TestSink();
+            var loggerFactory = new TestLoggerFactory(testSink, enabled: true);
+            var logger = loggerFactory.CreateLogger("test");
+
+            // Act
+            logger.ResourceFiltersExecutionPlan(filters);
+
+            // Assert
+            Assert.Single(testSink.Writes);
+            var write = testSink.Writes[0];
+            Assert.Equal(
+                "Execution plan of resource filters (in the following order): " +
+                $"{resourceFilter.GetType()}, {asyncResourceFilter.GetType()}, {orderedResourceFilter.GetType()} (Order: -100)",
+                write.State.ToString());
+        }
+
+        [Fact]
+        public void LogsListOfActionFilters()
+        {
+            // Arrange
+            var authFilter = Mock.Of<IAuthorizationFilter>();
+            var asyncAuthFilter = Mock.Of<IAsyncAuthorizationFilter>();
+            var actionFilter = Mock.Of<IActionFilter>();
+            var asyncActionFilter = Mock.Of<IAsyncActionFilter>();
+            var orderedActionFilterMock = new Mock<IOrderedActionFilter>();
+            orderedActionFilterMock.SetupGet(f => f.Order).Returns(-100);
+            var orderedActionFilter = orderedActionFilterMock.Object;
+            var exceptionFilter = Mock.Of<IExceptionFilter>();
+            var asyncExceptionFilter = Mock.Of<IAsyncExceptionFilter>();
+            var resultFilter = Mock.Of<IResultFilter>();
+            var asyncResultFilter = Mock.Of<IAsyncResultFilter>();
+            var resourceFilter = Mock.Of<IResourceFilter>();
+            var asyncResourceFilter = Mock.Of<IAsyncResourceFilter>();
+            var filters = new IFilterMetadata[]
+            {
+                actionFilter,
+                asyncActionFilter,
+                orderedActionFilter,
+                authFilter,
+                asyncAuthFilter,
+                exceptionFilter,
+                asyncExceptionFilter,
+                resultFilter,
+                asyncResultFilter,
+                resourceFilter,
+                asyncResourceFilter,
+            };
+            var testSink = new TestSink();
+            var loggerFactory = new TestLoggerFactory(testSink, enabled: true);
+            var logger = loggerFactory.CreateLogger("test");
+
+            // Act
+            logger.ActionFiltersExecutionPlan(filters);
+
+            // Assert
+            Assert.Single(testSink.Writes);
+            var write = testSink.Writes[0];
+            Assert.Equal(
+                "Execution plan of action filters (in the following order): " +
+                $"{actionFilter.GetType()}, {asyncActionFilter.GetType()}, {orderedActionFilter.GetType()} (Order: -100)",
+                write.State.ToString());
+        }
+
+        [Fact]
+        public void LogsListOfExceptionFilters()
+        {
+            // Arrange
+            var authFilter = Mock.Of<IAuthorizationFilter>();
+            var asyncAuthFilter = Mock.Of<IAsyncAuthorizationFilter>();
+            var actionFilter = Mock.Of<IActionFilter>();
+            var asyncActionFilter = Mock.Of<IAsyncActionFilter>();
+            var exceptionFilter = Mock.Of<IExceptionFilter>();
+            var asyncExceptionFilter = Mock.Of<IAsyncExceptionFilter>();
+            var orderedExceptionFilterMock = new Mock<IOrderedExceptionFilter>();
+            orderedExceptionFilterMock.SetupGet(f => f.Order).Returns(-100);
+            var orderedExceptionFilter = orderedExceptionFilterMock.Object;
+            var resultFilter = Mock.Of<IResultFilter>();
+            var asyncResultFilter = Mock.Of<IAsyncResultFilter>();
+            var resourceFilter = Mock.Of<IResourceFilter>();
+            var asyncResourceFilter = Mock.Of<IAsyncResourceFilter>();
+            var filters = new IFilterMetadata[]
+            {
+                actionFilter,
+                asyncActionFilter,
+                authFilter,
+                asyncAuthFilter,
+                exceptionFilter,
+                asyncExceptionFilter,
+                orderedExceptionFilter,
+                resultFilter,
+                asyncResultFilter,
+                resourceFilter,
+                asyncResourceFilter,
+            };
+            var testSink = new TestSink();
+            var loggerFactory = new TestLoggerFactory(testSink, enabled: true);
+            var logger = loggerFactory.CreateLogger("test");
+
+            // Act
+            logger.ExceptionFiltersExecutionPlan(filters);
+
+            // Assert
+            Assert.Single(testSink.Writes);
+            var write = testSink.Writes[0];
+            Assert.Equal(
+                "Execution plan of exception filters (in the following order): " +
+                $"{exceptionFilter.GetType()}, {asyncExceptionFilter.GetType()}, {orderedExceptionFilter.GetType()} (Order: -100)",
+                write.State.ToString());
+        }
+
+        [Fact]
+        public void LogsListOfResultFilters()
+        {
+            // Arrange
+            var authFilter = Mock.Of<IAuthorizationFilter>();
+            var asyncAuthFilter = Mock.Of<IAsyncAuthorizationFilter>();
+            var actionFilter = Mock.Of<IActionFilter>();
+            var asyncActionFilter = Mock.Of<IAsyncActionFilter>();
+            var exceptionFilter = Mock.Of<IExceptionFilter>();
+            var asyncExceptionFilter = Mock.Of<IAsyncExceptionFilter>();
+            var orderedResultFilterMock = new Mock<IOrderedResultFilter>();
+            orderedResultFilterMock.SetupGet(f => f.Order).Returns(-100);
+            var orderedResultFilter = orderedResultFilterMock.Object;
+            var resultFilter = Mock.Of<IResultFilter>();
+            var asyncResultFilter = Mock.Of<IAsyncResultFilter>();
+            var resourceFilter = Mock.Of<IResourceFilter>();
+            var asyncResourceFilter = Mock.Of<IAsyncResourceFilter>();
+            var filters = new IFilterMetadata[]
+            {
+                actionFilter,
+                asyncActionFilter,
+                authFilter,
+                asyncAuthFilter,
+                exceptionFilter,
+                asyncExceptionFilter,
+                resultFilter,
+                asyncResultFilter,
+                orderedResultFilter,
+                resourceFilter,
+                asyncResourceFilter,
+            };
+            var testSink = new TestSink();
+            var loggerFactory = new TestLoggerFactory(testSink, enabled: true);
+            var logger = loggerFactory.CreateLogger("test");
+
+            // Act
+            logger.ResultFiltersExecutionPlan(filters);
+
+            // Assert
+            Assert.Single(testSink.Writes);
+            var write = testSink.Writes[0];
+            Assert.Equal(
+                "Execution plan of result filters (in the following order): " +
+                $"{resultFilter.GetType()}, {asyncResultFilter.GetType()}, {orderedResultFilter.GetType()} (Order: -100)",
+                write.State.ToString());
+        }
+
+        public interface IOrderedAuthorizeFilter : IAuthorizationFilter, IAsyncAuthorizationFilter, IOrderedFilter { }
+
+        public interface IOrderedResourceFilter : IResourceFilter, IAsyncResourceFilter, IOrderedFilter { }
+
+        public interface IOrderedActionFilter : IActionFilter, IAsyncActionFilter, IOrderedFilter { }
+
+        public interface IOrderedExceptionFilter : IExceptionFilter, IAsyncExceptionFilter, IOrderedFilter { }
+
+        public interface IOrderedResultFilter : IResultFilter, IAsyncResultFilter, IOrderedFilter { }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/PageActionInvokerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/PageActionInvokerTest.cs
@@ -36,36 +36,6 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
         #region Diagnostics
 
         [Fact]
-        public async Task Invoke_Success_LogsCorrectValues()
-        {
-            // Arrange
-            var sink = new TestSink();
-            var loggerFactory = new TestLoggerFactory(sink, enabled: true);
-            var logger = loggerFactory.CreateLogger<PageActionInvoker>();
-
-            var actionDescriptor = CreateDescriptorForSimplePage();
-
-            var displayName = "/A/B/C";
-            actionDescriptor.DisplayName = displayName;
-
-            var invoker = CreateInvoker(filters: null, actionDescriptor: actionDescriptor, logger: logger);
-
-            // Act
-            await invoker.InvokeAsync();
-
-            // Assert
-            Assert.Single(sink.Scopes);
-            Assert.Equal(displayName, sink.Scopes[0].Scope?.ToString());
-
-            Assert.Equal(4, sink.Writes.Count);
-            Assert.Equal($"Executing action {displayName}", sink.Writes[0].State?.ToString());
-            Assert.Equal($"Executing handler method OnGetHandler1 with arguments ((null)) - ModelState is Valid", sink.Writes[1].State?.ToString());
-            Assert.Equal($"Executed handler method OnGetHandler1, returned result {typeof(PageResult).FullName}.", sink.Writes[2].State?.ToString());
-            // This message has the execution time embedded, which we don't want to verify.
-            Assert.StartsWith($"Executed action {displayName} ", sink.Writes[3].State?.ToString());
-        }
-
-        [Fact]
         public async Task Invoke_WritesDiagnostic_ActionSelected()
         {
             // Arrange


### PR DESCRIPTION
Related to issue #6498: When enabling "Trace" logging for MVC loggers, I should be buried in log messages

I am going to send different PRs for different subsystems.
In this PR I am only covering the execution of filter pipeline. There are some filters which need logging within themselves but will send a separate PR for them.

To see how additional logging in this PR shows up when 'Tracing' is enabled, you can take a look at my gist: https://gist.github.com/kichalla/9363b05448e009aaf661c2a88f766806