### PR TITLE
Allow `null` or empty `fullName` in one special case

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/InputTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/InputTagHelper.cs
@@ -203,7 +203,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 string.IsNullOrEmpty(ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix) &&
                 !string.IsNullOrEmpty(Name))
             {
-                htmlAttributes = new Dictionary<string, object>
+                htmlAttributes = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
                 {
                     { "name", Name },
                 };
@@ -382,7 +382,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
             if (htmlAttributes == null)
             {
-                htmlAttributes = new Dictionary<string, object>();
+                htmlAttributes = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
             }
 
             htmlAttributes["type"] = inputType;
@@ -416,7 +416,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
             if (htmlAttributes == null)
             {
-                htmlAttributes = new Dictionary<string, object>();
+                htmlAttributes = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
             }
 
             // In DefaultHtmlGenerator(), GenerateTextBox() calls GenerateInput() _almost_ identically to how

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/InputTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/InputTagHelper.cs
@@ -114,6 +114,15 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         public string InputTypeName { get; set; }
 
         /// <summary>
+        /// The name of the &lt;input&gt; element.
+        /// </summary>
+        /// <remarks>
+        /// Passed through to the generated HTML in all cases. Also used to determine whether <see cref="For"/> is
+        /// valid with an empty <see cref="ModelExpression.Name"/>.
+        /// </remarks>
+        public string Name { get; set; }
+
+        /// <summary>
         /// The value of the &lt;input&gt; element.
         /// </summary>
         /// <remarks>
@@ -144,6 +153,11 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             if (InputTypeName != null)
             {
                 output.CopyHtmlAttribute("type", context);
+            }
+
+            if (Name != null)
+            {
+                output.CopyHtmlAttribute(nameof(Name), context);
             }
 
             if (Value != null)
@@ -183,15 +197,27 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 output.Attributes.SetAttribute("type", inputType);
             }
 
+            // Ensure Generator does not throw due to empty "fullName" if user provided a name attribute.
+            IDictionary<string, object> htmlAttributes = null;
+            if (string.IsNullOrEmpty(For.Name) &&
+                string.IsNullOrEmpty(ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix) &&
+                !string.IsNullOrEmpty(Name))
+            {
+                htmlAttributes = new Dictionary<string, object>
+                {
+                    { "name", Name },
+                };
+            }
+
             TagBuilder tagBuilder;
             switch (inputType)
             {
                 case "hidden":
-                    tagBuilder = GenerateHidden(modelExplorer);
+                    tagBuilder = GenerateHidden(modelExplorer, htmlAttributes);
                     break;
 
                 case "checkbox":
-                    tagBuilder = GenerateCheckBox(modelExplorer, output);
+                    tagBuilder = GenerateCheckBox(modelExplorer, output, htmlAttributes);
                     break;
 
                 case "password":
@@ -200,15 +226,15 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                         modelExplorer,
                         For.Name,
                         value: null,
-                        htmlAttributes: null);
+                        htmlAttributes: htmlAttributes);
                     break;
 
                 case "radio":
-                    tagBuilder = GenerateRadio(modelExplorer);
+                    tagBuilder = GenerateRadio(modelExplorer, htmlAttributes);
                     break;
 
                 default:
-                    tagBuilder = GenerateTextBox(modelExplorer, inputTypeHint, inputType);
+                    tagBuilder = GenerateTextBox(modelExplorer, inputTypeHint, inputType, htmlAttributes);
                     break;
             }
 
@@ -248,7 +274,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             return inputTypeHint;
         }
 
-        private TagBuilder GenerateCheckBox(ModelExplorer modelExplorer, TagHelperOutput output)
+        private TagBuilder GenerateCheckBox(
+            ModelExplorer modelExplorer,
+            TagHelperOutput output,
+            IDictionary<string, object> htmlAttributes)
         {
             if (modelExplorer.ModelType == typeof(string))
             {
@@ -282,6 +311,14 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 var renderingMode =
                     output.TagMode == TagMode.SelfClosing ? TagRenderMode.SelfClosing : TagRenderMode.StartTag;
                 hiddenForCheckboxTag.TagRenderMode = renderingMode;
+                if (!hiddenForCheckboxTag.Attributes.ContainsKey("name") &&
+                    !string.IsNullOrEmpty(Name))
+                {
+                    // The checkbox and hidden elements should have the same name attribute value. Attributes will
+                    // match if both are present because both have a generated value. Reach here in the special case
+                    // where user provided a non-empty fallback name.
+                    hiddenForCheckboxTag.MergeAttribute("name", Name);
+                }
 
                 if (ViewContext.FormContext.CanRenderAtEndOfForm)
                 {
@@ -298,10 +335,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 modelExplorer,
                 For.Name,
                 isChecked: null,
-                htmlAttributes: null);
+                htmlAttributes: htmlAttributes);
         }
 
-        private TagBuilder GenerateRadio(ModelExplorer modelExplorer)
+        private TagBuilder GenerateRadio(ModelExplorer modelExplorer, IDictionary<string, object> htmlAttributes)
         {
             // Note empty string is allowed.
             if (Value == null)
@@ -319,10 +356,14 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 For.Name,
                 Value,
                 isChecked: null,
-                htmlAttributes: null);
+                htmlAttributes: htmlAttributes);
         }
 
-        private TagBuilder GenerateTextBox(ModelExplorer modelExplorer, string inputTypeHint, string inputType)
+        private TagBuilder GenerateTextBox(
+            ModelExplorer modelExplorer,
+            string inputTypeHint,
+            string inputType,
+            IDictionary<string, object> htmlAttributes)
         {
             var format = Format;
             if (string.IsNullOrEmpty(format))
@@ -338,12 +379,18 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                     format = GetFormat(modelExplorer, inputTypeHint, inputType);
                 }
             }
-            var htmlAttributes = new Dictionary<string, object>
-            {
-                { "type", inputType }
-            };
 
-            if (string.Equals(inputType, "file") && string.Equals(inputTypeHint, TemplateRenderer.IEnumerableOfIFormFileName))
+            if (htmlAttributes == null)
+            {
+                htmlAttributes = new Dictionary<string, object>();
+            }
+
+            htmlAttributes["type"] = inputType;
+            if (string.Equals(inputType, "file") &&
+                string.Equals(
+                    inputTypeHint,
+                    TemplateRenderer.IEnumerableOfIFormFileName,
+                    StringComparison.OrdinalIgnoreCase))
             {
                 htmlAttributes["multiple"] = "multiple";
             }
@@ -352,14 +399,14 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 ViewContext,
                 modelExplorer,
                 For.Name,
-                value: modelExplorer.Model,
-                format: format,
-                htmlAttributes: htmlAttributes);
+                modelExplorer.Model,
+                format,
+                htmlAttributes);
         }
 
         // Imitate Generator.GenerateHidden() using Generator.GenerateTextBox(). This adds support for asp-format that
         // is not available in Generator.GenerateHidden().
-        private TagBuilder GenerateHidden(ModelExplorer modelExplorer)
+        private TagBuilder GenerateHidden(ModelExplorer modelExplorer, IDictionary<string, object> htmlAttributes)
         {
             var value = For.Model;
             if (value is byte[] byteArrayValue)
@@ -367,21 +414,17 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 value = Convert.ToBase64String(byteArrayValue);
             }
 
+            if (htmlAttributes == null)
+            {
+                htmlAttributes = new Dictionary<string, object>();
+            }
+
             // In DefaultHtmlGenerator(), GenerateTextBox() calls GenerateInput() _almost_ identically to how
             // GenerateHidden() does and the main switch inside GenerateInput() handles InputType.Text and
             // InputType.Hidden identically. No behavior differences at all when a type HTML attribute already exists.
-            var htmlAttributes = new Dictionary<string, object>
-            {
-                { "type", "hidden" }
-            };
+            htmlAttributes["type"] = "hidden";
 
-            return Generator.GenerateTextBox(
-                ViewContext,
-                modelExplorer,
-                For.Name,
-                value: value,
-                format: Format,
-                htmlAttributes: htmlAttributes);
+            return Generator.GenerateTextBox(ViewContext, modelExplorer, For.Name, value, Format, htmlAttributes);
         }
 
         // Get a fall-back format based on the metadata.

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/SelectTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/SelectTagHelper.cs
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 string.IsNullOrEmpty(ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix) &&
                 !string.IsNullOrEmpty(Name))
             {
-                htmlAttributes = new Dictionary<string, object>
+                htmlAttributes = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
                 {
                     { "name", Name },
                 };

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/SelectTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/SelectTagHelper.cs
@@ -57,6 +57,15 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         [HtmlAttributeName(ItemsAttributeName)]
         public IEnumerable<SelectListItem> Items { get; set; }
 
+        /// <summary>
+        /// The name of the &lt;input&gt; element.
+        /// </summary>
+        /// <remarks>
+        /// Passed through to the generated HTML in all cases. Also used to determine whether <see cref="For"/> is
+        /// valid with an empty <see cref="ModelExpression.Name"/>.
+        /// </remarks>
+        public string Name { get; set; }
+
         /// <inheritdoc />
         public override void Init(TagHelperContext context)
         {
@@ -89,11 +98,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             var realModelType = For.ModelExplorer.ModelType;
             _allowMultiple = typeof(string) != realModelType &&
                 typeof(IEnumerable).IsAssignableFrom(realModelType);
-            _currentValues = Generator.GetCurrentValues(
-                ViewContext,
-                For.ModelExplorer,
-                expression: For.Name,
-                allowMultiple: _allowMultiple);
+            _currentValues = Generator.GetCurrentValues(ViewContext, For.ModelExplorer, For.Name, _allowMultiple);
 
             // Whether or not (not being highly unlikely) we generate anything, could update contained <option/>
             // elements. Provide selected values for <option/> tag helpers.
@@ -115,6 +120,13 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 throw new ArgumentNullException(nameof(output));
             }
 
+            // Pass through attribute that is also a well-known HTML attribute. Must be done prior to any copying
+            // from a TagBuilder.
+            if (Name != null)
+            {
+                output.CopyHtmlAttribute(nameof(Name), context);
+            }
+
             // Ensure GenerateSelect() _never_ looks anything up in ViewData.
             var items = Items ?? Enumerable.Empty<SelectListItem>();
 
@@ -125,6 +137,18 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 return;
             }
 
+            // Ensure Generator does not throw due to empty "fullName" if user provided a name attribute.
+            IDictionary<string, object> htmlAttributes = null;
+            if (string.IsNullOrEmpty(For.Name) &&
+                string.IsNullOrEmpty(ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix) &&
+                !string.IsNullOrEmpty(Name))
+            {
+                htmlAttributes = new Dictionary<string, object>
+                {
+                    { "name", Name },
+                };
+            }
+
             var tagBuilder = Generator.GenerateSelect(
                 ViewContext,
                 For.ModelExplorer,
@@ -133,7 +157,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 selectList: items,
                 currentValues: _currentValues,
                 allowMultiple: _allowMultiple,
-                htmlAttributes: null);
+                htmlAttributes: htmlAttributes);
 
             if (tagBuilder != null)
             {

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/TextAreaTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/TextAreaTagHelper.cs
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 string.IsNullOrEmpty(ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix) &&
                 !string.IsNullOrEmpty(Name))
             {
-                htmlAttributes = new Dictionary<string, object>
+                htmlAttributes = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
                 {
                     { "name", Name },
                 };

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/TextAreaTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/TextAreaTagHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
@@ -40,6 +41,15 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         [HtmlAttributeName(ForAttributeName)]
         public ModelExpression For { get; set; }
 
+        /// <summary>
+        /// The name of the &lt;input&gt; element.
+        /// </summary>
+        /// <remarks>
+        /// Passed through to the generated HTML in all cases. Also used to determine whether <see cref="For"/> is
+        /// valid with an empty <see cref="ModelExpression.Name"/>.
+        /// </remarks>
+        public string Name { get; set; }
+
         /// <inheritdoc />
         /// <remarks>Does nothing if <see cref="For"/> is <c>null</c>.</remarks>
         public override void Process(TagHelperContext context, TagHelperOutput output)
@@ -54,13 +64,32 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 throw new ArgumentNullException(nameof(output));
             }
 
+            // Pass through attribute that is also a well-known HTML attribute. Must be done prior to any copying
+            // from a TagBuilder.
+            if (Name != null)
+            {
+                output.CopyHtmlAttribute(nameof(Name), context);
+            }
+
+            // Ensure Generator does not throw due to empty "fullName" if user provided a name attribute.
+            IDictionary<string, object> htmlAttributes = null;
+            if (string.IsNullOrEmpty(For.Name) &&
+                string.IsNullOrEmpty(ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix) &&
+                !string.IsNullOrEmpty(Name))
+            {
+                htmlAttributes = new Dictionary<string, object>
+                {
+                    { "name", Name },
+                };
+            }
+
             var tagBuilder = Generator.GenerateTextArea(
                 ViewContext,
                 For.ModelExplorer,
                 For.Name,
                 rows: 0,
                 columns: 0,
-                htmlAttributes: null);
+                htmlAttributes: htmlAttributes);
 
             if (tagBuilder != null)
             {

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/ValidationMessageTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/ValidationMessageTagHelper.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                     string.IsNullOrEmpty(ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix) &&
                     output.Attributes.ContainsName(DataValidationForAttributeName))
                 {
-                    htmlAttributes = new Dictionary<string, object>
+                    htmlAttributes = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
                     {
                         { DataValidationForAttributeName, "-non-empty-value-" },
                     };

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/ValidationMessageTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/ValidationMessageTagHelper.cs
@@ -38,20 +38,6 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
         protected IHtmlGenerator Generator { get; }
 
-        /// <summary>
-        /// The name of an &lt;input&gt; element in the current &lt;form&gt; that has the same <see cref="For"/>
-        /// expression.
-        /// </summary>
-        /// <remarks>
-        /// Passed through to the generated HTML in all cases. Also used to determine whether <see cref="For"/> is
-        /// valid with an empty <see cref="ModelExpression.Name"/>.
-        /// </remarks>
-        [HtmlAttributeName(DataValidationForAttributeName)]
-        public string DataValidationFor { get; set; }
-
-        /// <summary>
-        /// An expression on the current model for which the associated element should contain validation messages.
-        /// </summary>
         [HtmlAttributeName(ValidationForAttributeName)]
         public ModelExpression For { get; set; }
 
@@ -69,24 +55,19 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 throw new ArgumentNullException(nameof(output));
             }
 
-            // Pass through attribute that is also an HTML attribute. Must be done prior to any copying from a
-            // TagBuilder.
-            if (DataValidationFor != null)
-            {
-                output.CopyHtmlAttribute(DataValidationForAttributeName, context);
-            }
-
             if (For != null)
             {
                 // Ensure Generator does not throw due to empty "fullName" if user provided data-valmsg-for attribute.
+                // Assume data-valmsg-for value is non-empty if attribute is present at all. Should align with name of
+                // another tag helper e.g. an <input/> and those tag helpers bind Name.
                 IDictionary<string, object> htmlAttributes = null;
                 if (string.IsNullOrEmpty(For.Name) &&
                     string.IsNullOrEmpty(ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix) &&
-                    !string.IsNullOrEmpty(DataValidationFor))
+                    output.Attributes.ContainsName(DataValidationForAttributeName))
                 {
                     htmlAttributes = new Dictionary<string, object>
                     {
-                        { DataValidationForAttributeName, DataValidationFor },
+                        { DataValidationForAttributeName, "-non-empty-value-" },
                     };
                 }
 

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/InputTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/InputTagHelperTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 {
     public class InputTagHelperTest
     {
-        public static TheoryData MultiAttributeCheckBoxData
+        public static TheoryData<TagHelperAttributeList, string> MultiAttributeCheckBoxData
         {
             get
             {
@@ -250,6 +250,304 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             Assert.Equal(content, HtmlContentUtilities.HtmlContentToString(output.Content));
             Assert.Equal(expectedContent, HtmlContentUtilities.HtmlContentToString(output));
             Assert.Equal(expectedPostElement, output.PostElement.GetContent());
+        }
+
+        [Theory]
+        [InlineData("checkbox")]
+        [InlineData("hidden")]
+        [InlineData("number")]
+        [InlineData("password")]
+        [InlineData("text")]
+        public void Process_WithEmptyForName_Throws(string inputTypeName)
+        {
+            // Arrange
+            var expectedMessage = "The name of an HTML field cannot be null or empty. Instead use methods " +
+                "Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper.Editor or Microsoft.AspNetCore.Mvc.Rendering." +
+                "IHtmlHelper`1.EditorFor with a non-empty htmlFieldName argument value.";
+
+            var metadataProvider = new EmptyModelMetadataProvider();
+            var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
+            var model = false;
+            var modelExplorer = metadataProvider.GetModelExplorerForType(typeof(bool), model);
+            var modelExpression = new ModelExpression(name: string.Empty, modelExplorer: modelExplorer);
+            var viewContext = TestableHtmlGenerator.GetViewContext(model, htmlGenerator, metadataProvider);
+            var tagHelper = new InputTagHelper(htmlGenerator)
+            {
+                For = modelExpression,
+                InputTypeName = inputTypeName,
+                ViewContext = viewContext,
+            };
+
+            var attributes = new TagHelperAttributeList
+            {
+                { "type", inputTypeName },
+            };
+
+            var context = new TagHelperContext(attributes, new Dictionary<object, object>(), "test");
+            var output = new TagHelperOutput(
+                "input",
+                new TagHelperAttributeList(),
+                getChildContentAsync: (useCachedResult, encoder) => Task.FromResult<TagHelperContent>(result: null))
+            {
+                TagMode = TagMode.SelfClosing,
+            };
+
+            // Act & Assert
+            ExceptionAssert.ThrowsArgument(
+                () => tagHelper.Process(context, output),
+                paramName: "expression",
+                exceptionMessage: expectedMessage);
+        }
+
+        [Fact]
+        public void Process_Radio_WithEmptyForName_Throws()
+        {
+            // Arrange
+            var expectedMessage = "The name of an HTML field cannot be null or empty. Instead use methods " +
+                "Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper.Editor or Microsoft.AspNetCore.Mvc.Rendering." +
+                "IHtmlHelper`1.EditorFor with a non-empty htmlFieldName argument value.";
+
+            var inputTypeName = "radio";
+            var metadataProvider = new EmptyModelMetadataProvider();
+            var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
+            var model = 23;
+            var modelExplorer = metadataProvider.GetModelExplorerForType(typeof(int), model);
+            var modelExpression = new ModelExpression(name: string.Empty, modelExplorer: modelExplorer);
+            var viewContext = TestableHtmlGenerator.GetViewContext(model, htmlGenerator, metadataProvider);
+            var tagHelper = new InputTagHelper(htmlGenerator)
+            {
+                For = modelExpression,
+                InputTypeName = inputTypeName,
+                Value = "24",
+                ViewContext = viewContext,
+            };
+
+            var attributes = new TagHelperAttributeList
+            {
+                { "type", inputTypeName },
+                { "value", "24" },
+            };
+
+            var context = new TagHelperContext(attributes, new Dictionary<object, object>(), "test");
+            var output = new TagHelperOutput(
+                "input",
+                new TagHelperAttributeList(),
+                getChildContentAsync: (useCachedResult, encoder) => Task.FromResult<TagHelperContent>(result: null))
+            {
+                TagMode = TagMode.SelfClosing,
+            };
+
+            // Act & Assert
+            ExceptionAssert.ThrowsArgument(
+                () => tagHelper.Process(context, output),
+                paramName: "expression",
+                exceptionMessage: expectedMessage);
+        }
+
+        public static TheoryData<string, TagHelperAttributeList> TypesAndExpectedAttributesData
+        {
+            get
+            {
+                return new TheoryData<string, TagHelperAttributeList>
+                {
+                    {
+                        "hidden", new TagHelperAttributeList
+                        {
+                            { "name",  "-expression-" },
+                            { "type", "hidden" },
+                            { "value", "False" },
+                        }
+                    },
+                    {
+                        "number", new TagHelperAttributeList
+                        {
+                            { "name",  "-expression-" },
+                            { "type", "number" },
+                            { "value", "False" },
+                        }
+                    },
+                    {
+                        "password", new TagHelperAttributeList
+                        {
+                            { "name",  "-expression-" },
+                            { "type", "password" },
+                        }
+                    },
+                    {
+                        "text", new TagHelperAttributeList
+                        {
+                            { "name",  "-expression-" },
+                            { "type", "text" },
+                            { "value", "False" },
+                        }
+                    },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TypesAndExpectedAttributesData))]
+        public void Process_WithEmptyForName_DoesNotThrow_WithName(
+            string inputTypeName,
+            TagHelperAttributeList expectedAttributes)
+        {
+            // Arrange
+            var expectedAttributeValue = "-expression-";
+            var expectedTagName = "input";
+
+            var metadataProvider = new EmptyModelMetadataProvider();
+            var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
+            var model = false;
+            var modelExplorer = metadataProvider.GetModelExplorerForType(typeof(bool), model);
+            var modelExpression = new ModelExpression(name: string.Empty, modelExplorer: modelExplorer);
+            var viewContext = TestableHtmlGenerator.GetViewContext(model, htmlGenerator, metadataProvider);
+            viewContext.ClientValidationEnabled = false;
+
+            var tagHelper = new InputTagHelper(htmlGenerator)
+            {
+                For = modelExpression,
+                InputTypeName = inputTypeName,
+                Name = expectedAttributeValue,
+                ViewContext = viewContext,
+            };
+
+            var attributes = new TagHelperAttributeList
+            {
+                { "name", expectedAttributeValue },
+                { "type", inputTypeName },
+            };
+
+            var context = new TagHelperContext(attributes, new Dictionary<object, object>(), "test");
+            var output = new TagHelperOutput(
+                expectedTagName,
+                new TagHelperAttributeList(),
+                getChildContentAsync: (useCachedResult, encoder) => Task.FromResult<TagHelperContent>(result: null))
+            {
+                TagMode = TagMode.SelfClosing,
+            };
+
+            // Act
+            tagHelper.Process(context, output);
+
+            // Assert
+            Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.False(output.IsContentModified);
+            Assert.Equal(expectedTagName, output.TagName);
+        }
+
+        [Fact]
+        public void Process_Checkbox_WithEmptyForName_DoesNotThrow_WithName()
+        {
+            // Arrange
+            var expectedAttributeValue = "-expression-";
+            var expectedEndOfFormContent = $"<input name=\"HtmlEncode[[{expectedAttributeValue}]]\" " +
+                "type=\"HtmlEncode[[hidden]]\" value=\"HtmlEncode[[false]]\" />";
+            var expectedTagName = "input";
+            var inputTypeName = "checkbox";
+            var expectedAttributes = new TagHelperAttributeList
+            {
+                { "name",  expectedAttributeValue },
+                { "type", inputTypeName },
+                { "value", "true" },
+            };
+
+            var metadataProvider = new EmptyModelMetadataProvider();
+            var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
+            var model = false;
+            var modelExplorer = metadataProvider.GetModelExplorerForType(typeof(bool), model);
+            var modelExpression = new ModelExpression(name: string.Empty, modelExplorer: modelExplorer);
+            var viewContext = TestableHtmlGenerator.GetViewContext(model, htmlGenerator, metadataProvider);
+            viewContext.ClientValidationEnabled = false;
+
+            var tagHelper = new InputTagHelper(htmlGenerator)
+            {
+                For = modelExpression,
+                InputTypeName = inputTypeName,
+                Name = expectedAttributeValue,
+                ViewContext = viewContext,
+            };
+
+            var attributes = new TagHelperAttributeList
+            {
+                { "name", expectedAttributeValue },
+                { "type", inputTypeName },
+            };
+
+            var context = new TagHelperContext(attributes, new Dictionary<object, object>(), "test");
+            var output = new TagHelperOutput(
+                expectedTagName,
+                new TagHelperAttributeList(),
+                getChildContentAsync: (useCachedResult, encoder) => Task.FromResult<TagHelperContent>(result: null))
+            {
+                TagMode = TagMode.SelfClosing,
+            };
+
+            // Act
+            tagHelper.Process(context, output);
+
+            // Assert
+            Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.False(output.IsContentModified);
+            Assert.Equal(expectedTagName, output.TagName);
+
+            Assert.False(viewContext.FormContext.HasEndOfFormContent);
+            Assert.Equal(expectedEndOfFormContent, HtmlContentUtilities.HtmlContentToString(output.PostElement));
+        }
+
+        [Fact]
+        public void Process_Radio_WithEmptyForName_DoesNotThrow_WithName()
+        {
+            // Arrange
+            var expectedAttributeValue = "-expression-";
+            var expectedTagName = "input";
+            var inputTypeName = "radio";
+            var expectedAttributes = new TagHelperAttributeList
+            {
+                { "name",  expectedAttributeValue },
+                { "type", inputTypeName },
+                { "value", "24" },
+            };
+
+            var metadataProvider = new EmptyModelMetadataProvider();
+            var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
+            var model = 23;
+            var modelExplorer = metadataProvider.GetModelExplorerForType(typeof(int), model);
+            var modelExpression = new ModelExpression(name: string.Empty, modelExplorer: modelExplorer);
+            var viewContext = TestableHtmlGenerator.GetViewContext(model, htmlGenerator, metadataProvider);
+            viewContext.ClientValidationEnabled = false;
+
+            var tagHelper = new InputTagHelper(htmlGenerator)
+            {
+                For = modelExpression,
+                InputTypeName = inputTypeName,
+                Name = expectedAttributeValue,
+                Value = "24",
+                ViewContext = viewContext,
+            };
+
+            var attributes = new TagHelperAttributeList
+            {
+                { "name", expectedAttributeValue },
+                { "type", inputTypeName },
+                { "value", "24" },
+            };
+
+            var context = new TagHelperContext(attributes, new Dictionary<object, object>(), "test");
+            var output = new TagHelperOutput(
+                expectedTagName,
+                new TagHelperAttributeList(),
+                getChildContentAsync: (useCachedResult, encoder) => Task.FromResult<TagHelperContent>(result: null))
+            {
+                TagMode = TagMode.SelfClosing,
+            };
+
+            // Act
+            tagHelper.Process(context, output);
+
+            // Assert
+            Assert.Equal(expectedAttributes, output.Attributes);
+            Assert.False(output.IsContentModified);
+            Assert.Equal(expectedTagName, output.TagName);
         }
 
         // Top-level container (List<Model> or Model instance), immediate container type (Model or NestModel),
@@ -1410,7 +1708,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             };
 
             var metadataProvider = TestModelMetadataProvider.CreateDefaultProvider();
-            
+
             var model = new DateTime(
                 year: 2000,
                 month: 1,

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/ValidationMessageTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/ValidationMessageTagHelperTest.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Mvc.ViewEngines;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Testing;
 using Moq;
 using Xunit;
 
@@ -87,6 +88,151 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             Assert.Equal(expectedContent, output.Content.GetContent());
             Assert.Equal(expectedPostContent, output.PostContent.GetContent());
             Assert.Equal(expectedTagName, output.TagName);
+        }
+
+        [Fact]
+        public async Task ProcessAsync_WithEmptyNameFor_Throws()
+        {
+            // Arrange
+            var expectedTagName = "span";
+            var expectedMessage = "The name of an HTML field cannot be null or empty. Instead use methods " +
+                "Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper.Editor or Microsoft.AspNetCore.Mvc.Rendering." +
+                "IHtmlHelper`1.EditorFor with a non-empty htmlFieldName argument value.";
+
+            var metadataProvider = new EmptyModelMetadataProvider();
+            var modelExpression = CreateModelExpression(string.Empty);
+            var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
+            var viewContext = TestableHtmlGenerator.GetViewContext(
+                model: null,
+                htmlGenerator: htmlGenerator,
+                metadataProvider: metadataProvider);
+
+            var validationMessageTagHelper = new ValidationMessageTagHelper(htmlGenerator)
+            {
+                For = modelExpression,
+                ViewContext = viewContext,
+            };
+
+            var tagHelperContext = new TagHelperContext(
+                expectedTagName,
+                new TagHelperAttributeList
+                {
+                    { "for", modelExpression },
+                },
+                new Dictionary<object, object>(),
+                "test");
+
+            var output = new TagHelperOutput(
+                expectedTagName,
+                new TagHelperAttributeList(),
+                (_, __) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+
+            // Act & Assert
+            await ExceptionAssert.ThrowsArgumentAsync(
+                () => validationMessageTagHelper.ProcessAsync(tagHelperContext, output),
+                paramName: "expression",
+                exceptionMessage: expectedMessage);
+        }
+
+        [Fact]
+        public async Task ProcessAsync_GeneratesExpectedOutput_WithEmptyNameFor_WithValidationFor()
+        {
+            // Arrange
+            var expectedAttributeValue = "-expression-";
+            var expectedTagName = "span";
+
+            var metadataProvider = new EmptyModelMetadataProvider();
+            var modelExpression = CreateModelExpression(string.Empty);
+            var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
+            var viewContext = TestableHtmlGenerator.GetViewContext(
+                model: null,
+                htmlGenerator: htmlGenerator,
+                metadataProvider: metadataProvider);
+
+            var validationMessageTagHelper = new ValidationMessageTagHelper(htmlGenerator)
+            {
+                DataValidationFor = expectedAttributeValue,
+                For = modelExpression,
+                ViewContext = viewContext,
+            };
+
+            var tagHelperContext = new TagHelperContext(
+                expectedTagName,
+                new TagHelperAttributeList
+                {
+                    { "data-valmsg-for", expectedAttributeValue },
+                    { "for", modelExpression },
+                },
+                new Dictionary<object, object>(),
+                "test");
+
+            var output = new TagHelperOutput(
+                expectedTagName,
+                new TagHelperAttributeList(),
+                (_, __) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+
+            validationMessageTagHelper.ViewContext = viewContext;
+
+            // Act
+            await validationMessageTagHelper.ProcessAsync(tagHelperContext, output);
+
+            // Assert
+            Assert.Equal(expectedTagName, output.TagName);
+            Assert.Collection(output.Attributes,
+                attribute =>
+                {
+                    Assert.Equal("data-valmsg-for", attribute.Name);
+                    Assert.Equal(expectedAttributeValue, attribute.Value);
+                },
+                attribute =>
+                {
+                    Assert.Equal("class", attribute.Name);
+                    Assert.Equal("field-validation-valid", attribute.Value);
+                },
+                attribute =>
+                {
+                    Assert.Equal("data-valmsg-replace", attribute.Name);
+                    Assert.Equal("true", attribute.Value);
+                });
+        }
+
+        [Fact]
+        public async Task ProcessAsync_PassesValidationForThrough_EvenIfNullFor()
+        {
+            // Arrange
+            var expectedAttributeValue = "-expression-";
+            var expectedTagName = "span";
+
+            // Generator is not used in this scenario.
+            var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
+            var validationMessageTagHelper = new ValidationMessageTagHelper(generator.Object)
+            {
+                DataValidationFor = expectedAttributeValue,
+                ViewContext = CreateViewContext(),
+            };
+
+            var tagHelperContext = new TagHelperContext(
+                expectedTagName,
+                new TagHelperAttributeList
+                {
+                    { "data-valmsg-for", expectedAttributeValue },
+                },
+                new Dictionary<object, object>(),
+                "test");
+
+            var output = new TagHelperOutput(
+                expectedTagName,
+                new TagHelperAttributeList(),
+                (_, __) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+
+            // Act
+            await validationMessageTagHelper.ProcessAsync(tagHelperContext, output);
+
+            // Assert
+            Assert.Equal(expectedTagName, output.TagName);
+            var attribute = Assert.Single(output.Attributes);
+            Assert.Equal("data-valmsg-for", attribute.Name);
+            Assert.Equal(expectedAttributeValue, attribute.Value);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/ValidationMessageTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/ValidationMessageTagHelperTest.cs
@@ -151,7 +151,6 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
             var validationMessageTagHelper = new ValidationMessageTagHelper(htmlGenerator)
             {
-                DataValidationFor = expectedAttributeValue,
                 For = modelExpression,
                 ViewContext = viewContext,
             };
@@ -160,7 +159,6 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 expectedTagName,
                 new TagHelperAttributeList
                 {
-                    { "data-valmsg-for", expectedAttributeValue },
                     { "for", modelExpression },
                 },
                 new Dictionary<object, object>(),
@@ -168,7 +166,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
             var output = new TagHelperOutput(
                 expectedTagName,
-                new TagHelperAttributeList(),
+                new TagHelperAttributeList
+                {
+                    { "data-valmsg-for", expectedAttributeValue },
+                },
                 (_, __) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
 
             validationMessageTagHelper.ViewContext = viewContext;
@@ -207,22 +208,21 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             var generator = new Mock<IHtmlGenerator>(MockBehavior.Strict);
             var validationMessageTagHelper = new ValidationMessageTagHelper(generator.Object)
             {
-                DataValidationFor = expectedAttributeValue,
                 ViewContext = CreateViewContext(),
             };
 
             var tagHelperContext = new TagHelperContext(
                 expectedTagName,
-                new TagHelperAttributeList
-                {
-                    { "data-valmsg-for", expectedAttributeValue },
-                },
+                new TagHelperAttributeList(),
                 new Dictionary<object, object>(),
                 "test");
 
             var output = new TagHelperOutput(
                 expectedTagName,
-                new TagHelperAttributeList(),
+                new TagHelperAttributeList
+                {
+                    { "data-valmsg-for", expectedAttributeValue },
+                },
                 (_, __) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
 
             // Act

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperCheckboxTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperCheckboxTest.cs
@@ -95,13 +95,36 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
                 "Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper.Editor or Microsoft.AspNetCore.Mvc.Rendering." +
                 "IHtmlHelper`1.EditorFor with a non-empty htmlFieldName argument value.";
 
-            var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetTestModelViewData());
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper(model: false);
 
             // Act & Assert
             ExceptionAssert.ThrowsArgument(
                 () => helper.CheckBox(null, isChecked: true, htmlAttributes: null),
                 "expression",
                 expected);
+        }
+
+        [Fact]
+        public void CheckBoxWithNullExpression_DoesNotThrow_WithNameAttribute()
+        {
+            // Arrange
+            var expected = @"<input class=""HtmlEncode[[some-class]]"" name=""HtmlEncode[[-expression-]]"" " +
+                @"type=""HtmlEncode[[checkbox]]"" value=""HtmlEncode[[true]]"" /><input " +
+                @"name=""HtmlEncode[[-expression-]]"" type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[false]]"" />";
+
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper(model: false);
+            helper.ViewContext.ClientValidationEnabled = false;
+            var attributes = new Dictionary<string, object>
+            {
+                { "class", "some-class"},
+                { "name", "-expression-" },
+            };
+
+            // Act
+            var html = helper.CheckBox(null, isChecked: false, htmlAttributes: attributes);
+
+            // Assert
+            Assert.Equal(expected, HtmlContentUtilities.HtmlContentToString(html));
         }
 
         [Fact]
@@ -413,12 +436,17 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             var requiredMessage = ValidationAttributeUtil.GetRequiredErrorMessage("Boolean");
             var expected =
                 $@"<input data-val=""HtmlEncode[[true]]"" data-val-required=""HtmlEncode[[{requiredMessage}]]"" " +
-                @"id=""HtmlEncode[[MyPrefix]]"" name=""HtmlEncode[[MyPrefix]]"" Property3=""HtmlEncode[[Property3Value]]"" " +
-                @"type=""HtmlEncode[[checkbox]]"" value=""HtmlEncode[[true]]"" /><input name=""HtmlEncode[[MyPrefix]]"" type=""HtmlEncode[[hidden]]"" " +
-                @"value=""HtmlEncode[[false]]"" />";
+                @"id=""HtmlEncode[[MyPrefix]]"" name=""HtmlEncode[[MyPrefix]]"" " +
+                @"Property3=""HtmlEncode[[Property3Value]]"" type=""HtmlEncode[[checkbox]]"" " +
+                @"value=""HtmlEncode[[true]]"" /><input name=""HtmlEncode[[MyPrefix]]"" " +
+                @"type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[false]]"" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(model: false);
-            var attributes = new Dictionary<string, object> { { "Property3", "Property3Value" } };
             helper.ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix = "MyPrefix";
+            var attributes = new Dictionary<string, object>
+            {
+                { "Property3", "Property3Value" },
+                { "name", "-expression-" }, // overridden
+            };
 
             // Act
             var html = helper.CheckBox(string.Empty, isChecked: false, htmlAttributes: attributes);
@@ -589,10 +617,15 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             var expected =
                 $@"<input data-val=""HtmlEncode[[true]]"" data-val-required=""HtmlEncode[[{requiredMessage}]]"" " +
                 @"id=""HtmlEncode[[Property1]]"" name=""HtmlEncode[[Property1]]"" " +
-                @"Property3=""HtmlEncode[[Property3Value]]"" type=""HtmlEncode[[checkbox]]"" value=""HtmlEncode[[true]]"" /><input " +
-                @"name=""HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[false]]"" />";
+                @"Property3=""HtmlEncode[[Property3Value]]"" type=""HtmlEncode[[checkbox]]"" " +
+                @"value=""HtmlEncode[[true]]"" /><input name=""HtmlEncode[[Property1]]"" " +
+                @"type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[false]]"" />";
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetTestModelViewData());
-            var attributes = new Dictionary<string, object> { { "Property3", "Property3Value" } };
+            var attributes = new Dictionary<string, object>
+            {
+                { "Property3", "Property3Value" },
+                { "name", "-expression-" }, // overridden
+            };
 
             // Act
             var html = helper.CheckBoxFor(m => m.Property1, attributes);

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperRadioButtonExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperRadioButtonExtensionsTest.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.TestCommon;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Testing;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.Core
@@ -122,13 +123,19 @@ namespace Microsoft.AspNetCore.Mvc.Core
         {
             // Arrange
             var helper = DefaultTemplatesUtilities.GetHtmlHelper();
+            var htmlAttributes = new
+            {
+                attr = "value",
+                name = "-expression-", // overridden
+            };
 
             // Act
-            var radioButtonResult = helper.RadioButton("Property1", value: "myvalue", htmlAttributes: new { attr = "value" });
+            var radioButtonResult = helper.RadioButton("Property1", "myvalue", htmlAttributes);
 
             // Assert
             Assert.Equal(
-                "<input attr=\"HtmlEncode[[value]]\" id=\"HtmlEncode[[Property1]]\" name=\"HtmlEncode[[Property1]]\" type=\"HtmlEncode[[radio]]\" value=\"HtmlEncode[[myvalue]]\" />",
+                "<input attr=\"HtmlEncode[[value]]\" id=\"HtmlEncode[[Property1]]\" " +
+                "name=\"HtmlEncode[[Property1]]\" type=\"HtmlEncode[[radio]]\" value=\"HtmlEncode[[myvalue]]\" />",
                 HtmlContentUtilities.HtmlContentToString(radioButtonResult));
         }
 
@@ -137,13 +144,61 @@ namespace Microsoft.AspNetCore.Mvc.Core
         {
             // Arrange
             var helper = DefaultTemplatesUtilities.GetHtmlHelper();
+            var htmlAttributes = new
+            {
+                attr = "value",
+                name = "-expression-", // overridden
+            };
 
             // Act
-            var radioButtonForResult = helper.RadioButtonFor(m => m.Property1, value: "myvalue", htmlAttributes: new { attr = "value" });
+            var radioButtonForResult = helper.RadioButtonFor(m => m.Property1, "myvalue", htmlAttributes);
 
             // Assert
             Assert.Equal(
-                "<input attr=\"HtmlEncode[[value]]\" id=\"HtmlEncode[[Property1]]\" name=\"HtmlEncode[[Property1]]\" type=\"HtmlEncode[[radio]]\" value=\"HtmlEncode[[myvalue]]\" />",
+                "<input attr=\"HtmlEncode[[value]]\" id=\"HtmlEncode[[Property1]]\" " +
+                "name=\"HtmlEncode[[Property1]]\" type=\"HtmlEncode[[radio]]\" value=\"HtmlEncode[[myvalue]]\" />",
+                HtmlContentUtilities.HtmlContentToString(radioButtonForResult));
+        }
+
+        [Fact]
+        public void RadioButtonFor_Throws_IfFullNameEmpty()
+        {
+            // Arrange
+            var expectedMessage = "The name of an HTML field cannot be null or empty. Instead use methods " +
+                "Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper.Editor or Microsoft.AspNetCore.Mvc.Rendering." +
+                "IHtmlHelper`1.EditorFor with a non-empty htmlFieldName argument value.";
+
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper("anotherValue");
+            var htmlAttributes = new
+            {
+                attr = "value",
+            };
+
+            // Act & Assert
+            ExceptionAssert.ThrowsArgument(
+                () => helper.RadioButtonFor(m => m, "myvalue", htmlAttributes),
+                paramName: "expression",
+                exceptionMessage: expectedMessage);
+        }
+
+        [Fact]
+        public void RadioButtonFor_DoesNotThrow_IfFullNameEmpty_WithNameAttribute()
+        {
+            // Arrange
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper("anotherValue");
+            var htmlAttributes = new
+            {
+                attr = "value",
+                name = "-expression-",
+            };
+
+            // Act
+            var radioButtonForResult = helper.RadioButtonFor(m => m, "myvalue", htmlAttributes);
+
+            // Assert
+            Assert.Equal(
+                "<input attr=\"HtmlEncode[[value]]\" " +
+                "name=\"HtmlEncode[[-expression-]]\" type=\"HtmlEncode[[radio]]\" value=\"HtmlEncode[[myvalue]]\" />",
                 HtmlContentUtilities.HtmlContentToString(radioButtonForResult));
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/DefaultHtmlGeneratorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/DefaultHtmlGeneratorTest.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         }
 
         [Fact]
-        public void GetCurrentValues_WithNullExpression_Throws()
+        public void GetCurrentValues_WithNullExpression_DoesNotThrow()
         {
             // Arrange
             var metadataProvider = new TestModelMetadataProvider();
@@ -77,19 +77,8 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             var viewContext = GetViewContext<Model>(model: null, metadataProvider: metadataProvider);
             var modelExplorer = metadataProvider.GetModelExplorerForType(typeof(string), model: null);
 
-            var expected = "The name of an HTML field cannot be null or empty. Instead use " +
-                "methods Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper.Editor or Microsoft.AspNetCore.Mvc.Rendering." +
-                "IHtmlHelper`1.EditorFor with a non-empty htmlFieldName argument value.";
-
-            // Act and assert
-            ExceptionAssert.ThrowsArgument(
-                () => htmlGenerator.GetCurrentValues(
-                    viewContext,
-                    modelExplorer,
-                    expression: null,
-                    allowMultiple: true),
-                "expression",
-                expected);
+            // Act and Assert (does not throw).
+            htmlGenerator.GetCurrentValues(viewContext, modelExplorer, expression: null, allowMultiple: true);
         }
 
         [Fact]
@@ -105,18 +94,47 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 "Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper.Editor or Microsoft.AspNetCore.Mvc.Rendering." +
                 "IHtmlHelper`1.EditorFor with a non-empty htmlFieldName argument value.";
 
-            // Act and assert
+            // Act and Assert
             ExceptionAssert.ThrowsArgument(
                 () => htmlGenerator.GenerateSelect(
                     viewContext,
                     modelExplorer,
                     "label",
-                    null,
-                    new List<SelectListItem>(),
-                    true,
-                    null),
+                    expression: null,
+                    selectList: new List<SelectListItem>(),
+                    allowMultiple: true,
+                    htmlAttributes: null),
                 "expression",
                 expected);
+        }
+
+        [Fact]
+        public void GenerateSelect_WithNullExpression_WithNameAttribute_DoesNotThrow()
+        {
+            // Arrange
+            var expected = "-expression-";
+            var metadataProvider = new TestModelMetadataProvider();
+            var htmlGenerator = GetGenerator(metadataProvider);
+            var viewContext = GetViewContext<Model>(model: null, metadataProvider: metadataProvider);
+            var modelExplorer = metadataProvider.GetModelExplorerForType(typeof(string), model: null);
+            var htmlAttributes = new Dictionary<string, object>
+            {
+                { "name", expected },
+            };
+
+            // Act
+            var tagBuilder = htmlGenerator.GenerateSelect(
+                viewContext,
+                modelExplorer,
+                "label",
+                expression: null,
+                selectList: new List<SelectListItem>(),
+                allowMultiple: true,
+                htmlAttributes: htmlAttributes);
+
+            // Assert
+            var attribute = Assert.Single(tagBuilder.Attributes, a => a.Key == "name");
+            Assert.Equal(expected, attribute.Value);
         }
 
         [Fact]
@@ -132,17 +150,45 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 "Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper.Editor or Microsoft.AspNetCore.Mvc.Rendering." +
                 "IHtmlHelper`1.EditorFor with a non-empty htmlFieldName argument value.";
 
-            // Act and assert
+            // Act and Assert
             ExceptionAssert.ThrowsArgument(
                 () => htmlGenerator.GenerateTextArea(
                     viewContext,
                     modelExplorer,
-                    null,
-                    1,
-                    1,
-                    null),
+                    expression: null,
+                    rows: 1,
+                    columns: 1,
+                    htmlAttributes: null),
                 "expression",
                 expected);
+        }
+
+        [Fact]
+        public void GenerateTextArea_WithNullExpression_WithNameAttribute_DoesNotThrow()
+        {
+            // Arrange
+            var expected = "-expression-";
+            var metadataProvider = new TestModelMetadataProvider();
+            var htmlGenerator = GetGenerator(metadataProvider);
+            var viewContext = GetViewContext<Model>(model: null, metadataProvider: metadataProvider);
+            var modelExplorer = metadataProvider.GetModelExplorerForType(typeof(string), model: null);
+            var htmlAttributes = new Dictionary<string, object>
+            {
+                { "name", expected },
+            };
+
+            // Act
+            var tagBuilder = htmlGenerator.GenerateTextArea(
+                viewContext,
+                modelExplorer,
+                expression: null,
+                rows: 1,
+                columns: 1,
+                htmlAttributes: htmlAttributes);
+
+            // Assert
+            var attribute = Assert.Single(tagBuilder.Attributes, a => a.Key == "name");
+            Assert.Equal(expected, attribute.Value);
         }
 
         [Fact]
@@ -158,11 +204,45 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 "Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper.Editor or Microsoft.AspNetCore.Mvc.Rendering." +
                 "IHtmlHelper`1.EditorFor with a non-empty htmlFieldName argument value.";
 
-            // Act and assert
+            // Act and Assert
             ExceptionAssert.ThrowsArgument(
-                () => htmlGenerator.GenerateValidationMessage(viewContext, null, null, "Message", "tag", null),
+                () => htmlGenerator.GenerateValidationMessage(
+                    viewContext,
+                    modelExplorer: null,
+                    expression: null,
+                    message: "Message",
+                    tag: "tag",
+                    htmlAttributes: null),
                 "expression",
                 expected);
+        }
+
+        [Fact]
+        public void GenerateValidationMessage_WithNullExpression_WithValidationForAttribute_DoesNotThrow()
+        {
+            // Arrange
+            var expected = "-expression-";
+            var metadataProvider = new TestModelMetadataProvider();
+            var htmlGenerator = GetGenerator(metadataProvider);
+            var viewContext = GetViewContext<Model>(model: null, metadataProvider: metadataProvider);
+            var modelExplorer = metadataProvider.GetModelExplorerForType(typeof(string), model: null);
+            var htmlAttributes = new Dictionary<string, object>
+            {
+                { "data-valmsg-for", expected },
+            };
+
+            // Act
+            var tagBuilder = htmlGenerator.GenerateValidationMessage(
+                viewContext,
+                modelExplorer: null,
+                expression: null,
+                message: "Message",
+                tag: "tag",
+                htmlAttributes: htmlAttributes);
+
+            // Assert
+            var attribute = Assert.Single(tagBuilder.Attributes, a => a.Key == "data-valmsg-for");
+            Assert.Equal(expected, attribute.Value);
         }
 
         [Theory]


### PR DESCRIPTION
- #6662
- users can now provide a `name` or `data-valmsg-for` attribute to avoid issues
  - affects `<input>`, `<select>`, `<textarea>` elements and validation message `<div>`s
- remove `fullName` check in `DefaultHtmlGenerator.GetCurrentValues(...)` entirely

The new workaround is _not_ identical to changing `ViewData.TemplateInfo.HtmlFieldPrefix`
- does not change where expression values are found in `ModelState` or `ViewData`
- likely needs to be combined with additional workarounds i.e. for advanced use only

nits:
- clean up some excessive argument naming; add a few missing argument names
- take VS suggestions in changed classes e.g. inline a few `out` variable declarations
- clean up some test data