### PR TITLE
TextOutputFormatter reads AcceptCharset header not using TypedHeaders

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Formatters/TextOutputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Formatters/TextOutputFormatter.cs
@@ -173,7 +173,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 return result;
             }
 
-            return null;
+            return Array.Empty<StringWithQualityHeaderValue>();
         }
 
         private string GetMediaTypeWithCharset(string mediaType, Encoding encoding)

--- a/src/Microsoft.AspNetCore.Mvc.Core/Formatters/TextOutputFormatter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Formatters/TextOutputFormatter.cs
@@ -76,8 +76,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 throw new InvalidOperationException(message);
             }
 
-            var request = context.HttpContext.Request;
-            var encoding = MatchAcceptCharacterEncoding(request.GetTypedHeaders().AcceptCharset);
+            var acceptCharsetHeaderValues = GetAcceptCharsetHeaderValues(context);
+            var encoding = MatchAcceptCharacterEncoding(acceptCharsetHeaderValues);
             if (encoding != null)
             {
                 return encoding;
@@ -164,6 +164,17 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         /// <param name="selectedEncoding">The <see cref="Encoding"/> that should be used to write the response.</param>
         /// <returns>A task which can write the response body.</returns>
         public abstract Task WriteResponseBodyAsync(OutputFormatterWriteContext context, Encoding selectedEncoding);
+
+        internal static IList<StringWithQualityHeaderValue> GetAcceptCharsetHeaderValues(OutputFormatterWriteContext context)
+        {
+            var request = context.HttpContext.Request;
+            if (StringWithQualityHeaderValue.TryParseList(request.Headers[HeaderNames.AcceptCharset], out IList<StringWithQualityHeaderValue> result))
+            {
+                return result;
+            }
+
+            return null;
+        }
 
         private string GetMediaTypeWithCharset(string mediaType, Encoding encoding)
         {

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/TextOutputFormatterTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/TextOutputFormatterTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -231,6 +232,30 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
             // Assert
             Assert.Equal(StatusCodes.Status406NotAcceptable, context.HttpContext.Response.StatusCode);
+        }
+
+        [Fact]
+        public void GetAcceptCharsetHeaderValues_Succeeds()
+        {
+            // Arrange
+            const string testCharsetValue = "fakeValue";
+
+            var formatter = new OverrideEncodingFormatter(encoding: null);
+            var context = new DefaultHttpContext();
+            context.Request.Headers[HeaderNames.AcceptCharset] = testCharsetValue;
+
+            var writerContext = new OutputFormatterWriteContext(
+                context,
+                new TestHttpResponseStreamWriterFactory().CreateWriter,
+                objectType: null,
+                @object: null);
+
+            // Act
+            var result = TextOutputFormatter.GetAcceptCharsetHeaderValues(writerContext);
+
+            //Assert
+            Assert.Equal(1, result.Count);
+            Assert.Equal(testCharsetValue, result.Single().Value);
         }
 
         private class TestOutputFormatter : TextOutputFormatter

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/TextOutputFormatterTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Formatters/TextOutputFormatterTests.cs
@@ -235,14 +235,14 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         }
 
         [Fact]
-        public void GetAcceptCharsetHeaderValues_Succeeds()
+        public void GetAcceptCharsetHeaderValues_ReadsHeaderAndParsesValues()
         {
             // Arrange
-            const string testCharsetValue = "fakeValue";
+            const string expectedValue = "expected";
 
             var formatter = new OverrideEncodingFormatter(encoding: null);
             var context = new DefaultHttpContext();
-            context.Request.Headers[HeaderNames.AcceptCharset] = testCharsetValue;
+            context.Request.Headers[HeaderNames.AcceptCharset] = expectedValue;
 
             var writerContext = new OutputFormatterWriteContext(
                 context,
@@ -254,8 +254,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             var result = TextOutputFormatter.GetAcceptCharsetHeaderValues(writerContext);
 
             //Assert
-            Assert.Equal(1, result.Count);
-            Assert.Equal(testCharsetValue, result.Single().Value);
+            Assert.Equal(expectedValue, Assert.Single(result).Value.Value);
         }
 
         private class TestOutputFormatter : TextOutputFormatter


### PR DESCRIPTION
This PR addresses: https://github.com/aspnet/Mvc/pull/7322.
This approach avoid instantiation of the RequestHeaders type.

@rynowak, please let me know whether this is the type of fix you were looking for.