### PR TITLE
Do not use `FormattedModelValue` in password editor template

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/DefaultEditorTemplates.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/DefaultEditorTemplates.cs
@@ -20,6 +20,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
     public static class DefaultEditorTemplates
     {
         private const string HtmlAttributeKey = "htmlAttributes";
+        private const string UsePasswordValue = "Switch.Microsoft.AspNetCore.Mvc.UsePasswordValue";
 
         public static IHtmlContent BooleanTemplate(IHtmlHelper htmlHelper)
         {
@@ -312,9 +313,15 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
 
         public static IHtmlContent PasswordTemplate(IHtmlHelper htmlHelper)
         {
+            object value = null;
+            if (AppContext.TryGetSwitch(UsePasswordValue, out var usePasswordValue) && usePasswordValue)
+            {
+                value = htmlHelper.ViewData.TemplateInfo.FormattedModelValue;
+            }
+
             return htmlHelper.Password(
                 expression: null,
-                value: htmlHelper.ViewData.TemplateInfo.FormattedModelValue,
+                value: value,
                 htmlAttributes: CreateHtmlAttributes(htmlHelper, "text-box single-line password"));
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Internal/DefaultEditorTemplatesTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Internal/DefaultEditorTemplatesTest.cs
@@ -521,6 +521,113 @@ Environment.NewLine;
             Assert.Equal(expected, HtmlContentUtilities.HtmlContentToString(result));
         }
 
+        [Fact]
+        public void PasswordTemplate_ReturnsInputElement_IgnoresExpressionValue()
+        {
+            // Arrange
+            var expected = "<input class=\"HtmlEncode[[text-box single-line password]]\" " +
+                "id=\"HtmlEncode[[FieldPrefix]]\" name=\"HtmlEncode[[FieldPrefix]]\" " +
+                "type=\"HtmlEncode[[password]]\" />";
+
+            var model = "Model string";
+
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
+            var viewData = helper.ViewData;
+            var templateInfo = viewData.TemplateInfo;
+            templateInfo.HtmlFieldPrefix = "FieldPrefix";
+
+            // Act
+            var result = DefaultEditorTemplates.PasswordTemplate(helper);
+
+            // Assert
+            Assert.Equal(expected, HtmlContentUtilities.HtmlContentToString(result));
+        }
+
+        [Fact]
+        public void PasswordTemplate_ReturnsInputElement_IgnoresFormattedModelValue()
+        {
+            // Arrange
+            var expected = "<input class=\"HtmlEncode[[text-box single-line password]]\" " +
+                "id=\"HtmlEncode[[FieldPrefix]]\" name=\"HtmlEncode[[FieldPrefix]]\" " +
+                "type=\"HtmlEncode[[password]]\" />";
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper<string>(model: null);
+            var viewData = helper.ViewData;
+            var templateInfo = viewData.TemplateInfo;
+            templateInfo.HtmlFieldPrefix = "FieldPrefix";
+
+            templateInfo.FormattedModelValue = "Formatted string";
+
+            // Act
+            var result = DefaultEditorTemplates.PasswordTemplate(helper);
+
+            // Assert
+            Assert.Equal(expected, HtmlContentUtilities.HtmlContentToString(result));
+        }
+
+        [Fact]
+        public void PasswordTemplate_ReturnsInputElement_IgnoresModelState()
+        {
+            // Arrange
+            var expected = "<input class=\"HtmlEncode[[text-box single-line password]]\" " +
+                "id=\"HtmlEncode[[FieldPrefix]]\" name=\"HtmlEncode[[FieldPrefix]]\" " +
+                "type=\"HtmlEncode[[password]]\" />";
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper<string>(model: null);
+            var viewData = helper.ViewData;
+            var templateInfo = viewData.TemplateInfo;
+            templateInfo.HtmlFieldPrefix = "FieldPrefix";
+
+            var modelState = viewData.ModelState;
+            modelState.SetModelValue("FieldPRefix", "Raw model string", "Attempted model string");
+
+            // Act
+            var result = DefaultEditorTemplates.PasswordTemplate(helper);
+
+            // Assert
+            Assert.Equal(expected, HtmlContentUtilities.HtmlContentToString(result));
+        }
+
+        [Fact]
+        public void PasswordTemplate_ReturnsInputElement_IgnoresViewData()
+        {
+            // Arrange
+            var expected = "<input class=\"HtmlEncode[[text-box single-line password]]\" " +
+                "id=\"HtmlEncode[[FieldPrefix]]\" name=\"HtmlEncode[[FieldPrefix]]\" " +
+                "type=\"HtmlEncode[[password]]\" />";
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper<string>(model: null);
+            var viewData = helper.ViewData;
+            var templateInfo = viewData.TemplateInfo;
+            templateInfo.HtmlFieldPrefix = "FieldPrefix";
+
+            viewData["FieldPrefix"] = "ViewData string";
+
+            // Act
+            var result = DefaultEditorTemplates.PasswordTemplate(helper);
+
+            // Assert
+            Assert.Equal(expected, HtmlContentUtilities.HtmlContentToString(result));
+        }
+
+        [Fact]
+        public void PasswordTemplate_ReturnsInputElement_UsesHtmlAttributes()
+        {
+            // Arrange
+            var expected = "<input class=\"HtmlEncode[[super text-box single-line password]]\" " +
+                "id=\"HtmlEncode[[FieldPrefix]]\" name=\"HtmlEncode[[FieldPrefix]]\" " +
+                "type=\"HtmlEncode[[password]]\" value=\"HtmlEncode[[Html attributes string]]\" />";
+            var helper = DefaultTemplatesUtilities.GetHtmlHelper<string>(model: null);
+            var viewData = helper.ViewData;
+            var templateInfo = viewData.TemplateInfo;
+            templateInfo.HtmlFieldPrefix = "FieldPrefix";
+
+            viewData["htmlAttributes"] = new { @class = "super", value = "Html attributes string" };
+
+            // Act
+            var result = DefaultEditorTemplates.PasswordTemplate(helper);
+
+            // Assert
+            Assert.Equal(expected, HtmlContentUtilities.HtmlContentToString(result));
+        }
+
         [Theory]
         [MemberData(nameof(TemplateNameData))]
         public void Editor_CallsExpectedHtmlHelper(string templateName, string expectedResult)

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Internal/DefaultEditorTemplatesTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Internal/DefaultEditorTemplatesTest.cs
@@ -522,13 +522,14 @@ Environment.NewLine;
         }
 
         [Fact]
-        public void PasswordTemplate_ReturnsInputElement_IgnoresExpressionValue()
+        public void PasswordTemplate_ReturnsInputElement_IgnoresValues()
         {
             // Arrange
             var expected = "<input class=\"HtmlEncode[[text-box single-line password]]\" " +
                 "id=\"HtmlEncode[[FieldPrefix]]\" name=\"HtmlEncode[[FieldPrefix]]\" " +
                 "type=\"HtmlEncode[[password]]\" />";
 
+            // Template ignores Model.
             var model = "Model string";
 
             var helper = DefaultTemplatesUtilities.GetHtmlHelper(model);
@@ -536,68 +537,9 @@ Environment.NewLine;
             var templateInfo = viewData.TemplateInfo;
             templateInfo.HtmlFieldPrefix = "FieldPrefix";
 
-            // Act
-            var result = DefaultEditorTemplates.PasswordTemplate(helper);
-
-            // Assert
-            Assert.Equal(expected, HtmlContentUtilities.HtmlContentToString(result));
-        }
-
-        [Fact]
-        public void PasswordTemplate_ReturnsInputElement_IgnoresFormattedModelValue()
-        {
-            // Arrange
-            var expected = "<input class=\"HtmlEncode[[text-box single-line password]]\" " +
-                "id=\"HtmlEncode[[FieldPrefix]]\" name=\"HtmlEncode[[FieldPrefix]]\" " +
-                "type=\"HtmlEncode[[password]]\" />";
-            var helper = DefaultTemplatesUtilities.GetHtmlHelper<string>(model: null);
-            var viewData = helper.ViewData;
-            var templateInfo = viewData.TemplateInfo;
-            templateInfo.HtmlFieldPrefix = "FieldPrefix";
-
+            // Template ignores FormattedModelValue, ModelState and ViewData.
             templateInfo.FormattedModelValue = "Formatted string";
-
-            // Act
-            var result = DefaultEditorTemplates.PasswordTemplate(helper);
-
-            // Assert
-            Assert.Equal(expected, HtmlContentUtilities.HtmlContentToString(result));
-        }
-
-        [Fact]
-        public void PasswordTemplate_ReturnsInputElement_IgnoresModelState()
-        {
-            // Arrange
-            var expected = "<input class=\"HtmlEncode[[text-box single-line password]]\" " +
-                "id=\"HtmlEncode[[FieldPrefix]]\" name=\"HtmlEncode[[FieldPrefix]]\" " +
-                "type=\"HtmlEncode[[password]]\" />";
-            var helper = DefaultTemplatesUtilities.GetHtmlHelper<string>(model: null);
-            var viewData = helper.ViewData;
-            var templateInfo = viewData.TemplateInfo;
-            templateInfo.HtmlFieldPrefix = "FieldPrefix";
-
-            var modelState = viewData.ModelState;
-            modelState.SetModelValue("FieldPRefix", "Raw model string", "Attempted model string");
-
-            // Act
-            var result = DefaultEditorTemplates.PasswordTemplate(helper);
-
-            // Assert
-            Assert.Equal(expected, HtmlContentUtilities.HtmlContentToString(result));
-        }
-
-        [Fact]
-        public void PasswordTemplate_ReturnsInputElement_IgnoresViewData()
-        {
-            // Arrange
-            var expected = "<input class=\"HtmlEncode[[text-box single-line password]]\" " +
-                "id=\"HtmlEncode[[FieldPrefix]]\" name=\"HtmlEncode[[FieldPrefix]]\" " +
-                "type=\"HtmlEncode[[password]]\" />";
-            var helper = DefaultTemplatesUtilities.GetHtmlHelper<string>(model: null);
-            var viewData = helper.ViewData;
-            var templateInfo = viewData.TemplateInfo;
-            templateInfo.HtmlFieldPrefix = "FieldPrefix";
-
+            viewData.ModelState.SetModelValue("FieldPrefix", "Raw model string", "Attempted model string");
             viewData["FieldPrefix"] = "ViewData string";
 
             // Act


### PR DESCRIPTION
- #7418
- add quirk switch to reverse this if necessary