### PR TITLE
Restore `ModelMetadata.PropertyName != null` behaviour

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelMetadata.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelMetadata.cs
@@ -38,12 +38,13 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         }
 
         /// <summary>
-        /// Gets the container type of this metadata if it represents a property, otherwise <c>null</c>.
+        /// Gets the type containing the property if this metadata is for a property; <see langword="null"/> otherwise.
         /// </summary>
         public Type ContainerType => Identity.ContainerType;
 
         /// <summary>
-        /// Gets the metadata of the container type that the current instance is part of.
+        /// Gets the metadata for <see cref="ContainerType"/> if this metadata is for a property;
+        /// <see langword="null"/> otherwise.
         /// </summary>
         public virtual ModelMetadata ContainerMetadata
         {
@@ -64,9 +65,20 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         public Type ModelType => Identity.ModelType;
 
         /// <summary>
-        /// Gets the property name represented by the current instance.
+        /// Gets the name of the parameter or property if this metadata is for a parameter or property;
+        /// <see langword="null"/> otherwise i.e. if this is the metadata for a type.
         /// </summary>
-        public string PropertyName => Identity.Name;
+        public string Name => Identity.Name;
+
+        /// <summary>
+        /// Gets the name of the parameter if this metadata is for a parameter; <see langword="null"/> otherwise.
+        /// </summary>
+        public string ParameterName => MetadataKind == ModelMetadataKind.Parameter ? Identity.Name : null;
+
+        /// <summary>
+        /// Gets the name of the property if this metadata is for a property; <see langword="null"/> otherwise.
+        /// </summary>
+        public string PropertyName => MetadataKind == ModelMetadataKind.Property ? Identity.Name : null;
 
         /// <summary>
         /// Gets the key for the current instance.
@@ -384,12 +396,12 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         /// </summary>
         /// <remarks>
         /// <see cref="GetDisplayName()"/> will return the first of the following expressions which has a
-        /// non-<c>null</c> value: <c>DisplayName</c>, <c>PropertyName</c>, <c>ModelType.Name</c>.
+        /// non-<see langword="null"/> value: <see cref="DisplayName"/>, <see cref="Name"/>, or <c>ModelType.Name</c>.
         /// </remarks>
         /// <returns>The display name.</returns>
         public string GetDisplayName()
         {
-            return DisplayName ?? PropertyName ?? ModelType.Name;
+            return DisplayName ?? Name ?? ModelType.Name;
         }
 
         /// <inheritdoc />
@@ -470,13 +482,16 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 
         private string DebuggerToString()
         {
-            if (Identity.MetadataKind == ModelMetadataKind.Type)
+            switch (MetadataKind)
             {
-                return $"ModelMetadata (Type: '{ModelType.Name}')";
-            }
-            else
-            {
-                return $"ModelMetadata (Property: '{ContainerType.Name}.{PropertyName}' Type: '{ModelType.Name}')";
+                case ModelMetadataKind.Parameter:
+                    return $"ModelMetadata (Parameter: '{ParameterName}' Type: '{ModelType.Name}')";
+                case ModelMetadataKind.Property:
+                    return $"ModelMetadata (Property: '{ContainerType.Name}.{PropertyName}' Type: '{ModelType.Name}')";
+                case ModelMetadataKind.Type:
+                    return $"ModelMetadata (Type: '{ModelType.Name}')";
+                default:
+                    return $"Unsupported MetadataKind '{MetadataKind}'.";
             }
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelStateDictionary.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelStateDictionary.cs
@@ -180,7 +180,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         /// </summary>
         /// <remarks>
         /// This method allows adding the <paramref name="exception"/> to the current <see cref="ModelStateDictionary"/>
-        /// when <see cref="ModelMetadata"/> is not available or the exact <paramref name="exception"/> 
+        /// when <see cref="ModelMetadata"/> is not available or the exact <paramref name="exception"/>
         /// must be maintained for later use (even if it is for example a <see cref="FormatException"/>).
         /// Where <see cref="ModelMetadata"/> is available, use <see cref="AddModelError(string, Exception, ModelMetadata)"/> instead.
         /// </remarks>

--- a/src/Microsoft.AspNetCore.Mvc.ApiExplorer/DefaultApiDescriptionProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ApiExplorer/DefaultApiDescriptionProvider.cs
@@ -620,7 +620,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                     ModelMetadata = metadata,
                     BinderModelName = bindingInfo?.BinderModelName ?? metadata.BinderModelName,
                     BindingSource = bindingInfo?.BindingSource ?? metadata.BindingSource,
-                    PropertyName = propertyName ?? metadata.PropertyName
+                    PropertyName = propertyName ?? metadata.Name,
                 };
             }
         }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcCoreLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcCoreLoggerExtensions.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.Formatters.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
@@ -104,7 +105,8 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         private static readonly Action<ILogger, MethodInfo, Exception> _unableToInferParameterSources;
         private static readonly Action<ILogger, IModelBinderProvider[], Exception> _registeredModelBinderProviders;
         private static readonly Action<ILogger, string, Type, string, Type, Exception> _foundNoValueForPropertyInRequest;
-        private static readonly Action<ILogger, string, string, Type, Exception> _foundNoValueInRequest;
+        private static readonly Action<ILogger, string, string, Type, Exception> _foundNoValueForParameterInRequest;
+        private static readonly Action<ILogger, string, Type, Exception> _foundNoValueInRequest;
         private static readonly Action<ILogger, string, Type, Exception> _noPublicSettableProperties;
         private static readonly Action<ILogger, Type, Exception> _cannotBindToComplexType;
         private static readonly Action<ILogger, string, Type, Exception> _cannotBindToFilesCollectionDueToUnsupportedContentType;
@@ -115,6 +117,8 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         private static readonly Action<ILogger, string, string, string, string, string, string, Exception> _attemptingToBindCollectionUsingIndices;
         private static readonly Action<ILogger, string, string, string, string, string, string, Exception> _attemptingToBindCollectionOfKeyValuePair;
         private static readonly Action<ILogger, string, string, string, Exception> _noKeyValueFormatForDictionaryModelBinder;
+        private static readonly Action<ILogger, string, Type, string, Exception> _attemptingToBindParameterModel;
+        private static readonly Action<ILogger, string, Type, Exception> _doneAttemptingToBindParameterModel;
         private static readonly Action<ILogger, Type, string, Type, string, Exception> _attemptingToBindPropertyModel;
         private static readonly Action<ILogger, Type, string, Type, Exception> _doneAttemptingToBindPropertyModel;
         private static readonly Action<ILogger, Type, string, Exception> _attemptingToBindModel;
@@ -475,7 +479,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                15,
                "Could not find a value in the request with name '{ModelName}' for binding property '{PropertyContainerType}.{ModelFieldName}' of type '{ModelType}'.");
 
-            _foundNoValueInRequest = LoggerMessage.Define<string, string, Type>(
+            _foundNoValueForParameterInRequest = LoggerMessage.Define<string, string, Type>(
                LogLevel.Debug,
                16,
                "Could not find a value in the request with name '{ModelName}' for binding parameter '{ModelFieldName}' of type '{ModelType}'.");
@@ -610,6 +614,21 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                LogLevel.Debug,
                43,
                "Could not create a binder for type '{ModelType}' as this binder only supports 'System.String' type or a collection of 'System.String'.");
+
+            _attemptingToBindParameterModel = LoggerMessage.Define<string, Type, string>(
+                LogLevel.Debug,
+                44,
+                "Attempting to bind parameter '{ParameterName}' of type '{ModelType}' using the name '{ModelName}' in request data ...");
+
+            _doneAttemptingToBindParameterModel = LoggerMessage.Define<string, Type>(
+               LogLevel.Debug,
+               45,
+               "Done attempting to bind parameter '{ParameterName}' of type '{ModelType}'.");
+
+            _foundNoValueInRequest = LoggerMessage.Define<string, Type>(
+               LogLevel.Debug,
+               46,
+               "Could not find a value in the request with name '{ModelName}' of type '{ModelType}'.");
         }
 
         public static void RegisteredOutputFormatters(this ILogger logger, IEnumerable<IOutputFormatter> outputFormatters)
@@ -1157,26 +1176,32 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             }
 
             var modelMetadata = bindingContext.ModelMetadata;
-            var isProperty = modelMetadata.ContainerType != null;
-
-            if (isProperty)
+            switch (modelMetadata.MetadataKind)
             {
-                _foundNoValueForPropertyInRequest(
-                    logger,
-                    bindingContext.ModelName,
-                    modelMetadata.ContainerType,
-                    modelMetadata.PropertyName,
-                    bindingContext.ModelType,
-                    null);
-            }
-            else
-            {
-                _foundNoValueInRequest(
-                    logger,
-                    bindingContext.ModelName,
-                    modelMetadata.PropertyName,
-                    bindingContext.ModelType,
-                    null);
+                case ModelMetadataKind.Parameter:
+                    _foundNoValueForParameterInRequest(
+                        logger,
+                        bindingContext.ModelName,
+                        modelMetadata.ParameterName,
+                        bindingContext.ModelType,
+                        null);
+                    break;
+                case ModelMetadataKind.Property:
+                    _foundNoValueForPropertyInRequest(
+                        logger,
+                        bindingContext.ModelName,
+                        modelMetadata.ContainerType,
+                        modelMetadata.PropertyName,
+                        bindingContext.ModelType,
+                        null);
+                    break;
+                case ModelMetadataKind.Type:
+                    _foundNoValueInRequest(
+                        logger,
+                        bindingContext.ModelName,
+                        bindingContext.ModelType,
+                        null);
+                    break;
             }
         }
 
@@ -1218,89 +1243,237 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             }
 
             var modelMetadata = bindingContext.ModelMetadata;
-            var isProperty = modelMetadata.ContainerType != null;
-
-            if (isProperty)
+            switch (modelMetadata.MetadataKind)
             {
-                _attemptingToBindPropertyModel(
-                    logger,
-                    modelMetadata.ContainerType,
-                    modelMetadata.PropertyName,
-                    modelMetadata.ModelType,
-                    bindingContext.ModelName,
-                    null);
-            }
-            else
-            {
-                _attemptingToBindModel(logger, bindingContext.ModelType, bindingContext.ModelName, null);
+                case ModelMetadataKind.Parameter:
+                    _attemptingToBindParameterModel(
+                        logger,
+                        modelMetadata.ParameterName,
+                        modelMetadata.ModelType,
+                        bindingContext.ModelName,
+                        null);
+                    break;
+                case ModelMetadataKind.Property:
+                    _attemptingToBindPropertyModel(
+                        logger,
+                        modelMetadata.ContainerType,
+                        modelMetadata.PropertyName,
+                        modelMetadata.ModelType,
+                        bindingContext.ModelName,
+                        null);
+                    break;
+                case ModelMetadataKind.Type:
+                    _attemptingToBindModel(logger, bindingContext.ModelType, bindingContext.ModelName, null);
+                    break;
             }
         }
 
         public static void DoneAttemptingToBindModel(this ILogger logger, ModelBindingContext bindingContext)
         {
+            if (!logger.IsEnabled(LogLevel.Debug))
+            {
+                return;
+            }
+
             var modelMetadata = bindingContext.ModelMetadata;
-            var isProperty = modelMetadata.ContainerType != null;
-
-            if (isProperty)
+            switch (modelMetadata.MetadataKind)
             {
-                _doneAttemptingToBindPropertyModel(
-                    logger,
-                    modelMetadata.ContainerType,
-                    modelMetadata.PropertyName,
-                    modelMetadata.ModelType,
-                    null);
-            }
-            else
-            {
-                _doneAttemptingToBindModel(logger, bindingContext.ModelType, bindingContext.ModelName, null);
-            }
-        }
-
-        public static void AttemptingToBindParameterOrProperty(this ILogger logger, ParameterDescriptor parameter, ModelBindingContext bindingContext)
-        {
-            if (parameter is ControllerBoundPropertyDescriptor propertyDescriptor)
-            {
-                _attemptingToBindProperty(logger, propertyDescriptor.PropertyInfo.DeclaringType, parameter.Name, bindingContext.ModelType, null);
-            }
-            else
-            {
-                _attemptingToBindParameter(logger, parameter.Name, bindingContext.ModelType, null);
+                case ModelMetadataKind.Parameter:
+                    _doneAttemptingToBindParameterModel(
+                        logger,
+                        modelMetadata.ParameterName,
+                        modelMetadata.ModelType,
+                        null);
+                    break;
+                case ModelMetadataKind.Property:
+                    _doneAttemptingToBindPropertyModel(
+                        logger,
+                        modelMetadata.ContainerType,
+                        modelMetadata.PropertyName,
+                        modelMetadata.ModelType,
+                        null);
+                    break;
+                case ModelMetadataKind.Type:
+                    _doneAttemptingToBindModel(logger, bindingContext.ModelType, bindingContext.ModelName, null);
+                    break;
             }
         }
 
-        public static void DoneAttemptingToBindParameterOrProperty(this ILogger logger, ParameterDescriptor parameter, ModelBindingContext bindingContext)
+        public static void AttemptingToBindParameterOrProperty(
+            this ILogger logger,
+            ParameterDescriptor parameter,
+            ModelBindingContext bindingContext)
         {
-            if (parameter is ControllerBoundPropertyDescriptor propertyDescriptor)
+            if (!logger.IsEnabled(LogLevel.Debug))
             {
-                _doneAttemptingToBindProperty(logger, propertyDescriptor.PropertyInfo.DeclaringType, parameter.Name, bindingContext.ModelType, null);
+                return;
             }
-            else
+
+            var modelMetadata = bindingContext.ModelMetadata;
+            switch (modelMetadata.MetadataKind)
             {
-                _doneAttemptingToBindParameter(logger, parameter.Name, bindingContext.ModelType, null);
+                case ModelMetadataKind.Parameter:
+                    _attemptingToBindParameter(logger, modelMetadata.ParameterName, modelMetadata.ModelType, null);
+                    break;
+                case ModelMetadataKind.Property:
+                    _attemptingToBindProperty(
+                        logger,
+                        modelMetadata.ContainerType,
+                        modelMetadata.PropertyName,
+                        modelMetadata.ModelType,
+                        null);
+                    break;
+                case ModelMetadataKind.Type:
+                    if (parameter is ControllerParameterDescriptor parameterDescriptor)
+                    {
+                        _attemptingToBindParameter(
+                            logger,
+                            parameterDescriptor.ParameterInfo.Name,
+                            modelMetadata.ModelType,
+                            null);
+                    }
+                    else
+                    {
+                        // Likely binding a page handler parameter. Due to various special cases, parameter.Name may
+                        // be empty. No way to determine actual name.
+                        _attemptingToBindParameter(logger, parameter.Name, modelMetadata.ModelType, null);
+                    }
+                    break;
             }
         }
 
-        public static void AttemptingToValidateParameterOrProperty(this ILogger logger, ParameterDescriptor parameter, ModelBindingContext bindingContext)
+        public static void DoneAttemptingToBindParameterOrProperty(
+            this ILogger logger,
+            ParameterDescriptor parameter,
+            ModelBindingContext bindingContext)
         {
-            if (parameter is ControllerBoundPropertyDescriptor propertyDescriptor)
+            if (!logger.IsEnabled(LogLevel.Debug))
             {
-                _attemptingToValidateProperty(logger, propertyDescriptor.PropertyInfo.DeclaringType, parameter.Name, bindingContext.ModelType, null);
+                return;
             }
-            else
+
+            var modelMetadata = bindingContext.ModelMetadata;
+            switch (modelMetadata.MetadataKind)
             {
-                _attemptingToValidateParameter(logger, parameter.Name, bindingContext.ModelType, null);
+                case ModelMetadataKind.Parameter:
+                    _doneAttemptingToBindParameter(logger, modelMetadata.ParameterName, modelMetadata.ModelType, null);
+                    break;
+                case ModelMetadataKind.Property:
+                    _doneAttemptingToBindProperty(
+                        logger,
+                        modelMetadata.ContainerType,
+                        modelMetadata.PropertyName,
+                        modelMetadata.ModelType,
+                        null);
+                    break;
+                case ModelMetadataKind.Type:
+                    if (parameter is ControllerParameterDescriptor parameterDescriptor)
+                    {
+                        _doneAttemptingToBindParameter(
+                            logger,
+                            parameterDescriptor.ParameterInfo.Name,
+                            modelMetadata.ModelType,
+                            null);
+                    }
+                    else
+                    {
+                        // Likely binding a page handler parameter. Due to various special cases, parameter.Name may
+                        // be empty. No way to determine actual name.
+                        _doneAttemptingToBindParameter(logger, parameter.Name, modelMetadata.ModelType, null);
+                    }
+                    break;
             }
         }
 
-        public static void DoneAttemptingToValidateParameterOrProperty(this ILogger logger, ParameterDescriptor parameter, ModelBindingContext bindingContext)
+        public static void AttemptingToValidateParameterOrProperty(
+            this ILogger logger,
+            ParameterDescriptor parameter,
+            ModelBindingContext bindingContext)
         {
-            if (parameter is ControllerBoundPropertyDescriptor propertyDescriptor)
+            if (!logger.IsEnabled(LogLevel.Debug))
             {
-                _doneAttemptingToValidateProperty(logger, propertyDescriptor.PropertyInfo.DeclaringType, parameter.Name, bindingContext.ModelType, null);
+                return;
             }
-            else
+
+            var modelMetadata = bindingContext.ModelMetadata;
+            switch (modelMetadata.MetadataKind)
             {
-                _doneAttemptingToValidateParameter(logger, parameter.Name, bindingContext.ModelType, null);
+                case ModelMetadataKind.Parameter:
+                    _attemptingToValidateParameter(logger, modelMetadata.ParameterName, modelMetadata.ModelType, null);
+                    break;
+                case ModelMetadataKind.Property:
+                    _attemptingToValidateProperty(
+                        logger,
+                        modelMetadata.ContainerType,
+                        modelMetadata.PropertyName,
+                        modelMetadata.ModelType,
+                        null);
+                    break;
+                case ModelMetadataKind.Type:
+                    if (parameter is ControllerParameterDescriptor parameterDescriptor)
+                    {
+                        _attemptingToValidateParameter(
+                            logger,
+                            parameterDescriptor.ParameterInfo.Name,
+                            modelMetadata.ModelType,
+                            null);
+                    }
+                    else
+                    {
+                        // Likely binding a page handler parameter. Due to various special cases, parameter.Name may
+                        // be empty. No way to determine actual name. This case is less likely than for binding logging
+                        // (above). Should occur only with a legacy IModelMetadataProvider implementation.
+                        _attemptingToValidateParameter(logger, parameter.Name, modelMetadata.ModelType, null);
+                    }
+                    break;
+            }
+        }
+
+        public static void DoneAttemptingToValidateParameterOrProperty(
+            this ILogger logger,
+            ParameterDescriptor parameter,
+            ModelBindingContext bindingContext)
+        {
+            if (!logger.IsEnabled(LogLevel.Debug))
+            {
+                return;
+            }
+
+            var modelMetadata = bindingContext.ModelMetadata;
+            switch (modelMetadata.MetadataKind)
+            {
+                case ModelMetadataKind.Parameter:
+                    _doneAttemptingToValidateParameter(
+                        logger,
+                        modelMetadata.ParameterName,
+                        modelMetadata.ModelType,
+                        null);
+                    break;
+                case ModelMetadataKind.Property:
+                    _doneAttemptingToValidateProperty(
+                        logger,
+                        modelMetadata.ContainerType,
+                        modelMetadata.PropertyName,
+                        modelMetadata.ModelType,
+                        null);
+                    break;
+                case ModelMetadataKind.Type:
+                    if (parameter is ControllerParameterDescriptor parameterDescriptor)
+                    {
+                        _doneAttemptingToValidateParameter(
+                            logger,
+                            parameterDescriptor.ParameterInfo.Name,
+                            modelMetadata.ModelType,
+                            null);
+                    }
+                    else
+                    {
+                        // Likely binding a page handler parameter. Due to various special cases, parameter.Name may
+                        // be empty. No way to determine actual name. This case is less likely than for binding logging
+                        // (above). Should occur only with a legacy IModelMetadataProvider implementation.
+                        _doneAttemptingToValidateParameter(logger, parameter.Name, modelMetadata.ModelType, null);
+                    }
+                    break;
             }
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Validation/ValidationVisitor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/Validation/ValidationVisitor.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
             ModelState = actionContext.ModelState;
             CurrentPath = new ValidationStack();
         }
-        
+
         protected IModelValidatorProvider ValidatorProvider { get; }
         protected IModelMetadataProvider MetadataProvider { get; }
         protected ValidatorCache Cache { get; }
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
         protected IValidationStrategy Strategy { get; set; }
 
         /// <summary>
-        /// Indicates whether validation of a complex type should be performed if validation fails for any of its children. The default behavior is false. 
+        /// Indicates whether validation of a complex type should be performed if validation fails for any of its children. The default behavior is false.
         /// </summary>
         public bool ValidateComplexTypesIfChildValidationFails { get; set; }
         /// <summary>
@@ -146,11 +146,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
                         var result = results[i];
                         var key = ModelNames.CreatePropertyModelName(Key, result.MemberName);
 
-                        // If this is a top-level parameter/property, the key would be empty,
-                        // so use the name of the top-level property
-                        if (string.IsNullOrEmpty(key) && Metadata.PropertyName != null)
+                        // If this is a top-level parameter/property, the key would be empty.
+                        // So, use the name of the top-level property/property.
+                        if (string.IsNullOrEmpty(key) && Metadata.Name != null)
                         {
-                            key = Metadata.PropertyName;
+                            key = Metadata.Name;
                         }
 
                         ModelState.TryAddModelError(key, result.Message);
@@ -306,8 +306,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
                 return null;
             }
 
-            ValidationStateEntry entry;
-            ValidationState.TryGetValue(model, out entry);
+            ValidationState.TryGetValue(model, out var entry);
             return entry;
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Properties/Resources.Designer.cs
@@ -1273,16 +1273,16 @@ namespace Microsoft.AspNetCore.Mvc.Core
         /// <summary>
         /// Could not create an instance of type '{0}'. Model bound complex types must not be abstract or value types and must have a parameterless constructor.
         /// </summary>
-        internal static string ComplexTypeModelBinder_NoParameterlessConstructor_TopLevelObject
+        internal static string ComplexTypeModelBinder_NoParameterlessConstructor_ForType
         {
-            get => GetString("ComplexTypeModelBinder_NoParameterlessConstructor_TopLevelObject");
+            get => GetString("ComplexTypeModelBinder_NoParameterlessConstructor_ForType");
         }
 
         /// <summary>
         /// Could not create an instance of type '{0}'. Model bound complex types must not be abstract or value types and must have a parameterless constructor.
         /// </summary>
-        internal static string FormatComplexTypeModelBinder_NoParameterlessConstructor_TopLevelObject(object p0)
-            => string.Format(CultureInfo.CurrentCulture, GetString("ComplexTypeModelBinder_NoParameterlessConstructor_TopLevelObject"), p0);
+        internal static string FormatComplexTypeModelBinder_NoParameterlessConstructor_ForType(object p0)
+            => string.Format(CultureInfo.CurrentCulture, GetString("ComplexTypeModelBinder_NoParameterlessConstructor_ForType"), p0);
 
         /// <summary>
         /// Could not create an instance of type '{0}'. Model bound complex types must not be abstract or value types and must have a parameterless constructor. Alternatively, set the '{1}' property to a non-null value in the '{2}' constructor.
@@ -1437,6 +1437,20 @@ namespace Microsoft.AspNetCore.Mvc.Core
         /// </summary>
         internal static string FormatApplicationAssembliesProvider_RelatedAssemblyCannotDefineAdditional(object p0, object p1)
             => string.Format(CultureInfo.CurrentCulture, GetString("ApplicationAssembliesProvider_RelatedAssemblyCannotDefineAdditional"), p0, p1);
+
+        /// <summary>
+        /// Could not create an instance of type '{0}'. Model bound complex types must not be abstract or value types and must have a parameterless constructor. Alternatively, give the '{1}' parameter a non-null default value.
+        /// </summary>
+        internal static string ComplexTypeModelBinder_NoParameterlessConstructor_ForParameter
+        {
+            get => GetString("ComplexTypeModelBinder_NoParameterlessConstructor_ForParameter");
+        }
+
+        /// <summary>
+        /// Could not create an instance of type '{0}'. Model bound complex types must not be abstract or value types and must have a parameterless constructor. Alternatively, give the '{1}' parameter a non-null default value.
+        /// </summary>
+        internal static string FormatComplexTypeModelBinder_NoParameterlessConstructor_ForParameter(object p0, object p1)
+            => string.Format(CultureInfo.CurrentCulture, GetString("ComplexTypeModelBinder_NoParameterlessConstructor_ForParameter"), p0, p1);
 
         private static string GetString(string name, params string[] formatterNames)
         {

--- a/src/Microsoft.AspNetCore.Mvc.Core/Resources.resx
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Resources.resx
@@ -400,7 +400,7 @@
     <value>'{0}' and '{1}' are out of bounds for the string.</value>
     <comment>'{0}' and '{1}' are the parameters which combine to be out of bounds.</comment>
   </data>
-  <data name="ComplexTypeModelBinder_NoParameterlessConstructor_TopLevelObject" xml:space="preserve">
+  <data name="ComplexTypeModelBinder_NoParameterlessConstructor_ForType" xml:space="preserve">
     <value>Could not create an instance of type '{0}'. Model bound complex types must not be abstract or value types and must have a parameterless constructor.</value>
   </data>
   <data name="ComplexTypeModelBinder_NoParameterlessConstructor_ForProperty" xml:space="preserve">
@@ -435,5 +435,8 @@
   </data>
   <data name="ApplicationAssembliesProvider_RelatedAssemblyCannotDefineAdditional" xml:space="preserve">
     <value>Assembly '{0}' declared as a related assembly by assembly '{1}' cannot define additional related assemblies.</value>
+  </data>
+  <data name="ComplexTypeModelBinder_NoParameterlessConstructor_ForParameter" xml:space="preserve">
+    <value>Could not create an instance of type '{0}'. Model bound complex types must not be abstract or value types and must have a parameterless constructor. Alternatively, give the '{1}' parameter a non-null default value.</value>
   </data>
 </root>

--- a/src/Microsoft.AspNetCore.Mvc.DataAnnotations/Internal/DataAnnotationsModelValidator.cs
+++ b/src/Microsoft.AspNetCore.Mvc.DataAnnotations/Internal/DataAnnotationsModelValidator.cs
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
             }
 
             var metadata = validationContext.ModelMetadata;
-            var memberName = metadata.PropertyName;
+            var memberName = metadata.Name;
             var container = validationContext.Container;
 
             var context = new ValidationContext(

--- a/src/Microsoft.AspNetCore.Mvc.DataAnnotations/Internal/NumericClientModelValidator.cs
+++ b/src/Microsoft.AspNetCore.Mvc.DataAnnotations/Internal/NumericClientModelValidator.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
             }
 
             var messageProvider = modelMetadata.ModelBindingMessageProvider;
-            var name = modelMetadata.DisplayName ?? modelMetadata.PropertyName;
+            var name = modelMetadata.DisplayName ?? modelMetadata.Name;
             if (name == null)
             {
                 return messageProvider.NonPropertyValueMustBeANumberAccessor();

--- a/src/Microsoft.AspNetCore.Mvc.DataAnnotations/Internal/ValidatableObjectAdapter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.DataAnnotations/Internal/ValidatableObjectAdapter.cs
@@ -19,8 +19,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
                 return Enumerable.Empty<ModelValidationResult>();
             }
 
-            var validatable = model as IValidatableObject;
-            if (validatable == null)
+            if (!(model is IValidatableObject validatable))
             {
                 var message = Resources.FormatValidatableObjectAdapter_IncompatibleType(
                     typeof(IValidatableObject).Name,
@@ -39,7 +38,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
                 items: null)
             {
                 DisplayName = context.ModelMetadata.GetDisplayName(),
-                MemberName = context.ModelMetadata.PropertyName,
+                MemberName = context.ModelMetadata.Name,
             };
 
             return ConvertResults(validatable.Validate(validationContext));

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/ComplexTypeModelBinderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/ComplexTypeModelBinderTest.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -369,6 +368,25 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                     "value types and must have a parameterless constructor.",
                     typeof(PointStruct).FullName),
                 exception.Message);
+        }
+
+        [Fact]
+        public void CreateModel_ForClassWithNoParameterlessConstructor_AsElement_ThrowsException()
+        {
+            // Arrange
+            var expectedMessage = "Could not create an instance of type " +
+                $"'{typeof(ClassWithNoParameterlessConstructor)}'. Model bound complex types must not be abstract " +
+                "or value types and must have a parameterless constructor.";
+            var metadata = GetMetadataForType(typeof(ClassWithNoParameterlessConstructor));
+            var bindingContext = new DefaultModelBindingContext
+            {
+                ModelMetadata = metadata,
+            };
+            var binder = CreateBinder(metadata);
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(() => binder.CreateModelPublic(bindingContext));
+            Assert.Equal(expectedMessage, exception.Message);
         }
 
         [Fact]
@@ -1094,6 +1112,16 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             }
             public double X { get; }
             public double Y { get; }
+        }
+
+        private class ClassWithNoParameterlessConstructor
+        {
+            public ClassWithNoParameterlessConstructor(string name)
+            {
+                Name = name;
+            }
+
+            public string Name { get; set; }
         }
 
         private class BindingOptionalProperty

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/ModelValidationResultComparer.cs
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/ModelValidationResultComparer.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
+{
+    public class ModelValidationResultComparer : IEqualityComparer<ModelValidationResult>
+    {
+        public static readonly ModelValidationResultComparer Instance = new ModelValidationResultComparer();
+
+        private ModelValidationResultComparer()
+        {
+        }
+
+        public bool Equals(ModelValidationResult x, ModelValidationResult y)
+        {
+            if (x == null || y == null)
+            {
+                return x == null && y == null;
+            }
+
+            return string.Equals(x.MemberName, y.MemberName, StringComparison.Ordinal) &&
+                string.Equals(x.Message, y.Message, StringComparison.Ordinal);
+        }
+
+        public int GetHashCode(ModelValidationResult obj)
+        {
+            if (obj == null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+
+            var hashCodeCombiner = HashCodeCombiner.Start();
+            hashCodeCombiner.Add(obj.MemberName, StringComparer.Ordinal);
+            hashCodeCombiner.Add(obj.Message, StringComparer.Ordinal);
+
+            return hashCodeCombiner.CombinedHash;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/ValidatableObjectAdapterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test/Internal/ValidatableObjectAdapterTest.cs
@@ -1,0 +1,221 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.DataAnnotations.Internal
+{
+    public class ValidatableObjectAdapterTest
+    {
+        private static readonly ModelMetadataProvider _metadataProvider
+            = TestModelMetadataProvider.CreateDefaultProvider();
+
+        // Inspired by DataAnnotationsModelValidatorTest.Validate_SetsMemberName_AsExpectedData but using a type that
+        // implements IValidatableObject. Values are metadata, expected DisplayName, and expected MemberName.
+        public static TheoryData<ModelMetadata, string, string> Validate_PassesExpectedNamesData
+        {
+            get
+            {
+                var method = typeof(SampleModel).GetMethod(nameof(SampleModel.IsLovely));
+                var parameter = method.GetParameters()[0]; // IsLovely(SampleModel other)
+                return new TheoryData<ModelMetadata, string, string>
+                {
+                    {
+                        // Validating a property.
+                        _metadataProvider.GetMetadataForProperty(
+                            typeof(SampleModelContainer),
+                            nameof(SampleModelContainer.SampleModel)),
+                        nameof(SampleModelContainer.SampleModel),
+                        nameof(SampleModelContainer.SampleModel)
+                    },
+                    {
+                        // Validating a property with [Display(Name = "...")].
+                        _metadataProvider.GetMetadataForProperty(
+                            typeof(SampleModelContainer),
+                            nameof(SampleModelContainer.SampleModelWithDisplay)),
+                        "sample model",
+                        nameof(SampleModelContainer.SampleModelWithDisplay)
+                    },
+                    {
+                        // Validating a parameter.
+                        _metadataProvider.GetMetadataForParameter(parameter),
+                        "other",
+                        "other"
+                    },
+                    {
+                        // Validating a top-level parameter when using old-fashioned metadata provider.
+                        // Or, validating an element of a collection.
+                        _metadataProvider.GetMetadataForType(typeof(SampleModel)),
+                        nameof(SampleModel),
+                        null
+                    },
+                };
+            }
+        }
+
+        public static TheoryData<ValidationResult[], ModelValidationResult[]> Validate_ReturnsExpectedResultsData
+        {
+            get
+            {
+                return new TheoryData<ValidationResult[], ModelValidationResult[]>
+                {
+                    {
+                        new[] { new ValidationResult("Error message") },
+                        new[] { new ModelValidationResult(memberName: null, message: "Error message") }
+                    },
+                    {
+                        new[] { new ValidationResult("Error message", new[] { nameof(SampleModel.FirstName) }) },
+                        new[] { new ModelValidationResult(nameof(SampleModel.FirstName), "Error message") }
+                    },
+                    {
+                        new[]
+                        {
+                            new ValidationResult("Error message1"),
+                            new ValidationResult("Error message2", new[] { nameof(SampleModel.FirstName) }),
+                            new ValidationResult("Error message3", new[] { nameof(SampleModel.LastName) }),
+                            new ValidationResult("Error message4", new[] { nameof(SampleModel) }),
+                        },
+                        new[]
+                        {
+                            new ModelValidationResult(memberName: null, message: "Error message1"),
+                            new ModelValidationResult(nameof(SampleModel.FirstName), "Error message2"),
+                            new ModelValidationResult(nameof(SampleModel.LastName), "Error message3"),
+                            // No special case for ValidationContext.MemberName==ValidationResult.MemberName
+                            new ModelValidationResult(nameof(SampleModel), "Error message4"),
+                        }
+                    },
+                    {
+                        new[]
+                        {
+                            new ValidationResult("Error message1", new[]
+                            {
+                                nameof(SampleModel.FirstName),
+                                nameof(SampleModel.LastName),
+                            }),
+                            new ValidationResult("Error message2"),
+                        },
+                        new[]
+                        {
+                            new ModelValidationResult(nameof(SampleModel.FirstName), "Error message1"),
+                            new ModelValidationResult(nameof(SampleModel.LastName), "Error message1"),
+                            new ModelValidationResult(memberName: null, message: "Error message2"),
+                        }
+                    },
+                };
+            }
+        }
+
+
+        [Theory]
+        [MemberData(nameof(Validate_PassesExpectedNamesData))]
+        public void Validate_PassesExpectedNames(
+            ModelMetadata metadata,
+            string expectedDisplayName,
+            string expectedMemberName)
+        {
+            // Arrange
+            var adapter = new ValidatableObjectAdapter();
+            var model = new SampleModel();
+            var validationContext = new ModelValidationContext(
+                new ActionContext(),
+                metadata,
+                _metadataProvider,
+                container: new SampleModelContainer(),
+                model: model);
+
+            // Act
+            var results = adapter.Validate(validationContext);
+
+            // Assert
+            Assert.NotNull(results);
+            Assert.Empty(results);
+
+            Assert.Equal(expectedDisplayName, model.DisplayName);
+            Assert.Equal(expectedMemberName, model.MemberName);
+            Assert.Equal(model, model.ObjectInstance);
+        }
+
+        [Theory]
+        [MemberData(nameof(Validate_ReturnsExpectedResultsData))]
+        public void Validate_ReturnsExpectedResults(
+            ValidationResult[] innerResults,
+            ModelValidationResult[] expectedResults)
+        {
+            // Arrange
+            var adapter = new ValidatableObjectAdapter();
+            var model = new SampleModel();
+            foreach (var result in innerResults)
+            {
+                model.ValidationResults.Add(result);
+            }
+
+            var metadata = _metadataProvider.GetMetadataForProperty(
+                typeof(SampleModelContainer),
+                nameof(SampleModelContainer.SampleModel));
+            var validationContext = new ModelValidationContext(
+                new ActionContext(),
+                metadata,
+                _metadataProvider,
+                container: null,
+                model: model);
+
+            // Act
+            var results = adapter.Validate(validationContext);
+
+            // Assert
+            Assert.NotNull(results);
+            Assert.Equal(expectedResults, results, ModelValidationResultComparer.Instance);
+        }
+
+        private class SampleModel : IValidatableObject
+        {
+            // "Real" properties.
+
+            public string FirstName { get; set; }
+
+            public string LastName { get; set; }
+
+            // ValidationContext members passed to Validate(...)
+
+            public string DisplayName { get; private set; }
+
+            public string MemberName { get; private set; }
+
+            public object ObjectInstance { get; private set; }
+
+            // What Validate(...) should return.
+
+            public IList<ValidationResult> ValidationResults { get; } = new List<ValidationResult>();
+
+            // Test method.
+
+            public bool IsLovely(SampleModel other)
+            {
+                return true;
+            }
+
+            // IValidatableObject for realz.
+
+            public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+            {
+                DisplayName = validationContext.DisplayName;
+                MemberName = validationContext.MemberName;
+                ObjectInstance = validationContext.ObjectInstance;
+
+                return ValidationResults;
+            }
+        }
+
+        private class SampleModelContainer
+        {
+            [Display(Name = "sample model")]
+            public SampleModel SampleModelWithDisplay { get; set; }
+
+            public SampleModel SampleModel { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.TestCommon/TestModelMetadataProvider.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TestCommon/TestModelMetadataProvider.cs
@@ -112,6 +112,15 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             return builder;
         }
 
+        public IMetadataBuilder ForParameter(ParameterInfo parameter)
+        {
+            var key = ModelMetadataIdentity.ForParameter(parameter);
+            var builder = new MetadataBuilder(key);
+            _detailsProvider.Builders.Add(builder);
+
+            return builder;
+        }
+
         public IMetadataBuilder ForProperty<TContainer>(string propertyName)
         {
             return ForProperty(typeof(TContainer), propertyName);


### PR DESCRIPTION
- #7413 part 2 of 2
- add `ModelMetadata.Name` and `ParameterName`
  - use `Name` instead of `PropertyName` in most cases
- update `ModelMetadata.ContainerType` and other property use
  - choose using `MetadataKind` almost everywhere; support all possibilties
    - usually parameter metadata was possible but not handled
    - worst case was one or two potential NREs, especially `ContainerType.*` dereferences
  - improve `MvcCoreLoggerExtensions` metadata handling
    - add three new debug messages, one for type metadata and two for parameter metadata
- update `ModelMetadata.ContainerMetadata`, `ContainerType` and `PropertyName` doc comments
- no changes needed in Microsoft.AspNetCore.Mvc.ViewFeatures because parameters aren't viewed

nits:
- add missing `TestModelMetadataProvider.ForParameter(...)` method
- remove unused `EmptyModelMetadataProvider` instances in `ModelMetadataTest`
- refactor `ModelValidationResultComparer` out of DataAnnotationsModelValidatorTest`
- take VS suggestions, mostly related to variable inlining and object initializers