### PR TITLE
Add page action executor provider.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/DependencyInjection/MvcRazorPagesMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/DependencyInjection/MvcRazorPagesMvcCoreBuilderExtensions.cs
@@ -110,8 +110,8 @@ namespace Microsoft.Extensions.DependencyInjection
             // Page and Page model creation and activation
             services.TryAddSingleton<IPageModelActivatorProvider, DefaultPageModelActivatorProvider>();
             services.TryAddSingleton<IPageModelFactoryProvider, DefaultPageModelFactoryProvider>();
-
             services.TryAddSingleton<IPageActivatorProvider, DefaultPageActivatorProvider>();
+            services.TryAddSingleton<IPageActionExectuorProvider, DefaultPageActionExectuorProvider>();
             services.TryAddSingleton<IPageFactoryProvider, DefaultPageFactoryProvider>();
 
             services.TryAddSingleton<IPageLoader, DefaultPageLoader>();

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/IPageActionExectuorProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/IPageActionExectuorProvider.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Mvc.RazorPages
+{
+    /// <summary>
+    /// Provides methods for get or creation page executors of Razor pages.
+    /// </summary>
+    public interface IPageActionExectuorProvider
+    {
+        /// <summary>
+        /// Get executors of <paramref name="actionDescriptor"/>.
+        /// </summary>
+        /// <param name="actionDescriptor">The <see cref="CompiledPageActionDescriptor"/>.</param>
+        /// <returns>The page action executors.</returns>
+        Func<object, object[], Task<IActionResult>>[] GetExecutors(CompiledPageActionDescriptor actionDescriptor);
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/DefaultPageActionExectuorProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/DefaultPageActionExectuorProvider.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+
+namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
+{
+    class DefaultPageActionExectuorProvider : IPageActionExectuorProvider
+    {
+        public Func<object, object[], Task<IActionResult>>[] GetExecutors(CompiledPageActionDescriptor actionDescriptor)
+        {
+
+            if(actionDescriptor.HandlerMethods == null || actionDescriptor.HandlerMethods.Count == 0)
+            {
+                return Array.Empty<Func<object, object[], Task<IActionResult>>>();
+            }
+
+            var results = new Func<object, object[], Task<IActionResult>>[actionDescriptor.HandlerMethods.Count];
+
+            for(var i = 0; i < actionDescriptor.HandlerMethods.Count; i++)
+            {
+                results[i] = ExecutorFactory.CreateExecutor(actionDescriptor.HandlerMethods[i]);
+            }
+
+            return results;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/PageActionInvokerProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/PageActionInvokerProvider.cs
@@ -28,6 +28,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 
         private readonly IPageLoader _loader;
         private readonly IPageFactoryProvider _pageFactoryProvider;
+        private readonly IPageActionExectuorProvider _pageActionExecutorProvider;
         private readonly IPageModelFactoryProvider _modelFactoryProvider;
         private readonly IRazorPageFactoryProvider _razorPageFactoryProvider;
         private readonly IActionDescriptorCollectionProvider _collectionProvider;
@@ -187,7 +188,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 
             var viewStartFactories = GetViewStartFactories(compiledActionDescriptor);
 
-            var executors = GetExecutors(compiledActionDescriptor);
+            var executors = _pageActionExecutorProvider.GetExecutors(compiledActionDescriptor);
 
             return new PageActionInvokerCacheEntry(
                 compiledActionDescriptor,
@@ -220,23 +221,6 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             }
 
             return viewStartFactories;
-        }
-
-        private static Func<object, object[], Task<IActionResult>>[] GetExecutors(CompiledPageActionDescriptor actionDescriptor)
-        {
-            if (actionDescriptor.HandlerMethods == null || actionDescriptor.HandlerMethods.Count == 0)
-            {
-                return Array.Empty<Func<object, object[], Task<IActionResult>>>();
-            }
-
-            var results = new Func<object, object[], Task<IActionResult>>[actionDescriptor.HandlerMethods.Count];
-
-            for (var i = 0; i < actionDescriptor.HandlerMethods.Count; i++)
-            {
-                results[i] = ExecutorFactory.CreateExecutor(actionDescriptor.HandlerMethods[i]);
-            }
-
-            return results;
         }
 
         internal class InnerCache


### PR DESCRIPTION
Support any object return type of Razor pages  handler method.
Like:
```csharp
private static Func<object, object[], Task<IActionResult>> CreateExecutor(HandlerMethodDescriptor handlerDescriptor)
{
    var method = handlerDescriptor.MethodInfo;
    var returnType = method.ReturnType;
    var isGTask = returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(Task<>);
    if(returnType == typeof(void)
        || returnType == typeof(Task)
        || typeof(IActionResult).IsAssignableFrom(returnType)
        || (isGTask && typeof(IActionResult).IsAssignableFrom(returnType.GetGenericArguments()[0])))
    {
        return ExecutorFactory.CreateExecutor(handlerDescriptor);
    }

    if(isGTask)
    {
        return new GenericTaskHandlerMethod(handlerDescriptor.Parameters.ToArray(), method).Execute;

    }
    else
    {
        return new ActionResultHandlerMethod(handlerDescriptor.Parameters.ToArray(), method).Execute;
    }

}        
```