### PR TITLE
Removed UrlTestEncoder references in tests

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AttributeRoutingTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/AttributeRoutingTest.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text.Encodings.Web;
-using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
@@ -16,9 +14,8 @@ using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Microsoft.Extensions.ObjectPool;
-using Microsoft.Extensions.WebEncoders.Testing;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -180,8 +177,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
             var services = new ServiceCollection()
                 .AddSingleton<IInlineConstraintResolver>(new DefaultInlineConstraintResolver(routeOptions.Object))
-                .AddSingleton<ObjectPoolProvider, DefaultObjectPoolProvider>()
-                .AddSingleton<UrlEncoder>(new UrlTestEncoder());
+                .AddSingleton<ObjectPoolProvider, DefaultObjectPoolProvider>();
 
             services.AddSingleton<ObjectPoolProvider, DefaultObjectPoolProvider>();
             services.AddRouting();

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.EditWarehouse.Encoded.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.EditWarehouse.Encoded.html
@@ -1,6 +1,6 @@
 <html>
 <body>
-    <form action="HtmlEncode[[/UrlEncode[[HtmlGeneration_Home]]/UrlEncode[[EditWarehouse]]]]" method="HtmlEncode[[post]]">
+    <form action="HtmlEncode[[/HtmlGeneration_Home/EditWarehouse]]" method="HtmlEncode[[post]]">
         <div>
             HtmlEncode[[City_1]]
             <input type="HtmlEncode[[text]]" data-val="HtmlEncode[[true]]" data-val-minlength="HtmlEncode[[The field City must be a string or array type with a minimum length of '2'.]]" data-val-minlength-min="HtmlEncode[[2]]" id="HtmlEncode[[City]]" name="HtmlEncode[[City]]" value="HtmlEncode[[City_1]]" />

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Index.Encoded.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Index.Encoded.html
@@ -1,10 +1,10 @@
 <html>
 <body>
     <div>
-        <a title="&lt;the title>" href="HtmlEncode[[/UrlEncode[[HtmlGeneration_Product]]]]">Product Index</a>
+        <a title="&lt;the title>" href="HtmlEncode[[/HtmlGeneration_Product]]">Product Index</a>
     </div>
     <div>
-        <a title='"the" title' href="HtmlEncode[[/UrlEncode[[HtmlGeneration_Product]]/UrlEncode[[List]]]]">Product List</a>
+        <a title='"the" title' href="HtmlEncode[[/HtmlGeneration_Product/List]]">Product List</a>
     </div>
     <div>
         <a id="HtmlGenerationWebSite_Index">HtmlGenerationWebSite Index</a>
@@ -13,10 +13,10 @@
         <a href="HtmlEncode[[/]]">Default Controller</a>
     </div>
     <div>
-        <a href="HtmlEncode[[/UrlEncode[[Product]]/UrlEncode[[Index]]#fragment]]">Product Index Fragment</a>
+        <a href="HtmlEncode[[/Product/Index#fragment]]">Product Index Fragment</a>
     </div>
     <div>
-        <a href="HtmlEncode[[/UrlEncode[[HtmlGeneration_Product]]/UrlEncode[[Submit]]#fragment]]">Product Submit Fragment</a>
+        <a href="HtmlEncode[[/HtmlGeneration_Product/Submit#fragment]]">Product Submit Fragment</a>
     </div>
     <div>
         <a id="HtmlGenerationWebSite_IndexFragment" href="HtmlEncode[[/#fragment]]">
@@ -29,7 +29,7 @@
         </a>
     </div>
     <div>
-        <a href="HtmlEncode[[unkonwn://localhost/UrlEncode[[HtmlGeneration_Product]]/UrlEncode[[List]]]]">
+        <a href="HtmlEncode[[unkonwn://localhost/HtmlGeneration_Product/List]]">
             Unknown Protocol Product List
         </a>
     </div>
@@ -39,32 +39,32 @@
         </a>
     </div>
     <div>
-        <a href="HtmlEncode[[/UrlEncode[[Customer]]/UrlEncode[[Customer]]#fragment]]">Customer Area Customer Index</a>
+        <a href="HtmlEncode[[/Customer/Customer#fragment]]">Customer Area Customer Index</a>
     </div>
     <div>
         <a href="/Order/List">Href Order List</a>
     </div>
     <div>
-        <a href="HtmlEncode[[/UrlEncode[[NonExistentController]]]]">Non-existent Controller</a>
+        <a href="HtmlEncode[[/NonExistentController]]">Non-existent Controller</a>
     </div>
     <div>
-        <a href="HtmlEncode[[/UrlEncode[[NonExistentController]]#fragment]]">
+        <a href="HtmlEncode[[/NonExistentController#fragment]]">
             Non-existent Controller Fragment
         </a>
     </div>
     <div>
-        <a href="HtmlEncode[[/UrlEncode[[Order]]/UrlEncode[[NonExistentAction]]]]">Non-existent Action</a>
+        <a href="HtmlEncode[[/Order/NonExistentAction]]">Non-existent Action</a>
     </div>
     <div>
         <a id="Id" href="HtmlEncode[[http://somewhere/]]">Some Where</a>
     </div>
     <div>
-        <a href="HtmlEncode[[unknown://localhost/UrlEncode[[NoControll]]#fragment]]">
+        <a href="HtmlEncode[[unknown://localhost/NoControll#fragment]]">
             Unknown Protocol Non-existent Controller Fragment
         </a>
     </div>
     <div>
-        <a href="HtmlEncode[[/UrlEncode[[Product]]/UrlEncode[[Submit]]?UrlEncode[[area]]=UrlEncode[[NonExistentArea]]&UrlEncode[[id]]=UrlEncode[[1]]#fragment]]">Product Route Non-existent Area Parameter</a>
+        <a href="HtmlEncode[[/Product/Submit?area=NonExistentArea&id=1#fragment]]">Product Route Non-existent Area Parameter</a>
     </div>
     <div>
         <a href="">Non-existent Area</a>

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Order.Encoded.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Order.Encoded.html
@@ -1,10 +1,10 @@
-<html>
+﻿<html>
 <head>
     <meta charset="utf-8" />
     <title></title>
 </head>
 <body>
-    <form action="HtmlEncode[[/UrlEncode[[HtmlGeneration_Order]]/UrlEncode[[Submit]]]]" method="HtmlEncode[[post]]">
+    <form action="HtmlEncode[[/HtmlGeneration_Order/Submit]]" method="HtmlEncode[[post]]">
         <div>
             <label class="order" for="HtmlEncode[[Shipping]]">HtmlEncode[[Shipping]]</label>
             <input type="HtmlEncode[[text]]" size="50" id="HtmlEncode[[Shipping]]" name="HtmlEncode[[Shipping]]" value="HtmlEncode[[Your shipping method is UPSP]]" />

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.OrderUsingHtmlHelpers.Encoded.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.OrderUsingHtmlHelpers.Encoded.html
@@ -1,10 +1,10 @@
-<html>
+﻿<html>
 <head>
     <meta charset="utf-8" />
     <title></title>
 </head>
 <body>
-<form action="HtmlEncode[[/UrlEncode[[HtmlGeneration_Order]]/UrlEncode[[Submit]]]]" method="HtmlEncode[[post]]">
+<form action="HtmlEncode[[/HtmlGeneration_Order/Submit]]" method="HtmlEncode[[post]]">
         <div>
             <label class="HtmlEncode[[order]]" for="HtmlEncode[[Shipping]]">HtmlEncode[[Shipping]]</label>
             <input id="HtmlEncode[[Shipping]]" name="HtmlEncode[[Shipping]]" size="HtmlEncode[[50]]" type="HtmlEncode[[text]]" value="HtmlEncode[[Your shipping method is UPSP]]" />

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Product.Encoded.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Product.Encoded.html
@@ -1,10 +1,10 @@
-<html>
+﻿<html>
 <head>
     <meta charset="utf-8" />
     <title></title>
 </head>
 <body>
-    <form method="HtmlEncode[[get]]" action="HtmlEncode[[/UrlEncode[[HtmlGeneration_Home]]/UrlEncode[[ProductSubmit]]]]">
+    <form method="HtmlEncode[[get]]" action="HtmlEncode[[/HtmlGeneration_Home/ProductSubmit]]">
         <div>
             <label class="product" for="HtmlEncode[[HomePage]]">HtmlEncode[[HomePage]]</label>
             <input type="HtmlEncode[[url]]" size="50" id="HtmlEncode[[HomePage]]" name="HtmlEncode[[HomePage]]" value="HtmlEncode[[http://www.contoso.com/]]" />

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/RemoteAttributeTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/RemoteAttributeTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
@@ -19,7 +18,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.ObjectPool;
 using Microsoft.Extensions.Options;
-using Microsoft.Extensions.WebEncoders.Testing;
 using Moq;
 using Xunit;
 using Resources = Microsoft.AspNetCore.Mvc.ViewFeatures.Test.Resources;
@@ -698,7 +696,7 @@ namespace Microsoft.AspNetCore.Mvc
                 kvp =>
                 {
                     Assert.Equal("data-val-remote-url", kvp.Key);
-                    Assert.Equal("/UrlEncode[[Controller]]/UrlEncode[[Action]]", kvp.Value);
+                    Assert.Equal("/Controller/Action", kvp.Value);
                 });
         }
 
@@ -723,7 +721,7 @@ namespace Microsoft.AspNetCore.Mvc
                 kvp =>
                 {
                     Assert.Equal("data-val-remote-url", kvp.Key);
-                    Assert.Equal("/UrlEncode[[Test]]/UrlEncode[[Controller]]/UrlEncode[[Action]]", kvp.Value);
+                    Assert.Equal("/Test/Controller/Action", kvp.Value);
                 });
         }
 
@@ -749,7 +747,7 @@ namespace Microsoft.AspNetCore.Mvc
                 kvp =>
                 {
                     Assert.Equal("data-val-remote-url", kvp.Key);
-                    Assert.Equal("/UrlEncode[[Controller]]/UrlEncode[[Action]]", kvp.Value);
+                    Assert.Equal("/Controller/Action", kvp.Value);
                 });
         }
 
@@ -775,7 +773,7 @@ namespace Microsoft.AspNetCore.Mvc
                 kvp =>
                 {
                     Assert.Equal("data-val-remote-url", kvp.Key);
-                    Assert.Equal("/UrlEncode[[Controller]]/UrlEncode[[Action]]", kvp.Value);
+                    Assert.Equal("/Controller/Action", kvp.Value);
                 });
         }
 
@@ -800,7 +798,7 @@ namespace Microsoft.AspNetCore.Mvc
                 kvp =>
                 {
                     Assert.Equal("data-val-remote-url", kvp.Key);
-                    Assert.Equal("/UrlEncode[[Test]]/UrlEncode[[Controller]]/UrlEncode[[Action]]", kvp.Value);
+                    Assert.Equal("/Test/Controller/Action", kvp.Value);
                 });
         }
 
@@ -825,7 +823,7 @@ namespace Microsoft.AspNetCore.Mvc
                 kvp =>
                 {
                     Assert.Equal("data-val-remote-url", kvp.Key);
-                    Assert.Equal("/UrlEncode[[Test]]/UrlEncode[[Controller]]/UrlEncode[[Action]]", kvp.Value);
+                    Assert.Equal("/Test/Controller/Action", kvp.Value);
                 });
         }
 
@@ -850,7 +848,7 @@ namespace Microsoft.AspNetCore.Mvc
                 kvp =>
                 {
                     Assert.Equal("data-val-remote-url", kvp.Key);
-                    Assert.Equal("/UrlEncode[[AnotherArea]]/UrlEncode[[Controller]]/UrlEncode[[Action]]", kvp.Value);
+                    Assert.Equal("/AnotherArea/Controller/Action", kvp.Value);
                 });
         }
 
@@ -1041,8 +1039,7 @@ namespace Microsoft.AspNetCore.Mvc
             var serviceCollection = new ServiceCollection();
             serviceCollection
                 .AddSingleton<ObjectPoolProvider, DefaultObjectPoolProvider>()
-                .AddSingleton<ILoggerFactory>(new NullLoggerFactory())
-                .AddSingleton<UrlEncoder>(new UrlTestEncoder());
+                .AddSingleton<ILoggerFactory>(new NullLoggerFactory());
 
             serviceCollection.AddOptions();
             serviceCollection.AddRouting();

--- a/test/WebSites/SimpleWebSite/Startup.cs
+++ b/test/WebSites/SimpleWebSite/Startup.cs
@@ -22,7 +22,6 @@ namespace SimpleWebSite
                 .AddAuthorization()
                 .AddFormatterMappings(m => m.SetMediaTypeMappingForFormat("js", new MediaTypeHeaderValue("application/json")))
                 .AddJsonFormatters(j => j.Formatting = Formatting.Indented);
-            services.AddSingleton<UrlEncoder, UrlTestEncoder>();
         }
 
         public void Configure(IApplicationBuilder app)


### PR DESCRIPTION
This is because with the following commit, Routing no longer depends on DI to get a UrlEncoder and always uses UrlEncoder.Default.
https://github.com/aspnet/Routing/commit/4184b2406d8c65dda7f7fb4faf365f79a2b45f02