### PR TITLE
Fix up a few pieces for the fallback integrity check feature.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/LinkTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/LinkTagHelper.cs
@@ -25,7 +25,6 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
     [HtmlTargetElement("link", Attributes = HrefIncludeAttributeName, TagStructure = TagStructure.WithoutEndTag)]
     [HtmlTargetElement("link", Attributes = HrefExcludeAttributeName, TagStructure = TagStructure.WithoutEndTag)]
     [HtmlTargetElement("link", Attributes = FallbackHrefAttributeName, TagStructure = TagStructure.WithoutEndTag)]
-    [HtmlTargetElement("link", Attributes = FallbackHrefIntegrityCheckAttributeName, TagStructure = TagStructure.WithoutEndTag)]
     [HtmlTargetElement("link", Attributes = FallbackHrefIncludeAttributeName, TagStructure = TagStructure.WithoutEndTag)]
     [HtmlTargetElement("link", Attributes = FallbackHrefExcludeAttributeName, TagStructure = TagStructure.WithoutEndTag)]
     [HtmlTargetElement("link", Attributes = FallbackTestClassAttributeName, TagStructure = TagStructure.WithoutEndTag)]
@@ -41,7 +40,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         private const string HrefIncludeAttributeName = "asp-href-include";
         private const string HrefExcludeAttributeName = "asp-href-exclude";
         private const string FallbackHrefAttributeName = "asp-fallback-href";
-        private const string FallbackHrefIntegrityCheckAttributeName = "asp-fallback-href-integrity-check";
+        private const string SuppressFallbackIntegrityAttributeName = "asp-suppress-fallback-integrity";
         private const string FallbackHrefIncludeAttributeName = "asp-fallback-href-include";
         private const string FallbackHrefExcludeAttributeName = "asp-fallback-href-exclude";
         private const string FallbackTestClassAttributeName = "asp-fallback-test-class";
@@ -50,6 +49,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         private const string AppendVersionAttributeName = "asp-append-version";
         private const string HrefAttributeName = "href";
         private const string RelAttributeName = "rel";
+        private const string IntegrityAttributeName = "integrity";
         private static readonly Func<Mode, Mode, int> Compare = (a, b) => a - b;
 
         private FileVersionProvider _fileVersionProvider;
@@ -150,12 +150,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         public string FallbackHref { get; set; }
 
         /// <summary>
-        /// Boolean value that determines if Integrity Hash will be compared with <see cref="FallbackHref"/> value.
-        /// Value defaults to true if not provided. 
-        /// Must be used in conjunction with <see cref="FallbackHref"/>.
+        /// Boolean value that determines if an integrity hash will be compared with <see cref="FallbackHref"/> value.
         /// </summary>
-        [HtmlAttributeName(FallbackHrefIntegrityCheckAttributeName)]
-        public bool? FallbackHrefIntegrityCheck { get; set; }
+        [HtmlAttributeName(SuppressFallbackIntegrityAttributeName)]
+        public bool SuppressFallbackIntegrity { get; set; }
 
         /// <summary>
         /// Value indicating if file version should be appended to the href urls.
@@ -377,8 +375,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                     continue;
                 }
 
-                // do not write integrity attribute when FallbackHrefIntegrityCheck is false
-                if (attribute.Name.Equals("integrity", StringComparison.OrdinalIgnoreCase) && FallbackHrefIntegrityCheck == false)
+                if (SuppressFallbackIntegrity && string.Equals(attribute.Name, IntegrityAttributeName, StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/LinkTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/LinkTagHelper.cs
@@ -25,6 +25,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
     [HtmlTargetElement("link", Attributes = HrefIncludeAttributeName, TagStructure = TagStructure.WithoutEndTag)]
     [HtmlTargetElement("link", Attributes = HrefExcludeAttributeName, TagStructure = TagStructure.WithoutEndTag)]
     [HtmlTargetElement("link", Attributes = FallbackHrefAttributeName, TagStructure = TagStructure.WithoutEndTag)]
+    [HtmlTargetElement("link", Attributes = FallbackHrefIntegrityCheckAttributeName, TagStructure = TagStructure.WithoutEndTag)]
     [HtmlTargetElement("link", Attributes = FallbackHrefIncludeAttributeName, TagStructure = TagStructure.WithoutEndTag)]
     [HtmlTargetElement("link", Attributes = FallbackHrefExcludeAttributeName, TagStructure = TagStructure.WithoutEndTag)]
     [HtmlTargetElement("link", Attributes = FallbackTestClassAttributeName, TagStructure = TagStructure.WithoutEndTag)]
@@ -40,6 +41,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         private const string HrefIncludeAttributeName = "asp-href-include";
         private const string HrefExcludeAttributeName = "asp-href-exclude";
         private const string FallbackHrefAttributeName = "asp-fallback-href";
+        private const string FallbackHrefIntegrityCheckAttributeName = "asp-fallback-href-integrity-check";
         private const string FallbackHrefIncludeAttributeName = "asp-fallback-href-include";
         private const string FallbackHrefExcludeAttributeName = "asp-fallback-href-exclude";
         private const string FallbackTestClassAttributeName = "asp-fallback-test-class";
@@ -146,6 +148,14 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         /// </summary>
         [HtmlAttributeName(FallbackHrefAttributeName)]
         public string FallbackHref { get; set; }
+
+        /// <summary>
+        /// Boolean value that determines if Integrity Hash will be compared with <see cref="FallbackHref"/> value.
+        /// Value defaults to true if not provided. 
+        /// Must be used in conjunction with <see cref="FallbackHref"/>.
+        /// </summary>
+        [HtmlAttributeName(FallbackHrefIntegrityCheckAttributeName)]
+        public bool? FallbackHrefIntegrityCheck { get; set; }
 
         /// <summary>
         /// Value indicating if file version should be appended to the href urls.
@@ -363,6 +373,12 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
             {
                 var attribute = attributes[i];
                 if (string.Equals(attribute.Name, HrefAttributeName, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                // do not write integrity attribute when FallbackHrefIntegrityCheck is false
+                if (attribute.Name.Equals("integrity", StringComparison.OrdinalIgnoreCase) && FallbackHrefIntegrityCheck == false)
                 {
                     continue;
                 }

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/ScriptTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/ScriptTagHelper.cs
@@ -27,6 +27,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
     [HtmlTargetElement("script", Attributes = FallbackSrcIncludeAttributeName)]
     [HtmlTargetElement("script", Attributes = FallbackSrcExcludeAttributeName)]
     [HtmlTargetElement("script", Attributes = FallbackTestExpressionAttributeName)]
+    [HtmlTargetElement("script", Attributes = FallbackIntegrityCheckAttributeName)]
     [HtmlTargetElement("script", Attributes = AppendVersionAttributeName)]
     public class ScriptTagHelper : UrlResolutionTagHelper
     {
@@ -34,6 +35,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         private const string SrcExcludeAttributeName = "asp-src-exclude";
         private const string FallbackSrcAttributeName = "asp-fallback-src";
         private const string FallbackSrcIncludeAttributeName = "asp-fallback-src-include";
+        private const string FallbackIntegrityCheckAttributeName = "asp-fallback-integrity-check";
         private const string FallbackSrcExcludeAttributeName = "asp-fallback-src-exclude";
         private const string FallbackTestExpressionAttributeName = "asp-fallback-test";
         private const string SrcAttributeName = "src";
@@ -128,6 +130,14 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         /// </summary>
         [HtmlAttributeName(FallbackSrcAttributeName)]
         public string FallbackSrc { get; set; }
+
+        /// <summary>
+        /// Boolean value that determines if Integrity Hash will be compared with <see cref="FallbackSrc"/> value.
+        /// Value defaults to true if not provided. 
+        /// Must be used in conjunction with <see cref="FallbackSrc"/>.
+        /// </summary>
+        [HtmlAttributeName(FallbackIntegrityCheckAttributeName)]
+        public bool? FallbackIntegrityCheck { get; set; }
 
         /// <summary>
         /// Value indicating if file version should be appended to src urls.
@@ -312,6 +322,9 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                         var attribute = attributes[i];
                         if (!attribute.Name.Equals(SrcAttributeName, StringComparison.OrdinalIgnoreCase))
                         {
+                            // do not write integrity attribute when fallbackintegrityCheck is false
+                            if (attribute.Name.Equals("integrity", StringComparison.OrdinalIgnoreCase) && FallbackIntegrityCheck == false) continue;
+
                             StringWriter.Write(' ');
                             attribute.WriteTo(StringWriter, HtmlEncoder);
                         }

--- a/src/Microsoft.AspNetCore.Mvc.TagHelpers/ScriptTagHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.TagHelpers/ScriptTagHelper.cs
@@ -27,7 +27,6 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
     [HtmlTargetElement("script", Attributes = FallbackSrcIncludeAttributeName)]
     [HtmlTargetElement("script", Attributes = FallbackSrcExcludeAttributeName)]
     [HtmlTargetElement("script", Attributes = FallbackTestExpressionAttributeName)]
-    [HtmlTargetElement("script", Attributes = FallbackIntegrityCheckAttributeName)]
     [HtmlTargetElement("script", Attributes = AppendVersionAttributeName)]
     public class ScriptTagHelper : UrlResolutionTagHelper
     {
@@ -35,10 +34,11 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         private const string SrcExcludeAttributeName = "asp-src-exclude";
         private const string FallbackSrcAttributeName = "asp-fallback-src";
         private const string FallbackSrcIncludeAttributeName = "asp-fallback-src-include";
-        private const string FallbackIntegrityCheckAttributeName = "asp-fallback-integrity-check";
+        private const string SuppressFallbackIntegrityAttributeName = "asp-suppress-fallback-integrity";
         private const string FallbackSrcExcludeAttributeName = "asp-fallback-src-exclude";
         private const string FallbackTestExpressionAttributeName = "asp-fallback-test";
         private const string SrcAttributeName = "src";
+        private const string IntegrityAttributeName = "integrity";
         private const string AppendVersionAttributeName = "asp-append-version";
         private static readonly Func<Mode, Mode, int> Compare = (a, b) => a - b;
         private FileVersionProvider _fileVersionProvider;
@@ -132,12 +132,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
         public string FallbackSrc { get; set; }
 
         /// <summary>
-        /// Boolean value that determines if Integrity Hash will be compared with <see cref="FallbackSrc"/> value.
-        /// Value defaults to true if not provided. 
-        /// Must be used in conjunction with <see cref="FallbackSrc"/>.
+        /// Boolean value that determines if an integrity hash will be compared with <see cref="FallbackSrc"/> value.
         /// </summary>
-        [HtmlAttributeName(FallbackIntegrityCheckAttributeName)]
-        public bool? FallbackIntegrityCheck { get; set; }
+        [HtmlAttributeName(SuppressFallbackIntegrityAttributeName)]
+        public bool SuppressFallbackIntegrity { get; set; }
 
         /// <summary>
         /// Value indicating if file version should be appended to src urls.
@@ -322,8 +320,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                         var attribute = attributes[i];
                         if (!attribute.Name.Equals(SrcAttributeName, StringComparison.OrdinalIgnoreCase))
                         {
-                            // do not write integrity attribute when fallbackintegrityCheck is false
-                            if (attribute.Name.Equals("integrity", StringComparison.OrdinalIgnoreCase) && FallbackIntegrityCheck == false) continue;
+                            if (SuppressFallbackIntegrity && string.Equals(IntegrityAttributeName, attribute.Name, StringComparison.OrdinalIgnoreCase))
+                            {
+                                continue;
+                            }
 
                             StringWriter.Write(' ');
                             attribute.WriteTo(StringWriter, HtmlEncoder);

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Link.Encoded.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Link.Encoded.html
@@ -11,10 +11,10 @@
     <link rel="stylesheet" title="&lt;the title>" href="HtmlEncode[[/styles/site.css]]" />
 
     <!-- Globbed link tag with comma separated pattern -->
-    <link rel="stylesheet" title="&lt;the title" href="HtmlEncode[[/styles/site.css]]" /><link rel="stylesheet" title="&lt;the title" href="HtmlEncode[[/styles/sub/site2.css]]" /><link rel="stylesheet" title="&lt;the title" href="HtmlEncode[[/styles/sub/site3.css]]" /><link rel="stylesheet" title="&lt;the title" href="HtmlEncode[[/styles/sub/site3.min.css]]" />
+    <link rel="stylesheet" title="&lt;the title" href="HtmlEncode[[/styles/site.css]]" /><link rel="stylesheet" title="&lt;the title" href="HtmlEncode[[/styles/siteIntegrity.css]]" /><link rel="stylesheet" title="&lt;the title" href="HtmlEncode[[/styles/sub/site2.css]]" /><link rel="stylesheet" title="&lt;the title" href="HtmlEncode[[/styles/sub/site3.css]]" /><link rel="stylesheet" title="&lt;the title" href="HtmlEncode[[/styles/sub/site3.min.css]]" />
 
     <!-- Globbed link tag with existing file and exclude -->
-    <link rel="stylesheet" title='"the" title' href="HtmlEncode[[/styles/site.css]]" /><link rel="stylesheet" title='"the" title' href="HtmlEncode[[/styles/sub/site2.css]]" />
+    <link rel="stylesheet" title='"the" title' href="HtmlEncode[[/styles/site.css]]" /><link rel="stylesheet" title='"the" title' href="HtmlEncode[[/styles/siteIntegrity.css]]" /><link rel="stylesheet" title='"the" title' href="HtmlEncode[[/styles/sub/site2.css]]" />
 
     <!-- Globbed link tag missing include -->
     <link rel="stylesheet">
@@ -40,6 +40,18 @@
     <!-- Fallback to static href -->
     <link href="HtmlEncode[[/styles/site.min.css?a=b&c=d]]" rel="stylesheet" data-extra="test" title='"the" title' />
 <meta name="x-stylesheet-fallback-test" content="" class="HtmlEncode[[hidden]]" /><script>!function(a,b,c,d){var e,f=document,g=f.getElementsByTagName("SCRIPT"),h=g[g.length-1].previousElementSibling,i=f.defaultView&&f.defaultView.getComputedStyle?f.defaultView.getComputedStyle(h):h.currentStyle;if(i&&i[a]!==b)for(e=0;e<c.length;e++)f.write('<link href="'+c[e]+'" '+d+"/>")}("JavaScriptEncode[[visibility]]","JavaScriptEncode[[hidden]]",["JavaScriptEncode[[HtmlEncode[[/styles/site.css?a=b&c=d]]]]"], "JavaScriptEncode[[rel="stylesheet" data-extra="test" title='"the" title' ]]");</script>
+
+    <!-- Fallback to static href with no asp-suppress-fallback-integrity attribute, default behavior is to keep integrity hash -->
+    <link href="HtmlEncode[[/styles/site.min.css?a=b&c=d]]" rel="stylesheet" data-extra="test" title='"the" title' integrity="XY7YsMemPf8AGU4SIX9ED9eOjK1LOQWu2dmCNmh+pQc=" crossorigin="anonymous" />
+<meta name="x-stylesheet-fallback-test" content="" class="HtmlEncode[[hidden]]" /><script>!function(a,b,c,d){var e,f=document,g=f.getElementsByTagName("SCRIPT"),h=g[g.length-1].previousElementSibling,i=f.defaultView&&f.defaultView.getComputedStyle?f.defaultView.getComputedStyle(h):h.currentStyle;if(i&&i[a]!==b)for(e=0;e<c.length;e++)f.write('<link href="'+c[e]+'" '+d+"/>")}("JavaScriptEncode[[visibility]]","JavaScriptEncode[[hidden]]",["JavaScriptEncode[[HtmlEncode[[/styles/site.css?a=b&c=d]]]]"], "JavaScriptEncode[[rel="stylesheet" data-extra="test" title='"the" title' integrity="XY7YsMemPf8AGU4SIX9ED9eOjK1LOQWu2dmCNmh+pQc=" crossorigin="anonymous" ]]");</script>
+
+    <!-- Fallback to static href with asp-suppress-fallback-integrity set to false, behavior is to keep integrity hash -->
+    <link href="HtmlEncode[[/styles/site.min.css?a=b&c=d]]" rel="stylesheet" data-extra="test" title='"the" title' integrity="XY7YsMemPf8AGU4SIX9ED9eOjK1LOQWu2dmCNmh+pQc=" crossorigin="anonymous" />
+<meta name="x-stylesheet-fallback-test" content="" class="HtmlEncode[[hidden]]" /><script>!function(a,b,c,d){var e,f=document,g=f.getElementsByTagName("SCRIPT"),h=g[g.length-1].previousElementSibling,i=f.defaultView&&f.defaultView.getComputedStyle?f.defaultView.getComputedStyle(h):h.currentStyle;if(i&&i[a]!==b)for(e=0;e<c.length;e++)f.write('<link href="'+c[e]+'" '+d+"/>")}("JavaScriptEncode[[visibility]]","JavaScriptEncode[[hidden]]",["JavaScriptEncode[[HtmlEncode[[/styles/site.css?a=b&c=d]]]]"], "JavaScriptEncode[[rel="stylesheet" data-extra="test" title='"the" title' integrity="XY7YsMemPf8AGU4SIX9ED9eOjK1LOQWu2dmCNmh+pQc=" crossorigin="anonymous" ]]");</script>
+
+    <!-- Fallback to static href with asp-suppress-fallback-integrity provided, removes integrity attribute on fallback so that different CSS can be loaded  -->
+    <link href="HtmlEncode[[/styles/site.min.css?a=b&c=d]]" rel="stylesheet" data-extra="test" title='"the" title' integrity="XY7YsMemPf8AGU4SIX9ED9eOjK1LOQWu2dmCNmh+pQc=" crossorigin="anonymous" />
+<meta name="x-stylesheet-fallback-test" content="" class="HtmlEncode[[hidden]]" /><script>!function(a,b,c,d){var e,f=document,g=f.getElementsByTagName("SCRIPT"),h=g[g.length-1].previousElementSibling,i=f.defaultView&&f.defaultView.getComputedStyle?f.defaultView.getComputedStyle(h):h.currentStyle;if(i&&i[a]!==b)for(e=0;e<c.length;e++)f.write('<link href="'+c[e]+'" '+d+"/>")}("JavaScriptEncode[[visibility]]","JavaScriptEncode[[hidden]]",["JavaScriptEncode[[HtmlEncode[[/styles/siteIntegrity.css?a=b&c=d]]]]"], "JavaScriptEncode[[rel="stylesheet" data-extra="test" title='"the" title' crossorigin="anonymous" ]]");</script>
 
     <!-- Fallback to static href with dynamic attributes -->
     <link href="HtmlEncode[[/styles/site.min.css?a=b&c=d]]" rel="HtmlEncode[[stylesheet]]" data-extra="HtmlEncode[[test]]" title='HtmlEncode[["the" title]]' />
@@ -81,7 +93,7 @@
 
     <!-- Fallback to static and globbed href with exclude -->
     <link href="HtmlEncode[[/styles/site.min.css]]" rel="stylesheet" data-extra="test" />
-<meta name="x-stylesheet-fallback-test" content="" class="HtmlEncode[[hidden]]" /><script>!function(a,b,c,d){var e,f=document,g=f.getElementsByTagName("SCRIPT"),h=g[g.length-1].previousElementSibling,i=f.defaultView&&f.defaultView.getComputedStyle?f.defaultView.getComputedStyle(h):h.currentStyle;if(i&&i[a]!==b)for(e=0;e<c.length;e++)f.write('<link href="'+c[e]+'" '+d+"/>")}("JavaScriptEncode[[visibility]]","JavaScriptEncode[[hidden]]",["JavaScriptEncode[[HtmlEncode[[/styles/site.css]]]]","JavaScriptEncode[[HtmlEncode[[/styles/sub/site2.css]]]]"], "JavaScriptEncode[[rel="stylesheet" data-extra="test" ]]");</script>
+<meta name="x-stylesheet-fallback-test" content="" class="HtmlEncode[[hidden]]" /><script>!function(a,b,c,d){var e,f=document,g=f.getElementsByTagName("SCRIPT"),h=g[g.length-1].previousElementSibling,i=f.defaultView&&f.defaultView.getComputedStyle?f.defaultView.getComputedStyle(h):h.currentStyle;if(i&&i[a]!==b)for(e=0;e<c.length;e++)f.write('<link href="'+c[e]+'" '+d+"/>")}("JavaScriptEncode[[visibility]]","JavaScriptEncode[[hidden]]",["JavaScriptEncode[[HtmlEncode[[/styles/site.css]]]]","JavaScriptEncode[[HtmlEncode[[/styles/siteIntegrity.css]]]]","JavaScriptEncode[[HtmlEncode[[/styles/sub/site2.css]]]]"], "JavaScriptEncode[[rel="stylesheet" data-extra="test" ]]");</script>
 
     <!-- Fallback from globbed href to glbobed href -->
     
@@ -101,7 +113,7 @@
 
     <!-- Kitchen sink, all the attributes -->
     <link href="HtmlEncode[[styles/site.min.css]]" rel="stylesheet" data-extra="test" />
-<meta name="x-stylesheet-fallback-test" content="" class="HtmlEncode[[hidden]]" /><script>!function(a,b,c,d){var e,f=document,g=f.getElementsByTagName("SCRIPT"),h=g[g.length-1].previousElementSibling,i=f.defaultView&&f.defaultView.getComputedStyle?f.defaultView.getComputedStyle(h):h.currentStyle;if(i&&i[a]!==b)for(e=0;e<c.length;e++)f.write('<link href="'+c[e]+'" '+d+"/>")}("JavaScriptEncode[[visibility]]","JavaScriptEncode[[hidden]]",["JavaScriptEncode[[HtmlEncode[[/styles/site.css]]]]","JavaScriptEncode[[HtmlEncode[[/styles/sub/site2.css]]]]"], "JavaScriptEncode[[rel="stylesheet" data-extra="test" ]]");</script>
+<meta name="x-stylesheet-fallback-test" content="" class="HtmlEncode[[hidden]]" /><script>!function(a,b,c,d){var e,f=document,g=f.getElementsByTagName("SCRIPT"),h=g[g.length-1].previousElementSibling,i=f.defaultView&&f.defaultView.getComputedStyle?f.defaultView.getComputedStyle(h):h.currentStyle;if(i&&i[a]!==b)for(e=0;e<c.length;e++)f.write('<link href="'+c[e]+'" '+d+"/>")}("JavaScriptEncode[[visibility]]","JavaScriptEncode[[hidden]]",["JavaScriptEncode[[HtmlEncode[[/styles/site.css]]]]","JavaScriptEncode[[HtmlEncode[[/styles/siteIntegrity.css]]]]","JavaScriptEncode[[HtmlEncode[[/styles/sub/site2.css]]]]"], "JavaScriptEncode[[rel="stylesheet" data-extra="test" ]]");</script>
 
     <!-- Fallback to globbed href that doesn't exist -->
     <link href="HtmlEncode[[/styles/site.min.css]]" rel="stylesheet" data-extra="test" />
@@ -129,7 +141,7 @@
 <meta name="x-stylesheet-fallback-test" content="" class="HtmlEncode[[hidden]]" /><script>!function(a,b,c,d){var e,f=document,g=f.getElementsByTagName("SCRIPT"),h=g[g.length-1].previousElementSibling,i=f.defaultView&&f.defaultView.getComputedStyle?f.defaultView.getComputedStyle(h):h.currentStyle;if(i&&i[a]!==b)for(e=0;e<c.length;e++)f.write('<link href="'+c[e]+'" '+d+"/>")}("JavaScriptEncode[[visibility]]","JavaScriptEncode[[hidden]]",["JavaScriptEncode[[HtmlEncode[[/styles/site.css?v=XY7YsMemPf8AGU4SIX9ED9eOjK1LOQWu2dmCNmh-pQc]]]]"], "JavaScriptEncode[[rel="stylesheet" data-extra="test" ]]");</script>
 
     <!-- Globbed link tag with existing file, static href and file version -->
-    <link href="HtmlEncode[[/styles/site.css?v=XY7YsMemPf8AGU4SIX9ED9eOjK1LOQWu2dmCNmh-pQc]]" rel="stylesheet" /><link href="HtmlEncode[[/styles/sub/site2.css?v=30cxPex0tA9xEatW7f1Qhnn8tVLAHgE6xwIZhESq0y0]]" rel="stylesheet" /><link href="HtmlEncode[[/styles/sub/site3.css?v=fSxxOr1Q4Dq2uPuzlju5UYGuK0SKABI-ghvaIGEsZDc]]" rel="stylesheet" /><link href="HtmlEncode[[/styles/sub/site3.min.css?v=s8JMmAZxBn0dzuhRtQ0wgOvNBK4XRJRWEC2wfzsVF9M]]" rel="stylesheet" />
+    <link href="HtmlEncode[[/styles/site.css?v=XY7YsMemPf8AGU4SIX9ED9eOjK1LOQWu2dmCNmh-pQc]]" rel="stylesheet" /><link href="HtmlEncode[[/styles/siteIntegrity.css?v=2PJDxTb5ea6QWpW5p3vvrvP3bat7l18amFI0M8-xBls]]" rel="stylesheet" /><link href="HtmlEncode[[/styles/sub/site2.css?v=30cxPex0tA9xEatW7f1Qhnn8tVLAHgE6xwIZhESq0y0]]" rel="stylesheet" /><link href="HtmlEncode[[/styles/sub/site3.css?v=fSxxOr1Q4Dq2uPuzlju5UYGuK0SKABI-ghvaIGEsZDc]]" rel="stylesheet" /><link href="HtmlEncode[[/styles/sub/site3.min.css?v=s8JMmAZxBn0dzuhRtQ0wgOvNBK4XRJRWEC2wfzsVF9M]]" rel="stylesheet" />
 </head>
 <body>
 

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Link.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Link.html
@@ -11,10 +11,10 @@
     <link rel="stylesheet" title="&lt;the title>" href="/styles/site.css" />
 
     <!-- Globbed link tag with comma separated pattern -->
-    <link rel="stylesheet" title="&lt;the title" href="/styles/site.css" /><link rel="stylesheet" title="&lt;the title" href="/styles/sub/site2.css" /><link rel="stylesheet" title="&lt;the title" href="/styles/sub/site3.css" /><link rel="stylesheet" title="&lt;the title" href="/styles/sub/site3.min.css" />
+    <link rel="stylesheet" title="&lt;the title" href="/styles/site.css" /><link rel="stylesheet" title="&lt;the title" href="/styles/siteIntegrity.css" /><link rel="stylesheet" title="&lt;the title" href="/styles/sub/site2.css" /><link rel="stylesheet" title="&lt;the title" href="/styles/sub/site3.css" /><link rel="stylesheet" title="&lt;the title" href="/styles/sub/site3.min.css" />
 
     <!-- Globbed link tag with existing file and exclude -->
-    <link rel="stylesheet" title='"the" title' href="/styles/site.css" /><link rel="stylesheet" title='"the" title' href="/styles/sub/site2.css" />
+    <link rel="stylesheet" title='"the" title' href="/styles/site.css" /><link rel="stylesheet" title='"the" title' href="/styles/siteIntegrity.css" /><link rel="stylesheet" title='"the" title' href="/styles/sub/site2.css" />
 
     <!-- Globbed link tag missing include -->
     <link rel="stylesheet">
@@ -40,6 +40,18 @@
     <!-- Fallback to static href -->
     <link href="/styles/site.min.css?a=b&amp;c=d" rel="stylesheet" data-extra="test" title='"the" title' />
 <meta name="x-stylesheet-fallback-test" content="" class="hidden" /><script>!function(a,b,c,d){var e,f=document,g=f.getElementsByTagName("SCRIPT"),h=g[g.length-1].previousElementSibling,i=f.defaultView&&f.defaultView.getComputedStyle?f.defaultView.getComputedStyle(h):h.currentStyle;if(i&&i[a]!==b)for(e=0;e<c.length;e++)f.write('<link href="'+c[e]+'" '+d+"/>")}("visibility","hidden",["\/styles\/site.css?a=b\u0026amp;c=d"], "rel=\u0022stylesheet\u0022 data-extra=\u0022test\u0022 title=\u0027\u0022the\u0022 title\u0027 ");</script>
+
+    <!-- Fallback to static href with no asp-suppress-fallback-integrity attribute, default behavior is to keep integrity hash -->
+    <link href="/styles/site.min.css?a=b&amp;c=d" rel="stylesheet" data-extra="test" title='"the" title' integrity="XY7YsMemPf8AGU4SIX9ED9eOjK1LOQWu2dmCNmh+pQc=" crossorigin="anonymous" />
+<meta name="x-stylesheet-fallback-test" content="" class="hidden" /><script>!function(a,b,c,d){var e,f=document,g=f.getElementsByTagName("SCRIPT"),h=g[g.length-1].previousElementSibling,i=f.defaultView&&f.defaultView.getComputedStyle?f.defaultView.getComputedStyle(h):h.currentStyle;if(i&&i[a]!==b)for(e=0;e<c.length;e++)f.write('<link href="'+c[e]+'" '+d+"/>")}("visibility","hidden",["\/styles\/site.css?a=b\u0026amp;c=d"], "rel=\u0022stylesheet\u0022 data-extra=\u0022test\u0022 title=\u0027\u0022the\u0022 title\u0027 integrity=\u0022XY7YsMemPf8AGU4SIX9ED9eOjK1LOQWu2dmCNmh\u002BpQc=\u0022 crossorigin=\u0022anonymous\u0022 ");</script>
+
+    <!-- Fallback to static href with asp-suppress-fallback-integrity set to false, behavior is to keep integrity hash -->
+    <link href="/styles/site.min.css?a=b&amp;c=d" rel="stylesheet" data-extra="test" title='"the" title' integrity="XY7YsMemPf8AGU4SIX9ED9eOjK1LOQWu2dmCNmh+pQc=" crossorigin="anonymous" />
+<meta name="x-stylesheet-fallback-test" content="" class="hidden" /><script>!function(a,b,c,d){var e,f=document,g=f.getElementsByTagName("SCRIPT"),h=g[g.length-1].previousElementSibling,i=f.defaultView&&f.defaultView.getComputedStyle?f.defaultView.getComputedStyle(h):h.currentStyle;if(i&&i[a]!==b)for(e=0;e<c.length;e++)f.write('<link href="'+c[e]+'" '+d+"/>")}("visibility","hidden",["\/styles\/site.css?a=b\u0026amp;c=d"], "rel=\u0022stylesheet\u0022 data-extra=\u0022test\u0022 title=\u0027\u0022the\u0022 title\u0027 integrity=\u0022XY7YsMemPf8AGU4SIX9ED9eOjK1LOQWu2dmCNmh\u002BpQc=\u0022 crossorigin=\u0022anonymous\u0022 ");</script>
+
+    <!-- Fallback to static href with asp-suppress-fallback-integrity provided, removes integrity attribute on fallback so that different CSS can be loaded  -->
+    <link href="/styles/site.min.css?a=b&amp;c=d" rel="stylesheet" data-extra="test" title='"the" title' integrity="XY7YsMemPf8AGU4SIX9ED9eOjK1LOQWu2dmCNmh+pQc=" crossorigin="anonymous" />
+<meta name="x-stylesheet-fallback-test" content="" class="hidden" /><script>!function(a,b,c,d){var e,f=document,g=f.getElementsByTagName("SCRIPT"),h=g[g.length-1].previousElementSibling,i=f.defaultView&&f.defaultView.getComputedStyle?f.defaultView.getComputedStyle(h):h.currentStyle;if(i&&i[a]!==b)for(e=0;e<c.length;e++)f.write('<link href="'+c[e]+'" '+d+"/>")}("visibility","hidden",["\/styles\/siteIntegrity.css?a=b\u0026amp;c=d"], "rel=\u0022stylesheet\u0022 data-extra=\u0022test\u0022 title=\u0027\u0022the\u0022 title\u0027 crossorigin=\u0022anonymous\u0022 ");</script>
 
     <!-- Fallback to static href with dynamic attributes -->
     <link href="/styles/site.min.css?a=b&amp;c=d" rel="stylesheet" data-extra="test" title='&quot;the&quot; title' />
@@ -82,7 +94,7 @@
 
     <!-- Fallback to static and globbed href with exclude -->
     <link href="/styles/site.min.css" rel="stylesheet" data-extra="test" />
-<meta name="x-stylesheet-fallback-test" content="" class="hidden" /><script>!function(a,b,c,d){var e,f=document,g=f.getElementsByTagName("SCRIPT"),h=g[g.length-1].previousElementSibling,i=f.defaultView&&f.defaultView.getComputedStyle?f.defaultView.getComputedStyle(h):h.currentStyle;if(i&&i[a]!==b)for(e=0;e<c.length;e++)f.write('<link href="'+c[e]+'" '+d+"/>")}("visibility","hidden",["\/styles\/site.css","\/styles\/sub\/site2.css"], "rel=\u0022stylesheet\u0022 data-extra=\u0022test\u0022 ");</script>
+<meta name="x-stylesheet-fallback-test" content="" class="hidden" /><script>!function(a,b,c,d){var e,f=document,g=f.getElementsByTagName("SCRIPT"),h=g[g.length-1].previousElementSibling,i=f.defaultView&&f.defaultView.getComputedStyle?f.defaultView.getComputedStyle(h):h.currentStyle;if(i&&i[a]!==b)for(e=0;e<c.length;e++)f.write('<link href="'+c[e]+'" '+d+"/>")}("visibility","hidden",["\/styles\/site.css","\/styles\/siteIntegrity.css","\/styles\/sub\/site2.css"], "rel=\u0022stylesheet\u0022 data-extra=\u0022test\u0022 ");</script>
 
     <!-- Fallback from globbed href to glbobed href -->
     
@@ -102,7 +114,7 @@
 
     <!-- Kitchen sink, all the attributes -->
     <link href="styles/site.min.css" rel="stylesheet" data-extra="test" />
-<meta name="x-stylesheet-fallback-test" content="" class="hidden" /><script>!function(a,b,c,d){var e,f=document,g=f.getElementsByTagName("SCRIPT"),h=g[g.length-1].previousElementSibling,i=f.defaultView&&f.defaultView.getComputedStyle?f.defaultView.getComputedStyle(h):h.currentStyle;if(i&&i[a]!==b)for(e=0;e<c.length;e++)f.write('<link href="'+c[e]+'" '+d+"/>")}("visibility","hidden",["\/styles\/site.css","\/styles\/sub\/site2.css"], "rel=\u0022stylesheet\u0022 data-extra=\u0022test\u0022 ");</script>
+<meta name="x-stylesheet-fallback-test" content="" class="hidden" /><script>!function(a,b,c,d){var e,f=document,g=f.getElementsByTagName("SCRIPT"),h=g[g.length-1].previousElementSibling,i=f.defaultView&&f.defaultView.getComputedStyle?f.defaultView.getComputedStyle(h):h.currentStyle;if(i&&i[a]!==b)for(e=0;e<c.length;e++)f.write('<link href="'+c[e]+'" '+d+"/>")}("visibility","hidden",["\/styles\/site.css","\/styles\/siteIntegrity.css","\/styles\/sub\/site2.css"], "rel=\u0022stylesheet\u0022 data-extra=\u0022test\u0022 ");</script>
 
     <!-- Fallback to globbed href that doesn't exist -->
     <link href="/styles/site.min.css" rel="stylesheet" data-extra="test" />
@@ -130,7 +142,7 @@
 <meta name="x-stylesheet-fallback-test" content="" class="hidden" /><script>!function(a,b,c,d){var e,f=document,g=f.getElementsByTagName("SCRIPT"),h=g[g.length-1].previousElementSibling,i=f.defaultView&&f.defaultView.getComputedStyle?f.defaultView.getComputedStyle(h):h.currentStyle;if(i&&i[a]!==b)for(e=0;e<c.length;e++)f.write('<link href="'+c[e]+'" '+d+"/>")}("visibility","hidden",["\/styles\/site.css?v=XY7YsMemPf8AGU4SIX9ED9eOjK1LOQWu2dmCNmh-pQc"], "rel=\u0022stylesheet\u0022 data-extra=\u0022test\u0022 ");</script>
 
     <!-- Globbed link tag with existing file, static href and file version -->
-    <link href="/styles/site.css?v=XY7YsMemPf8AGU4SIX9ED9eOjK1LOQWu2dmCNmh-pQc" rel="stylesheet" /><link href="/styles/sub/site2.css?v=30cxPex0tA9xEatW7f1Qhnn8tVLAHgE6xwIZhESq0y0" rel="stylesheet" /><link href="/styles/sub/site3.css?v=fSxxOr1Q4Dq2uPuzlju5UYGuK0SKABI-ghvaIGEsZDc" rel="stylesheet" /><link href="/styles/sub/site3.min.css?v=s8JMmAZxBn0dzuhRtQ0wgOvNBK4XRJRWEC2wfzsVF9M" rel="stylesheet" />
+    <link href="/styles/site.css?v=XY7YsMemPf8AGU4SIX9ED9eOjK1LOQWu2dmCNmh-pQc" rel="stylesheet" /><link href="/styles/siteIntegrity.css?v=2PJDxTb5ea6QWpW5p3vvrvP3bat7l18amFI0M8-xBls" rel="stylesheet" /><link href="/styles/sub/site2.css?v=30cxPex0tA9xEatW7f1Qhnn8tVLAHgE6xwIZhESq0y0" rel="stylesheet" /><link href="/styles/sub/site3.css?v=fSxxOr1Q4Dq2uPuzlju5UYGuK0SKABI-ghvaIGEsZDc" rel="stylesheet" /><link href="/styles/sub/site3.min.css?v=s8JMmAZxBn0dzuhRtQ0wgOvNBK4XRJRWEC2wfzsVF9M" rel="stylesheet" />
 </head>
 <body>
 

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Script.Encoded.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Script.Encoded.html
@@ -19,11 +19,27 @@
         // Fallback to globbed src
     </script>
 <script>(false||document.write("JavaScriptEncode[[<script src="HtmlEncode[[/styles/site.js]]" title='"the" title'></script>]]"));</script>
+    
+    <script src="HtmlEncode[[/styles/siteIntegrity.js?a=integrity]]" crossorigin="anonymous" integrity="sha256-tMQLOHBNPE829MHQPO8metegsGobA/henDPOvtZOWhQ=">
+       // Script loading primary source, applied integrity hash to primary source.
+    </script>
+<script>(true||document.write("JavaScriptEncode[[<script src="HtmlEncode[[/styles/sub/site2.js?a=integrity]]" crossorigin="anonymous" integrity="sha256-tMQLOHBNPE829MHQPO8metegsGobA/henDPOvtZOWhQ="></script>]]"));</script>
+
+    <script src="HtmlEncode[[/styles/siteIntegrity.js?a=integrity]]" crossorigin="anonymous" integrity="sha256-tMQLOHBNPE829MHQPO8metegsGobA/henDPOvtZOWhQ=">
+
+       // Script uses fallback source, applies integrity hash to fallback.
+    </script>
+<script>(false||document.write("JavaScriptEncode[[<script src="HtmlEncode[[/styles/sub/siteIntegrity2.js?a=integrity]]" crossorigin="anonymous" integrity="sha256-tMQLOHBNPE829MHQPO8metegsGobA/henDPOvtZOWhQ="></script>]]"));</script>
+
+    <script src="HtmlEncode[[/styles/siteIntegrity.js?a=integrity]]" crossorigin="anonymous" integrity="sha256-tMQLOHBNPE829MHQPO8metegsGobA/henDPOvtZOWhQ=">
+       // Script uses fallback source, ignores integrity hash on fallback.
+    </script>
+<script>(false||document.write("JavaScriptEncode[[<script src="HtmlEncode[[/styles/sub/siteIntegrity3.js?a=integrity]]" crossorigin="anonymous"></script>]]"));</script>
 
     <script src="HtmlEncode[[/blank.js]]">
         // Fallback to globbed src with exclude
     </script>
-<script>(false||document.write("JavaScriptEncode[[<script src="HtmlEncode[[/styles/site.js]]"></script><script src="HtmlEncode[[/styles/sub/site2.js]]"></script>]]"));</script>
+<script>(false||document.write("JavaScriptEncode[[<script src="HtmlEncode[[/styles/site.js]]"></script><script src="HtmlEncode[[/styles/siteIntegrity.js]]"></script><script src="HtmlEncode[[/styles/sub/site2.js]]"></script><script src="HtmlEncode[[/styles/sub/siteIntegrity2.js]]"></script><script src="HtmlEncode[[/styles/sub/siteIntegrity3.js]]"></script>]]"));</script>
 
     <script src="HtmlEncode[[/blank.js]]">
         // Fallback to globbed and static src
@@ -65,7 +81,7 @@
     <script src="HtmlEncode[[/styles/site.js]]"></script>
 
     <!-- Globbed script tag with existing file and exclude -->
-    <script src="HtmlEncode[[/styles/site.js]]"></script><script src="HtmlEncode[[/styles/sub/site2.js]]"></script>
+    <script src="HtmlEncode[[/styles/site.js]]"></script><script src="HtmlEncode[[/styles/siteIntegrity.js]]"></script><script src="HtmlEncode[[/styles/sub/site2.js]]"></script><script src="HtmlEncode[[/styles/sub/siteIntegrity2.js]]"></script><script src="HtmlEncode[[/styles/sub/siteIntegrity3.js]]"></script>
 
     <script>
         // Globbed script tag missing include
@@ -76,7 +92,7 @@
     </script>
 
     <!-- Globbed script tag with comma separated include pattern -->
-    <script src="HtmlEncode[[/styles/site.js]]"></script><script src="HtmlEncode[[/styles/sub/site2.js]]"></script><script src="HtmlEncode[[/styles/sub/site3.js]]"></script>
+    <script src="HtmlEncode[[/styles/site.js]]"></script><script src="HtmlEncode[[/styles/siteIntegrity.js]]"></script><script src="HtmlEncode[[/styles/sub/site2.js]]"></script><script src="HtmlEncode[[/styles/sub/site3.js]]"></script><script src="HtmlEncode[[/styles/sub/siteIntegrity2.js]]"></script><script src="HtmlEncode[[/styles/sub/siteIntegrity3.js]]"></script>
 
     <!-- Globbed script tag with missing file -->
     
@@ -110,9 +126,9 @@
     </script>
 
     <!-- Globbed script tag with existing files and version -->
-    <script src="HtmlEncode[[/styles/site.js?v=jx1PJjLX32-xgQQx2BxnckU9QH9DVKkm4-M5bSK869I]]"></script><script src="HtmlEncode[[/styles/sub/site2.js?v=pwJaxaQxnb-rPAdF2JlAp4xiPNq1XuJFd6TyOOfNF-0]]"></script><script src="HtmlEncode[[/styles/sub/site3.js?v=lmeAMiqm76lnGyqHhu6PIBHAC0Vt46mgVB_KaG_gGdA]]"></script>
+    <script src="HtmlEncode[[/styles/site.js?v=jx1PJjLX32-xgQQx2BxnckU9QH9DVKkm4-M5bSK869I]]"></script><script src="HtmlEncode[[/styles/siteIntegrity.js?v=tMQLOHBNPE829MHQPO8metegsGobA_henDPOvtZOWhQ]]"></script><script src="HtmlEncode[[/styles/sub/site2.js?v=pwJaxaQxnb-rPAdF2JlAp4xiPNq1XuJFd6TyOOfNF-0]]"></script><script src="HtmlEncode[[/styles/sub/site3.js?v=lmeAMiqm76lnGyqHhu6PIBHAC0Vt46mgVB_KaG_gGdA]]"></script><script src="HtmlEncode[[/styles/sub/siteIntegrity2.js?v=tMQLOHBNPE829MHQPO8metegsGobA_henDPOvtZOWhQ]]"></script><script src="HtmlEncode[[/styles/sub/siteIntegrity3.js?v=6I1ncApSzTYytACF7244bg3a_sEnKrGH8nVudoaN984]]"></script>
 
     <!-- Globbed script tag with existing file, exclude and version -->
-    <script src="HtmlEncode[[/styles/site.js?v=jx1PJjLX32-xgQQx2BxnckU9QH9DVKkm4-M5bSK869I]]"></script><script src="HtmlEncode[[/styles/sub/site2.js?v=pwJaxaQxnb-rPAdF2JlAp4xiPNq1XuJFd6TyOOfNF-0]]"></script>
+    <script src="HtmlEncode[[/styles/site.js?v=jx1PJjLX32-xgQQx2BxnckU9QH9DVKkm4-M5bSK869I]]"></script><script src="HtmlEncode[[/styles/siteIntegrity.js?v=tMQLOHBNPE829MHQPO8metegsGobA_henDPOvtZOWhQ]]"></script><script src="HtmlEncode[[/styles/sub/site2.js?v=pwJaxaQxnb-rPAdF2JlAp4xiPNq1XuJFd6TyOOfNF-0]]"></script><script src="HtmlEncode[[/styles/sub/siteIntegrity2.js?v=tMQLOHBNPE829MHQPO8metegsGobA_henDPOvtZOWhQ]]"></script><script src="HtmlEncode[[/styles/sub/siteIntegrity3.js?v=6I1ncApSzTYytACF7244bg3a_sEnKrGH8nVudoaN984]]"></script>
 </body>
 </html>

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Script.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/HtmlGenerationWebSite.HtmlGeneration_Home.Script.html
@@ -19,11 +19,27 @@
         // Fallback to globbed src
     </script>
 <script>(false||document.write("\u003Cscript src=\u0022\/styles\/site.js\u0022 title=\u0027\u0022the\u0022 title\u0027\u003E\u003C\/script\u003E"));</script>
+    
+    <script src="/styles/siteIntegrity.js?a=integrity" crossorigin="anonymous" integrity="sha256-tMQLOHBNPE829MHQPO8metegsGobA/henDPOvtZOWhQ=">
+       // Script loading primary source, applied integrity hash to primary source.
+    </script>
+<script>(true||document.write("\u003Cscript src=\u0022\/styles\/sub\/site2.js?a=integrity\u0022 crossorigin=\u0022anonymous\u0022 integrity=\u0022sha256-tMQLOHBNPE829MHQPO8metegsGobA\/henDPOvtZOWhQ=\u0022\u003E\u003C\/script\u003E"));</script>
+
+    <script src="/styles/siteIntegrity.js?a=integrity" crossorigin="anonymous" integrity="sha256-tMQLOHBNPE829MHQPO8metegsGobA/henDPOvtZOWhQ=">
+
+       // Script uses fallback source, applies integrity hash to fallback.
+    </script>
+<script>(false||document.write("\u003Cscript src=\u0022\/styles\/sub\/siteIntegrity2.js?a=integrity\u0022 crossorigin=\u0022anonymous\u0022 integrity=\u0022sha256-tMQLOHBNPE829MHQPO8metegsGobA\/henDPOvtZOWhQ=\u0022\u003E\u003C\/script\u003E"));</script>
+
+    <script src="/styles/siteIntegrity.js?a=integrity" crossorigin="anonymous" integrity="sha256-tMQLOHBNPE829MHQPO8metegsGobA/henDPOvtZOWhQ=">
+       // Script uses fallback source, ignores integrity hash on fallback.
+    </script>
+<script>(false||document.write("\u003Cscript src=\u0022\/styles\/sub\/siteIntegrity3.js?a=integrity\u0022 crossorigin=\u0022anonymous\u0022\u003E\u003C\/script\u003E"));</script>
 
     <script src="/blank.js">
         // Fallback to globbed src with exclude
     </script>
-<script>(false||document.write("\u003Cscript src=\u0022\/styles\/site.js\u0022\u003E\u003C\/script\u003E\u003Cscript src=\u0022\/styles\/sub\/site2.js\u0022\u003E\u003C\/script\u003E"));</script>
+<script>(false||document.write("\u003Cscript src=\u0022\/styles\/site.js\u0022\u003E\u003C\/script\u003E\u003Cscript src=\u0022\/styles\/siteIntegrity.js\u0022\u003E\u003C\/script\u003E\u003Cscript src=\u0022\/styles\/sub\/site2.js\u0022\u003E\u003C\/script\u003E\u003Cscript src=\u0022\/styles\/sub\/siteIntegrity2.js\u0022\u003E\u003C\/script\u003E\u003Cscript src=\u0022\/styles\/sub\/siteIntegrity3.js\u0022\u003E\u003C\/script\u003E"));</script>
 
     <script src="/blank.js">
         // Fallback to globbed and static src
@@ -65,7 +81,7 @@
     <script src="/styles/site.js"></script>
 
     <!-- Globbed script tag with existing file and exclude -->
-    <script src="/styles/site.js"></script><script src="/styles/sub/site2.js"></script>
+    <script src="/styles/site.js"></script><script src="/styles/siteIntegrity.js"></script><script src="/styles/sub/site2.js"></script><script src="/styles/sub/siteIntegrity2.js"></script><script src="/styles/sub/siteIntegrity3.js"></script>
 
     <script>
         // Globbed script tag missing include
@@ -76,7 +92,7 @@
     </script>
 
     <!-- Globbed script tag with comma separated include pattern -->
-    <script src="/styles/site.js"></script><script src="/styles/sub/site2.js"></script><script src="/styles/sub/site3.js"></script>
+    <script src="/styles/site.js"></script><script src="/styles/siteIntegrity.js"></script><script src="/styles/sub/site2.js"></script><script src="/styles/sub/site3.js"></script><script src="/styles/sub/siteIntegrity2.js"></script><script src="/styles/sub/siteIntegrity3.js"></script>
 
     <!-- Globbed script tag with missing file -->
     
@@ -110,9 +126,9 @@
     </script>
 
     <!-- Globbed script tag with existing files and version -->
-    <script src="/styles/site.js?v=jx1PJjLX32-xgQQx2BxnckU9QH9DVKkm4-M5bSK869I"></script><script src="/styles/sub/site2.js?v=pwJaxaQxnb-rPAdF2JlAp4xiPNq1XuJFd6TyOOfNF-0"></script><script src="/styles/sub/site3.js?v=lmeAMiqm76lnGyqHhu6PIBHAC0Vt46mgVB_KaG_gGdA"></script>
+    <script src="/styles/site.js?v=jx1PJjLX32-xgQQx2BxnckU9QH9DVKkm4-M5bSK869I"></script><script src="/styles/siteIntegrity.js?v=tMQLOHBNPE829MHQPO8metegsGobA_henDPOvtZOWhQ"></script><script src="/styles/sub/site2.js?v=pwJaxaQxnb-rPAdF2JlAp4xiPNq1XuJFd6TyOOfNF-0"></script><script src="/styles/sub/site3.js?v=lmeAMiqm76lnGyqHhu6PIBHAC0Vt46mgVB_KaG_gGdA"></script><script src="/styles/sub/siteIntegrity2.js?v=tMQLOHBNPE829MHQPO8metegsGobA_henDPOvtZOWhQ"></script><script src="/styles/sub/siteIntegrity3.js?v=6I1ncApSzTYytACF7244bg3a_sEnKrGH8nVudoaN984"></script>
 
     <!-- Globbed script tag with existing file, exclude and version -->
-    <script src="/styles/site.js?v=jx1PJjLX32-xgQQx2BxnckU9QH9DVKkm4-M5bSK869I"></script><script src="/styles/sub/site2.js?v=pwJaxaQxnb-rPAdF2JlAp4xiPNq1XuJFd6TyOOfNF-0"></script>
+    <script src="/styles/site.js?v=jx1PJjLX32-xgQQx2BxnckU9QH9DVKkm4-M5bSK869I"></script><script src="/styles/siteIntegrity.js?v=tMQLOHBNPE829MHQPO8metegsGobA_henDPOvtZOWhQ"></script><script src="/styles/sub/site2.js?v=pwJaxaQxnb-rPAdF2JlAp4xiPNq1XuJFd6TyOOfNF-0"></script><script src="/styles/sub/siteIntegrity2.js?v=tMQLOHBNPE829MHQPO8metegsGobA_henDPOvtZOWhQ"></script><script src="/styles/sub/siteIntegrity3.js?v=6I1ncApSzTYytACF7244bg3a_sEnKrGH8nVudoaN984"></script>
 </body>
 </html>

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/RazorPagesWebSite.SimpleForms.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/RazorPagesWebSite.SimpleForms.html
@@ -4,3 +4,4 @@
 <form action="" method="post"><input name="__RequestVerificationToken" type="hidden" value="{0}" /></form>
 <form action="/Foo/Bar/Baz.html" method="get"></form>
 <form action="/Foo/Bar/Baz.html" method="post"></form>
+<form action="/RedirectToPage" method="post"><input name="__RequestVerificationToken" type="hidden" value="{0}" /></form>

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/RazorPagesWebSite.SimpleForms.html
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/compiler/resources/RazorPagesWebSite.SimpleForms.html
@@ -4,4 +4,3 @@
 <form action="" method="post"><input name="__RequestVerificationToken" type="hidden" value="{0}" /></form>
 <form action="/Foo/Bar/Baz.html" method="get"></form>
 <form action="/Foo/Bar/Baz.html" method="post"></form>
-<form action="/RedirectToPage" method="post"><input name="__RequestVerificationToken" type="hidden" value="{0}" /></form>

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/LinkTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/LinkTagHelperTest.cs
@@ -263,7 +263,49 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                             tagHelper.FallbackTestValue = "hidden";
                             tagHelper.AppendVersion = true;
                         }
-                    }
+                    },
+                    // asp-fallback-href-integrity-check Attribute true
+                    {
+                        new TagHelperAttributeList
+                        {
+                            new TagHelperAttribute("asp-fallback-href", "test.css"),
+                            new TagHelperAttribute("asp-fallback-test-class", "hidden"),
+                            new TagHelperAttribute("asp-fallback-test-property", "visibility"),
+                            new TagHelperAttribute("asp-fallback-test-value", "hidden"),
+                            new TagHelperAttribute("asp-append-version", "true"),
+                            new TagHelperAttribute("asp-fallback-href-integrity-check", "true")
+                        },
+                        tagHelper =>
+                        {
+                            tagHelper.FallbackHref = "test.css";
+                            tagHelper.FallbackTestClass = "hidden";
+                            tagHelper.FallbackTestProperty = "visibility";
+                            tagHelper.FallbackTestValue = "hidden";
+                            tagHelper.AppendVersion = true;
+                            tagHelper.FallbackHrefIntegrityCheck = true;
+                        }
+                    },
+                    // asp-fallback-href-integrity-check Attribute false
+                    {
+                        new TagHelperAttributeList
+                        {
+                            new TagHelperAttribute("asp-fallback-href", "test.css"),
+                            new TagHelperAttribute("asp-fallback-test-class", "hidden"),
+                            new TagHelperAttribute("asp-fallback-test-property", "visibility"),
+                            new TagHelperAttribute("asp-fallback-test-value", "hidden"),
+                            new TagHelperAttribute("asp-append-version", "true"),
+                            new TagHelperAttribute("asp-fallback-href-integrity-check", "false")
+                        },
+                        tagHelper =>
+                        {
+                            tagHelper.FallbackHref = "test.css";
+                            tagHelper.FallbackTestClass = "hidden";
+                            tagHelper.FallbackTestProperty = "visibility";
+                            tagHelper.FallbackTestValue = "hidden";
+                            tagHelper.AppendVersion = true;
+                            tagHelper.FallbackHrefIntegrityCheck = false;
+                        }
+                    },
                 };
             }
         }

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/LinkTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/LinkTagHelperTest.cs
@@ -264,7 +264,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                             tagHelper.AppendVersion = true;
                         }
                     },
-                    // asp-fallback-href-integrity-check Attribute true
+                    // asp-suppress-fallback-integrity Attribute true
                     {
                         new TagHelperAttributeList
                         {
@@ -273,7 +273,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                             new TagHelperAttribute("asp-fallback-test-property", "visibility"),
                             new TagHelperAttribute("asp-fallback-test-value", "hidden"),
                             new TagHelperAttribute("asp-append-version", "true"),
-                            new TagHelperAttribute("asp-fallback-href-integrity-check", "true")
+                            new TagHelperAttribute("asp-suppress-fallback-integrity", "true")
                         },
                         tagHelper =>
                         {
@@ -282,10 +282,10 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                             tagHelper.FallbackTestProperty = "visibility";
                             tagHelper.FallbackTestValue = "hidden";
                             tagHelper.AppendVersion = true;
-                            tagHelper.FallbackHrefIntegrityCheck = true;
+                            tagHelper.SuppressFallbackIntegrity = true;
                         }
                     },
-                    // asp-fallback-href-integrity-check Attribute false
+                    // asp-suppress-fallback-integrity Attribute false
                     {
                         new TagHelperAttributeList
                         {
@@ -294,7 +294,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                             new TagHelperAttribute("asp-fallback-test-property", "visibility"),
                             new TagHelperAttribute("asp-fallback-test-value", "hidden"),
                             new TagHelperAttribute("asp-append-version", "true"),
-                            new TagHelperAttribute("asp-fallback-href-integrity-check", "false")
+                            new TagHelperAttribute("asp-suppress-fallback-integrity", "false")
                         },
                         tagHelper =>
                         {
@@ -303,7 +303,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                             tagHelper.FallbackTestProperty = "visibility";
                             tagHelper.FallbackTestValue = "hidden";
                             tagHelper.AppendVersion = true;
-                            tagHelper.FallbackHrefIntegrityCheck = false;
+                            tagHelper.SuppressFallbackIntegrity = false;
                         }
                     },
                 };

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/ScriptTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/ScriptTagHelperTest.cs
@@ -161,13 +161,13 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                         {
                             new TagHelperAttribute("asp-fallback-src", "test.js"),
                             new TagHelperAttribute("asp-fallback-test", "isavailable()"),
-                            new TagHelperAttribute("asp-fallback-integrity-check", "false")
+                            new TagHelperAttribute("asp-suppress-fallback-integrity", "false")
                         },
                         tagHelper =>
                         {
                             tagHelper.FallbackSrc = "test.js";
                             tagHelper.FallbackTestExpression = "isavailable()";
-                            tagHelper.FallbackIntegrityCheck = false;
+                            tagHelper.SuppressFallbackIntegrity = false;
                         }
                     },
                     {
@@ -202,14 +202,14 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                             new TagHelperAttribute("asp-fallback-src", "test.js"),
                             new TagHelperAttribute("asp-fallback-src-include", "*.js"),
                             new TagHelperAttribute("asp-fallback-test", "isavailable()"),
-                            new TagHelperAttribute("asp-fallback-integrity-check", "false")
+                            new TagHelperAttribute("asp-suppress-fallback-integrity", "false")
                         },
                         tagHelper =>
                         {
                             tagHelper.FallbackSrc = "test.js";
                             tagHelper.FallbackSrcInclude = "*.css";
                             tagHelper.FallbackTestExpression = "isavailable()";
-                            tagHelper.FallbackIntegrityCheck = false;
+                            tagHelper.SuppressFallbackIntegrity = false;
                         }
                     },
                     {

--- a/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/ScriptTagHelperTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.TagHelpers.Test/ScriptTagHelperTest.cs
@@ -159,6 +159,20 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                     {
                         new TagHelperAttributeList
                         {
+                            new TagHelperAttribute("asp-fallback-src", "test.js"),
+                            new TagHelperAttribute("asp-fallback-test", "isavailable()"),
+                            new TagHelperAttribute("asp-fallback-integrity-check", "false")
+                        },
+                        tagHelper =>
+                        {
+                            tagHelper.FallbackSrc = "test.js";
+                            tagHelper.FallbackTestExpression = "isavailable()";
+                            tagHelper.FallbackIntegrityCheck = false;
+                        }
+                    },
+                    {
+                        new TagHelperAttributeList
+                        {
                             new TagHelperAttribute("asp-fallback-src-include", "*.js"),
                             new TagHelperAttribute("asp-fallback-test", "isavailable()")
                         },
@@ -180,6 +194,22 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                             tagHelper.FallbackSrc = "test.js";
                             tagHelper.FallbackSrcInclude = "*.css";
                             tagHelper.FallbackTestExpression = "isavailable()";
+                        }
+                    },
+                    {
+                        new TagHelperAttributeList
+                        {
+                            new TagHelperAttribute("asp-fallback-src", "test.js"),
+                            new TagHelperAttribute("asp-fallback-src-include", "*.js"),
+                            new TagHelperAttribute("asp-fallback-test", "isavailable()"),
+                            new TagHelperAttribute("asp-fallback-integrity-check", "false")
+                        },
+                        tagHelper =>
+                        {
+                            tagHelper.FallbackSrc = "test.js";
+                            tagHelper.FallbackSrcInclude = "*.css";
+                            tagHelper.FallbackTestExpression = "isavailable()";
+                            tagHelper.FallbackIntegrityCheck = false;
                         }
                     },
                     {

--- a/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Link.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Link.cshtml
@@ -46,6 +46,35 @@
           asp-fallback-test-property="visibility"
           asp-fallback-test-value="hidden" />
 
+    <!-- Fallback to static href with no asp-fallback-href-integrity-check attribute, default behavior is to keep integrity hash -->
+    <link href="~/styles/site.min.css?a=b&c=d" rel="stylesheet" data-extra="test" title='"the" title'
+          integrity="XY7YsMemPf8AGU4SIX9ED9eOjK1LOQWu2dmCNmh+pQc="
+          crossorigin="anonymous"
+          asp-fallback-href="~/styles/site.css?a=b&c=d"
+          asp-fallback-test-class="hidden"
+          asp-fallback-test-property="visibility"
+          asp-fallback-test-value="hidden" />
+
+    <!-- Fallback to static href with asp-fallback-href-integrity-check set to true, default behavior is to keep integrity hash -->
+    <link href="~/styles/site.min.css?a=b&c=d" rel="stylesheet" data-extra="test" title='"the" title'
+          integrity="XY7YsMemPf8AGU4SIX9ED9eOjK1LOQWu2dmCNmh+pQc="
+          crossorigin="anonymous"
+          asp-fallback-href="~/styles/site.css?a=b&c=d"
+          asp-fallback-test-class="hidden"
+          asp-fallback-test-property="visibility"
+          asp-fallback-test-value="hidden"
+          asp-fallback-href-integrity-check="true" />
+
+    <!-- Fallback to static href with asp-fallback-href-integrity-check set to false, removes integrity attribute on fallback so that different CSS can be loaded  -->
+    <link href="~/styles/site.min.css?a=b&c=d" rel="stylesheet" data-extra="test" title='"the" title'
+          integrity="XY7YsMemPf8AGU4SIX9ED9eOjK1LOQWu2dmCNmh+pQc="
+          crossorigin="anonymous"
+          asp-fallback-href="~/styles/siteIntegrity.css?a=b&c=d"
+          asp-fallback-test-class="hidden"
+          asp-fallback-test-property="visibility"
+          asp-fallback-test-value="hidden"
+          asp-fallback-href-integrity-check="false" />
+
     <!-- Fallback to static href with dynamic attributes -->
     <link href="~/styles/site.min.css?a=b&c=d" rel="@("stylesheet")" data-extra="@("test")" title='@(@"""the"" title")'
           asp-fallback-href="~/styles/site.css?a=b&c=d"

--- a/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Link.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Link.cshtml
@@ -46,7 +46,7 @@
           asp-fallback-test-property="visibility"
           asp-fallback-test-value="hidden" />
 
-    <!-- Fallback to static href with no asp-fallback-href-integrity-check attribute, default behavior is to keep integrity hash -->
+    <!-- Fallback to static href with no asp-suppress-fallback-integrity attribute, default behavior is to keep integrity hash -->
     <link href="~/styles/site.min.css?a=b&c=d" rel="stylesheet" data-extra="test" title='"the" title'
           integrity="XY7YsMemPf8AGU4SIX9ED9eOjK1LOQWu2dmCNmh+pQc="
           crossorigin="anonymous"
@@ -55,7 +55,7 @@
           asp-fallback-test-property="visibility"
           asp-fallback-test-value="hidden" />
 
-    <!-- Fallback to static href with asp-fallback-href-integrity-check set to true, default behavior is to keep integrity hash -->
+    <!-- Fallback to static href with asp-suppress-fallback-integrity set to false, behavior is to keep integrity hash -->
     <link href="~/styles/site.min.css?a=b&c=d" rel="stylesheet" data-extra="test" title='"the" title'
           integrity="XY7YsMemPf8AGU4SIX9ED9eOjK1LOQWu2dmCNmh+pQc="
           crossorigin="anonymous"
@@ -63,9 +63,9 @@
           asp-fallback-test-class="hidden"
           asp-fallback-test-property="visibility"
           asp-fallback-test-value="hidden"
-          asp-fallback-href-integrity-check="true" />
+          asp-suppress-fallback-integrity="false" />
 
-    <!-- Fallback to static href with asp-fallback-href-integrity-check set to false, removes integrity attribute on fallback so that different CSS can be loaded  -->
+    <!-- Fallback to static href with asp-suppress-fallback-integrity provided, removes integrity attribute on fallback so that different CSS can be loaded  -->
     <link href="~/styles/site.min.css?a=b&c=d" rel="stylesheet" data-extra="test" title='"the" title'
           integrity="XY7YsMemPf8AGU4SIX9ED9eOjK1LOQWu2dmCNmh+pQc="
           crossorigin="anonymous"
@@ -73,7 +73,7 @@
           asp-fallback-test-class="hidden"
           asp-fallback-test-property="visibility"
           asp-fallback-test-value="hidden"
-          asp-fallback-href-integrity-check="false" />
+          asp-suppress-fallback-integrity />
 
     <!-- Fallback to static href with dynamic attributes -->
     <link href="~/styles/site.min.css?a=b&c=d" rel="@("stylesheet")" data-extra="@("test")" title='@(@"""the"" title")'

--- a/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Script.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Script.cshtml
@@ -1,4 +1,4 @@
-@*
+﻿@*
     Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
     Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 *@
@@ -21,6 +21,33 @@
 
     <script src="~/blank.js" asp-fallback-src-include="**/site.js" asp-fallback-test="false" title='"the" title'>
         // Fallback to globbed src
+    </script>
+    
+    <script src="~/styles/siteIntegrity.js?a=integrity"
+            asp-fallback-src="~/styles/sub/site2.js?a=integrity"
+            asp-fallback-test="true"
+            crossorigin="anonymous"
+            integrity="sha256-tMQLOHBNPE829MHQPO8metegsGobA/henDPOvtZOWhQ=">
+       // Script loading primary source, applied integrity hash to primary source.
+    </script>
+
+    <script src="~/styles/siteIntegrity.js?a=integrity"
+            asp-fallback-src="~/styles/sub/siteIntegrity2.js?a=integrity"
+            asp-fallback-test="false"
+            asp-fallback-integrity-check="true"
+            crossorigin="anonymous"
+            integrity="sha256-tMQLOHBNPE829MHQPO8metegsGobA/henDPOvtZOWhQ=">
+
+       // Script uses fallback source, applies integrity hash to fallback.
+    </script>
+
+    <script src="~/styles/siteIntegrity.js?a=integrity"
+            asp-fallback-src="~/styles/sub/siteIntegrity3.js?a=integrity"
+            asp-fallback-test="false"
+            asp-fallback-integrity-check="false"
+            crossorigin="anonymous"
+            integrity="sha256-tMQLOHBNPE829MHQPO8metegsGobA/henDPOvtZOWhQ=">
+       // Script uses fallback source, ignores integrity hash on fallback.
     </script>
 
     <script src="~/blank.js"

--- a/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Script.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Script.cshtml
@@ -34,7 +34,7 @@
     <script src="~/styles/siteIntegrity.js?a=integrity"
             asp-fallback-src="~/styles/sub/siteIntegrity2.js?a=integrity"
             asp-fallback-test="false"
-            asp-fallback-integrity-check="true"
+            asp-suppress-fallback-integrity="false"
             crossorigin="anonymous"
             integrity="sha256-tMQLOHBNPE829MHQPO8metegsGobA/henDPOvtZOWhQ=">
 
@@ -44,7 +44,7 @@
     <script src="~/styles/siteIntegrity.js?a=integrity"
             asp-fallback-src="~/styles/sub/siteIntegrity3.js?a=integrity"
             asp-fallback-test="false"
-            asp-fallback-integrity-check="false"
+            asp-suppress-fallback-integrity="true"
             crossorigin="anonymous"
             integrity="sha256-tMQLOHBNPE829MHQPO8metegsGobA/henDPOvtZOWhQ=">
        // Script uses fallback source, ignores integrity hash on fallback.

--- a/test/WebSites/HtmlGenerationWebSite/wwwroot/styles/siteIntegrity.css
+++ b/test/WebSites/HtmlGenerationWebSite/wwwroot/styles/siteIntegrity.css
@@ -1,0 +1,6 @@
+﻿body::after {
+    display: block;
+    color: #0fa912;
+    margin-top: 2.4em;
+    content: "Stylesheet 'siteIntegrity.css' loaded successfully!";
+}

--- a/test/WebSites/HtmlGenerationWebSite/wwwroot/styles/siteIntegrity.js
+++ b/test/WebSites/HtmlGenerationWebSite/wwwroot/styles/siteIntegrity.js
@@ -1,0 +1,6 @@
+﻿(function () {
+    var p = document.createElement("P");
+    p.appendChild(document.createTextNode("Integrity Script loaded successfully!"));
+    p.style.color = "#0fa912";
+    document.body.appendChild(p);
+})();

--- a/test/WebSites/HtmlGenerationWebSite/wwwroot/styles/sub/siteIntegrity2.js
+++ b/test/WebSites/HtmlGenerationWebSite/wwwroot/styles/sub/siteIntegrity2.js
@@ -1,0 +1,6 @@
+﻿(function () {
+    var p = document.createElement("P");
+    p.appendChild(document.createTextNode("Integrity Script loaded successfully!"));
+    p.style.color = "#0fa912";
+    document.body.appendChild(p);
+})();

--- a/test/WebSites/HtmlGenerationWebSite/wwwroot/styles/sub/siteIntegrity3.js
+++ b/test/WebSites/HtmlGenerationWebSite/wwwroot/styles/sub/siteIntegrity3.js
@@ -1,0 +1,6 @@
+﻿(function () {
+    var p = document.createElement("P");
+    p.appendChild(document.createTextNode("Integrity Script with different hash loaded successfully!"));
+    p.style.color = "#0fa912";
+    document.body.appendChild(p);
+})();


### PR DESCRIPTION
- Regenerated test baselines.
- Update code styling in TagHelpers.
- Modified some comments for clarity.
- Renamed the `LinkTagHelper`s fallback integrity check attribute to exclude `href`.

#7845

@jmhmaine here's the grouped fixes. If you want to see the specifics of what I changed you can take a look at my commit only.
