### PR TITLE
Fix test failures

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,7 +5,7 @@
   <PropertyGroup Label="Package Versions">
     <AngleSharpPackageVersion>0.9.9</AngleSharpPackageVersion>
     <BenchmarkDotNetPackageVersion>0.10.13</BenchmarkDotNetPackageVersion>
-    <InternalAspNetCoreSdkPackageVersion>2.1.0-preview3-17018</InternalAspNetCoreSdkPackageVersion>
+    <InternalAspNetCoreSdkPackageVersion>2.1.0-preview3-17032</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftAspNetCoreAntiforgeryPackageVersion>2.1.0-preview3-32233</MicrosoftAspNetCoreAntiforgeryPackageVersion>
     <MicrosoftAspNetCoreAuthenticationCookiesPackageVersion>2.1.0-preview3-32233</MicrosoftAspNetCoreAuthenticationCookiesPackageVersion>
     <MicrosoftAspNetCoreAuthenticationCorePackageVersion>2.1.0-preview3-32233</MicrosoftAspNetCoreAuthenticationCorePackageVersion>

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.0-preview3-17018
-commithash:af264ca131f212b5ba8aafbc5110fc0fc510a2be
+version:2.1.0-preview3-17032
+commithash:d3d9c5682617da4d0a69372aae5d736ed733d156

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/RazorProjectPageRouteModelProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/RazorProjectPageRouteModelProvider.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 {
     public class RazorProjectPageRouteModelProvider : IPageRouteModelProvider
     {
-        private const string AreaRootDirectory = "/Areas/";
+        private const string AreaRootDirectory = "/Areas";
         private readonly RazorProjectFileSystem _razorFileSystem;
         private readonly RazorPagesOptions _pagesOptions;
         private readonly PageRouteModelFactory _routeModelFactory;

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ApplicationParts/ApplicationAssembliesProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ApplicationParts/ApplicationAssembliesProviderTest.cs
@@ -464,6 +464,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationParts
             var excludeAssemblies = new string[]
             {
                 "Microsoft.AspNetCore.Mvc.Core.Test",
+                "Microsoft.AspNetCore.Mvc.Razor.Extensions.Reference",
                 "Microsoft.AspNetCore.Mvc.TestCommon",
                 "Microsoft.AspNetCore.Mvc.TestDiagnosticListener",
                 "Microsoft.AspNetCore.Mvc.WebApiCompatShim",

--- a/test/WebSites/RazorPagesClassLibrary/RazorPagesClassLibrary.csproj
+++ b/test/WebSites/RazorPagesClassLibrary/RazorPagesClassLibrary.csproj
@@ -2,10 +2,14 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <!--  Workaround https://github.com/dotnet/core-setup/issues/3726 -->
+    <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Microsoft.AspNetCore.Mvc\Microsoft.AspNetCore.Mvc.csproj" />
+
+    <PackageReference Include="Microsoft.NET.Sdk.Razor" Version="$(MicrosoftNETSdkRazorPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
* Disable deps file generation in class library project. This workarounds known issue - https://github.com/dotnet/core-setup/issues/3726
* Update RazorProjectRouteModelProvider to not specify a trailing slash. This produces paths with a single slash as opposed to two slashes messing with route creation.
* React to Microsoft.AspNetCore.Mvc.Razor.Extensions.Reference that shows up in the deps file.