### PR TITLE
StatusCode() to take HttpStatusCode as parameter

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
@@ -229,6 +229,16 @@ namespace Microsoft.AspNetCore.Mvc
         }
 
         /// <summary>
+        /// Creates a <see cref="ObjectResult"/> object by specifying a <paramref name="statusCode"/> and <paramref name="value"/>
+        /// </summary>
+        /// <param name="statusCode">The status code to set on the response.</param>
+        /// <param name="value">The value to set on the <see cref="ObjectResult"/>.</param>
+        /// <returns>The created <see cref="ObjectResult"/> object for the response.</returns>
+        [NonAction]
+        public virtual ObjectResult StatusCode(HttpStatusCode statusCode, object value)
+            => StatusCode((int)statusCode, value);
+
+        /// <summary>
         /// Creates a <see cref="ContentResult"/> object with <see cref="StatusCodes.Status200OK"/> by specifying a
         /// <paramref name="content"/> string.
         /// </summary>


### PR DESCRIPTION
**Summary of the changes:**
Added extension method for StatusCode to take HttpStatusCode as parameter.
---
**Description:**
First there are these two methods:
```
StatusCode(int statusCode)
StatusCode(HttpStatusCode statusCode)
```

This is their object overload:
`StatusCode(int statusCode, object value)`


Extension method does not exist for **(and I just added it)**
`StatusCode(HttpStatusCode statusCode, object value)`

---

**Reasons to add this extension method:**
- Adds flexibility to use `HttpStatusCode` . No need to cast `HttpStatusCode` to `int`: 
```
return StatusCode((int) HttpStatusCode.ExpectationFailed, "Failed to fetch resource.");
```

- Help to prevent issues with invalid HttpStatusCodes: (example: typo 41 instead of 417)
```
return StatusCode(41, "Failed to fetch resource."); // triggers server error (w/ Postman)
```
