### PR TITLE
Fix binding & validating dictionaries of non-simple types in jQuery requests

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ShortFormDictionaryValidationStrategy.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ShortFormDictionaryValidationStrategy.cs
@@ -17,14 +17,14 @@ namespace Microsoft.AspNetCore.Mvc.Internal
     /// <remarks>
     /// This implementation handles cases like:
     /// <example>
-    ///     Model: IDictionary&lt;string, Student&gt; 
+    ///     Model: IDictionary&lt;string, Student&gt;
     ///     Query String: ?students[Joey].Age=8&amp;students[Katherine].Age=9
-    /// 
+    ///
     ///     In this case, 'Joey' and 'Katherine' are the keys of the dictionary, used to bind two 'Student'
     ///     objects. The enumerator returned from this class will yield two 'Student' objects with corresponding
     ///     keys 'students[Joey]' and 'students[Katherine]'
     /// </example>
-    /// 
+    ///
     /// Using this key format, the enumerator enumerates model objects of type <typeparamref name="TValue"/>. The
     /// keys of the dictionary are not validated as they must be simple types.
     /// </remarks>
@@ -35,7 +35,9 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         /// <summary>
         /// Creates a new <see cref="ShortFormDictionaryValidationStrategy{TKey, TValue}"/>.
         /// </summary>
-        /// <param name="keyMappings">The mapping from model prefix key to dictionary key.</param>
+        /// <param name="keyMappings">
+        /// The mapping from <see cref="ModelStateDictionary"/> key to dictionary key.
+        /// </param>
         /// <param name="valueMetadata">
         /// The <see cref="ModelMetadata"/> associated with <typeparamref name="TValue"/>.
         /// </param>
@@ -48,7 +50,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         /// <summary>
-        /// Gets the mapping from model prefix key to dictionary key.
+        /// Gets the mapping from <see cref="ModelStateDictionary"/> key to dictionary key.
         /// </summary>
         public IEnumerable<KeyValuePair<string, TKey>> KeyMappings { get; }
 
@@ -58,12 +60,12 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             string key,
             object model)
         {
-            return new Enumerator(_valueMetadata, key, KeyMappings, (IDictionary<TKey, TValue>)model);
+            // key is not needed because KeyMappings maps from full ModelState keys to dictionary keys.
+            return new Enumerator(_valueMetadata, KeyMappings, (IDictionary<TKey, TValue>)model);
         }
 
         private class Enumerator : IEnumerator<ValidationEntry>
         {
-            private readonly string _key;
             private readonly ModelMetadata _metadata;
             private readonly IDictionary<TKey, TValue> _model;
             private readonly IEnumerator<KeyValuePair<string, TKey>> _keyMappingEnumerator;
@@ -72,14 +74,11 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
             public Enumerator(
                 ModelMetadata metadata,
-                string key,
                 IEnumerable<KeyValuePair<string, TKey>> keyMappings,
                 IDictionary<TKey, TValue> model)
             {
                 _metadata = metadata;
-                _key = key;
                 _model = model;
-
                 _keyMappingEnumerator = keyMappings.GetEnumerator();
             }
 
@@ -104,10 +103,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                     }
                 }
 
-                var key = ModelNames.CreateIndexModelName(_key, _keyMappingEnumerator.Current.Key);
-                var model = value;
-
-                _entry = new ValidationEntry(_metadata, key, model);
+                _entry = new ValidationEntry(_metadata, _keyMappingEnumerator.Current.Key, value);
 
                 return true;
             }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/JQueryKeyValuePairNormalizer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/JQueryKeyValuePairNormalizer.cs
@@ -86,7 +86,12 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 else
                 {
                     // Field name. Convert to dot notation.
-                    builder.Append('.');
+                    if (builder.Length != 0)
+                    {
+                        // Was x[field], not [field] or [][field].
+                        builder.Append('.');
+                    }
+
                     builder.Append(key, indexOpen + 1, indexClose - indexOpen - 1);
                 }
 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ShortFormDictionaryValidationStrategyTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/ShortFormDictionaryValidationStrategyTest.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using Xunit;
 
-
 namespace Microsoft.AspNetCore.Mvc.Internal
 {
     public class ShortFormDictionaryValidationStrategyTest
@@ -28,14 +27,14 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             var valueMetadata = metadataProvider.GetMetadataForType(typeof(string));
             var strategy = new ShortFormDictionaryValidationStrategy<int, string>(new Dictionary<string, int>()
             {
-                { "2", 2 },
-                { "3", 3 },
-                { "5", 5 },
+                { "prefix[2]", 2 },
+                { "prefix[3]", 3 },
+                { "prefix[5]", 5 },
             },
             valueMetadata);
 
             // Act
-            var enumerator = strategy.GetChildren(metadata, "prefix", model);
+            var enumerator = strategy.GetChildren(metadata, "ignored prefix", model);
 
             // Assert
             Assert.Collection(
@@ -76,13 +75,13 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             var valueMetadata = metadataProvider.GetMetadataForType(typeof(string));
             var strategy = new ShortFormDictionaryValidationStrategy<int, string>(new Dictionary<string, int>()
             {
-                { "2", 2 },
-                { "3", 3 },
+                { "prefix[2]", 2 },
+                { "prefix[3]", 3 },
             },
             valueMetadata);
 
             // Act
-            var enumerator = strategy.GetChildren(metadata, "prefix", model);
+            var enumerator = strategy.GetChildren(metadata, "ignored prefix", model);
 
             // Assert
             Assert.Collection(
@@ -116,14 +115,14 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             var valueMetadata = metadataProvider.GetMetadataForType(typeof(string));
             var strategy = new ShortFormDictionaryValidationStrategy<int, string>(new Dictionary<string, int>()
             {
-                { "2", 2 },
-                { "3", 3 },
-                { "5", 5 },
+                { "prefix[2]", 2 },
+                { "prefix[3]", 3 },
+                { "prefix[5]", 5 },
             },
             valueMetadata);
 
             // Act
-            var enumerator = strategy.GetChildren(metadata, "prefix", model);
+            var enumerator = strategy.GetChildren(metadata, "ignored prefix", model);
 
             // Assert
             Assert.Collection(

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/DictionaryModelBinderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/Binders/DictionaryModelBinderTest.cs
@@ -302,8 +302,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             Assert.Equal(
                 new KeyValuePair<string, int>[]
                 {
-                    new KeyValuePair<string, int>("23", 23),
-                    new KeyValuePair<string, int>("27", 27),
+                    new KeyValuePair<string, int>("prefix[23]", 23),
+                    new KeyValuePair<string, int>("prefix[27]", 27),
                 }.OrderBy(kvp => kvp.Key),
                 strategy.KeyMappings.OrderBy(kvp => kvp.Key));
         }
@@ -532,15 +532,14 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
 
             public override bool Equals(object obj)
             {
-                var other = obj as ModelWithProperties;
-                return other != null &&
+                return obj is ModelWithProperties other &&
                     Id == other.Id &&
                     string.Equals(Name, other.Name, StringComparison.Ordinal);
             }
 
             public override int GetHashCode()
             {
-                int nameCode = Name == null ? 0 : Name.GetHashCode();
+                var nameCode = Name == null ? 0 : Name.GetHashCode();
                 return nameCode ^ Id.GetHashCode();
             }
 

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/JQueryFormValueProviderFactoryTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/JQueryFormValueProviderFactoryTest.cs
@@ -89,12 +89,12 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Test
                     "[14]property1[15]property2",
                     "prefix.property1[13]",
                     "prefix[14][15]",
-                    ".property5",
-                    ".property6Value",
+                    "property5",
+                    "property6Value",
                     "prefix.property2",
                     "prefix.propertyValue",
-                    ".property7.property8",
-                    ".property9.property10Value",
+                    "property7.property8",
+                    "property9.property10Value",
                 };
             }
         }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/JQueryQueryStringValueProviderFactoryTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ModelBinding/JQueryQueryStringValueProviderFactoryTest.cs
@@ -17,6 +17,12 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Test
     {
         private static readonly Dictionary<string, StringValues> _backingStore = new Dictionary<string, StringValues>
         {
+            // Reviewers: A fair number of cases in the following dataset seem impossible for jQuery.ajax() to send
+            // given how $.ajax() and $.param() are defined i.e. $.param() won't add a bare name after ']'. Also, the
+            // names we generate for <input/> elements are always valid. Should we remove these weird / invalid cases
+            // e.g. normalizing "property[]Value"? (That normalizes to "propertyValue".) See also
+            // https://github.com/jquery/jquery/blob/1ea092a54b00aa4d902f4e22ada3854d195d4a18/src/serialize.js#L13-L92
+            // The alternative is to handle "[]name" and "[index]name" cases while normalizing keys.
             { "[]", new[] { "found" } },
             { "[]property1", new[] { "found" } },
             { "property2[]", new[] { "found" } },
@@ -57,12 +63,12 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Test
                     "[14]property1[15]property2",
                     "prefix.property1[13]",
                     "prefix[14][15]",
-                    ".property5",
-                    ".property6Value",
+                    "property5",
+                    "property6Value",
                     "prefix.property2",
                     "prefix.propertyValue",
-                    ".property7.property8",
-                    ".property9.property10Value",
+                    "property7.property8",
+                    "property9.property10Value",
                 };
             }
         }


### PR DESCRIPTION
- #7423
- retry failed inner bindings with alternate syntax in `ModelStateDictionary`
  - use property syntax if first attempt tried index syntax and visa versa
- instantiate `ShortFormDictionaryValidationStrategy` with full `ModelState` keys
  - can now provide exact `ModelState` keys that `ModelStateDictionary` used in inner bindings
- normalize model names without a leading period in `JQueryKeyValuePairNormalizer`

nits:
- take a few VS suggestions