### PR TITLE
Do not unnecessarily execute GetName() method

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.DataAnnotations/Internal/DataAnnotationsMetadataProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.DataAnnotations/Internal/DataAnnotationsMetadataProvider.cs
@@ -130,7 +130,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
 
             // DisplayName
             // DisplayAttribute has precedence over DisplayNameAttribute.
-            if (displayAttribute?.GetName() != null)
+            if (displayAttribute?.Name != null)
             {
                 if (localizer != null &&
                     !string.IsNullOrEmpty(displayAttribute.Name) &&


### PR DESCRIPTION
Because GetName() executes the localization logic, but we may not need it actually.