### PR TITLE
Move to RazorProjectEngine.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor/DependencyInjection/MvcRazorMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/DependencyInjection/MvcRazorMvcCoreBuilderExtensions.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
+using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.Mvc.Razor.Compilation;
@@ -14,7 +16,10 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using CompilationTagHelperFeature = Microsoft.CodeAnalysis.Razor.CompilationTagHelperFeature;
+using DefaultTagHelperDescriptorProvider = Microsoft.CodeAnalysis.Razor.DefaultTagHelperDescriptorProvider;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -141,7 +146,19 @@ namespace Microsoft.Extensions.DependencyInjection
                 IRazorViewEngineFileProviderAccessor,
                 DefaultRazorViewEngineFileProviderAccessor>();
 
-            services.TryAddSingleton<IRazorViewEngine, RazorViewEngine>();
+            services.TryAddSingleton<IRazorViewEngine>(s =>
+            {
+                var pageFactory = s.GetRequiredService<IRazorPageFactoryProvider>();
+                var pageActivator = s.GetRequiredService<IRazorPageActivator>();
+                var htmlEncoder = s.GetRequiredService<HtmlEncoder>();
+                var optionsAccessor = s.GetRequiredService<IOptions<RazorViewEngineOptions>>();
+                var razorFileSystem = s.GetRequiredService<RazorProjectFileSystem>();
+                var loggerFactory = s.GetRequiredService<ILoggerFactory>();
+                var diagnosticSource = s.GetRequiredService<DiagnosticSource>();
+
+                var viewEngine = new RazorViewEngine(pageFactory, pageActivator, htmlEncoder, optionsAccessor, razorFileSystem, loggerFactory, diagnosticSource);
+                return viewEngine;
+            });
             services.TryAddSingleton<IViewCompilerProvider, RazorViewCompilerProvider>();
 
             // In the default scenario the following services are singleton by virtue of being initialized as part of
@@ -151,26 +168,32 @@ namespace Microsoft.Extensions.DependencyInjection
             //
             // Razor compilation infrastructure
             //
-            services.TryAddSingleton<RazorProject, FileProviderRazorProject>();
-            services.TryAddSingleton<RazorTemplateEngine, MvcRazorTemplateEngine>();
             services.TryAddSingleton<LazyMetadataReferenceFeature>();
-
+            services.TryAddSingleton<RazorProjectFileSystem, FileProviderRazorProjectFileSystem>();
             services.TryAddSingleton(s =>
             {
-                return RazorEngine.Create(b =>
+                var fileSystem = s.GetRequiredService<RazorProjectFileSystem>();
+                var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, fileSystem, builder =>
                 {
-                    RazorExtensions.Register(b);
+                    RazorExtensions.Register(builder);
 
                     // Roslyn + TagHelpers infrastructure
                     var metadataReferenceFeature = s.GetRequiredService<LazyMetadataReferenceFeature>();
-                    b.Features.Add(metadataReferenceFeature);
-                    b.Features.Add(new Microsoft.CodeAnalysis.Razor.CompilationTagHelperFeature());
+                    builder.Features.Add(metadataReferenceFeature);
+                    builder.Features.Add(new CompilationTagHelperFeature());
 
                     // TagHelperDescriptorProviders (actually do tag helper discovery)
-                    b.Features.Add(new Microsoft.CodeAnalysis.Razor.DefaultTagHelperDescriptorProvider());
-                    b.Features.Add(new ViewComponentTagHelperDescriptorProvider());
+                    builder.Features.Add(new DefaultTagHelperDescriptorProvider());
+                    builder.Features.Add(new ViewComponentTagHelperDescriptorProvider());
                 });
+
+                return projectEngine;
             });
+
+            // Legacy Razor compilation services
+            services.TryAddSingleton<RazorProject>(s => s.GetRequiredService<RazorProjectEngine>().FileSystem);
+            services.TryAddSingleton<RazorTemplateEngine, MvcRazorTemplateEngine>();
+            services.TryAddSingleton(s => s.GetRequiredService<RazorProjectEngine>().Engine);
 
             // This caches Razor page activation details that are valid for the lifetime of the application.
             services.TryAddSingleton<IRazorPageActivator, RazorPageActivator>();

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/ChecksumValidator.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/ChecksumValidator.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
         // Validates that we can use an existing precompiled view by comparing checksums with files on
         // disk.
-        public static bool IsItemValid(RazorProject project, RazorCompiledItem item)
+        public static bool IsItemValid(RazorProjectFileSystem project, RazorCompiledItem item)
         {
             if (project == null)
             {

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/FileProviderRazorProject.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/FileProviderRazorProject.cs
@@ -10,13 +10,13 @@ using Microsoft.Extensions.FileProviders;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 {
-    public class FileProviderRazorProject : RazorProject
+    public class FileProviderRazorProjectFileSystem : RazorProjectFileSystem
     {
         private const string RazorFileExtension = ".cshtml";
         private readonly IFileProvider _provider;
         private readonly IHostingEnvironment _hostingEnvironment;
 
-        public FileProviderRazorProject(IRazorViewEngineFileProviderAccessor accessor, IHostingEnvironment hostingEnviroment)
+        public FileProviderRazorProjectFileSystem(IRazorViewEngineFileProviderAccessor accessor, IHostingEnvironment hostingEnviroment)
         {
             if (accessor == null)
             {

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/RazorViewCompilerProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/RazorViewCompilerProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 {
     public class RazorViewCompilerProvider : IViewCompilerProvider
     {
-        private readonly RazorTemplateEngine _razorTemplateEngine;
+        private readonly RazorProjectEngine _razorProjectEngine;
         private readonly ApplicationPartManager _applicationPartManager;
         private readonly IRazorViewEngineFileProviderAccessor _fileProviderAccessor;
         private readonly CSharpCompiler _csharpCompiler;
@@ -28,14 +28,14 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
         public RazorViewCompilerProvider(
             ApplicationPartManager applicationPartManager,
-            RazorTemplateEngine razorTemplateEngine,
+            RazorProjectEngine razorProjectEngine,
             IRazorViewEngineFileProviderAccessor fileProviderAccessor,
             CSharpCompiler csharpCompiler,
             IOptions<RazorViewEngineOptions> viewEngineOptionsAccessor,
             ILoggerFactory loggerFactory)
         {
             _applicationPartManager = applicationPartManager;
-            _razorTemplateEngine = razorTemplateEngine;
+            _razorProjectEngine = razorProjectEngine;
             _fileProviderAccessor = fileProviderAccessor;
             _csharpCompiler = csharpCompiler;
             _viewEngineOptions = viewEngineOptionsAccessor.Value;
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             return new RazorViewCompiler(
                 _fileProviderAccessor.FileProvider,
-                _razorTemplateEngine,
+                _razorProjectEngine,
                 _csharpCompiler,
                 _viewEngineOptions.CompilationCallback,
                 feature.ViewDescriptors,

--- a/src/Microsoft.AspNetCore.Mvc.Razor/RazorViewEngine.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/RazorViewEngine.cs
@@ -43,12 +43,13 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         private readonly HtmlEncoder _htmlEncoder;
         private readonly ILogger _logger;
         private readonly RazorViewEngineOptions _options;
-        private readonly RazorProject _razorProject;
+        private readonly RazorProject _razorFileSystem;
         private readonly DiagnosticSource _diagnosticSource;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RazorViewEngine" />.
         /// </summary>
+        [Obsolete("This constructor is obsolete and will be removed in a future version.")]
         public RazorViewEngine(
             IRazorPageFactoryProvider pageFactory,
             IRazorPageActivator pageActivator,
@@ -78,9 +79,26 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             _pageActivator = pageActivator;
             _htmlEncoder = htmlEncoder;
             _logger = loggerFactory.CreateLogger<RazorViewEngine>();
-            _razorProject = razorProject;
+            _razorFileSystem = razorProject;
             _diagnosticSource = diagnosticSource;
             ViewLookupCache = new MemoryCache(new MemoryCacheOptions());
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the RazorViewEngine
+        /// </summary>
+        public RazorViewEngine(
+            IRazorPageFactoryProvider pageFactory,
+            IRazorPageActivator pageActivator,
+            HtmlEncoder htmlEncoder,
+            IOptions<RazorViewEngineOptions> optionsAccessor,
+            RazorProjectFileSystem razorFileSystem,
+            ILoggerFactory loggerFactory,
+            DiagnosticSource diagnosticSource)
+#pragma warning disable CS0618 // Type or member is obsolete
+            : this (pageFactory, pageActivator, htmlEncoder, optionsAccessor, (RazorProject)razorFileSystem, loggerFactory, diagnosticSource)
+#pragma warning restore CS0618 // Type or member is obsolete
+        {
         }
 
         /// <summary>
@@ -441,7 +459,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         {
             var viewStartPages = new List<ViewLocationCacheItem>();
 
-            foreach (var viewStartProjectItem in _razorProject.FindHierarchicalItems(path, ViewStartFileName))
+            foreach (var viewStartProjectItem in _razorFileSystem.FindHierarchicalItems(path, ViewStartFileName))
             {
                 var result = _pageFactory.CreateFactory(viewStartProjectItem.FilePath);
                 var viewDescriptor = result.ViewDescriptor;

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/CompiledPageRouteModelProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/CompiledPageRouteModelProvider.cs
@@ -19,20 +19,20 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
     {
         private readonly ApplicationPartManager _applicationManager;
         private readonly RazorPagesOptions _pagesOptions;
-        private readonly RazorTemplateEngine _templateEngine;
+        private readonly RazorProjectEngine _razorProjectEngine;
         private readonly ILogger<CompiledPageRouteModelProvider> _logger;
         private readonly PageRouteModelFactory _routeModelFactory;
 
         public CompiledPageRouteModelProvider(
             ApplicationPartManager applicationManager,
             IOptions<RazorPagesOptions> pagesOptionsAccessor,
-            RazorTemplateEngine templateEngine,
+            RazorProjectEngine razorProjectEngine,
             ILogger<CompiledPageRouteModelProvider> logger)
         {
             _applicationManager = applicationManager ?? throw new ArgumentNullException(nameof(applicationManager));
             _pagesOptions = pagesOptionsAccessor?.Value ?? throw new ArgumentNullException(nameof(pagesOptionsAccessor));
-            _templateEngine = templateEngine ?? throw new ArgumentNullException(nameof(templateEngine));
-            _logger = logger ?? throw new ArgumentNullException(nameof(templateEngine));
+            _razorProjectEngine = razorProjectEngine ?? throw new ArgumentNullException(nameof(razorProjectEngine));
+            _logger = logger ?? throw new ArgumentNullException(nameof(razorProjectEngine));
             _routeModelFactory = new PageRouteModelFactory(_pagesOptions, _logger);
         }
 
@@ -90,7 +90,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 
             foreach (var viewDescriptor in GetViewDescriptors(_applicationManager))
             {
-                if (viewDescriptor.Item != null && !ChecksumValidator.IsItemValid(_templateEngine.Project, viewDescriptor.Item))
+                if (viewDescriptor.Item != null && !ChecksumValidator.IsItemValid(_razorProjectEngine.FileSystem, viewDescriptor.Item))
                 {
                     // If we get here, this compiled Page has different local content, so ignore it.
                     continue;

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/PageActionInvokerProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/PageActionInvokerProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
         private readonly ITempDataDictionaryFactory _tempDataFactory;
         private readonly HtmlHelperOptions _htmlHelperOptions;
         private readonly IPageHandlerMethodSelector _selector;
-        private readonly RazorProject _razorProject;
+        private readonly RazorProjectFileSystem _razorFileSystem;
         private readonly DiagnosticSource _diagnosticSource;
         private readonly ILogger<PageActionInvoker> _logger;
         private volatile InnerCache _currentCache;
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             IOptions<MvcOptions> mvcOptions,
             IOptions<HtmlHelperOptions> htmlHelperOptions,
             IPageHandlerMethodSelector selector,
-            RazorProject razorProject,
+            RazorProjectFileSystem razorFileSystem,
             DiagnosticSource diagnosticSource,
             ILoggerFactory loggerFactory)
         {
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             _tempDataFactory = tempDataFactory;
             _htmlHelperOptions = htmlHelperOptions.Value;
             _selector = selector;
-            _razorProject = razorProject;
+            _razorFileSystem = razorFileSystem;
             _diagnosticSource = diagnosticSource;
             _logger = loggerFactory.CreateLogger<PageActionInvoker>();
         }
@@ -213,7 +213,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
         {
             var viewStartFactories = new List<Func<IRazorPage>>();
             // Always pick up all _ViewStarts, including the ones outside the Pages root.
-            var viewStartItems = _razorProject.FindHierarchicalItems(
+            var viewStartItems = _razorFileSystem.FindHierarchicalItems(
                 descriptor.RelativePath,
                 ViewStartFileName);
             foreach (var item in viewStartItems)

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/RazorProjectPageRouteModelProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/RazorProjectPageRouteModelProvider.cs
@@ -13,17 +13,17 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 {
     public class RazorProjectPageRouteModelProvider : IPageRouteModelProvider
     {
-        private readonly RazorProject _project;
+        private readonly RazorProjectFileSystem _razorFileSystem;
         private readonly RazorPagesOptions _pagesOptions;
         private readonly PageRouteModelFactory _routeModelFactory;
         private readonly ILogger<RazorProjectPageRouteModelProvider> _logger;
 
         public RazorProjectPageRouteModelProvider(
-            RazorProject razorProject,
+            RazorProjectFileSystem razorFileSystem,
             IOptions<RazorPagesOptions> pagesOptionsAccessor,
             ILoggerFactory loggerFactory)
         {
-            _project = razorProject;
+            _razorFileSystem = razorFileSystem;
             _pagesOptions = pagesOptionsAccessor.Value;
             _logger = loggerFactory.CreateLogger<RazorProjectPageRouteModelProvider>();
             _routeModelFactory = new PageRouteModelFactory(_pagesOptions, _logger);
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                 normalizedAreaRootDirectory += "/";
             }
 
-            foreach (var item in _project.EnumerateItems(_pagesOptions.RootDirectory))
+            foreach (var item in _razorFileSystem.EnumerateItems(_pagesOptions.RootDirectory))
             {
                 if (!IsRouteable(item))
                 {
@@ -102,7 +102,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 
         private void AddAreaPageModels(PageRouteModelProviderContext context)
         {
-            foreach (var item in _project.EnumerateItems(_pagesOptions.AreaRootDirectory))
+            foreach (var item in _razorFileSystem.EnumerateItems(_pagesOptions.AreaRootDirectory))
             {
                 if (!IsRouteable(item))
                 {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/ChecksumValidatorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/ChecksumValidatorTest.cs
@@ -15,12 +15,12 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
         public ChecksumValidatorTest()
         {
             FileProvider = new TestFileProvider();
-            Project = new FileProviderRazorProject(
+            FileSystem = new FileProviderRazorProjectFileSystem(
                 Mock.Of<IRazorViewEngineFileProviderAccessor>(a => a.FileProvider == FileProvider),
                 Mock.Of<IHostingEnvironment>(e => e.ContentRootPath == "BasePath"));
         }
 
-        public RazorProject Project { get; }
+        public RazorProjectFileSystem FileSystem { get; }
 
         public TestFileProvider FileProvider { get; }
 
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var item = new TestRazorCompiledItem(typeof(string), "mvc.1.0.view", "/Views/Home/Index.cstml", new object[] { });
 
             // Act
-            var result = ChecksumValidator.IsItemValid(Project, item);
+            var result = ChecksumValidator.IsItemValid(FileSystem, item);
 
             // Assert
             Assert.True(result);
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             });
 
             // Act
-            var result = ChecksumValidator.IsItemValid(Project, item);
+            var result = ChecksumValidator.IsItemValid(FileSystem, item);
 
             // Assert
             Assert.True(result);
@@ -113,7 +113,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             FileProvider.AddFile("/Views/Home/_ViewImports.cstml", "dkdkfkdf"); // This will be ignored
 
             // Act
-            var result = ChecksumValidator.IsItemValid(Project, item);
+            var result = ChecksumValidator.IsItemValid(FileSystem, item);
 
             // Assert
             Assert.True(result);
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             FileProvider.AddFile("/Views/Home/Index.cstml", "other content");
 
             // Act
-            var result = ChecksumValidator.IsItemValid(Project, item);
+            var result = ChecksumValidator.IsItemValid(FileSystem, item);
 
             // Assert
             Assert.False(result);
@@ -151,7 +151,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             FileProvider.AddFile("/Views/Home/Index.cstml", "some content");
 
             // Act
-            var result = ChecksumValidator.IsItemValid(Project, item);
+            var result = ChecksumValidator.IsItemValid(FileSystem, item);
 
             // Assert
             Assert.False(result);
@@ -171,7 +171,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             FileProvider.AddFile("/Views/Home/_ViewImports.cstml", "some other import");
 
             // Act
-            var result = ChecksumValidator.IsItemValid(Project, item);
+            var result = ChecksumValidator.IsItemValid(FileSystem, item);
 
             // Assert
             Assert.False(result);
@@ -193,7 +193,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             FileProvider.AddFile("/Views/_ViewImports.cstml", "some other import");
 
             // Act
-            var result = ChecksumValidator.IsItemValid(Project, item);
+            var result = ChecksumValidator.IsItemValid(FileSystem, item);
 
             // Assert
             Assert.True(result);

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/CompilerFailedExceptionFactoryTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/CompilerFailedExceptionFactoryTest.cs
@@ -28,9 +28,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             fileProvider.AddFile(viewPath, "<span name=\"@(User.Id\">");
             var accessor = Mock.Of<IRazorViewEngineFileProviderAccessor>(a => a.FileProvider == fileProvider);
 
-            var razorProject = new FileProviderRazorProject(accessor, _hostingEnvironment);
+            var fileSystem = new FileProviderRazorProjectFileSystem(accessor, _hostingEnvironment);
 
-            var templateEngine = new MvcRazorTemplateEngine(razorEngine, razorProject);
+            var templateEngine = new MvcRazorTemplateEngine(razorEngine, fileSystem);
             var codeDocument = templateEngine.CreateCodeDocument(viewPath);
 
             // Act
@@ -62,8 +62,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var accessor = Mock.Of<IRazorViewEngineFileProviderAccessor>(a => a.FileProvider == fileProvider);
 
             var razorEngine = RazorEngine.Create();
-            var razorProject = new FileProviderRazorProject(accessor, _hostingEnvironment);
-            var templateEngine = new MvcRazorTemplateEngine(razorEngine, razorProject);
+            var fileSystem = new FileProviderRazorProjectFileSystem(accessor, _hostingEnvironment);
+            var templateEngine = new MvcRazorTemplateEngine(razorEngine, fileSystem);
 
             var codeDocument = templateEngine.CreateCodeDocument(viewPath);
 
@@ -94,8 +94,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             fileProvider.AddFile(viewPath, fileContent);
             var accessor = Mock.Of<IRazorViewEngineFileProviderAccessor>(a => a.FileProvider == fileProvider);
 
-            var razorProject = new FileProviderRazorProject(accessor, _hostingEnvironment);
-            var templateEngine = new MvcRazorTemplateEngine(razorEngine, razorProject);
+            var fileSystem = new FileProviderRazorProjectFileSystem(accessor, _hostingEnvironment);
+            var templateEngine = new MvcRazorTemplateEngine(razorEngine, fileSystem);
 
             var codeDocument = templateEngine.CreateCodeDocument(viewPath);
 
@@ -124,8 +124,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             var accessor = Mock.Of<IRazorViewEngineFileProviderAccessor>(a => a.FileProvider == fileProvider);
 
             var razorEngine = RazorEngine.Create();
-            var razorProject = new FileProviderRazorProject(accessor, _hostingEnvironment);
-            var templateEngine = new MvcRazorTemplateEngine(razorEngine, razorProject)
+            var fileSystem = new FileProviderRazorProjectFileSystem(accessor, _hostingEnvironment);
+            var templateEngine = new MvcRazorTemplateEngine(razorEngine, fileSystem)
             {
                 Options =
                 {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/FileProviderRazorProjectFileSystemTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/FileProviderRazorProjectFileSystemTest.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 {
-    public class FileProviderRazorProjectTest
+    public class FileProviderRazorProjectFileSystemTest
     {
         [Fact]
         public void EnumerateFiles_ReturnsEmptySequenceIfNoCshtmlFilesArePresent()
@@ -23,10 +23,10 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             var accessor = Mock.Of<IRazorViewEngineFileProviderAccessor>(a => a.FileProvider == fileProvider);
 
-            var razorProject = new FileProviderRazorProject(accessor, Mock.Of<IHostingEnvironment>(e => e.ContentRootPath == "BasePath"));
+            var fileSystem = new FileProviderRazorProjectFileSystem(accessor, Mock.Of<IHostingEnvironment>(e => e.ContentRootPath == "BasePath"));
 
             // Act
-            var razorFiles = razorProject.EnumerateItems("/");
+            var razorFiles = fileSystem.EnumerateItems("/");
 
             // Assert
             Assert.Empty(razorFiles);
@@ -44,10 +44,10 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             var accessor = Mock.Of<IRazorViewEngineFileProviderAccessor>(a => a.FileProvider == fileProvider);
 
-            var razorProject = new FileProviderRazorProject(accessor, Mock.Of<IHostingEnvironment>(e => e.ContentRootPath == "BasePath"));
+            var fileSystem = new FileProviderRazorProjectFileSystem(accessor, Mock.Of<IHostingEnvironment>(e => e.ContentRootPath == "BasePath"));
 
             // Act
-            var razorFiles = razorProject.EnumerateItems("/");
+            var razorFiles = fileSystem.EnumerateItems("/");
 
             // Assert
             Assert.Collection(
@@ -98,10 +98,10 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             var accessor = Mock.Of<IRazorViewEngineFileProviderAccessor>(a => a.FileProvider == fileProvider);
 
-            var razorProject = new FileProviderRazorProject(accessor, Mock.Of<IHostingEnvironment>(e => e.ContentRootPath == "BasePath"));
+            var fileSystem = new FileProviderRazorProjectFileSystem(accessor, Mock.Of<IHostingEnvironment>(e => e.ContentRootPath == "BasePath"));
 
             // Act
-            var razorFiles = razorProject.EnumerateItems("/");
+            var razorFiles = fileSystem.EnumerateItems("/");
 
             // Assert
             Assert.Collection(razorFiles.OrderBy(f => f.FilePath),
@@ -165,10 +165,10 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             var accessor = Mock.Of<IRazorViewEngineFileProviderAccessor>(a => a.FileProvider == fileProvider);
 
-            var razorProject = new FileProviderRazorProject(accessor, Mock.Of<IHostingEnvironment>(e => e.ContentRootPath == "BasePath"));
+            var fileSystem = new FileProviderRazorProjectFileSystem(accessor, Mock.Of<IHostingEnvironment>(e => e.ContentRootPath == "BasePath"));
 
             // Act
-            var razorFiles = razorProject.EnumerateItems("/Level1-Dir1");
+            var razorFiles = fileSystem.EnumerateItems("/Level1-Dir1");
 
             // Assert
             Assert.Collection(razorFiles.OrderBy(f => f.FilePath),
@@ -199,10 +199,10 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             var accessor = Mock.Of<IRazorViewEngineFileProviderAccessor>(a => a.FileProvider == fileProvider);
 
-            var razorProject = new FileProviderRazorProject(accessor, Mock.Of<IHostingEnvironment>(e => e.ContentRootPath == "BasePath"));
+            var fileSystem = new FileProviderRazorProjectFileSystem(accessor, Mock.Of<IHostingEnvironment>(e => e.ContentRootPath == "BasePath"));
 
             // Act
-            var item = razorProject.GetItem("/File3.cshtml");
+            var item = fileSystem.GetItem("/File3.cshtml");
 
             // Assert
             Assert.True(item.Exists);
@@ -223,10 +223,10 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             var accessor = Mock.Of<IRazorViewEngineFileProviderAccessor>(a => a.FileProvider == fileProvider);
 
-            var razorProject = new FileProviderRazorProject(accessor, Mock.Of<IHostingEnvironment>(e => e.ContentRootPath == "BasePath"));
+            var fileSystem = new FileProviderRazorProjectFileSystem(accessor, Mock.Of<IHostingEnvironment>(e => e.ContentRootPath == "BasePath"));
 
             // Act
-            var item = razorProject.GetItem("/File3.cshtml");
+            var item = fileSystem.GetItem("/File3.cshtml");
 
             // Assert
             Assert.True(item.Exists);
@@ -245,10 +245,10 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             fileProvider.AddDirectoryContent("/", new IFileInfo[] { file });
             var accessor = Mock.Of<IRazorViewEngineFileProviderAccessor>(a => a.FileProvider == fileProvider);
 
-            var razorProject = new FileProviderRazorProject(accessor, Mock.Of<IHostingEnvironment>(e => e.ContentRootPath == "BasePath"));
+            var fileSystem = new FileProviderRazorProjectFileSystem(accessor, Mock.Of<IHostingEnvironment>(e => e.ContentRootPath == "BasePath"));
 
             // Act
-            var item = razorProject.GetItem("/NotFound.cshtml");
+            var item = fileSystem.GetItem("/NotFound.cshtml");
 
             // Assert
             Assert.False(item.Exists);

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/RazorViewCompilerProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/RazorViewCompilerProviderTest.cs
@@ -33,9 +33,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
 
             var provider = new RazorViewCompilerProvider(
                 partManager,
-                new RazorTemplateEngine(
-                    RazorEngine.Create(), 
-                    new FileProviderRazorProject(accessor, Mock.Of<IHostingEnvironment>())),
+                RazorProjectEngine.Create(
+                    RazorConfiguration.Default, 
+                    new FileProviderRazorProjectFileSystem(accessor, Mock.Of<IHostingEnvironment>())),
                 accessor,
                 new CSharpCompiler(referenceManager, Mock.Of<IHostingEnvironment>()),
                 options,

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/RazorViewCompilerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/Internal/RazorViewCompilerTest.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Razor.Compilation;
+using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 using Microsoft.AspNetCore.Razor.Hosting;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis;
@@ -79,9 +80,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             Assert.Collection(
                 result.ExpirationTokens,
                 token => Assert.Same(fileProvider.GetChangeToken(path), token),
-                token => Assert.Same(fileProvider.GetChangeToken("/file/exists/_ViewImports.cshtml"), token),
+                token => Assert.Same(fileProvider.GetChangeToken("/_ViewImports.cshtml"), token),
                 token => Assert.Same(fileProvider.GetChangeToken("/file/_ViewImports.cshtml"), token),
-                token => Assert.Same(fileProvider.GetChangeToken("/_ViewImports.cshtml"), token));
+                token => Assert.Same(fileProvider.GetChangeToken("/file/exists/_ViewImports.cshtml"), token));
         }
 
         [Theory]
@@ -822,17 +823,14 @@ this should fail";
             precompiledViews = precompiledViews ?? Array.Empty<CompiledViewDescriptor>();
 
             var hostingEnvironment = Mock.Of<IHostingEnvironment>(e => e.ContentRootPath == "BasePath");
-            var projectSystem = new FileProviderRazorProject(accessor, hostingEnvironment);
-            var templateEngine = new RazorTemplateEngine(RazorEngine.Create(), projectSystem)
+            var fileSystem = new FileProviderRazorProjectFileSystem(accessor, hostingEnvironment);
+            var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, fileSystem, builder =>
             {
-                Options =
-                {
-                    ImportsFileName = "_ViewImports.cshtml",
-                }
-            };
+                RazorExtensions.Register(builder);
+            });
             var viewCompiler = new TestRazorViewCompiler(
                 fileProvider,
-                templateEngine,
+                projectEngine,
                 new CSharpCompiler(referenceManager, hostingEnvironment),
                 compilationCallback,
                 precompiledViews);
@@ -843,12 +841,12 @@ this should fail";
         {
             public TestRazorViewCompiler(
                 TestFileProvider fileProvider,
-                RazorTemplateEngine templateEngine,
+                RazorProjectEngine projectEngine,
                 CSharpCompiler csharpCompiler,
                 Action<RoslynCompilationContext> compilationCallback,
                 IList<CompiledViewDescriptor> precompiledViews,
                 Func<string, CompiledViewDescriptor> compile = null) :
-                base(fileProvider, templateEngine, csharpCompiler, compilationCallback, precompiledViews, NullLogger.Instance)
+                base(fileProvider, projectEngine, csharpCompiler, compilationCallback, precompiledViews, NullLogger.Instance)
             {
                 Compile = compile;
                 if (Compile == null)

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorViewEngineTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorViewEngineTest.cs
@@ -935,8 +935,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor
 
             var fileProvider = new TestFileProvider();
             var accessor = Mock.Of<IRazorViewEngineFileProviderAccessor>(a => a.FileProvider == fileProvider);
-            var razorProject = new FileProviderRazorProject(accessor, Mock.Of<IHostingEnvironment>());
-            var viewEngine = CreateViewEngine(pageFactory.Object, razorProject: razorProject);
+            var fileSystem = new FileProviderRazorProjectFileSystem(accessor, Mock.Of<IHostingEnvironment>());
+            var viewEngine = CreateViewEngine(pageFactory.Object, fileSystem: fileSystem);
             var context = GetActionContext(_controllerTestContext);
 
             // Act 1
@@ -1385,7 +1385,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
                 Mock.Of<IRazorPageActivator>(),
                 new HtmlTestEncoder(),
                 GetOptionsAccessor(expanders: null),
-                new FileProviderRazorProject(
+                new FileProviderRazorProjectFileSystem(
                     Mock.Of<IRazorViewEngineFileProviderAccessor>(a => a.FileProvider == new TestFileProvider()),
                     Mock.Of<IHostingEnvironment>()),
                 loggerFactory,
@@ -1969,15 +1969,15 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         private TestableRazorViewEngine CreateViewEngine(
             IRazorPageFactoryProvider pageFactory = null,
             IEnumerable<IViewLocationExpander> expanders = null,
-            RazorProject razorProject = null)
+            RazorProjectFileSystem fileSystem = null)
         {
             pageFactory = pageFactory ?? Mock.Of<IRazorPageFactoryProvider>();
-            if (razorProject == null)
+            if (fileSystem == null)
             {
                 var accessor = Mock.Of<IRazorViewEngineFileProviderAccessor>(a => a.FileProvider == new TestFileProvider());
-                razorProject = new FileProviderRazorProject(accessor, Mock.Of<IHostingEnvironment>());
+                fileSystem = new FileProviderRazorProjectFileSystem(accessor, Mock.Of<IHostingEnvironment>());
             }
-            return new TestableRazorViewEngine(pageFactory, GetOptionsAccessor(expanders), razorProject);
+            return new TestableRazorViewEngine(pageFactory, GetOptionsAccessor(expanders), fileSystem);
         }
 
         private static IOptions<RazorViewEngineOptions> GetOptionsAccessor(
@@ -2080,7 +2080,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
                 : this(
                       pageFactory,
                       optionsAccessor,
-                      new FileProviderRazorProject(
+                      new FileProviderRazorProjectFileSystem(
                           Mock.Of<IRazorViewEngineFileProviderAccessor>(a => a.FileProvider == new TestFileProvider()),
                           Mock.Of<IHostingEnvironment>()))
             {
@@ -2089,8 +2089,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             public TestableRazorViewEngine(
                 IRazorPageFactoryProvider pageFactory,
                 IOptions<RazorViewEngineOptions> optionsAccessor,
-                RazorProject razorProject)
-                : base(pageFactory, Mock.Of<IRazorPageActivator>(), new HtmlTestEncoder(), optionsAccessor, razorProject, NullLoggerFactory.Instance, new DiagnosticListener("Microsoft.AspNetCore.Mvc.Razor"))
+                RazorProjectFileSystem fileSystem)
+                : base(pageFactory, Mock.Of<IRazorPageActivator>(), new HtmlTestEncoder(), optionsAccessor, fileSystem, NullLoggerFactory.Instance, new DiagnosticListener("Microsoft.AspNetCore.Mvc.Razor"))
             {
             }
 

--- a/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/CompiledPageRouteModelProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/CompiledPageRouteModelProviderTest.cs
@@ -522,15 +522,15 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
         {
             options = options ?? new RazorPagesOptions();
             fileProvider = fileProvider ?? new TestFileProvider();
-            var project = new FileProviderRazorProject(
+            var fileSystem = new FileProviderRazorProjectFileSystem(
                 Mock.Of<IRazorViewEngineFileProviderAccessor>(a => a.FileProvider == fileProvider),
                 Mock.Of<IHostingEnvironment>(e => e.ContentRootPath == "BasePath"));
-            var templateEngine = new RazorTemplateEngine(RazorEngine.Create(), project);
+            var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, fileSystem);
 
             var provider = new TestCompiledPageRouteModelProvider(
                 new ApplicationPartManager(),
                 Options.Create(options),
-                templateEngine,
+                projectEngine,
                 NullLogger<CompiledPageRouteModelProvider>.Instance);
 
             provider.Descriptors.AddRange(descriptors ?? Array.Empty<CompiledViewDescriptor>());
@@ -565,9 +565,9 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             public TestCompiledPageRouteModelProvider(
                 ApplicationPartManager partManager,
                 IOptions<RazorPagesOptions> options,
-                RazorTemplateEngine templateEngine,
+                RazorProjectEngine projectEngine,
                 ILogger<CompiledPageRouteModelProvider> logger)
-                : base(partManager, options, templateEngine, logger)
+                : base(partManager, options, projectEngine, logger)
             {
             }
 

--- a/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/PageActionDescriptorChangeProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/PageActionDescriptorChangeProviderTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 
             var templateEngine = new RazorTemplateEngine(
                 RazorEngine.Create(),
-                new FileProviderRazorProject(accessor, _hostingEnvironment));
+                new FileProviderRazorProjectFileSystem(accessor, _hostingEnvironment));
             var options = Options.Create(new RazorPagesOptions());
             var changeProvider = new PageActionDescriptorChangeProvider(templateEngine, accessor, options);
 
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 
             var templateEngine = new RazorTemplateEngine(
                 RazorEngine.Create(),
-                new FileProviderRazorProject(accessor, _hostingEnvironment));
+                new FileProviderRazorProjectFileSystem(accessor, _hostingEnvironment));
             var options = Options.Create(new RazorPagesOptions());
             options.Value.RootDirectory = rootDirectory;
 
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 
             var templateEngine = new RazorTemplateEngine(
                 RazorEngine.Create(),
-                new FileProviderRazorProject(accessor, _hostingEnvironment));
+                new FileProviderRazorProjectFileSystem(accessor, _hostingEnvironment));
             var options = Options.Create(new RazorPagesOptions { AllowAreas = true });
             var changeProvider = new PageActionDescriptorChangeProvider(templateEngine, accessor, options);
 
@@ -100,7 +100,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 
             var templateEngine = new RazorTemplateEngine(
                 RazorEngine.Create(),
-                new FileProviderRazorProject(accessor, _hostingEnvironment));
+                new FileProviderRazorProjectFileSystem(accessor, _hostingEnvironment));
             var options = Options.Create(new RazorPagesOptions
             {
                 AllowAreas = true,
@@ -124,7 +124,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 
             var templateEngine = new RazorTemplateEngine(
                 RazorEngine.Create(),
-                new FileProviderRazorProject(accessor, _hostingEnvironment));
+                new FileProviderRazorProjectFileSystem(accessor, _hostingEnvironment));
             templateEngine.Options.ImportsFileName = "_ViewImports.cshtml";
             var options = Options.Create(new RazorPagesOptions());
             options.Value.RootDirectory = "/dir1/dir2";
@@ -148,7 +148,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 
             var templateEngine = new RazorTemplateEngine(
                 RazorEngine.Create(),
-                new FileProviderRazorProject(accessor, _hostingEnvironment));
+                new FileProviderRazorProjectFileSystem(accessor, _hostingEnvironment));
             templateEngine.Options.ImportsFileName = "_ViewImports.cshtml";
             var options = Options.Create(new RazorPagesOptions());
             options.Value.RootDirectory = "/dir1/dir2";
@@ -176,7 +176,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 
             var templateEngine = new RazorTemplateEngine(
                 RazorEngine.Create(),
-                new FileProviderRazorProject(accessor, _hostingEnvironment));
+                new FileProviderRazorProjectFileSystem(accessor, _hostingEnvironment));
             templateEngine.Options.ImportsFileName = "_ViewImports.cshtml";
             var options = Options.Create(new RazorPagesOptions { AllowAreas = false });
 

--- a/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/PageActionInvokerProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/PageActionInvokerProviderTest.cs
@@ -196,13 +196,13 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             fileProvider.AddFile("/_ViewStart.cshtml", "content2");
             var accessor = Mock.Of<IRazorViewEngineFileProviderAccessor>(a => a.FileProvider == fileProvider);
 
-            var defaultRazorProject = new FileProviderRazorProject(accessor, _hostingEnvironment);
+            var defaultFileSystem = new FileProviderRazorProjectFileSystem(accessor, _hostingEnvironment);
 
             var invokerProvider = CreateInvokerProvider(
                 loader.Object,
                 CreateActionDescriptorCollection(descriptor),
                 razorPageFactoryProvider: razorPageFactoryProvider.Object,
-                razorProject: defaultRazorProject);
+                fileSystem: defaultFileSystem);
 
             var context = new ActionInvokerProviderContext(new ActionContext()
             {
@@ -353,7 +353,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             fileProvider.AddFile("/Pages/Level1/Level2/_ViewStart.cshtml", "page content");
             fileProvider.AddFile("/Pages/Level1/Level3/_ViewStart.cshtml", "page content");
 
-            var razorProject = new TestRazorProject(fileProvider, _hostingEnvironment);
+            var fileSystem = new TestRazorProjectFileSystem(fileProvider, _hostingEnvironment);
 
             var mock = new Mock<IRazorPageFactoryProvider>(MockBehavior.Strict);
             mock
@@ -379,7 +379,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                 loader.Object,
                 CreateActionDescriptorCollection(descriptor),
                 razorPageFactoryProvider: razorPageFactoryProvider,
-                razorProject: razorProject);
+                fileSystem: fileSystem);
 
             // Act
             var factories = invokerProvider.GetViewStartFactories(compiledPageDescriptor);
@@ -419,7 +419,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 
             // No files
             var fileProvider = new TestFileProvider();
-            var razorProject = new TestRazorProject(fileProvider, _hostingEnvironment);
+            var fileSystem = new TestRazorProjectFileSystem(fileProvider, _hostingEnvironment);
 
             var invokerProvider = CreateInvokerProvider(
                 loader.Object,
@@ -427,7 +427,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                 pageProvider: null,
                 modelProvider: null,
                 razorPageFactoryProvider: pageFactory.Object,
-                razorProject: razorProject);
+                fileSystem: fileSystem);
 
             var compiledDescriptor = CreateCompiledPageActionDescriptor(descriptor);
 
@@ -473,16 +473,16 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             IPageFactoryProvider pageProvider = null,
             IPageModelFactoryProvider modelProvider = null,
             IRazorPageFactoryProvider razorPageFactoryProvider = null,
-            RazorProject razorProject = null)
+            RazorProjectFileSystem fileSystem = null)
         {
             var tempDataFactory = new Mock<ITempDataDictionaryFactory>();
             tempDataFactory
                 .Setup(t => t.GetTempData(It.IsAny<HttpContext>()))
                 .Returns((HttpContext context) => new TempDataDictionary(context, Mock.Of<ITempDataProvider>()));
 
-            if (razorProject == null)
+            if (fileSystem == null)
             {
-                razorProject = Mock.Of<RazorProject>();
+                fileSystem = Mock.Of<RazorProjectFileSystem>();
             }
 
             var modelMetadataProvider = TestModelMetadataProvider.CreateDefaultProvider();
@@ -507,7 +507,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                 Options.Create(new MvcOptions()),
                 Options.Create(new HtmlHelperOptions()),
                 Mock.Of<IPageHandlerMethodSelector>(),
-                razorProject,
+                fileSystem,
                 new DiagnosticListener("Microsoft.AspNetCore"),
                 NullLoggerFactory.Instance);
         }

--- a/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/RazorProjectPageRouteModelProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/RazorProjectPageRouteModelProviderTest.cs
@@ -29,11 +29,11 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             var dir1 = fileProvider.AddDirectoryContent("/Pages", new IFileInfo[] { file1, file2 });
             fileProvider.AddDirectoryContent("/", new[] { dir1 });
 
-            var project = new TestRazorProject(fileProvider, _hostingEnvironment);
+            var fileSystem = new TestRazorProjectFileSystem(fileProvider, _hostingEnvironment);
 
             var optionsManager = Options.Create(new RazorPagesOptions());
             optionsManager.Value.RootDirectory = "/";
-            var provider = new RazorProjectPageRouteModelProvider(project, optionsManager, NullLoggerFactory.Instance);
+            var provider = new RazorProjectPageRouteModelProvider(fileSystem, optionsManager, NullLoggerFactory.Instance);
             var context = new PageRouteModelProviderContext();
 
             // Act
@@ -71,10 +71,10 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             var areasDir = fileProvider.AddDirectoryContent("/Areas", new[] { productsDir });
             var rootDir = fileProvider.AddDirectoryContent("/", new[] { areasDir });
 
-            var project = new TestRazorProject(fileProvider, _hostingEnvironment);
+            var fileSystem = new TestRazorProjectFileSystem(fileProvider, _hostingEnvironment);
 
             var optionsManager = Options.Create(new RazorPagesOptions { AllowAreas = true });
-            var provider = new RazorProjectPageRouteModelProvider(project, optionsManager, NullLoggerFactory.Instance);
+            var provider = new RazorProjectPageRouteModelProvider(fileSystem, optionsManager, NullLoggerFactory.Instance);
             var context = new PageRouteModelProviderContext();
 
             // Act
@@ -155,10 +155,10 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             var pagesDir = fileProvider.AddDirectoryContent("/Pages", new[] { file4 });
             var rootDir = fileProvider.AddDirectoryContent("/", new[] { areasDir, pagesDir });
 
-            var project = new TestRazorProject(fileProvider, _hostingEnvironment);
+            var fileSystem = new TestRazorProjectFileSystem(fileProvider, _hostingEnvironment);
 
             var optionsManager = Options.Create(new RazorPagesOptions { AllowAreas = false });
-            var provider = new RazorProjectPageRouteModelProvider(project, optionsManager, NullLoggerFactory.Instance);
+            var provider = new RazorProjectPageRouteModelProvider(fileSystem, optionsManager, NullLoggerFactory.Instance);
             var context = new PageRouteModelProviderContext();
 
             // Act
@@ -189,7 +189,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             var areasDir = fileProvider.AddDirectoryContent("/Areas", new IFileInfo[] { productsDir, nonConformingFileUnderAreasDirectory });
             var rootDir = fileProvider.AddDirectoryContent("/", new IFileInfo[] { areasDir, rootFile });
 
-            var project = new TestRazorProject(fileProvider, _hostingEnvironment);
+            var fileSystem = new TestRazorProjectFileSystem(fileProvider, _hostingEnvironment);
 
             var optionsManager = Options.Create(new RazorPagesOptions
             {
@@ -197,7 +197,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                 AreaRootDirectory = "/Areas",
                 AllowAreas = true,
             });
-            var provider = new RazorProjectPageRouteModelProvider(project, optionsManager, NullLoggerFactory.Instance);
+            var provider = new RazorProjectPageRouteModelProvider(fileSystem, optionsManager, NullLoggerFactory.Instance);
             var context = new PageRouteModelProviderContext();
 
             // Act
@@ -251,11 +251,11 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             var dir1 = fileProvider.AddDirectoryContent("/Pages", new IFileInfo[] { dir2, file1, file2 });
             fileProvider.AddDirectoryContent("/", new[] { dir1 });
 
-            var project = new TestRazorProject(fileProvider, _hostingEnvironment);
+            var fileSystem = new TestRazorProjectFileSystem(fileProvider, _hostingEnvironment);
 
             var optionsManager = Options.Create(new RazorPagesOptions());
             optionsManager.Value.RootDirectory = "/";
-            var provider = new RazorProjectPageRouteModelProvider(project, optionsManager, NullLoggerFactory.Instance);
+            var provider = new RazorProjectPageRouteModelProvider(fileSystem, optionsManager, NullLoggerFactory.Instance);
             var context = new PageRouteModelProviderContext();
 
             // Act
@@ -289,11 +289,11 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             var file = fileProvider.AddFile("/Index.cshtml", "@page \"/custom-route\"");
             fileProvider.AddDirectoryContent("/", new[] { file });
 
-            var project = new TestRazorProject(fileProvider, _hostingEnvironment);
+            var fileSystem = new TestRazorProjectFileSystem(fileProvider, _hostingEnvironment);
 
             var optionsManager = Options.Create(new RazorPagesOptions());
             optionsManager.Value.RootDirectory = "/";
-            var provider = new RazorProjectPageRouteModelProvider(project, optionsManager, NullLoggerFactory.Instance);
+            var provider = new RazorProjectPageRouteModelProvider(fileSystem, optionsManager, NullLoggerFactory.Instance);
             var context = new PageRouteModelProviderContext();
 
             // Act
@@ -325,11 +325,11 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                 });
             fileProvider.AddDirectoryContent("/", new[] { dir1 });
 
-            var project = new TestRazorProject(fileProvider, _hostingEnvironment);
+            var fileSystem = new TestRazorProjectFileSystem(fileProvider, _hostingEnvironment);
 
             var optionsManager = Options.Create(new RazorPagesOptions());
             optionsManager.Value.RootDirectory = "/";
-            var provider = new RazorProjectPageRouteModelProvider(project, optionsManager, NullLoggerFactory.Instance);
+            var provider = new RazorProjectPageRouteModelProvider(fileSystem, optionsManager, NullLoggerFactory.Instance);
             var context = new PageRouteModelProviderContext();
 
             // Act
@@ -363,11 +363,11 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             var rootFile = fileProvider.AddFile("/Index.cshtml", "@page");
             fileProvider.AddDirectoryContent("/", new IFileInfo[] { rootFile, dir1, dir2 });
 
-            var project = new TestRazorProject(fileProvider, _hostingEnvironment);
+            var fileSystem = new TestRazorProjectFileSystem(fileProvider, _hostingEnvironment);
 
             var optionsManager = Options.Create(new RazorPagesOptions());
             optionsManager.Value.RootDirectory = "/Pages";
-            var provider = new RazorProjectPageRouteModelProvider(project, optionsManager, NullLoggerFactory.Instance);
+            var provider = new RazorProjectPageRouteModelProvider(fileSystem, optionsManager, NullLoggerFactory.Instance);
             var context = new PageRouteModelProviderContext();
 
             // Act
@@ -392,11 +392,11 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             var dir1 = fileProvider.AddDirectoryContent("/Pages", new IFileInfo[] { file1, file2 });
             fileProvider.AddDirectoryContent("/", new[] { dir1 });
 
-            var project = new TestRazorProject(fileProvider, _hostingEnvironment);
+            var fileSystem = new TestRazorProjectFileSystem(fileProvider, _hostingEnvironment);
 
             var optionsManager = Options.Create(new RazorPagesOptions());
             optionsManager.Value.RootDirectory = "/";
-            var provider = new RazorProjectPageRouteModelProvider(project, optionsManager, NullLoggerFactory.Instance);
+            var provider = new RazorProjectPageRouteModelProvider(fileSystem, optionsManager, NullLoggerFactory.Instance);
             var context = new PageRouteModelProviderContext();
             var pageModel = new PageRouteModel("/Pages/Test.cshtml", "/Pages/Test");
             context.RouteModels.Add(pageModel);

--- a/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/TestRazorProjectFileSystem.cs
+++ b/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/TestRazorProjectFileSystem.cs
@@ -8,9 +8,9 @@ using Moq;
 
 namespace Microsoft.AspNetCore.Mvc.RazorPages
 {
-    public class TestRazorProject : FileProviderRazorProject
+    public class TestRazorProjectFileSystem : FileProviderRazorProjectFileSystem
     {
-        public TestRazorProject(IFileProvider fileProvider, IHostingEnvironment hostingEnvironment)
+        public TestRazorProjectFileSystem(IFileProvider fileProvider, IHostingEnvironment hostingEnvironment)
             :base(GetAccessor(fileProvider), hostingEnvironment)
         {
         }

--- a/test/WebSites/RazorPageExecutionInstrumentationWebSite/Startup.cs
+++ b/test/WebSites/RazorPageExecutionInstrumentationWebSite/Startup.cs
@@ -16,7 +16,7 @@ namespace RazorPageExecutionInstrumentationWebSite
         public void ConfigureServices(IServiceCollection services)
         {
             // Normalize line endings to avoid changes in instrumentation locations between systems.
-            services.AddTransient<RazorProject, TestRazorProject>();
+            services.AddTransient<RazorProjectFileSystem, TestRazorProjectFileSystem>();
 
             // Add MVC services to the services container.
             services.AddMvc();

--- a/test/WebSites/RazorPageExecutionInstrumentationWebSite/TestRazorCompilationService.cs
+++ b/test/WebSites/RazorPageExecutionInstrumentationWebSite/TestRazorCompilationService.cs
@@ -9,9 +9,9 @@ using Microsoft.AspNetCore.Razor.Language;
 
 namespace RazorPageExecutionInstrumentationWebSite
 {
-    public class TestRazorProject : FileProviderRazorProject
+    public class TestRazorProjectFileSystem : FileProviderRazorProjectFileSystem
     {
-        public TestRazorProject(IRazorViewEngineFileProviderAccessor fileProviderAccessor, IHostingEnvironment hostingEnvironment)
+        public TestRazorProjectFileSystem(IRazorViewEngineFileProviderAccessor fileProviderAccessor, IHostingEnvironment hostingEnvironment)
             : base(fileProviderAccessor, hostingEnvironment)
         {
         }


### PR DESCRIPTION
- Updated our consumption of `RazorEngine` and `RazorTemplateEngine` to use `RazorProjectEngine` and its features.
- Updated service registrations to maintain existing services but to also register new ones.
- When moving `RazorViewEngine` to use `RazorProjectFileSystem` I had to add an unused constructor item in order to disambiguate the constructors.
- Updated tests to use `RazorProjectEngine` and `RazorProjectFileSystem`.

#7377 

/cc @mkArtakMSFT 