### PR TITLE
Fix documentation AnchorTagHelper

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/AnchorTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/AnchorTagHelper.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         /// The name of the area.
         /// </summary>
         /// <remarks>
-        /// Must be <c>null</c> if <see cref="Route"/> or <see cref="Page"/> is non-<c>null</c>.
+        /// Must be <c>null</c> if <see cref="Route"/> is non-<c>null</c>.
         /// </remarks>
         [HtmlAttributeName(AreaAttributeName)]
         public string Area { get; set; }
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         /// </summary>
         /// <remarks>
         /// Must be <c>null</c> if <see cref="Route"/> or <see cref="Action"/>, <see cref="Controller"/>
-        /// or <see cref="Area"/> is non-<c>null</c>.
+        /// is non-<c>null</c>.
         /// </remarks>
         [HtmlAttributeName(PageAttributeName)]
         public string Page { get; set; }


### PR DESCRIPTION
Fixed incorrect documentation.
Because of the wrong documentation I got confused.

I was trying to ['scaffold Identity'](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/scaffold-identity?view=aspnetcore-2.1&tabs=visual-studio). And wanted to add a link to the 'Razor Pages' in the 'Identity' area. Because of the 'wrong' documentation I was trying to fix this in an incorrect way.

After checking how Identity did it there self I found out that using `asp-page` and `asp-area` together is allowed. 
https://github.com/aspnet/Identity/blob/ae6933af2e15f5dddf2fcebb1150be2f2104509d/samples/IdentitySample.DefaultUI/Views/Shared/_LoginPartial.cshtml#L10

### Actual behavior:

|TagHelper|Description|
|-----------|-------------|
|asp-area|The name of the area. Must be null if AnchorTagHelper.Route or AnchorTagHelper.Page is non-null.
|asp-page|The name of the page. Must be null if AnchorTagHelper.Route or AnchorTagHelper.Action, AnchorTagHelper.Controller or AnchorTagHelper.Area is non-null.|

### Expected behavior:
|TagHelper|Description|
|-----------|-------------|
|asp-area|The name of the area. Must be null if AnchorTagHelper.Route is non-null.
|asp-page|The name of the page. Must be null if AnchorTagHelper.Route or AnchorTagHelper.Action, AnchorTagHelper.Controller is non-null.|

Sincerely,
Brecht