### PR TITLE
Use `ExceptionDispatchInfo` in `MiddlewareFilterBuilder` if available

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/MiddlewareFilterBuilder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/MiddlewareFilterBuilder.cs
@@ -71,13 +71,20 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 var resourceExecutionDelegate = feature.ResourceExecutionDelegate;
 
                 var resourceExecutedContext = await resourceExecutionDelegate();
-
-                // Ideally we want the experience of a middleware pipeline to behave the same as if it was registered,
-                // in Startup. In this scenario an exception thrown in a middelware later in the pipeline gets propagated
-                // back to earlier middleware.
-                // So check if a later resource filter threw an exception and propagate that back to the middleware pipeline.
-                if (!resourceExecutedContext.ExceptionHandled && resourceExecutedContext.Exception != null)
+                if (resourceExecutedContext == null || resourceExecutedContext.ExceptionHandled)
                 {
+                    return;
+                }
+
+                // Ideally we want the experience of a middleware pipeline to behave the same as if it was registered
+                // in Startup. In this scenario, an Exception thrown in a middelware later in the pipeline gets
+                // propagated back to earlier middleware. So, check if a later resource filter threw an Exception and
+                // propagate that back to the middleware pipeline.
+                resourceExecutedContext.ExceptionDispatchInfo?.Throw();
+                if (resourceExecutedContext.Exception != null)
+                {
+                    // This line is rarely reachable because ResourceInvoker captures thrown Exceptions using
+                    // ExceptionDispatchInfo. That said, filters could set only resourceExecutedContext.Exception.
                     throw resourceExecutedContext.Exception;
                 }
             });


### PR DESCRIPTION
- #6596
- align this code with `ResourceInvoker.Rethrow()`
  - e.g. also add a `null` check of `resourceExecutedContext`

nits:
- take VS suggestions in `MiddlewareFilterBuilderTest`
- clean up names like `httpCtxt`
- remove unused `Pipeline2` class