### PR TITLE
Discover assembly parts for Microsoft.AspnetCore.All

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/DefaultAssemblyPartDiscoveryProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/DefaultAssemblyPartDiscoveryProvider.cs
@@ -16,6 +16,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
     {
         internal static HashSet<string> ReferenceAssemblies { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
+            "Microsoft.AspNetCore.All",
             "Microsoft.AspNetCore.Mvc",
             "Microsoft.AspNetCore.Mvc.Abstractions",
             "Microsoft.AspNetCore.Mvc.ApiExplorer",

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/DefaultAssemblyPartDiscoveryProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/DefaultAssemblyPartDiscoveryProviderTest.cs
@@ -245,6 +245,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             {
                 // The following assemblies are not reachable from Microsoft.AspNetCore.Mvc
                 "Microsoft.AspNetCore.Mvc.Formatters.Xml",
+                "Microsoft.AspnetCore.All",
             };
 
             var dependencyContextLibraries = DependencyContext.Load(CurrentAssembly)


### PR DESCRIPTION
To split our shared frameworks into Microsoft.AspNetCore.App and Microsoft.AspnetCore.All we will need to update MVC to consider any assembly that reference .All as a candidate for containing controllers. The reason we need to make this change is that references to MVC assemblies are contained in .App. When generating the .All shared framework, dotnet sdk trims shared framework dependencies (in this case, the dependency is the .App package) from the .deps.json file of the .All shared framework so the link between .All and MVC assemblies is not maintained. This is the expected behaviour for dotnet so we need to update MVC to take this into account.