### PR TITLE
Fix cancellation token binding source inference

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ApiBehaviorApplicationModelProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ApiBehaviorApplicationModelProvider.cs
@@ -139,7 +139,8 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             actionModel.Filters.Add(_modelStateInvalidFilter);
         }
 
-        private void InferParameterBindingSources(ActionModel actionModel)
+        // Internal for unit testing
+        internal void InferParameterBindingSources(ActionModel actionModel)
         {
             if (_modelMetadataProvider == null || _apiBehaviorOptions.SuppressInferBindingSourcesForParameters)
             {


### PR DESCRIPTION
I think this will fix #7546.

Without the changes to `ApiBehaviorModelProvider`, the test failed with

![image](https://user-images.githubusercontent.com/582487/37907717-34f8ee68-3106-11e8-8cd6-02d820f7ef99.png)

I'm still puzzled why

https://github.com/aspnet/Mvc/blob/fa629cd5e112d89db7cef7374694eb08dbc6bf9c/src/Microsoft.AspNetCore.Mvc.Core/Internal/ApiBehaviorApplicationModelProvider.cs#L154-L158

Ends up calling into `InferBindingSourceForParameter` 🤔 