### PR TITLE
Add model attribute for PartialTagHelper.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/Properties/Resources.Designer.cs
@@ -192,6 +192,20 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         internal static string FormatViewEngine_PartialViewNotFound(object p0, object p1)
             => string.Format(CultureInfo.CurrentCulture, GetString("ViewEngine_PartialViewNotFound"), p0, p1);
 
+        /// <summary>
+        /// Cannot use '{0}' with both '{1}' and '{2}' attributes.
+        /// </summary>
+        internal static string PartialTagHelper_InvalidModelAttributes
+        {
+            get => GetString("PartialTagHelper_InvalidModelAttributes");
+        }
+
+        /// <summary>
+        /// Cannot use '{0}' with both '{1}' and '{2}' attributes.
+        /// </summary>
+        internal static string FormatPartialTagHelper_InvalidModelAttributes(object p0, object p1, object p2)
+            => string.Format(CultureInfo.CurrentCulture, GetString("PartialTagHelper_InvalidModelAttributes"), p0, p1, p2);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/Resources.resx
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/Resources.resx
@@ -156,4 +156,7 @@
   <data name="ViewEngine_PartialViewNotFound" xml:space="preserve">
     <value>The partial view '{0}' was not found. The following locations were searched:{1}</value>
   </data>
+  <data name="PartialTagHelper_InvalidModelAttributes" xml:space="preserve">
+    <value>Cannot use '{0}' with both '{1}' and '{2}' attributes.</value>
+  </data>
 </root>

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.ProductListUsingTagHelpers.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.ProductListUsingTagHelpers.html
@@ -62,5 +62,13 @@ Product_2 description</textarea>
         <div>HtmlFieldPrefix = </div>
         <input type="submit" />
     <input name="__RequestVerificationToken" type="hidden" value="{0}" /></form>
+
+    
+
+<hr />
+<h2>You might also like these products!</h2>
+<ul>
+        <li><a href="http://www.contoso.com/">THE Best Product</a></li>
+</ul>
 </body>
 </html>

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.ProductListUsingTagHelpersWithNullModel.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.ProductListUsingTagHelpersWithNullModel.html
@@ -26,5 +26,13 @@
         <div>HtmlFieldPrefix = </div>
         <input type="submit" />
     <input name="__RequestVerificationToken" type="hidden" value="{0}" /></form>
+
+    
+
+<hr />
+<h2>You might also like these products!</h2>
+<ul>
+        <li><a href="http://www.contoso.com/">THE Best Product</a></li>
+</ul>
 </body>
 </html>

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/PartialTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/PartialTagHelperTest.cs
@@ -24,6 +24,90 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
     public class PartialTagHelperTest
     {
         [Fact]
+        public void ResolveModel_ReturnsModelWhenProvided()
+        {
+            // Arrange
+            var expectedModel = new object();
+            var tagHelper = new PartialTagHelper(Mock.Of<ICompositeViewEngine>(), Mock.Of<IViewBufferScope>())
+            {
+                Model = expectedModel,
+            };
+
+            // Act
+            var model = tagHelper.ResolveModel();
+
+            // Assert
+            Assert.Same(expectedModel, model);
+        }
+
+        [Fact]
+        public void ResolveModel_ReturnsForModelWhenProvided()
+        {
+            // Arrange
+            var expectedModel = new PropertyModel();
+            var modelMetadataProvider = new TestModelMetadataProvider();
+            var containerModel = new TestModel()
+            {
+                Property = expectedModel
+            };
+            var containerModelExplorer = modelMetadataProvider.GetModelExplorerForType(
+                typeof(TestModel),
+                containerModel);
+            var propertyModelExplorer = containerModelExplorer.GetExplorerForProperty(nameof(TestModel.Property));
+            var tagHelper = new PartialTagHelper(Mock.Of<ICompositeViewEngine>(), Mock.Of<IViewBufferScope>())
+            {
+                For = new ModelExpression("Property", propertyModelExplorer),
+            };
+
+            // Act
+            var model = tagHelper.ResolveModel();
+
+            // Assert
+            Assert.Same(expectedModel, model);
+        }
+
+        [Fact]
+        public void ResolveModel_ReturnsViewContextsViewDataModelWhenModelAndForAreNull()
+        {
+            // Arrange
+            var expectedModel = new object();
+            var viewContext = GetViewContext();
+            viewContext.ViewData.Model = expectedModel;
+            var tagHelper = new PartialTagHelper(Mock.Of<ICompositeViewEngine>(), Mock.Of<IViewBufferScope>())
+            {
+                ViewContext = viewContext
+            };
+
+            // Act
+            var model = tagHelper.ResolveModel();
+
+            // Assert
+            Assert.Same(expectedModel, model);
+        }
+
+        [Fact]
+        public void ResolveModel_ThrowsWhenModelAndForProvided()
+        {
+            // Arrange
+            var modelMetadataProvider = new TestModelMetadataProvider();
+            var containerModel = new TestModel();
+            var containerModelExplorer = modelMetadataProvider.GetModelExplorerForType(
+                typeof(TestModel),
+                containerModel);
+            var propertyModelExplorer = containerModelExplorer.GetExplorerForProperty(nameof(TestModel.Property));
+            var tagHelper = new PartialTagHelper(Mock.Of<ICompositeViewEngine>(), Mock.Of<IViewBufferScope>())
+            {
+                Model = new object(),
+                For = new ModelExpression("Property", propertyModelExplorer),
+            };
+            var expectedMessage = Resources.FormatPartialTagHelper_InvalidModelAttributes(typeof(PartialTagHelper).FullName, "for", "model");
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(() => tagHelper.ResolveModel());
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Fact]
         public async Task ProcessAsync_RendersPartialView_IfGetViewReturnsView()
         {
             // Arrange

--- a/test/WebSites/HtmlGenerationWebSite/Models/ProductRecommendations.cs
+++ b/test/WebSites/HtmlGenerationWebSite/Models/ProductRecommendations.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace HtmlGenerationWebSite.Models
+{
+    public class ProductRecommendations
+    {
+        public ProductRecommendations(params Product[] products)
+        {
+            if (products == null)
+            {
+                throw new ArgumentNullException(nameof(products));
+            }
+
+            Products = products;
+        }
+
+        public IEnumerable<Product> Products { get; }
+    }
+}

--- a/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/ProductListUsingTagHelpers.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/ProductListUsingTagHelpers.cshtml
@@ -21,5 +21,7 @@
         <div>HtmlFieldPrefix = @ViewData.TemplateInfo.HtmlFieldPrefix</div>
         <input type="submit" />
     </form>
+
+    <partial name="_ProductRecommendations" model='new ProductRecommendations(new Product() { ProductName = "THE Best Product", HomePage = new Uri("http://www.contoso.com")})' />
 </body>
 </html>

--- a/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/_ProductRecommendations.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/_ProductRecommendations.cshtml
@@ -1,0 +1,13 @@
+@using HtmlGenerationWebSite.Models
+@model ProductRecommendations
+
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+<hr />
+<h2>You might also like these products!</h2>
+<ul>
+    @foreach (var product in Model.Products)
+    {
+        <li><a href="@product.HomePage">@product.ProductName</a></li>
+    }
+</ul>


### PR DESCRIPTION
- The model attribute is used to define any object based model to be passed to a `TagHelper`. It enables scenarios when users want to pass in `new` poco types.
- Added unit tests for the new `ResolveModel` method in `PartialTagHelper`.
- Added a single functional test to verify the end-to-end.

#7374