### PR TITLE
Implement IDisposable for derived types for WebApplicationFactory<T>

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Testing/WebApplicationFactory.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Testing/WebApplicationFactory.cs
@@ -20,6 +20,7 @@ namespace Microsoft.AspNetCore.Mvc.Testing
     /// Typically the Startup or Program classes can be used.</typeparam>
     public class WebApplicationFactory<TEntryPoint> : IDisposable where TEntryPoint : class
     {
+        private bool _disposed;
         private TestServer _server;
         private Action<IWebHostBuilder> _configuration;
         private IList<HttpClient> _clients = new List<HttpClient>();
@@ -52,6 +53,14 @@ namespace Microsoft.AspNetCore.Mvc.Testing
         public WebApplicationFactory()
         {
             _configuration = ConfigureWebHost;
+        }
+
+        /// <summary>
+        /// Finalizes an instance of the <see cref="WebApplicationFactory{TEntryPoint}"/> class.
+        /// </summary>
+        ~WebApplicationFactory()
+        {
+            Dispose(false);
         }
 
         /// <summary>
@@ -327,6 +336,24 @@ namespace Microsoft.AspNetCore.Mvc.Testing
         /// <inheritdoc />
         public void Dispose()
         {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        /// <param name="disposing">
+        /// <see langword="true" /> to release both managed and unmanaged resources;
+        /// <see langword="false" /> to release only unmanaged resources.
+        /// </param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
             foreach (var client in _clients)
             {
                 client.Dispose();
@@ -338,6 +365,7 @@ namespace Microsoft.AspNetCore.Mvc.Testing
             }
 
             _server?.Dispose();
+            _disposed = true;
         }
 
         private class DelegatedWebApplicationFactory : WebApplicationFactory<TEntryPoint>

--- a/src/Microsoft.AspNetCore.Mvc.Testing/WebApplicationFactory.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Testing/WebApplicationFactory.cs
@@ -354,17 +354,21 @@ namespace Microsoft.AspNetCore.Mvc.Testing
                 return;
             }
 
-            foreach (var client in _clients)
+            if (disposing)
             {
-                client.Dispose();
-            }
+                foreach (var client in _clients)
+                {
+                    client.Dispose();
+                }
 
-            foreach (var factory in _derivedFactories)
-            {
-                factory.Dispose();
-            }
+                foreach (var factory in _derivedFactories)
+                {
+                    factory.Dispose();
+                }
 
-            _server?.Dispose();
+                _server?.Dispose();
+            }
+            
             _disposed = true;
         }
 


### PR DESCRIPTION
Add a protected `Dispose(bool)` method and a finalizer to `WebApplicationFactory<T>` for use in classes that derive from it and want to dispose of their own resources.

Resolves #7631.