### PR TITLE
Plumb new Razor metadata through MVC

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor/Compilation/CompiledViewDescriptor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Compilation/CompiledViewDescriptor.cs
@@ -1,13 +1,60 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.Razor.Internal;
+using Microsoft.AspNetCore.Razor.Hosting;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
 {
+    /// <summary>
+    /// Represents a compiled Razor View or Page.
+    /// </summary>
     public class CompiledViewDescriptor
     {
+        /// <summary>
+        /// Creates a new <see cref="CompiledViewDescriptor"/>.
+        /// </summary>
+        public CompiledViewDescriptor()
+        {
+
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="CompiledViewDescriptor"/>. At least one of <paramref name="attribute"/> or
+        /// <paramref name="item"/> must be non-<c>null</c>.
+        /// </summary>
+        /// <param name="item">The <see cref="RazorCompiledItem"/>.</param>
+        /// <param name="attribute">The <see cref="RazorViewAttribute"/>.</param>
+        public CompiledViewDescriptor(RazorCompiledItem item, RazorViewAttribute attribute)
+        {
+            if (item == null && attribute == null)
+            {
+                // We require at least one of these to be specified.
+                throw new ArgumentException(Resources.FormatCompiledViewDescriptor_NoData(nameof(item), nameof(attribute)));
+            }
+
+            Item = item;
+
+            //
+            // For now we expect that MVC views and pages will still have either:
+            // [RazorView(...)] or 
+            // [RazorPage(...)].
+            //
+            // In theory we could look at the 'Item.Kind' to determine what kind of thing we're dealing
+            // with, but for compat reasons we're basing it on ViewAttribute since that's what 2.0 had.
+            ViewAttribute = attribute;
+
+            // We don't have access to the file provider here so we can't check if the files
+            // even exist or what their checksums are. For now leave this empty, it will be updated
+            // later.
+            ExpirationTokens = Array.Empty<IChangeToken>();
+            RelativePath = ViewPath.NormalizePath(item?.Identifier ?? attribute.Path);
+            IsPrecompiled = true;
+        }
+
         /// <summary>
         /// The normalized application relative path of the view.
         /// </summary>
@@ -27,5 +74,15 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
         /// Gets a value that determines if the view is precompiled.
         /// </summary>
         public bool IsPrecompiled { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="RazorCompiledItem"/> descriptor for this view.
+        /// </summary>
+        public RazorCompiledItem Item { get; set; }
+
+        /// <summary>
+        /// Gets the type of the compiled item.
+        /// </summary>
+        public Type Type => Item?.Type ?? ViewAttribute?.ViewType;
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Compilation/ViewsFeatureProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Compilation/ViewsFeatureProvider.cs
@@ -7,8 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
-using Microsoft.AspNetCore.Mvc.Razor.Internal;
-using Microsoft.Extensions.Primitives;
+using Microsoft.AspNetCore.Razor.Hosting;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
 {
@@ -19,26 +18,79 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
     {
         public static readonly string PrecompiledViewsAssemblySuffix = ".PrecompiledViews";
 
+        public static readonly IReadOnlyList<string> ViewAssemblySuffixes = new string[]
+        {
+            PrecompiledViewsAssemblySuffix,
+            ".Views",
+        };
+
         /// <inheritdoc />
         public void PopulateFeature(IEnumerable<ApplicationPart> parts, ViewsFeature feature)
         {
             foreach (var assemblyPart in parts.OfType<AssemblyPart>())
             {
-                var viewAttributes = GetViewAttributes(assemblyPart);
-                foreach (var attribute in viewAttributes)
-                {
-                    var relativePath = ViewPath.NormalizePath(attribute.Path);
-                    var viewDescriptor = new CompiledViewDescriptor
-                    {
-                        ExpirationTokens = Array.Empty<IChangeToken>(),
-                        RelativePath = relativePath,
-                        ViewAttribute = attribute,
-                        IsPrecompiled = true,
-                    };
+                var attributes = GetViewAttributes(assemblyPart);
+                var items = LoadItems(assemblyPart);
 
-                    feature.ViewDescriptors.Add(viewDescriptor);
+                var merged = Merge(items, attributes);
+                foreach (var entry in merged)
+                {
+                    feature.ViewDescriptors.Add(new CompiledViewDescriptor(entry.item, entry.attribute));
                 }
             }
+        }
+
+        private ICollection<(RazorCompiledItem item, RazorViewAttribute attribute)> Merge(
+            IReadOnlyList<RazorCompiledItem> items, 
+            IEnumerable<RazorViewAttribute> attributes)
+        {
+            // This code is a intentionally defensive. We assume that it's possible to have duplicates
+            // of attributes, and also items that have a single kind of metadata, but not the other.
+            var dictionary = new Dictionary<string, (RazorCompiledItem item, RazorViewAttribute attribute)>();
+            for (var i = 0; i < items.Count; i++)
+            {
+                var item = items[i];
+                if (!dictionary.TryGetValue(item.Identifier, out var entry))
+                {
+                    dictionary.Add(item.Identifier, (item, null));
+
+                }
+                else if (entry.item == null)
+                {
+                    dictionary[item.Identifier] = (item, entry.attribute);
+                }
+            }
+
+            foreach (var attribute in attributes)
+            {
+                if (!dictionary.TryGetValue(attribute.Path, out var entry))
+                {
+                    dictionary.Add(attribute.Path, (null, attribute));
+                }
+                else if (entry.attribute == null)
+                {
+                    dictionary[attribute.Path] = (entry.item, attribute);
+                }
+            }
+
+            return dictionary.Values;
+        }
+
+        protected virtual IReadOnlyList<RazorCompiledItem> LoadItems(AssemblyPart assemblyPart)
+        {
+            if (assemblyPart == null)
+            {
+                throw new ArgumentNullException(nameof(assemblyPart));
+            }
+
+            var viewAssembly = GetViewAssembly(assemblyPart);
+            if (viewAssembly != null)
+            {
+                var loader = new RazorCompiledItemLoader();
+                return loader.LoadItems(viewAssembly);
+            }
+
+            return Array.Empty<RazorCompiledItem>();
         }
 
         /// <summary>
@@ -53,7 +105,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
                 throw new ArgumentNullException(nameof(assemblyPart));
             }
 
-            var featureAssembly = GetFeatureAssembly(assemblyPart);
+            var featureAssembly = GetViewAssembly(assemblyPart);
             if (featureAssembly != null)
             {
                 return featureAssembly.GetCustomAttributes<RazorViewAttribute>();
@@ -62,29 +114,28 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
             return Enumerable.Empty<RazorViewAttribute>();
         }
 
-        private static Assembly GetFeatureAssembly(AssemblyPart assemblyPart)
+        private Assembly GetViewAssembly(AssemblyPart assemblyPart)
         {
             if (assemblyPart.Assembly.IsDynamic || string.IsNullOrEmpty(assemblyPart.Assembly.Location))
             {
                 return null;
             }
 
-            var precompiledAssemblyFileName = assemblyPart.Assembly.GetName().Name
-                + PrecompiledViewsAssemblySuffix
-                + ".dll";
-            var precompiledAssemblyFilePath = Path.Combine(
-                Path.GetDirectoryName(assemblyPart.Assembly.Location),
-                precompiledAssemblyFileName);
-
-            if (File.Exists(precompiledAssemblyFilePath))
+            for (var i = 0; i < ViewAssemblySuffixes.Count; i++)
             {
-                try
+                var fileName = assemblyPart.Assembly.GetName().Name + ViewAssemblySuffixes[i] + ".dll";
+                var filePath = Path.Combine(Path.GetDirectoryName(assemblyPart.Assembly.Location), fileName);
+
+                if (File.Exists(filePath))
                 {
-                    return Assembly.LoadFile(precompiledAssemblyFilePath);
-                }
-                catch (FileLoadException)
-                {
-                    // Don't throw if assembly cannot be loaded. This can happen if the file is not a managed assembly.
+                    try
+                    {
+                        return Assembly.LoadFile(filePath);
+                    }
+                    catch (FileLoadException)
+                    {
+                        // Don't throw if assembly cannot be loaded. This can happen if the file is not a managed assembly.
+                    }
                 }
             }
 

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/DefaultRazorPageFactoryProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/DefaultRazorPageFactoryProvider.cs
@@ -43,12 +43,12 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             var compileTask = Compiler.CompileAsync(relativePath);
             var viewDescriptor = compileTask.GetAwaiter().GetResult();
-            if (viewDescriptor.ViewAttribute != null)
-            {
-                var compiledType = viewDescriptor.ViewAttribute.ViewType;
 
-                var newExpression = Expression.New(compiledType);
-                var pathProperty = compiledType.GetTypeInfo().GetProperty(nameof(IRazorPage.Path));
+            var viewType = viewDescriptor.Type;
+            if (viewType != null)
+            {
+                var newExpression = Expression.New(viewType);
+                var pathProperty = viewType.GetTypeInfo().GetProperty(nameof(IRazorPage.Path));
 
                 // Generate: page.Path = relativePath;
                 // Use the normalized path specified from the result.

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Properties/Resources.Designer.cs
@@ -378,6 +378,20 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         internal static string FormatUnsupportedDebugInformationFormat(object p0)
             => string.Format(CultureInfo.CurrentCulture, GetString("UnsupportedDebugInformationFormat"), p0);
 
+        /// <summary>
+        /// At least one of the '{0}' or '{1}' values must be non-null.
+        /// </summary>
+        internal static string CompiledViewDescriptor_NoData
+        {
+            get => GetString("CompiledViewDescriptor_NoData");
+        }
+
+        /// <summary>
+        /// At least one of the '{0}' or '{1}' values must be non-null.
+        /// </summary>
+        internal static string FormatCompiledViewDescriptor_NoData(object p0, object p1)
+            => string.Format(CultureInfo.CurrentCulture, GetString("CompiledViewDescriptor_NoData"), p0, p1);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Resources.resx
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Resources.resx
@@ -197,4 +197,7 @@
   <data name="UnsupportedDebugInformationFormat" xml:space="preserve">
     <value>The debug type specified in the dependency context could be parsed. The debug type value '{0}' is not supported.</value>
   </data>
+  <data name="CompiledViewDescriptor_NoData" xml:space="preserve">
+    <value>At least one of the '{0}' or '{1}' values must be non-null.</value>
+  </data>
 </root>

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Compilation/ViewsFeatureProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Compilation/ViewsFeatureProviderTest.cs
@@ -212,21 +212,11 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
 
             protected override IEnumerable<RazorViewAttribute> GetViewAttributes(AssemblyPart assemblyPart)
             {
-                if (_attributes == null)
-                {
-                    throw new InvalidOperationException("This shouldn't be called.");
-                }
-
                 return _attributes[assemblyPart];
             }
 
             protected override IReadOnlyList<RazorCompiledItem> LoadItems(AssemblyPart assemblyPart)
             {
-                if (_items == null)
-                {
-                    throw new InvalidOperationException("This shouldn't be called.");
-                }
-
                 return _items[assemblyPart];
             }
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Compilation/ViewsFeatureProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Compilation/ViewsFeatureProviderTest.cs
@@ -6,7 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Text;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.AspNetCore.Razor.Hosting;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
@@ -17,14 +19,13 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
         public void PopulateFeature_ReturnsEmptySequenceIfNoAssemblyPartHasViewAssembly()
         {
             // Arrange
-            var applicationPartManager = new ApplicationPartManager();
-            applicationPartManager.ApplicationParts.Add(
-                new AssemblyPart(typeof(ViewsFeatureProviderTest).GetTypeInfo().Assembly));
-            applicationPartManager.FeatureProviders.Add(new ViewsFeatureProvider());
+            var partManager = new ApplicationPartManager();
+            partManager.ApplicationParts.Add(new AssemblyPart(typeof(ViewsFeatureProviderTest).GetTypeInfo().Assembly));
+            partManager.FeatureProviders.Add(new ViewsFeatureProvider());
             var feature = new ViewsFeature();
 
             // Act
-            applicationPartManager.PopulateFeature(feature);
+            partManager.PopulateFeature(feature);
 
             // Assert
             Assert.Empty(feature.ViewDescriptors);
@@ -36,7 +37,29 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
             // Arrange
             var part1 = new AssemblyPart(typeof(object).GetTypeInfo().Assembly);
             var part2 = new AssemblyPart(GetType().GetTypeInfo().Assembly);
-            var featureProvider = new TestableViewsFeatureProvider(new Dictionary<AssemblyPart, IEnumerable<RazorViewAttribute>>
+
+            var items = new Dictionary<AssemblyPart, IReadOnlyList<RazorCompiledItem>>
+            {
+                {
+                    part1,
+                    new[]
+                    {
+                        new TestRazorCompiledItem(typeof(object), "mvc.1.0.view", "/Views/test/Index.cshtml", new object[]{ }),
+
+                        // This one doesn't have a RazorViewAttribute
+                        new TestRazorCompiledItem(typeof(StringBuilder), "mvc.1.0.view", "/Views/test/About.cshtml", new object[]{ }),
+                    }
+                },
+                {
+                    part2,
+                    new[]
+                    {
+                        new TestRazorCompiledItem(typeof(string), "mvc.1.0.view", "/Areas/Admin/Views/Index.cshtml", new object[]{ }),
+                    }
+                },
+            };
+
+            var attributes = new Dictionary<AssemblyPart, IEnumerable<RazorViewAttribute>>
             {
                 {
                     part1,
@@ -50,35 +73,70 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
                     new[]
                     {
                         new RazorViewAttribute("/Areas/Admin/Views/Index.cshtml", typeof(string)),
+
+                        // This one doesn't have a RazorCompiledItem
                         new RazorViewAttribute("/Areas/Admin/Views/About.cshtml", typeof(int)),
                     }
                 },
-            });
+            };
 
-            var applicationPartManager = new ApplicationPartManager();
-            applicationPartManager.ApplicationParts.Add(part1);
-            applicationPartManager.ApplicationParts.Add(part2);
-            applicationPartManager.FeatureProviders.Add(featureProvider);
+            var featureProvider = new TestableViewsFeatureProvider(items, attributes);
+            var partManager = new ApplicationPartManager();
+            partManager.ApplicationParts.Add(part1);
+            partManager.ApplicationParts.Add(part2);
+            partManager.FeatureProviders.Add(featureProvider);
             var feature = new ViewsFeature();
 
             // Act
-            applicationPartManager.PopulateFeature(feature);
+            partManager.PopulateFeature(feature);
 
             // Assert
             Assert.Collection(feature.ViewDescriptors.OrderBy(f => f.RelativePath, StringComparer.Ordinal),
                 view =>
                 {
+                    Assert.Empty(view.ExpirationTokens);
+                    Assert.True(view.IsPrecompiled);
+                    Assert.Null(view.Item);
                     Assert.Equal("/Areas/Admin/Views/About.cshtml", view.RelativePath);
+                    Assert.Equal(typeof(int), view.Type);
+                    Assert.Equal("/Areas/Admin/Views/About.cshtml", view.ViewAttribute.Path);
                     Assert.Equal(typeof(int), view.ViewAttribute.ViewType);
                 },
                 view =>
                 {
+                    // This one doesn't have a RazorCompiledItem
+                    Assert.Empty(view.ExpirationTokens);
+                    Assert.True(view.IsPrecompiled);
+                    Assert.Equal("/Areas/Admin/Views/Index.cshtml", view.Item.Identifier);
+                    Assert.Equal("mvc.1.0.view", view.Item.Kind);
+                    Assert.Equal(typeof(string), view.Item.Type);
                     Assert.Equal("/Areas/Admin/Views/Index.cshtml", view.RelativePath);
+                    Assert.Equal(typeof(string), view.Type);
+                    Assert.Equal("/Areas/Admin/Views/Index.cshtml", view.ViewAttribute.Path);
                     Assert.Equal(typeof(string), view.ViewAttribute.ViewType);
                 },
                 view =>
                 {
+                    // This one doesn't have a RazorViewAttribute
+                    Assert.Empty(view.ExpirationTokens);
+                    Assert.True(view.IsPrecompiled);
+                    Assert.Equal("/Views/test/About.cshtml", view.Item.Identifier);
+                    Assert.Equal("mvc.1.0.view", view.Item.Kind);
+                    Assert.Equal(typeof(StringBuilder), view.Item.Type);
+                    Assert.Equal("/Views/test/About.cshtml", view.RelativePath);
+                    Assert.Equal(typeof(StringBuilder), view.Type);
+                    Assert.Null(view.ViewAttribute);
+                },
+                view =>
+                {
+                    Assert.Empty(view.ExpirationTokens);
+                    Assert.True(view.IsPrecompiled);
+                    Assert.Equal("/Views/test/Index.cshtml", view.Item.Identifier);
+                    Assert.Equal("mvc.1.0.view", view.Item.Kind);
+                    Assert.Equal(typeof(object), view.Item.Type);
                     Assert.Equal("/Views/test/Index.cshtml", view.RelativePath);
+                    Assert.Equal(typeof(object), view.Type);
+                    Assert.Equal("/Views/test/Index.cshtml", view.ViewAttribute.Path);
                     Assert.Equal(typeof(object), view.ViewAttribute.ViewType);
                 });
         }
@@ -88,50 +146,88 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
         {
             // Arrange
             var name = new AssemblyName($"DynamicAssembly-{Guid.NewGuid()}");
-            var assembly = AssemblyBuilder.DefineDynamicAssembly(name,
-                AssemblyBuilderAccess.RunAndCollect);
+            var assembly = AssemblyBuilder.DefineDynamicAssembly(name, AssemblyBuilderAccess.RunAndCollect);
 
-            var applicationPartManager = new ApplicationPartManager();
-            applicationPartManager.ApplicationParts.Add(new AssemblyPart(assembly));
-            applicationPartManager.FeatureProviders.Add(new ViewsFeatureProvider());
+            var partManager = new ApplicationPartManager();
+            partManager.ApplicationParts.Add(new AssemblyPart(assembly));
+            partManager.FeatureProviders.Add(new ViewsFeatureProvider());
             var feature = new ViewsFeature();
 
             // Act
-            applicationPartManager.PopulateFeature(feature);
+            partManager.PopulateFeature(feature);
 
             // Assert
             Assert.Empty(feature.ViewDescriptors);
         }
+
 
         [Fact]
         public void PopulateFeature_DoesNotFail_IfAssemblyHasEmptyLocation()
         {
             // Arrange
             var assembly = new AssemblyWithEmptyLocation();
-            var applicationPartManager = new ApplicationPartManager();
-            applicationPartManager.ApplicationParts.Add(new AssemblyPart(assembly));
-            applicationPartManager.FeatureProviders.Add(new ViewsFeatureProvider());
+            var partManager = new ApplicationPartManager();
+            partManager.ApplicationParts.Add(new AssemblyPart(assembly));
+            partManager.FeatureProviders.Add(new ViewsFeatureProvider());
             var feature = new ViewsFeature();
 
             // Act
-            applicationPartManager.PopulateFeature(feature);
+            partManager.PopulateFeature(feature);
 
             // Assert
             Assert.Empty(feature.ViewDescriptors);
         }
 
+        private class TestRazorCompiledItem : RazorCompiledItem
+        {
+            public TestRazorCompiledItem(Type type, string kind, string identifier, object[] metadata)
+            {
+                Type = type;
+                Kind = kind;
+                Identifier = identifier;
+                Metadata = metadata;
+            }
+
+            public override string Identifier { get; }
+
+            public override string Kind { get; }
+
+            public override IReadOnlyList<object> Metadata { get; }
+
+            public override Type Type { get; }
+        }
+
         private class TestableViewsFeatureProvider : ViewsFeatureProvider
         {
-            private readonly Dictionary<AssemblyPart, IEnumerable<RazorViewAttribute>> _attributeLookup;
+            private readonly Dictionary<AssemblyPart, IEnumerable<RazorViewAttribute>> _attributes;
+            private readonly Dictionary<AssemblyPart, IReadOnlyList<RazorCompiledItem>> _items;
 
-            public TestableViewsFeatureProvider(Dictionary<AssemblyPart, IEnumerable<RazorViewAttribute>> attributeLookup)
+            public TestableViewsFeatureProvider(
+                Dictionary<AssemblyPart, IReadOnlyList<RazorCompiledItem>> items,
+                Dictionary<AssemblyPart, IEnumerable<RazorViewAttribute>> attributes)
             {
-                _attributeLookup = attributeLookup;
+                _items = items;
+                _attributes = attributes;
             }
 
             protected override IEnumerable<RazorViewAttribute> GetViewAttributes(AssemblyPart assemblyPart)
             {
-                return _attributeLookup[assemblyPart];
+                if (_attributes == null)
+                {
+                    throw new InvalidOperationException("This shouldn't be called.");
+                }
+
+                return _attributes[assemblyPart];
+            }
+
+            protected override IReadOnlyList<RazorCompiledItem> LoadItems(AssemblyPart assemblyPart)
+            {
+                if (_items == null)
+                {
+                    throw new InvalidOperationException("This shouldn't be called.");
+                }
+
+                return _items[assemblyPart];
             }
         }
 


### PR DESCRIPTION
This change hooks up the new default Razor metadata to MVC so we can
start consuming it. This is the first step towards processing checksums
in MVC.