### PR TITLE
Avoid null Server property

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Testing/WebApplicationFactory.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Testing/WebApplicationFactory.cs
@@ -66,7 +66,14 @@ namespace Microsoft.AspNetCore.Mvc.Testing
         /// <summary>
         /// Gets the <see cref="TestServer"/> created by this <see cref="WebApplicationFactory{TEntryPoint}"/>.
         /// </summary>
-        public TestServer Server => _server;
+        public TestServer Server
+        {
+            get 
+            {
+                EnsureServer(); // alternately throw exception if _server == null
+                return _server;
+            }
+        }
 
         /// <summary>
         /// Gets the <see cref="IReadOnlyList{WebApplicationFactory}"/> of factories created from this factory


### PR DESCRIPTION
Avoid having to call CreateClient to get a Server. It’s confusing and not intuitive. If something has to be called in order for Server to be initialized, throw when this isn’t done as expected by the factory.