### PR TITLE
Test application factory preserves environment name set by variable.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ApiExplorer/ApiResponseTypeProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ApiExplorer/ApiResponseTypeProvider.cs
@@ -86,12 +86,23 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                 {
                     metadataAttribute.SetContentTypes(contentTypes);
 
-                    if (metadataAttribute.Type != null)
+                    if (metadataAttribute.Type == typeof(void) &&
+                        type != null &&
+                        (metadataAttribute.StatusCode == StatusCodes.Status200OK || metadataAttribute.StatusCode == StatusCodes.Status201Created))
+                    {
+                        // ProducesResponseTypeAttribute's constructor defaults to setting "Type" to void when no value is specified.
+                        // In this event, use the action's return type for 200 or 201 status codes. This lets you decorate an action with a
+                        // [ProducesResponseType(201)] instead of [ProducesResponseType(201, typeof(Person)] when typeof(Person) can be inferred
+                        // from the return type.
+                        objectTypes[metadataAttribute.StatusCode] = type;
+                    }
+                    else if (metadataAttribute.Type != null)
                     {
                         objectTypes[metadataAttribute.StatusCode] = metadataAttribute.Type;
                     }
                 }
             }
+
 
             // Set the default status only when no status has already been set explicitly
             if (objectTypes.Count == 0 && type != null)

--- a/src/Microsoft.AspNetCore.Mvc.Testing/WebApplicationFactory.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Testing/WebApplicationFactory.cs
@@ -260,7 +260,9 @@ namespace Microsoft.AspNetCore.Mvc.Testing
             }
             else
             {
-                return builder.UseEnvironment("Development");
+                var environmentName = builder.GetSetting(WebHostDefaults.EnvironmentKey) ??
+                                      EnvironmentName.Development;
+                return builder.UseEnvironment(environmentName);
             }
         }
 

--- a/src/Microsoft.AspNetCore.Mvc/MvcServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc/MvcServiceCollectionExtensions.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc;
@@ -59,15 +61,15 @@ namespace Microsoft.Extensions.DependencyInjection
         private static void AddDefaultFrameworkParts(ApplicationPartManager partManager)
         {
             var mvcTagHelpersAssembly = typeof(InputTagHelper).GetTypeInfo().Assembly;
-            if(!partManager.ApplicationParts.OfType<AssemblyPart>().Any(p => p.Assembly == mvcTagHelpersAssembly))
+            if (!partManager.ApplicationParts.OfType<AssemblyPart>().Any(p => p.Assembly == mvcTagHelpersAssembly))
             {
-                partManager.ApplicationParts.Add(new AssemblyPart(mvcTagHelpersAssembly));
+                partManager.ApplicationParts.Add(new FrameworkAssemblyPart(mvcTagHelpersAssembly));
             }
-            
+
             var mvcRazorAssembly = typeof(UrlResolutionTagHelper).GetTypeInfo().Assembly;
-            if(!partManager.ApplicationParts.OfType<AssemblyPart>().Any(p => p.Assembly == mvcRazorAssembly))
+            if (!partManager.ApplicationParts.OfType<AssemblyPart>().Any(p => p.Assembly == mvcRazorAssembly))
             {
-                partManager.ApplicationParts.Add(new AssemblyPart(mvcRazorAssembly));
+                partManager.ApplicationParts.Add(new FrameworkAssemblyPart(mvcRazorAssembly));
             }
         }
 
@@ -93,6 +95,17 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.Configure(setupAction);
 
             return builder;
+        }
+
+        [DebuggerDisplay("{Name}")]
+        private class FrameworkAssemblyPart : AssemblyPart, ICompilationReferencesProvider
+        {
+            public FrameworkAssemblyPart(Assembly assembly)
+                : base(assembly)
+            {
+            }
+
+            IEnumerable<string> ICompilationReferencesProvider.GetReferencePaths() => Enumerable.Empty<string>();
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.ApiExplorer.Test/ApiResponseTypeProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ApiExplorer.Test/ApiResponseTypeProviderTest.cs
@@ -98,9 +98,11 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                responseType =>
                {
                    Assert.Equal(200, responseType.StatusCode);
-                   Assert.Equal(typeof(void), responseType.Type);
+                   Assert.Equal(typeof(BaseModel), responseType.Type);
                    Assert.False(responseType.IsDefaultResponse);
-                   Assert.Empty(responseType.ApiResponseFormats);
+                   Assert.Collection(
+                        responseType.ApiResponseFormats,
+                        format => Assert.Equal("application/json", format.MediaType));
                },
                responseType =>
                {

--- a/test/Microsoft.AspNetCore.Mvc.ApiExplorer.Test/DefaultApiDescriptionProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ApiExplorer.Test/DefaultApiDescriptionProviderTest.cs
@@ -666,6 +666,216 @@ namespace Microsoft.AspNetCore.Mvc.Description
         }
 
         [Theory]
+        [InlineData(nameof(ReturnsActionResultOfProduct))]
+        [InlineData(nameof(ReturnsTaskOfActionResultOfProduct))]
+        public void GetApiDescription_ReturnsActionResultOfTWithProducesContentType(
+            string methodName)
+        {
+            // Arrange
+            var action = CreateActionDescriptor(methodName);
+            action.FilterDescriptors = new List<FilterDescriptor>()
+            {
+                // Since action is returning Void or Task, it does not make sense to provide a value for the
+                // 'Type' property to ProducesAttribute. But the same action could return other types of data
+                // based on runtime conditions.
+                new FilterDescriptor(
+                    new ProducesAttribute("text/json", "application/json"),
+                    FilterScope.Action),
+                new FilterDescriptor(
+                    new ProducesResponseTypeAttribute(200),
+                    FilterScope.Action),
+                new FilterDescriptor(
+                    new ProducesResponseTypeAttribute(202),
+                    FilterScope.Action),
+                new FilterDescriptor(
+                    new ProducesResponseTypeAttribute(typeof(BadData), 400),
+                    FilterScope.Action),
+                new FilterDescriptor(
+                    new ProducesResponseTypeAttribute(typeof(ErrorDetails), 500),
+                    FilterScope.Action)
+            };
+            var expectedMediaTypes = new[] { "application/json", "text/json" };
+
+            // Act
+            var descriptions = GetApiDescriptions(action);
+
+            // Assert
+            var description = Assert.Single(descriptions);
+            Assert.Equal(4, description.SupportedResponseTypes.Count);
+
+            Assert.Collection(
+                description.SupportedResponseTypes.OrderBy(responseType => responseType.StatusCode),
+                responseType =>
+                {
+                    Assert.Equal(typeof(Product), responseType.Type);
+                    Assert.Equal(200, responseType.StatusCode);
+                    Assert.NotNull(responseType.ModelMetadata);
+                    Assert.Equal(expectedMediaTypes, GetSortedMediaTypes(responseType));
+                },
+                responseType =>
+                {
+                    Assert.Equal(typeof(void), responseType.Type);
+                    Assert.Equal(202, responseType.StatusCode);
+                    Assert.Null(responseType.ModelMetadata);
+                    Assert.Empty(GetSortedMediaTypes(responseType));
+                },
+                responseType =>
+                {
+                    Assert.Equal(typeof(BadData), responseType.Type);
+                    Assert.Equal(400, responseType.StatusCode);
+                    Assert.NotNull(responseType.ModelMetadata);
+                    Assert.Equal(expectedMediaTypes, GetSortedMediaTypes(responseType));
+                },
+                responseType =>
+                {
+                    Assert.Equal(typeof(ErrorDetails), responseType.Type);
+                    Assert.Equal(500, responseType.StatusCode);
+                    Assert.NotNull(responseType.ModelMetadata);
+                    Assert.Equal(expectedMediaTypes, GetSortedMediaTypes(responseType));
+                });
+        }
+
+        [Theory]
+        [InlineData(nameof(ReturnsActionResultOfProduct))]
+        [InlineData(nameof(ReturnsTaskOfActionResultOfProduct))]
+        public void GetApiDescription_ReturnsActionResultOfTWithProducesContentType_ForStatusCode201(
+            string methodName)
+        {
+            // Arrange
+            var action = CreateActionDescriptor(methodName);
+            action.FilterDescriptors = new List<FilterDescriptor>()
+            {
+                // Since action is returning Void or Task, it does not make sense to provide a value for the
+                // 'Type' property to ProducesAttribute. But the same action could return other types of data
+                // based on runtime conditions.
+                new FilterDescriptor(
+                    new ProducesAttribute("text/json", "application/json"),
+                    FilterScope.Action),
+                new FilterDescriptor(
+                    new ProducesResponseTypeAttribute(201),
+                    FilterScope.Action),
+                new FilterDescriptor(
+                    new ProducesResponseTypeAttribute(204),
+                    FilterScope.Action),
+                new FilterDescriptor(
+                    new ProducesResponseTypeAttribute(typeof(BadData), 400),
+                    FilterScope.Action),
+                new FilterDescriptor(
+                    new ProducesResponseTypeAttribute(typeof(ErrorDetails), 500),
+                    FilterScope.Action)
+            };
+            var expectedMediaTypes = new[] { "application/json", "text/json" };
+
+            // Act
+            var descriptions = GetApiDescriptions(action);
+
+            // Assert
+            var description = Assert.Single(descriptions);
+            Assert.Equal(4, description.SupportedResponseTypes.Count);
+
+            Assert.Collection(
+                description.SupportedResponseTypes.OrderBy(responseType => responseType.StatusCode),
+                responseType =>
+                {
+                    Assert.Equal(typeof(Product), responseType.Type);
+                    Assert.Equal(201, responseType.StatusCode);
+                    Assert.NotNull(responseType.ModelMetadata);
+                    Assert.Equal(expectedMediaTypes, GetSortedMediaTypes(responseType));
+                },
+                responseType =>
+                {
+                    Assert.Equal(typeof(void), responseType.Type);
+                    Assert.Equal(204, responseType.StatusCode);
+                    Assert.Null(responseType.ModelMetadata);
+                    Assert.Empty(GetSortedMediaTypes(responseType));
+                },
+                responseType =>
+                {
+                    Assert.Equal(typeof(BadData), responseType.Type);
+                    Assert.Equal(400, responseType.StatusCode);
+                    Assert.NotNull(responseType.ModelMetadata);
+                    Assert.Equal(expectedMediaTypes, GetSortedMediaTypes(responseType));
+                },
+                responseType =>
+                {
+                    Assert.Equal(typeof(ErrorDetails), responseType.Type);
+                    Assert.Equal(500, responseType.StatusCode);
+                    Assert.NotNull(responseType.ModelMetadata);
+                    Assert.Equal(expectedMediaTypes, GetSortedMediaTypes(responseType));
+                });
+        }
+
+        [Theory]
+        [InlineData(nameof(ReturnsActionResultOfSequenceOfProducts))]
+        [InlineData(nameof(ReturnsTaskOfActionResultOfSequenceOfProducts))]
+        public void GetApiDescription_ReturnsActionResultOfSequenceOfTWithProducesContentType(
+            string methodName)
+        {
+            // Arrange
+            var action = CreateActionDescriptor(methodName);
+            action.FilterDescriptors = new List<FilterDescriptor>()
+            {
+                // Since action is returning Void or Task, it does not make sense to provide a value for the
+                // 'Type' property to ProducesAttribute. But the same action could return other types of data
+                // based on runtime conditions.
+                new FilterDescriptor(
+                    new ProducesAttribute("text/json", "application/json"),
+                    FilterScope.Action),
+                new FilterDescriptor(
+                    new ProducesResponseTypeAttribute(200),
+                    FilterScope.Action),
+                new FilterDescriptor(
+                    new ProducesResponseTypeAttribute(201),
+                    FilterScope.Action),
+                new FilterDescriptor(
+                    new ProducesResponseTypeAttribute(typeof(BadData), 400),
+                    FilterScope.Action),
+                new FilterDescriptor(
+                    new ProducesResponseTypeAttribute(typeof(ErrorDetails), 500),
+                    FilterScope.Action)
+            };
+            var expectedMediaTypes = new[] { "application/json", "text/json" };
+
+            // Act
+            var descriptions = GetApiDescriptions(action);
+
+            // Assert
+            var description = Assert.Single(descriptions);
+            Assert.Equal(4, description.SupportedResponseTypes.Count);
+
+            Assert.Collection(
+                description.SupportedResponseTypes.OrderBy(responseType => responseType.StatusCode),
+                responseType =>
+                {
+                    Assert.Equal(typeof(IEnumerable<Product>), responseType.Type);
+                    Assert.Equal(200, responseType.StatusCode);
+                    Assert.NotNull(responseType.ModelMetadata);
+                    Assert.Equal(expectedMediaTypes, GetSortedMediaTypes(responseType));
+                },
+                responseType =>
+                {
+                    Assert.Equal(typeof(IEnumerable<Product>), responseType.Type);
+                    Assert.Equal(201, responseType.StatusCode);
+                    Assert.NotNull(responseType.ModelMetadata);
+                    Assert.Equal(expectedMediaTypes, GetSortedMediaTypes(responseType));
+                },
+                responseType =>
+                {
+                    Assert.Equal(typeof(BadData), responseType.Type);
+                    Assert.Equal(400, responseType.StatusCode);
+                    Assert.NotNull(responseType.ModelMetadata);
+                    Assert.Equal(expectedMediaTypes, GetSortedMediaTypes(responseType));
+                },
+                responseType =>
+                {
+                    Assert.Equal(typeof(ErrorDetails), responseType.Type);
+                    Assert.Equal(500, responseType.StatusCode);
+                    Assert.NotNull(responseType.ModelMetadata);
+                    Assert.Equal(expectedMediaTypes, GetSortedMediaTypes(responseType));
+                });
+        }
+
+        [Theory]
         [InlineData(nameof(ReturnsVoid))]
         [InlineData(nameof(ReturnsTask))]
         public void GetApiDescription_DefaultVoidStatus(string methodName)

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ApiExplorerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/ApiExplorerTest.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using ApiExplorerWebSite;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Testing.xunit;
@@ -1156,6 +1157,9 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
         private async Task ApiConvention_ForGetMethod(string action)
         {
+            // Arrange
+            var expectedMediaTypes = new[] { "application/json", "application/xml", "text/json", "text/xml" };
+
             // Act
             var response = await Client.GetStringAsync(
                 $"ApiExplorerResponseTypeWithApiConventionController/{action}");
@@ -1168,9 +1172,9 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                 description.SupportedResponseTypes.OrderBy(r => r.StatusCode),
                 responseType =>
                 {
-                    Assert.Equal(typeof(void).FullName, responseType.ResponseType);
+                    Assert.Equal(typeof(Product).FullName, responseType.ResponseType);
                     Assert.Equal(200, responseType.StatusCode);
-                    Assert.Empty(responseType.ResponseFormats);
+                    Assert.Equal(expectedMediaTypes, GetSortedMediaTypes(responseType));
                 },
                 responseType =>
                 {
@@ -1198,7 +1202,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                 description.SupportedResponseTypes.OrderBy(r => r.StatusCode),
                 responseType =>
                 {
-                    Assert.Equal(typeof(IEnumerable<ApiExplorerWebSite.Product>).FullName, responseType.ResponseType);
+                    Assert.Equal(typeof(IEnumerable<Product>).FullName, responseType.ResponseType);
                     Assert.Equal(200, responseType.StatusCode);
                     var actualMediaTypes = responseType.ResponseFormats.Select(r => r.MediaType).OrderBy(r => r);
                     Assert.Equal(expectedMediaTypes, actualMediaTypes);

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/TestingInfrastructureEnvironmentTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/TestingInfrastructureEnvironmentTests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.FunctionalTests
+{
+    public class TestingInfrastructureEnvironmentTests
+    { 
+        [Fact]
+        public void TestingInfrastructure_DefaultsEnvironmentToDevelopment()
+        {
+            var factory = new DefaultEnvironmentWebApplicationFactory();
+            var client = factory.CreateClient();
+            Assert.Equal(EnvironmentName.Development, factory.EnvironmentName);
+        }
+
+        [Fact]
+        public void TestingInfrastructure_PreservesEnvironmentSetByVariable()
+        {
+            var factory = new StagingEnvironmentWebApplicationFactory();
+            var client = factory.CreateClient();
+            Assert.Equal(EnvironmentName.Staging, factory.EnvironmentName);
+        }
+    }
+
+    public class DefaultEnvironmentWebApplicationFactory : WebApplicationFactory<BasicWebSite.Startup>
+    {
+        public string EnvironmentName { get; private set; }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.ConfigureAppConfiguration((context, configurationBuilder) =>
+            {
+                EnvironmentName = context.HostingEnvironment.EnvironmentName;
+            });
+        }
+    }
+
+    public class StagingEnvironmentWebApplicationFactory : WebApplicationFactory<BasicWebSite.Startup>
+    {
+        protected override IWebHostBuilder CreateWebHostBuilder()
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", Hosting.EnvironmentName.Staging);
+            return base.CreateWebHostBuilder();
+        }
+
+        public string EnvironmentName { get; private set; }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.ConfigureAppConfiguration((context, configurationBuilder) =>
+            {
+                EnvironmentName = context.HostingEnvironment.EnvironmentName;
+            });
+        }
+    }
+}

--- a/test/WebSites/BasicWebSite/Controllers/HomeController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/HomeController.cs
@@ -129,7 +129,7 @@ namespace BasicWebSite.Controllers
             // Ensures that the entry assembly part is marked correctly.
             var assemblyPartMetadata = applicationPartManager
                 .ApplicationParts
-                .Where(part => part.GetType() == typeof(AssemblyPart))
+                .OfType<AssemblyPart>()
                 .Select(part => part.Name)
                 .ToArray();
 

--- a/version.props
+++ b/version.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.2.0</VersionPrefix>
-    <VersionSuffix>preview1</VersionSuffix>
+    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionSuffix>alpha1</VersionSuffix>
     <BuildNumber Condition="'$(BuildNumber)' == ''">t000</BuildNumber>
     <FeatureBranchVersionPrefix Condition="'$(FeatureBranchVersionPrefix)' == ''">a-</FeatureBranchVersionPrefix>
 
@@ -10,8 +10,8 @@
     <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(FeatureBranchVersionSuffix)' != ''">$(FeatureBranchVersionPrefix)$(VersionSuffix)-$([System.Text.RegularExpressions.Regex]::Replace('$(FeatureBranchVersionSuffix)', '[^\w-]', '-'))</VersionSuffix>
     <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
 
-    <ExperimentalVersionPrefix>0.2.0</ExperimentalVersionPrefix>
-    <ExperimentalVersionSuffix>preview1</ExperimentalVersionSuffix>
+    <ExperimentalVersionPrefix>0.3.0</ExperimentalVersionPrefix>
+    <ExperimentalVersionSuffix>alpha1</ExperimentalVersionSuffix>
 
     <ExperimentalPackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(ExperimentalVersionSuffix)' == 'rtm' ">$(ExperimentalVersionPrefix)</ExperimentalPackageVersion>
     <ExperimentalPackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(ExperimentalVersionSuffix)' != 'rtm' ">$(ExperimentalVersionPrefix)-$(ExperimentalVersionSuffix)-final</ExperimentalPackageVersion>


### PR DESCRIPTION
- If it has not been set, use "Development" as default as before.
- Also, add tests for these two cases.

Addresses #7976