### PR TITLE
Ensure ViewData is set on PageResult after a handler method executes

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/PageActionInvoker.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/PageActionInvoker.cs
@@ -278,7 +278,8 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                 _result = new PageResult();
             }
 
-            // We also have some special initialization we need to do for PageResult.
+            // Ensure ViewData is set on PageResult for backwards compatibility (For example, Identity UI accesses
+            // ViewData in a PageFilter's PageHandlerExecutedMethod)
             if (_result is PageResult pageResult)
             {
                 pageResult.ViewData = pageResult.ViewData ?? _pageContext.ViewData;

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/PageActionInvoker.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/PageActionInvoker.cs
@@ -128,7 +128,6 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                 {
                     _page = (PageBase)CacheEntry.PageFactory(_pageContext, _viewContext);
                 }
-
                 pageResult.Page = _page;
                 pageResult.ViewData = pageResult.ViewData ?? _pageContext.ViewData;
             }
@@ -277,6 +276,12 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             if (_result == null)
             {
                 _result = new PageResult();
+            }
+
+            // We also have some special initialization we need to do for PageResult.
+            if (_result is PageResult pageResult)
+            {
+                pageResult.ViewData = pageResult.ViewData ?? _pageContext.ViewData;
             }
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RazorPagesTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RazorPagesTest.cs
@@ -1295,6 +1295,16 @@ Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary`1[AspNetCore.InjectedPa
             Assert.Equal("From ShortCircuitPageAtPageFilter.cshtml", content);
         }
 
+        [Fact]
+        public async Task ViewDataAvaialableInPageFilter_AfterHandlerMethod_ReturnsPageResult()
+        {
+            // Act
+            var content = await Client.GetStringAsync("http://localhost/Pages/ViewDataAvailableAfterHandlerExecuted");
+
+            // Assert
+            Assert.Equal("ViewData: Bar", content);
+        }
+
         private async Task AddAntiforgeryHeaders(HttpRequestMessage request)
         {
             var getResponse = await Client.GetAsync(request.RequestUri);

--- a/test/WebSites/RazorPagesWebSite/Pages/ViewDataAvailableAfterHandlerExecuted.cshtml
+++ b/test/WebSites/RazorPagesWebSite/Pages/ViewDataAvailableAfterHandlerExecuted.cshtml
@@ -1,0 +1,5 @@
+﻿@page
+@model ViewDataAvailableAfterHandlerExecutedModel
+@{
+}
+ViewData: @ViewData["Foo"]

--- a/test/WebSites/RazorPagesWebSite/Pages/ViewDataAvailableAfterHandlerExecuted.cshtml.cs
+++ b/test/WebSites/RazorPagesWebSite/Pages/ViewDataAvailableAfterHandlerExecuted.cshtml.cs
@@ -20,6 +20,8 @@ namespace RazorPagesWebSite.Pages
         {
             public void OnPageHandlerExecuted(PageHandlerExecutedContext context)
             {
+                // This usage mimics Identity UI where it sets data into ViewData in a PageFilters's
+                // PageHandlerExecuted method.
                 if (context.Result is PageResult pageResult)
                 {
                     pageResult.ViewData["Foo"] = "Bar";

--- a/test/WebSites/RazorPagesWebSite/Pages/ViewDataAvailableAfterHandlerExecuted.cshtml.cs
+++ b/test/WebSites/RazorPagesWebSite/Pages/ViewDataAvailableAfterHandlerExecuted.cshtml.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace RazorPagesWebSite.Pages
+{
+    [TestPageFilter]
+    public class ViewDataAvailableAfterHandlerExecutedModel : PageModel
+    {
+        public IActionResult OnGet()
+        {
+            return Page();
+        }
+
+        private class TestPageFilterAttribute : Attribute, IPageFilter
+        {
+            public void OnPageHandlerExecuted(PageHandlerExecutedContext context)
+            {
+                if (context.Result is PageResult pageResult)
+                {
+                    pageResult.ViewData["Foo"] = "Bar";
+                }
+            }
+
+            public void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+            {
+            }
+
+            public void OnPageHandlerSelected(PageHandlerSelectedContext context)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
[Fixes #7665] Initializing PageResult.Page as part of result execution breaks Identity UI