### PR TITLE
Throw exception if filter factory types are provided to either TypeFi…

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Filters/FilterCollection.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Filters/FilterCollection.cs
@@ -78,14 +78,6 @@ namespace Microsoft.AspNetCore.Mvc.Filters
                 throw new ArgumentNullException(nameof(filterType));
             }
 
-            if (!typeof(IFilterMetadata).IsAssignableFrom(filterType))
-            {
-                var message = Resources.FormatTypeMustDeriveFromType(
-                    filterType.FullName,
-                    typeof(IFilterMetadata).FullName);
-                throw new ArgumentException(message, nameof(filterType));
-            }
-
             var filter = new TypeFilterAttribute(filterType) { Order = order };
             Add(filter);
             return filter;
@@ -158,14 +150,6 @@ namespace Microsoft.AspNetCore.Mvc.Filters
             if (filterType == null)
             {
                 throw new ArgumentNullException(nameof(filterType));
-            }
-
-            if (!typeof(IFilterMetadata).IsAssignableFrom(filterType))
-            {
-                var message = Resources.FormatTypeMustDeriveFromType(
-                    filterType.FullName,
-                    typeof(IFilterMetadata).FullName);
-                throw new ArgumentException(message, nameof(filterType));
             }
 
             var filter = new ServiceFilterAttribute(filterType) { Order = order };

--- a/src/Microsoft.AspNetCore.Mvc.Core/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Properties/Resources.Designer.cs
@@ -207,7 +207,7 @@ namespace Microsoft.AspNetCore.Mvc.Core
             => string.Format(CultureInfo.CurrentCulture, GetString("AsyncResultFilter_InvalidShortCircuit"), p0, p1, p2, p3);
 
         /// <summary>
-        /// The type provided to '{0}' must implement '{1}'.
+        /// The type '{0}' provided to '{1}' must implement '{2}'.
         /// </summary>
         internal static string FilterFactoryAttribute_TypeMustImplementIFilter
         {
@@ -215,10 +215,10 @@ namespace Microsoft.AspNetCore.Mvc.Core
         }
 
         /// <summary>
-        /// The type provided to '{0}' must implement '{1}'.
+        /// The type '{0}' provided to '{1}' must implement '{2}'.
         /// </summary>
-        internal static string FormatFilterFactoryAttribute_TypeMustImplementIFilter(object p0, object p1)
-            => string.Format(CultureInfo.CurrentCulture, GetString("FilterFactoryAttribute_TypeMustImplementIFilter"), p0, p1);
+        internal static string FormatFilterFactoryAttribute_TypeMustImplementIFilter(object p0, object p1, object p2)
+            => string.Format(CultureInfo.CurrentCulture, GetString("FilterFactoryAttribute_TypeMustImplementIFilter"), p0, p1, p2);
 
         /// <summary>
         /// Cannot return null from an action method with a return type of '{0}'.
@@ -1453,7 +1453,7 @@ namespace Microsoft.AspNetCore.Mvc.Core
             => string.Format(CultureInfo.CurrentCulture, GetString("ComplexTypeModelBinder_NoParameterlessConstructor_ForParameter"), p0, p1);
 
         /// <summary>
-        /// Action '{0}' has more than one parameter that were specified or inferred as bound from request body. Only one parameter per action may be bound from body. Inspect the following parameters, and use '{1}' to specify query string bound, '{2}' to specify route bound, and '{3}' for parameters to be bound from body:
+        /// Action '{0}' has more than one parameter that was specified or inferred as bound from request body. Only one parameter per action may be bound from body. Inspect the following parameters, and use '{1}' to specify bound from query, '{2}' to specify bound from route, and '{3}' for parameters to be bound from body:
         /// </summary>
         internal static string ApiController_MultipleBodyParametersFound
         {
@@ -1461,10 +1461,24 @@ namespace Microsoft.AspNetCore.Mvc.Core
         }
 
         /// <summary>
-        /// Action '{0}' has more than one parameter that were specified or inferred as bound from request body. Only one parameter per action may be bound from body. Inspect the following parameters, and use '{1}' to specify query string bound, '{2}' to specify route bound, and '{3}' for parameters to be bound from body:
+        /// Action '{0}' has more than one parameter that was specified or inferred as bound from request body. Only one parameter per action may be bound from body. Inspect the following parameters, and use '{1}' to specify bound from query, '{2}' to specify bound from route, and '{3}' for parameters to be bound from body:
         /// </summary>
         internal static string FormatApiController_MultipleBodyParametersFound(object p0, object p1, object p2, object p3)
             => string.Format(CultureInfo.CurrentCulture, GetString("ApiController_MultipleBodyParametersFound"), p0, p1, p2, p3);
+
+        /// <summary>
+        /// Cannot use a filter factory type '{0}' from within another filter factory type '{1}'.
+        /// </summary>
+        internal static string CannotUseFilterFactoryWithinFilterFactory
+        {
+            get => GetString("CannotUseFilterFactoryWithinFilterFactory");
+        }
+
+        /// <summary>
+        /// Cannot use a filter factory type '{0}' from within another filter factory type '{1}'.
+        /// </summary>
+        internal static string FormatCannotUseFilterFactoryWithinFilterFactory(object p0, object p1)
+            => string.Format(CultureInfo.CurrentCulture, GetString("CannotUseFilterFactoryWithinFilterFactory"), p0, p1);
 
         private static string GetString(string name, params string[] formatterNames)
         {

--- a/src/Microsoft.AspNetCore.Mvc.Core/Resources.resx
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Resources.resx
@@ -160,7 +160,7 @@
     <value>If an {0} cancels execution by setting the {1} property of {2} to 'true', then it cannot call the next filter by invoking {3}.</value>
   </data>
   <data name="FilterFactoryAttribute_TypeMustImplementIFilter" xml:space="preserve">
-    <value>The type provided to '{0}' must implement '{1}'.</value>
+    <value>The type '{0}' provided to '{1}' must implement '{2}'.</value>
   </data>
   <data name="ActionResult_ActionReturnValueCannotBeNull" xml:space="preserve">
     <value>Cannot return null from an action method with a return type of '{0}'.</value>
@@ -441,5 +441,8 @@
   </data>
   <data name="ApiController_MultipleBodyParametersFound" xml:space="preserve">
     <value>Action '{0}' has more than one parameter that was specified or inferred as bound from request body. Only one parameter per action may be bound from body. Inspect the following parameters, and use '{1}' to specify bound from query, '{2}' to specify bound from route, and '{3}' for parameters to be bound from body:</value>
+  </data>
+  <data name="CannotUseFilterFactoryWithinFilterFactory" xml:space="preserve">
+    <value>Cannot use a filter factory type '{0}' from within another filter factory type '{1}'.</value>
   </data>
 </root>

--- a/src/Microsoft.AspNetCore.Mvc.Core/ServiceFilterAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ServiceFilterAttribute.cs
@@ -37,6 +37,20 @@ namespace Microsoft.AspNetCore.Mvc
             }
 
             ServiceType = type;
+
+            if (typeof(IFilterFactory).IsAssignableFrom(ServiceType))
+            {
+                throw new InvalidOperationException(
+                    Resources.FormatCannotUseFilterFactoryWithinFilterFactory(ServiceType, GetType()));
+            }
+
+            if (!typeof(IFilterMetadata).IsAssignableFrom(ServiceType))
+            {
+                throw new InvalidOperationException(Resources.FormatFilterFactoryAttribute_TypeMustImplementIFilter(
+                    ServiceType,
+                    typeof(ServiceFilterAttribute),
+                    typeof(IFilterMetadata)));
+            }
         }
 
         /// <inheritdoc />
@@ -58,17 +72,7 @@ namespace Microsoft.AspNetCore.Mvc
                 throw new ArgumentNullException(nameof(serviceProvider));
             }
 
-            var service = serviceProvider.GetRequiredService(ServiceType);
-
-            var filter = service as IFilterMetadata;
-            if (filter == null)
-            {
-                throw new InvalidOperationException(Resources.FormatFilterFactoryAttribute_TypeMustImplementIFilter(
-                    typeof(ServiceFilterAttribute).Name,
-                    typeof(IFilterMetadata).Name));
-            }
-
-            return filter;
+            return (IFilterMetadata)serviceProvider.GetRequiredService(ServiceType);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/TypeFilterAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/TypeFilterAttribute.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.AspNetCore.Mvc.Core;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -40,6 +41,20 @@ namespace Microsoft.AspNetCore.Mvc
             }
 
             ImplementationType = type;
+
+            if (typeof(IFilterFactory).IsAssignableFrom(ImplementationType))
+            {
+                throw new InvalidOperationException(
+                    Resources.FormatCannotUseFilterFactoryWithinFilterFactory(ImplementationType, GetType()));
+            }
+
+            if (!typeof(IFilterMetadata).IsAssignableFrom(ImplementationType))
+            {
+                throw new InvalidOperationException(Resources.FormatFilterFactoryAttribute_TypeMustImplementIFilter(
+                    ImplementationType,
+                    typeof(TypeFilterAttribute),
+                    typeof(IFilterMetadata)));
+            }
         }
 
         /// <summary>

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/FilterFactoryTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/FilterFactoryTest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             var filterProvider = new TestFilterProvider(
                 context => context.Results.Clear(),
                 content => { });
-            var filter = new FilterDescriptor(new TypeFilterAttribute(typeof(object)), FilterScope.Global);
+            var filter = new FilterDescriptor(new TestOrderedFilter(), FilterScope.Global);
             var actionContext = CreateActionContext(new[] { filter });
 
             // Act

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ServiceFilterAttributeTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ServiceFilterAttributeTest.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.Core.Test
+{
+    public class ServiceFilterAttributeTest
+    {
+        [Fact]
+        public void ThrowsException_OnInstantiating_WithAFilterFactoryType()
+        {
+            // Arrange
+            var serviceType = typeof(FilterFactoryImplementingType);
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => new ServiceFilterAttribute(serviceType));
+            Assert.Equal(
+                $"Cannot use a filter factory type '{serviceType}' from within another" +
+                $" filter factory type '{typeof(ServiceFilterAttribute)}'.",
+                exception.Message);
+        }
+
+        [Theory]
+        [InlineData(typeof(JustFilterMetadataType))]
+        [InlineData(typeof(TestAuthorizationFilter))]
+        public void DoesNotThrow_OnInstantiating_WithNonFilterFactoryType(Type serviceType)
+        {
+            // Act
+            var serviceFilter = new ServiceFilterAttribute(serviceType);
+
+            // Assert
+            Assert.Same(serviceType, serviceFilter.ServiceType);
+        }
+
+        [Fact]
+        public void ThrowsException_WhenProvidedType_IsNotAFilter()
+        {
+            // Arrange
+            var serviceType = typeof(NotFilter);
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => new ServiceFilterAttribute(serviceType));
+            Assert.Equal(
+                $"The type '{serviceType}' provided to '{typeof(ServiceFilterAttribute)}' must implement '{typeof(IFilterMetadata)}'.",
+                exception.Message);
+        }
+
+        private class FilterFactoryImplementingType : IFilterFactory
+        {
+            public bool IsReusable => throw new NotImplementedException();
+
+            public IFilterMetadata CreateInstance(IServiceProvider serviceProvider)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class JustFilterMetadataType : IFilterMetadata
+        {
+        }
+
+        private class TestAuthorizationFilter : IAsyncAuthorizationFilter
+        {
+            public Task OnAuthorizationAsync(AuthorizationFilterContext context)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class NotFilter { }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/TypeFilterAttributeTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/TypeFilterAttributeTest.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.Core.Test
+{
+    public class TypeFilterAttributeTest
+    {
+        [Fact]
+        public void ThrowsException_OnInstantiating_WithAFilterFactoryType()
+        {
+            // Arrange
+            var implementationType = typeof(FilterFactoryImplementingType);
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => new TypeFilterAttribute(implementationType));
+            Assert.Equal(
+                $"Cannot use a filter factory type '{implementationType}' from within another" +
+                $" filter factory type '{typeof(TypeFilterAttribute)}'.",
+                exception.Message);
+        }
+
+        [Theory]
+        [InlineData(typeof(JustFilterMetadataType))]
+        [InlineData(typeof(TestAuthorizationFilter))]
+        public void DoesNotThrow_OnInstantiating_WithNonFilterFactoryType(Type implementationType)
+        {
+            // Act
+            var typeFilter = new TypeFilterAttribute(implementationType);
+
+            // Assert
+            Assert.Same(implementationType, typeFilter.ImplementationType);
+        }
+
+        [Fact]
+        public void ThrowsException_WhenProvidedType_IsNotAFilter()
+        {
+            // Arrange
+            var implementationType = typeof(NotFilter);
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => new TypeFilterAttribute(implementationType));
+            Assert.Equal(
+                $"The type '{implementationType}' provided to '{typeof(TypeFilterAttribute)}' must implement '{typeof(IFilterMetadata)}'.",
+                exception.Message);
+        }
+
+        private class FilterFactoryImplementingType : IFilterFactory
+        {
+            public bool IsReusable => throw new NotImplementedException();
+
+            public IFilterMetadata CreateInstance(IServiceProvider serviceProvider)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class JustFilterMetadataType : IFilterMetadata
+        {
+        }
+
+        private class TestAuthorizationFilter : IAsyncAuthorizationFilter
+        {
+            public Task OnAuthorizationAsync(AuthorizationFilterContext context)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class NotFilter { }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/DefaultPageApplicationModelProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/DefaultPageApplicationModelProviderTest.cs
@@ -1090,9 +1090,16 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 
         [PageModel]
         [Serializable]
-        [TypeFilter(typeof(object))]
+        [TypeFilter(typeof(TestAuthorizationFilter))]
         private class FilterModel
         {
+        }
+
+        private class TestAuthorizationFilter : IAuthorizationFilter
+        {
+            public void OnAuthorization(AuthorizationFilterContext context)
+            {
+            }
         }
 
         [Fact]
@@ -1178,7 +1185,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                 filter => Assert.IsType<PageHandlerPageFilter>(filter));
         }
 
-        [ServiceFilter(typeof(IServiceProvider))]
+        [ServiceFilter(typeof(TestAuthorizationFilter))]
         private class DerivedFromPageModel : PageModel { }
 
         private static DefaultPageApplicationModelProvider CreateProvider()


### PR DESCRIPTION
…lterAttribute or ServiceFilterAttribute

[Fixes #7855] AutoValidateAntiforgeryTokenAttribute does not validate requests when registered globally by type