### PR TITLE
[Fixes #7587] No easy way to change ASPNETCORE_ENVIRONMENT

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Testing/WebApplicationFactory.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Testing/WebApplicationFactory.cs
@@ -234,13 +234,22 @@ namespace Microsoft.AspNetCore.Mvc.Testing
         /// array as arguments.
         /// </remarks>
         /// <returns>A <see cref="IWebHostBuilder"/> instance.</returns>
-        protected virtual IWebHostBuilder CreateWebHostBuilder() =>
-            WebHostBuilderFactory.CreateFromTypesAssemblyEntryPoint<TEntryPoint>(Array.Empty<string>()) ??
-            throw new InvalidOperationException(Resources.FormatMissingCreateWebHostBuilderMethod(
-                nameof(IWebHostBuilder),
-                typeof(TEntryPoint).Assembly.EntryPoint.DeclaringType.FullName,
-                typeof(WebApplicationFactory<TEntryPoint>).Name,
-                nameof(CreateWebHostBuilder)));
+        protected virtual IWebHostBuilder CreateWebHostBuilder()
+        {
+            var builder = WebHostBuilderFactory.CreateFromTypesAssemblyEntryPoint<TEntryPoint>(Array.Empty<string>());
+            if (builder == null)
+            {
+                throw new InvalidOperationException(Resources.FormatMissingCreateWebHostBuilderMethod(
+                    nameof(IWebHostBuilder),
+                    typeof(TEntryPoint).Assembly.EntryPoint.DeclaringType.FullName,
+                    typeof(WebApplicationFactory<TEntryPoint>).Name,
+                    nameof(CreateWebHostBuilder)));
+            }
+            else
+            {
+                return builder.UseEnvironment("Development");
+            }
+        }
 
         /// <summary>
         /// Creates the <see cref="TestServer"/> with the bootstrapped application in <paramref name="builder"/>.


### PR DESCRIPTION
Set the environment to development by default. This allows users to write tests as long as the app runs with dotnet run/F5 on visual studio.