### PR TITLE
Use OSS package versions consistent with aspnet/benchmarks and Microsoft.AspNetcore.All 2.1.2

### DIFF
--- a/benchmarkapps/BasicApi/Controllers/PetController.cs
+++ b/benchmarkapps/BasicApi/Controllers/PetController.cs
@@ -25,6 +25,9 @@ namespace BasicApi.Controllers
         public BasicApiContext DbContext { get; }
 
         [HttpGet("{id}", Name = "FindPetById")]
+        [ProducesResponseType(typeof(Pet),  StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<ActionResult<Pet>> FindById(int id)
         {
             var pet = await DbContext.Pets
@@ -42,6 +45,8 @@ namespace BasicApi.Controllers
 
         [AllowAnonymous]
         [HttpGet("anonymous/{id}")]
+        [ProducesResponseType(typeof(Pet), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<ActionResult<Pet>> FindByIdWithoutToken(int id)
         {
             var pet = await DbContext.Pets
@@ -58,6 +63,9 @@ namespace BasicApi.Controllers
         }
 
         [HttpGet("findByCategory/{categoryId}")]
+        [ProducesResponseType(typeof(Pet), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<ActionResult<Pet>> FindByCategory(int categoryId)
         {
             var pet = await DbContext.Pets
@@ -74,6 +82,9 @@ namespace BasicApi.Controllers
         }
 
         [HttpGet("findByStatus")]
+        [ProducesResponseType(typeof(Pet), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<ActionResult<Pet>> FindByStatus(string status)
         {
             var pet = await DbContext.Pets
@@ -90,6 +101,9 @@ namespace BasicApi.Controllers
         }
 
         [HttpGet("findByTags")]
+        [ProducesResponseType(typeof(Pet), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<ActionResult<Pet>> FindByTags(string[] tags)
         {
             var pet = await DbContext.Pets
@@ -107,6 +121,9 @@ namespace BasicApi.Controllers
 
         [Authorize("pet-store-writer")]
         [HttpPost]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> AddPet([FromBody] Pet pet)
         {
             DbContext.Pets.Add(pet);

--- a/benchmarkapps/BasicApi/Controllers/TokenController.cs
+++ b/benchmarkapps/BasicApi/Controllers/TokenController.cs
@@ -7,6 +7,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
@@ -45,11 +46,13 @@ namespace BasicApi.Controllers
         }
 
         [HttpGet("/token")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public IActionResult GetToken(string username)
         {
             if (username == null || !_identities.TryGetValue(username, out var identity))
             {
-                return new StatusCodeResult(403);
+                return new StatusCodeResult(StatusCodes.Status403Forbidden);
             }
 
             var handler = _options.SecurityTokenValidators.OfType<JwtSecurityTokenHandler>().First();

--- a/benchmarkapps/BasicApi/Startup.cs
+++ b/benchmarkapps/BasicApi/Startup.cs
@@ -68,7 +68,7 @@ namespace BasicApi
                 case "MYSQL":
                     services
                         .AddEntityFrameworkMySql()
-                        .AddDbContext<BasicApiContext>(options => options.UseMySql(connectionString));
+                        .AddDbContextPool<BasicApiContext>(options => options.UseMySql(connectionString));
                     break;
 #endif
 

--- a/benchmarkapps/BasicViews/Startup.cs
+++ b/benchmarkapps/BasicViews/Startup.cs
@@ -49,7 +49,7 @@ namespace BasicViews
                 case "MYSQL":
                     services
                         .AddEntityFrameworkMySql()
-                        .AddDbContext<BasicViewsContext>(options => options.UseMySql(connectionString));
+                        .AddDbContextPool<BasicViewsContext>(options => options.UseMySql(connectionString));
                     break;
 #endif
 

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -7,15 +7,15 @@
       is not otherwise referenced. They avoid unnecessary changes to the Universe build graph or to product
       dependencies. Do not use these properties elsewhere.
     -->
-  
+
     <AngleSharpPackageVersion>0.9.9</AngleSharpPackageVersion>
     <BenchmarkDotNetPackageVersion>0.10.13</BenchmarkDotNetPackageVersion>
-    <BenchmarksOnlyMicrosoftEntityFrameworkCoreDesignPackageVersion>2.1.0</BenchmarksOnlyMicrosoftEntityFrameworkCoreDesignPackageVersion>
-    <BenchmarksOnlyMicrosoftEntityFrameworkCoreSqlitePackageVersion>2.1.0</BenchmarksOnlyMicrosoftEntityFrameworkCoreSqlitePackageVersion>
-    <BenchmarksOnlyMicrosoftEntityFrameworkCoreSqlServerPackageVersion>2.1.0</BenchmarksOnlyMicrosoftEntityFrameworkCoreSqlServerPackageVersion>
-    <BenchmarksOnlyMySqlConnectorPackageVersion>0.42.1</BenchmarksOnlyMySqlConnectorPackageVersion>
-    <BenchmarksOnlyNpgsqlEntityFrameworkCorePostgreSQLPackageVersion>2.1.0</BenchmarksOnlyNpgsqlEntityFrameworkCorePostgreSQLPackageVersion>
-    <BenchmarksOnlyPomeloEntityFrameworkCoreMySqlPackageVersion>2.1.0-rc1-final</BenchmarksOnlyPomeloEntityFrameworkCoreMySqlPackageVersion>
+    <BenchmarksOnlyMicrosoftEntityFrameworkCoreDesignPackageVersion>2.1.1</BenchmarksOnlyMicrosoftEntityFrameworkCoreDesignPackageVersion>
+    <BenchmarksOnlyMicrosoftEntityFrameworkCoreSqlitePackageVersion>2.1.1</BenchmarksOnlyMicrosoftEntityFrameworkCoreSqlitePackageVersion>
+    <BenchmarksOnlyMicrosoftEntityFrameworkCoreSqlServerPackageVersion>2.1.1</BenchmarksOnlyMicrosoftEntityFrameworkCoreSqlServerPackageVersion>
+    <BenchmarksOnlyMySqlConnectorPackageVersion>0.43.0</BenchmarksOnlyMySqlConnectorPackageVersion>
+    <BenchmarksOnlyNpgsqlEntityFrameworkCorePostgreSQLPackageVersion>2.1.1.1</BenchmarksOnlyNpgsqlEntityFrameworkCorePostgreSQLPackageVersion>
+    <BenchmarksOnlyPomeloEntityFrameworkCoreMySqlPackageVersion>2.1.1</BenchmarksOnlyPomeloEntityFrameworkCoreMySqlPackageVersion>
     <InternalAspNetCoreAnalyzersPackageVersion>2.2.0-preview1-34823</InternalAspNetCoreAnalyzersPackageVersion>
     <InternalAspNetCoreSdkPackageVersion>2.2.0-preview1-17102</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftAspNetCoreAllPackageVersion>2.2.0-preview1-34823</MicrosoftAspNetCoreAllPackageVersion>


### PR DESCRIPTION
- update our own NuGet packages to align lower-level dependencies
- add metadata to BasicApi controllers
  - avoids analyzer failures when building with Microsoft.AspNetCore.All e.g. in benchmark runs
  - especially important in `PetController` because it's associated with `[ApiContoller]`
- use pooled `DbContext`s for MySql too