### PR TITLE
Set model prefix for [ApiController]

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ApiBehaviorApplicationModelProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ApiBehaviorApplicationModelProviderTest.cs
@@ -399,6 +399,38 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         [Fact]
+        public void InferBoundPropertyModelPrefixes_SetsModelPrefix_ForComplexTypeFromValueProvider()
+        {
+            // Arrange
+            var controller = GetControllerModel(typeof(ControllerWithBoundProperty));
+
+            var provider = GetProvider();
+
+            // Act
+            provider.InferBoundPropertyModelPrefixes(controller);
+
+            // Assert
+            var property = Assert.Single(controller.ControllerProperties);
+            Assert.Equal(string.Empty, property.BindingInfo.BinderModelName);
+        }
+
+        [Fact]
+        public void InferParameterModelPrefixes_SetsModelPrefix_ForComplexTypeFromValueProvider()
+        {
+            // Arrange
+            var action = GetActionModel(typeof(ControllerWithBoundProperty), nameof(ControllerWithBoundProperty.SomeAction));
+
+            var provider = GetProvider();
+
+            // Act
+            provider.InferParameterModelPrefixes(action);
+
+            // Assert
+            var parameter = Assert.Single(action.Parameters);
+            Assert.Equal(string.Empty, parameter.BindingInfo.BinderModelName);
+        }
+
+        [Fact]
         public void AddMultipartFormDataConsumesAttribute_NoOpsIfBehaviorIsDisabled()
         {
             // Arrange
@@ -481,6 +513,12 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             var context = new ApplicationModelProviderContext(new[] { type.GetTypeInfo() });
             new DefaultApplicationModelProvider(Options.Create(new MvcOptions())).OnProvidersExecuting(context);
             return context;
+        }
+
+        private static ControllerModel GetControllerModel(Type controllerType)
+        {
+            var context = GetContext(controllerType);
+            return Assert.Single(context.Result.Controllers);
         }
 
         private static ActionModel GetActionModel(Type controllerType, string actionName)
@@ -621,6 +659,15 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         {
             public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
                 => sourceType == typeof(string);
+        }
+
+        [ApiController]
+        private class ControllerWithBoundProperty
+        {
+            [FromQuery]
+            public TestModel TestProperty { get; set; }
+
+            public IActionResult SomeAction([FromQuery] TestModel test) => null;
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ApiBehaviorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ApiBehaviorTest.cs
@@ -124,5 +124,47 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal(name, result.Name);
             Assert.Equal(email, result.Email);
         }
+
+        [Fact]
+        public async Task ActionsWithApiBehavior_InferEmptyPrefixForComplexValueProviderModel_Success()
+        {
+            // Arrange
+            var id = 31;
+            var name = "test_user";
+            var email = "email@test.com";
+            var url = $"/contact/ActionWithInferredEmptyPrefix?name={name}&contactid={id}&email={email}";
+
+            // Act
+            var response = await Client.GetAsync(url);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var result = await response.Content.ReadAsAsync<Contact>();
+            Assert.Equal(id, result.ContactId);
+            Assert.Equal(name, result.Name);
+            Assert.Equal(email, result.Email);
+        }
+
+        [Fact]
+        public async Task ActionsWithApiBehavior_InferEmptyPrefixForComplexValueProviderModel_Ignored()
+        {
+            // Arrange
+            var id = 31;
+            var name = "test_user";
+            var email = "email@test.com";
+            var url = $"/contact/ActionWithInferredEmptyPrefix?contact.name={name}&contact.contactid={id}&contact.email={email}";
+
+            // Act
+            var response = await Client.GetAsync(url);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var result = await response.Content.ReadAsAsync<Contact>();
+            Assert.Equal(0, result.ContactId);
+            Assert.Null(result.Name);
+            Assert.Null(result.Email);
+        }
     }
 }

--- a/test/WebSites/BasicWebSite/Controllers/ContactApiController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/ContactApiController.cs
@@ -61,5 +61,11 @@ namespace BasicWebSite
                 Email = email,
             };
         }
+
+        [HttpGet("[action]")]
+        public ActionResult<Contact> ActionWithInferredEmptyPrefix([FromQuery] Contact contact)
+        {
+            return contact;
+        }
     }
 }


### PR DESCRIPTION
Infers the 'empty' model prefix for complex types that are read from the value
providers. This gives us better defaults when using the parameter object
pattern with respect to swagger/API explorer.