### PR TITLE
Set ProblemDetails status field during ObjectResult formatting

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/ObjectResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ObjectResult.cs
@@ -50,6 +50,11 @@ namespace Microsoft.AspNetCore.Mvc
             if (StatusCode.HasValue)
             {
                 context.HttpContext.Response.StatusCode = StatusCode.Value;
+
+                if (Value is ProblemDetails details && !details.Status.HasValue)
+                {
+                    details.Status = StatusCode.Value;
+                }
             }
         }
     }

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/ObjectResultTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/ObjectResultTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -59,6 +60,38 @@ namespace Microsoft.AspNetCore.Mvc
 
             // Assert
             Assert.Equal(404, actionContext.HttpContext.Response.StatusCode);
+        }
+
+        [Fact]
+        public async Task ObjectResult_ExecuteResultAsync_SetsProblemDetailsStatus()
+        {
+            // Arrange
+            var modelState = new ModelStateDictionary();
+
+            var details = new ValidationProblemDetails(modelState);
+
+            var result = new ObjectResult(details)
+            {
+                StatusCode = StatusCodes.Status422UnprocessableEntity,
+                Formatters = new FormatterCollection<IOutputFormatter>()
+                {
+                    new NoOpOutputFormatter(),
+                },
+            };
+
+            var actionContext = new ActionContext()
+            {
+                HttpContext = new DefaultHttpContext()
+                {
+                    RequestServices = CreateServices(),
+                }
+            };
+
+            // Act
+            await result.ExecuteResultAsync(actionContext);
+
+            // Assert
+            Assert.Equal(StatusCodes.Status422UnprocessableEntity, details.Status.Value);
         }
 
         private static IServiceProvider CreateServices()


### PR DESCRIPTION
I just think it's convenient to have the status field present.

This allows you to do

```csharp
var problem = new ValidationProblemDetails(ModelState);
return new UnprocessableEntityObjectResult(problem);
```

or

```csharp
var problem = new ValidationProblemDetails(ModelState);
return new BadRequestObjectResult(problem);
```

And have the correct status code reflected in the problem details response.

One question is; should the result even override an existing status value?

The RFC [states](https://tools.ietf.org/html/rfc7807#section-3.1):

> Generators MUST use the same status code in the actual HTTP response, to assure that generic HTTP software that does not understand this format still behaves correctly.