### PR TITLE
Added ObjectResult implementation for Unauthorized response

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
@@ -1705,6 +1705,14 @@ namespace Microsoft.AspNetCore.Mvc
             => new UnauthorizedResult();
 
         /// <summary>
+        /// Creates an <see cref="UnauthorizedObjectResult"/> that produces a <see cref="StatusCodes.Status401Unauthorized"/> response.
+        /// </summary>
+        /// <returns>The created <see cref="UnauthorizedObjectResult"/> for the response.</returns>
+        [NonAction]
+        public virtual UnauthorizedObjectResult Unauthorized(object value)
+            => new UnauthorizedObjectResult(value);
+
+        /// <summary>
         /// Creates an <see cref="NotFoundResult"/> that produces a <see cref="StatusCodes.Status404NotFound"/> response.
         /// </summary>
         /// <returns>The created <see cref="NotFoundResult"/> for the response.</returns>

--- a/src/Microsoft.AspNetCore.Mvc.Core/UnauthorizedObjectResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/UnauthorizedObjectResult.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+
+namespace Microsoft.AspNetCore.Mvc
+{
+    /// <summary>
+    /// An <see cref="ObjectResult"/> that when executed will produce a Unauthorized (401) response.
+    /// </summary>
+    [DefaultStatusCode(DefaultStatusCode)]
+    public class UnauthorizedObjectResult : ObjectResult
+    {
+        private const int DefaultStatusCode = StatusCodes.Status401Unauthorized;
+
+        /// <summary>
+        /// Creates a new <see cref="UnauthorizedObjectResult"/> instance.
+        /// </summary>
+        public UnauthorizedObjectResult(object value) : base(value)
+        {
+            StatusCode = DefaultStatusCode;
+        }
+    }
+}


### PR DESCRIPTION
In some cases it would be very helpful to include message body that would explain reason of refusal.  For example: Lack of some permission may result in 401 response with message body that explains which permissions are required for this action.