### PR TITLE
Prevent NullReferenceException when calling View() with null model

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ExpressionMetadataProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ExpressionMetadataProvider.cs
@@ -84,7 +84,14 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             {
                 try
                 {
-                    return CachedExpressionCompiler.Process(expression)((TModel)container);
+                    var cachedExpression = CachedExpressionCompiler.Process(expression);
+                    if (container != null ||
+                        (expression?.Body as MemberExpression)?.Expression?.NodeType == ExpressionType.Constant)
+                    {
+                        return cachedExpression((TModel)container);
+                    }
+
+                    return null;
                 }
                 catch (NullReferenceException)
                 {

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperSelectTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Rendering/HtmlHelperSelectTest.cs
@@ -1038,7 +1038,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         [Fact]
-        public void ListBoxFor_WithUnreleatedExpression_GeneratesExpectedValue()
+        public void ListBoxFor_WithUnrelatedExpression_GeneratesExpectedValue()
         {
             // Arrange
             var unrelated = new[] { "2" };


### PR DESCRIPTION
Addresses #7378

In addition to the null checking, I added a condition to make sure existing unit tests does not fail, namely:
- DropDownListFor_WithUnrelatedExpression_GeneratesExpectedValue
- ListBoxFor_WithUnreleatedExpression_GeneratesExpectedValue
(I also fixed this unit test name typo: releated => related)

I am not sure if this is the correct/elegant way to address this issue, but I have successfully confirmed that it works after "patching" the official binary (Microsoft.AspNetCore.Mvc.ViewFeatures.dll, 2.1.0-preview2-30106) with this modified version.
(This is my first PR. I know I should have discussed it before sending this PR. To satisfy my curiosity, I tried to fix it for exercise, but later decided to try to send this PR.)