### PR TITLE
Made ViewResultExecutor.ExecuteAsync method 'virtual'

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ViewResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ViewResultExecutor.cs
@@ -147,7 +147,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         }
 
         /// <inheritdoc />
-        public async Task ExecuteAsync(ActionContext context, ViewResult result)
+        public virtual async Task ExecuteAsync(ActionContext context, ViewResult result)
         {
             if (context == null)
             {


### PR DESCRIPTION
[Fixes #7897] Microsoft.AspNetCore.Mvc.ViewFeatures.ViewResultExecutor.ExecuteAsync no longer virtual.