### PR TITLE
Make CreateDefaultClient() virtual in WebApplicationFactory<T>

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Testing/WebApplicationFactory.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Testing/WebApplicationFactory.cs
@@ -293,7 +293,7 @@ namespace Microsoft.AspNetCore.Mvc.Testing
         /// <param name="handlers">A list of <see cref="DelegatingHandler"/> instances to set up on the
         /// <see cref="HttpClient"/>.</param>
         /// <returns>The <see cref="HttpClient"/>.</returns>
-        public HttpClient CreateDefaultClient(Uri baseAddress, params DelegatingHandler[] handlers)
+        public virtual HttpClient CreateDefaultClient(Uri baseAddress, params DelegatingHandler[] handlers)
         {
             EnsureServer();
             if (handlers == null || handlers.Length == 0)


### PR DESCRIPTION
Make `CreateDefaultClient(Uri, DelegatingHandler[])` virtual to make it easier for consumers of `WebApplicationFactory<T>` to modify created instances of `HttpClient` in derived types.

Resolves #7635.
