### PR TITLE
HtmlHelper.DisplayTextFor should use DisplayAttribute of enums

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ModelExplorerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ModelExplorerExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 
@@ -38,6 +39,22 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             if (modelExplorer.Model == null)
             {
                 return modelExplorer.Metadata.NullDisplayText;
+            }
+
+            if (modelExplorer.Metadata.IsEnum && modelExplorer.Model is Enum modelEnum)
+            {
+                var enumStringValue = modelEnum.ToString("d");
+                var enumGroupedDisplayNamesAndValues = modelExplorer.Metadata.EnumGroupedDisplayNamesAndValues;
+
+                Debug.Assert(enumGroupedDisplayNamesAndValues != null);
+
+                foreach (var kvp in enumGroupedDisplayNamesAndValues)
+                {
+                    if (string.Equals(kvp.Value, enumStringValue, StringComparison.Ordinal))
+                    {
+                        return kvp.Key.Name;
+                    }
+                }
             }
 
             var stringResult = Convert.ToString(modelExplorer.Model, CultureInfo.CurrentCulture);

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperDisplayTextTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperDisplayTextTest.cs
@@ -305,10 +305,28 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
 
             // Act
-            var result = helper.DisplayTextFor(m => m);
+            var result = helper.DisplayText(expression: string.Empty);
+            var forResult = helper.DisplayTextFor(m => m);
 
             // Assert
             Assert.Equal("Value One", result);
+            Assert.Equal("Value One", forResult);
+        }
+
+        [Fact]
+        public void DisplayTextFor_EnumDisplayAttribute_WhenPresentOnProperty()
+        {
+            // Arrange
+            var model = new EnumWithDisplayAttributeContainer { EnumValue = EnumWithDisplayAttribute.Value1 };
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
+
+            // Act
+            var result = helper.DisplayText(expression: nameof(EnumWithDisplayAttributeContainer.EnumValue));
+            var forResult = helper.DisplayTextFor(m => m.EnumValue);
+
+            // Assert
+            Assert.Equal("Value One", result);
+            Assert.Equal("Value One", forResult);
         }
 
         [Fact]
@@ -319,10 +337,12 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
 
             // Act
-            var result = helper.DisplayTextFor(m => m);
+            var result = helper.DisplayText(expression: null);
+            var forResult = helper.DisplayTextFor(m => m);
 
             // Assert
             Assert.Equal("Value1", result);
+            Assert.Equal("Value1", forResult);
         }
 
         // ModelMetadata.SimpleDisplayText returns ToString() result if that method has been overridden.
@@ -345,15 +365,20 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             }
         }
 
-        public enum EnumWithDisplayAttribute
+        private enum EnumWithDisplayAttribute
         {
             [Display(Name = "Value One")]
             Value1
         }
 
-        public enum EnumWithoutDisplayAttribute
+        private enum EnumWithoutDisplayAttribute
         {
             Value1
+        }
+
+        private class EnumWithDisplayAttributeContainer
+        {
+            public EnumWithDisplayAttribute EnumValue { get; set; }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperDisplayTextTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperDisplayTextTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Xunit;
 
@@ -296,6 +297,34 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             Assert.Equal("Property value", result);
         }
 
+        [Fact]
+        public void DisplayTextFor_EnumDisplayAttribute_WhenPresent()
+        {
+            // Arrange
+            var model = EnumWithDisplayAttribute.Value1;
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
+
+            // Act
+            var result = helper.DisplayTextFor(m => m);
+
+            // Assert
+            Assert.Equal("Value One", result);
+        }
+
+        [Fact]
+        public void DisplayTextFor_EnumDisplayAttribute_WhenNotPresent()
+        {
+            // Arrange
+            var model = EnumWithoutDisplayAttribute.Value1;
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
+
+            // Act
+            var result = helper.DisplayTextFor(m => m);
+
+            // Assert
+            Assert.Equal("Value1", result);
+        }
+
         // ModelMetadata.SimpleDisplayText returns ToString() result if that method has been overridden.
         private sealed class OverriddenToStringModel
         {
@@ -314,6 +343,17 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             {
                 return _simpleDisplayText;
             }
+        }
+
+        public enum EnumWithDisplayAttribute
+        {
+            [Display(Name = "Value One")]
+            Value1
+        }
+
+        public enum EnumWithoutDisplayAttribute
+        {
+            Value1
         }
     }
 }


### PR DESCRIPTION
Continue on from #7149 with a few more tests
- includes @mistakenot's original #7033 though squashed and rebased