### PR TITLE
Generate full pdb when running in net461

### DIFF
--- a/test/WebSites/ErrorPageMiddlewareWebSite/ErrorPageMiddlewareWebSite.csproj
+++ b/test/WebSites/ErrorPageMiddlewareWebSite/ErrorPageMiddlewareWebSite.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(StandardTestWebsiteTfms)</TargetFrameworks>
+    <DebugType Condition="'$(TargetFramework)' == 'net461'">full</DebugType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#7201 

Looks like portable pdbs can't be read by machines where net471 is not installed.

FYI @ryanbrandenburg  @mkArtakMSFT 