### PR TITLE
Remove `xUnit1026` workaround in test projects

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -10,7 +10,6 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <WarningsNotAsErrors>xUnit1026:$(WarningsNotAsErrors)</WarningsNotAsErrors>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)MvcTests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 


### PR DESCRIPTION
- contained a typo (colon versus semicolon) and just doesn't matter