### PR TITLE
Introduce BindPropertiesAttribute

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/BindPropertiesAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/BindPropertiesAttribute.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Mvc
+{
+    /// <summary>
+    /// An attribute that enables binding for all properties the decorated controller or Razor Page model defines.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public class BindPropertiesAttribute : Attribute
+    {
+        /// <summary>
+        /// When <c>true</c>, allows properties to be bound on GET requests. When <c>false</c>, properties
+        /// do not get model bound or validated on GET requests.
+        /// <para>
+        /// Defaults to <c>false</c>.
+        /// </para>
+        /// </summary>
+        public bool SupportsGet { get; set; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/BindPropertyAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/BindPropertyAttribute.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Microsoft.AspNetCore.Mvc
 {
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public class BindPropertyAttribute : Attribute, IModelNameProvider, IBinderTypeProviderMetadata, IRequestPredicateProvider
     {
         private static readonly Func<ActionContext, bool> _supportsAllRequests = (c) => true;

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/DefaultApplicationModelProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/DefaultApplicationModelProviderTest.cs
@@ -1127,7 +1127,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             Assert.Equal(typeInfo, action.ActionMethod.DeclaringType.GetTypeInfo());
         }
 
-        [BindProperty]
+        [BindProperties]
         public class BindPropertyController
         {
             public string Property { get; set; }
@@ -1140,7 +1140,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         [Fact]
-        public void CreatePropertyModel_AddsBindingInfoToProperty_IfDeclaringTypeHasBindPropertyAttribute()
+        public void CreatePropertyModel_AddsBindingInfoToProperty_IfDeclaringTypeHasBindPropertiesAttribute()
         {
             // Arrange
             var propertyInfo = typeof(BindPropertyController).GetProperty(nameof(BindPropertyController.Property));
@@ -1155,7 +1155,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             Assert.Null(bindingInfo.BinderType);
             Assert.Null(bindingInfo.BindingSource);
             Assert.Null(bindingInfo.PropertyFilterProvider);
-            Assert.Null(bindingInfo.RequestPredicate);
+            Assert.NotNull(bindingInfo.RequestPredicate);
         }
 
         [Fact]
@@ -1206,7 +1206,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             Assert.NotNull(property.BindingInfo);
         }
 
-        [BindProperty]
+        [BindProperties]
         public class UserController : ControllerBase
         {
             public string DerivedProperty { get; set; }

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RazorPagesTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RazorPagesTest.cs
@@ -1153,15 +1153,15 @@ Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary`1[AspNetCore.InjectedPa
         }
 
         [Fact]
-        public async Task BindPropertyAttribute_CanBeAppliedToModelType()
+        public async Task BindPropertiesAttribute_CanBeAppliedToModelType()
         {
             // Arrange
             var expected = "Property1 = 123, Property2 = 25,";
-            var request = new HttpRequestMessage(HttpMethod.Post, "/Pages/PropertyBinding/BindPropertyOnModel?Property1=123")
+            var request = new HttpRequestMessage(HttpMethod.Post, "/Pages/PropertyBinding/BindPropertiesOnModel?Property1=123")
             {
-                Content = new FormUrlEncodedContent(new[]
+                Content = new FormUrlEncodedContent(new Dictionary<string, string>
                 {
-                    new KeyValuePair<string, string>("Property2", "25"),
+                    { "Property2", "25" },
                 }),
             };
             await AddAntiforgeryHeaders(request);
@@ -1176,11 +1176,26 @@ Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary`1[AspNetCore.InjectedPa
         }
 
         [Fact]
+        public async Task BindPropertiesAttribute_CanBeAppliedToModelType_AllowsBindingOnGet()
+        {
+            // Arrange
+            var url = "/Pages/PropertyBinding/BindPropertiesWithSupportsGetOnModel?Property=Property-Value";
+
+            // Act
+            var response = await Client.GetAsync(url);
+
+            // Assert
+            await response.AssertStatusCodeAsync(HttpStatusCode.OK);
+            var content = await response.Content.ReadAsStringAsync();
+            Assert.Equal("Property-Value", content.Trim());
+        }
+
+        [Fact]
         public async Task BindingInfoOnPropertiesIsPreferredToBindingInfoOnType()
         {
             // Arrange
             var expected = "Property1 = 123, Property2 = 25,";
-            var request = new HttpRequestMessage(HttpMethod.Post, "/Pages/PropertyBinding/BindPropertyOnModel?Property1=123")
+            var request = new HttpRequestMessage(HttpMethod.Post, "/Pages/PropertyBinding/BindPropertiesOnModel?Property1=123")
             {
                 Content = new FormUrlEncodedContent(new[]
                 {

--- a/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/DefaultPageApplicationModelProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/DefaultPageApplicationModelProviderTest.cs
@@ -273,7 +273,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             public string Property1 { get; set; }
         }
 
-        [BindProperty]
+        [BindProperties]
         private class ModelLevel2 : ModelLevel1
         {
             public string Property2 { get; set; }
@@ -397,7 +397,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             public override Task ExecuteAsync() => null;
         }
 
-        [BindProperty]
+        [BindProperties]
         [PageModel]
         private class ModelWithBindProperty
         {

--- a/test/WebSites/BasicWebSite/Controllers/BindPropertiesController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/BindPropertiesController.cs
@@ -8,8 +8,8 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace BasicWebSite
 {
-    [BindProperty]
-    public class BindPropertyController : Controller
+    [BindProperties]
+    public class BindPropertiesController : Controller
     {
         public string Name { get; set; }
 
@@ -21,7 +21,10 @@ namespace BasicWebSite
         [ModelBinder(typeof(CustomBoundModelBinder))]
         public string CustomBound { get; set; }
 
-        public object Action() => new { Name, Id, IdFromRoute, CustomBound };
+        [BindNever]
+        public string BindNeverProperty { get; set; }
+
+        public object Action() => new { Name, Id, IdFromRoute, CustomBound, BindNeverProperty };
 
         private class CustomBoundModelBinder : IModelBinder
         {

--- a/test/WebSites/BasicWebSite/Controllers/BindPropertiesSupportsGetController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/BindPropertiesSupportsGetController.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace BasicWebSite
+{
+    [BindProperties(SupportsGet = true)]
+    public class BindPropertiesSupportsGetController : Controller
+    {
+        public string Name { get; set; }
+
+        public IActionResult Action() => Content(Name);
+    }
+}

--- a/test/WebSites/RazorPagesWebSite/Pages/PropertyBinding/BindPropertiesOnModel.cs
+++ b/test/WebSites/RazorPagesWebSite/Pages/PropertyBinding/BindPropertiesOnModel.cs
@@ -7,8 +7,8 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace RazorPagesWebSite
 {
-    [BindProperty]
-    public class BindPropertyOnModel : PageModel
+    [BindProperties]
+    public class BindPropertiesOnModel : PageModel
     {
         [FromQuery]
         public string Property1 { get; set; }

--- a/test/WebSites/RazorPagesWebSite/Pages/PropertyBinding/BindPropertiesOnModel.cshtml
+++ b/test/WebSites/RazorPagesWebSite/Pages/PropertyBinding/BindPropertiesOnModel.cshtml
@@ -1,5 +1,5 @@
 @page
-@model BindPropertyOnModel
+@model BindPropertiesOnModel
 
 Property1 = @Model.Property1, Property2 = @Model.Property2,
 

--- a/test/WebSites/RazorPagesWebSite/Pages/PropertyBinding/BindPropertiesWithSupportsGetOnModel.cs
+++ b/test/WebSites/RazorPagesWebSite/Pages/PropertyBinding/BindPropertiesWithSupportsGetOnModel.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace RazorPagesWebSite
+{
+    [BindProperties(SupportsGet = true)]
+    public class BindPropertiesWithSupportsGetOnModel : PageModel
+    {
+        public string Property { get; set; }
+    }
+}

--- a/test/WebSites/RazorPagesWebSite/Pages/PropertyBinding/BindPropertiesWithSupportsGetOnModel.cshtml
+++ b/test/WebSites/RazorPagesWebSite/Pages/PropertyBinding/BindPropertiesWithSupportsGetOnModel.cshtml
@@ -1,0 +1,3 @@
+@page
+@model BindPropertiesWithSupportsGetOnModel
+@Model.Property


### PR DESCRIPTION
* Allow controller and Razor Page models to be annotated with BindPropertiesAttribute
* Disallow BindPropertyAttribute from being declared on types.
* Do not allow arbitrary binding attributes to be applied to Razor Page models.

Fixes #7686