### PR TITLE
Razor runtime compilation produces errors if running on a shared runtime that's rolled forward

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc/MvcServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc/MvcServiceCollectionExtensions.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc;
@@ -59,15 +61,15 @@ namespace Microsoft.Extensions.DependencyInjection
         private static void AddDefaultFrameworkParts(ApplicationPartManager partManager)
         {
             var mvcTagHelpersAssembly = typeof(InputTagHelper).GetTypeInfo().Assembly;
-            if(!partManager.ApplicationParts.OfType<AssemblyPart>().Any(p => p.Assembly == mvcTagHelpersAssembly))
+            if (!partManager.ApplicationParts.OfType<AssemblyPart>().Any(p => p.Assembly == mvcTagHelpersAssembly))
             {
-                partManager.ApplicationParts.Add(new AssemblyPart(mvcTagHelpersAssembly));
+                partManager.ApplicationParts.Add(new FrameworkAssemblyPart(mvcTagHelpersAssembly));
             }
-            
+
             var mvcRazorAssembly = typeof(UrlResolutionTagHelper).GetTypeInfo().Assembly;
-            if(!partManager.ApplicationParts.OfType<AssemblyPart>().Any(p => p.Assembly == mvcRazorAssembly))
+            if (!partManager.ApplicationParts.OfType<AssemblyPart>().Any(p => p.Assembly == mvcRazorAssembly))
             {
-                partManager.ApplicationParts.Add(new AssemblyPart(mvcRazorAssembly));
+                partManager.ApplicationParts.Add(new FrameworkAssemblyPart(mvcRazorAssembly));
             }
         }
 
@@ -93,6 +95,17 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.Configure(setupAction);
 
             return builder;
+        }
+
+        [DebuggerDisplay("{Name}")]
+        private class FrameworkAssemblyPart : AssemblyPart, ICompilationReferencesProvider
+        {
+            public FrameworkAssemblyPart(Assembly assembly)
+                : base(assembly)
+            {
+            }
+
+            IEnumerable<string> ICompilationReferencesProvider.GetReferencePaths() => Enumerable.Empty<string>();
         }
     }
 }

--- a/test/WebSites/BasicWebSite/Controllers/HomeController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/HomeController.cs
@@ -129,7 +129,7 @@ namespace BasicWebSite.Controllers
             // Ensures that the entry assembly part is marked correctly.
             var assemblyPartMetadata = applicationPartManager
                 .ApplicationParts
-                .Where(part => part.GetType() == typeof(AssemblyPart))
+                .OfType<AssemblyPart>()
                 .Select(part => part.Name)
                 .ToArray();
 


### PR DESCRIPTION
Do not provide compilation references from runtime MVC assemblies. This avoids cases where the app is compiled
against an older MVC but running against a newer one (e.g. shared fx roll forward) resulting in compiling against multiple
versions of MVC assemblies

Fixes #7969