### PR TITLE
Fix #4604 for good

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/ObjectResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/ObjectResultExecutor.cs
@@ -125,7 +125,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
                 return Task.CompletedTask;
             }
 
-            Logger.ObjectResultExecuting(context);
+            Logger.ObjectResultExecuting(result.Value);
 
             result.OnFormatting(context);
             return selectedFormatter.WriteAsync(formatterContext);


### PR DESCRIPTION
```
info: Microsoft.AspNetCore.Mvc.Infrastructure.ObjectResultExecutor[1]
      Executing ObjectResult, writing value of type '<>f__AnonymousType0'.
```