### PR TITLE
HtmlHelper.DisplayTextFor uses DisplayAttribute of Enums.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ModelExplorerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ModelExplorerExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 
@@ -38,6 +39,25 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             if (modelExplorer.Model == null)
             {
                 return modelExplorer.Metadata.NullDisplayText;
+            }
+
+            if (modelExplorer.Metadata.IsEnum)
+            {
+                var modelEnum = (Enum) modelExplorer.Model;
+                var enumStringValue = modelEnum.ToString("d");
+                var enumGroupedDisplayNamesAndValues = modelExplorer.Metadata.EnumGroupedDisplayNamesAndValues;
+
+                Debug.Assert(enumGroupedDisplayNamesAndValues != null);
+
+                var enumDisplayValue = enumGroupedDisplayNamesAndValues
+                    .Where(enumGroup => enumGroup.Value == enumStringValue)
+                    .Select(kv => kv.Key.Name)
+                    .FirstOrDefault(value => value != null);
+
+                if (enumDisplayValue != null)
+                {
+                    return enumDisplayValue;
+                }
             }
 
             var stringResult = Convert.ToString(modelExplorer.Model, CultureInfo.CurrentCulture);

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ModelExplorerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ModelExplorerExtensions.cs
@@ -41,22 +41,19 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 return modelExplorer.Metadata.NullDisplayText;
             }
 
-            if (modelExplorer.Metadata.IsEnum)
+            if (modelExplorer.Metadata.IsEnum && modelExplorer.Model is Enum modelEnum)
             {
-                var modelEnum = (Enum) modelExplorer.Model;
                 var enumStringValue = modelEnum.ToString("d");
                 var enumGroupedDisplayNamesAndValues = modelExplorer.Metadata.EnumGroupedDisplayNamesAndValues;
 
                 Debug.Assert(enumGroupedDisplayNamesAndValues != null);
 
-                var enumDisplayValue = enumGroupedDisplayNamesAndValues
-                    .Where(enumGroup => enumGroup.Value == enumStringValue)
-                    .Select(kv => kv.Key.Name)
-                    .FirstOrDefault(value => value != null);
-
-                if (enumDisplayValue != null)
+                foreach (var kvp in enumGroupedDisplayNamesAndValues)
                 {
-                    return enumDisplayValue;
+                    if (string.Equals(kvp.Value, enumStringValue, StringComparison.Ordinal))
+                    {
+                        return kvp.Key.Name;
+                    }
                 }
             }
 

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperDisplayTextTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperDisplayTextTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Xunit;
 
@@ -296,6 +297,34 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             Assert.Equal("Property value", result);
         }
 
+        [Fact]
+        public void DisplayTextFor_EnumDisplayAttribute_WhenPresent()
+        {
+            // Arrange
+            var model = EnumWithDisplayAttribute.Value1;
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
+
+            // Act
+            var result = helper.DisplayTextFor(m => m);
+
+            // Assert
+            Assert.Equal("Value One", result);
+        }
+
+        [Fact]
+        public void DisplayTextFor_EnumDisplayAttribute_WhenNotPresent()
+        {
+            // Arrange
+            var model = EnumWithoutDisplayAttribute.Value1;
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
+
+            // Act
+            var result = helper.DisplayTextFor(m => m);
+
+            // Assert
+            Assert.Equal("Value1", result);
+        }
+
         // ModelMetadata.SimpleDisplayText returns ToString() result if that method has been overridden.
         private sealed class OverriddenToStringModel
         {
@@ -314,6 +343,17 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             {
                 return _simpleDisplayText;
             }
+        }
+
+        public enum EnumWithDisplayAttribute
+        {
+            [Display(Name = "Value One")]
+            Value1
+        }
+
+        public enum EnumWithoutDisplayAttribute
+        {
+            Value1
         }
     }
 }


### PR DESCRIPTION
HtmlHelper.DisplayTextFor uses DisplayAttribute for Enum values.
- Special case added for when value is Enum in file ModelExplorerExtensions.cs based off suggestions in original issue filing.
- Tests added for enum with and without DisplayAttribute.

Addresses #7033 