### PR TITLE
UrlHelperFactory.GetUrlHelper throws NullReferenceException when action context is null.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Routing/UrlHelperFactory.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Routing/UrlHelperFactory.cs
@@ -15,6 +15,11 @@ namespace Microsoft.AspNetCore.Mvc.Routing
         /// <inheritdoc />
         public IUrlHelper GetUrlHelper(ActionContext context)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(Resources.ArgumentCannotBeNullOrEmpty, (nameof(context)));
+            }
+
             var httpContext = context.HttpContext;
 
             if (httpContext == null)


### PR DESCRIPTION
This change validates the action context parameter and add tests for
all argument exceptions for UrlHelperFactory.GetUrlHelper.