### PR TITLE
Warn when the parameter name for a model bound complex parameter has …

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Analyzers/DiagnosticDescriptors.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Analyzers/DiagnosticDescriptors.cs
@@ -42,5 +42,14 @@ namespace Microsoft.AspNetCore.Mvc.Analyzers
                 "Usage",
                 DiagnosticSeverity.Warning,
                 isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor MVC1004_ParameterNameCollidesWithTopLevelProperty =
+            new DiagnosticDescriptor(
+                "MVC1004",
+                "Rename model bound parameter.",
+                "Top level property on '{0}' has the same name as parameter '{1}'. This may produce incorrect model binding. Consider renaming the parameter name.",
+                "Usage",
+                DiagnosticSeverity.Warning,
+                isEnabledByDefault: true);
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Analyzers/DiagnosticDescriptors.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Analyzers/DiagnosticDescriptors.cs
@@ -47,9 +47,10 @@ namespace Microsoft.AspNetCore.Mvc.Analyzers
             new DiagnosticDescriptor(
                 "MVC1004",
                 "Rename model bound parameter.",
-                "Top level property on '{0}' has the same name as parameter '{1}'. This may produce incorrect model binding. Consider renaming the parameter name.",
-                "Usage",
+                "Property on type '{0}' has the same name as parameter '{1}'. This may result in incorrect model binding. Consider renaming the parameter or using a model binding attribute to override the name.",
+                "Naming",
                 DiagnosticSeverity.Warning,
-                isEnabledByDefault: true);
+                isEnabledByDefault: true,
+                helpLinkUri: "https://aka.ms/AA20pbc");
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Analyzers/MvcFacts.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Analyzers/MvcFacts.cs
@@ -5,7 +5,7 @@ using System;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis;
 
-namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
+namespace Microsoft.AspNetCore.Mvc.Analyzers
 {
     internal static class MvcFacts
     {

--- a/src/Microsoft.AspNetCore.Mvc.Analyzers/SymbolNames.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Analyzers/SymbolNames.cs
@@ -19,9 +19,13 @@ namespace Microsoft.AspNetCore.Mvc.Analyzers
 
         public const string AuthorizeAttribute = "Microsoft.AspNetCore.Authorization.AuthorizeAttribute";
 
+        public const string BindAttribute = "Microsoft.AspNetCore.Mvc.BindAttribute";
+
         public const string ControllerAttribute = "Microsoft.AspNetCore.Mvc.ControllerAttribute";
 
         public const string DefaultStatusCodeAttribute = "Microsoft.AspNetCore.Mvc.Infrastructure.DefaultStatusCodeAttribute";
+
+        public const string FromBodyAttribute = "Microsoft.AspNetCore.Mvc.FromBodyAttribute";
 
         public const string HtmlHelperPartialExtensionsType = "Microsoft.AspNetCore.Mvc.Rendering.HtmlHelperPartialExtensions";
 
@@ -34,6 +38,8 @@ namespace Microsoft.AspNetCore.Mvc.Analyzers
         public const string IFilterMetadataType = "Microsoft.AspNetCore.Mvc.Filters.IFilterMetadata";
 
         public const string IHtmlHelperType = "Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper";
+
+        public const string IModelNameProvider = "Microsoft.AspNetCore.Mvc.ModelBinding.IModelNameProvider";
 
         public const string IRouteTemplateProvider = "Microsoft.AspNetCore.Mvc.Routing.IRouteTemplateProvider";
 

--- a/src/Microsoft.AspNetCore.Mvc.Analyzers/TopLevelParameterNameAnalyzer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Analyzers/TopLevelParameterNameAnalyzer.cs
@@ -1,0 +1,125 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class TopLevelParameterNameAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+            DiagnosticDescriptors.MVC1004_ParameterNameCollidesWithTopLevelProperty);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            context.RegisterCompilationStartAction(compilationStartAnalysisContext =>
+            {
+                var typeCache = new SymbolCache(compilationStartAnalysisContext.Compilation);
+                if (typeCache.ControllerAttribute == null || typeCache.ControllerAttribute.TypeKind == TypeKind.Error)
+                {
+                    // No-op if we can't find types we care about.
+                    return;
+                }
+
+                InitializeWorker(compilationStartAnalysisContext, typeCache);
+            });
+        }
+
+        private void InitializeWorker(CompilationStartAnalysisContext compilationStartAnalysisContext, SymbolCache symbolCache)
+        {
+            compilationStartAnalysisContext.RegisterSymbolAction(symbolAnalysisContext =>
+            {
+                var method = (IMethodSymbol)symbolAnalysisContext.Symbol;
+                if (method.MethodKind != MethodKind.Ordinary)
+                {
+                    return;
+                }
+
+                if (method.Parameters.Length == 0)
+                {
+                    return;
+                }
+
+                if (!MvcFacts.IsController(method.ContainingType, symbolCache.ControllerAttribute, symbolCache.NonControllerAttribute) &&
+                    !MvcFacts.IsControllerAction(method, symbolCache.NonActionAttribute, symbolCache.IDisposableDispose))
+                {
+                    return;
+                }
+
+                if (method.ContainingType.HasAttribute(symbolCache.IApiBehaviorMetadata, inherit: true))
+                {
+                    // Don't execute the analyzer on ApiController instances.
+                    return;
+                }
+
+                for (var i = 0; i < method.Parameters.Length; i++)
+                {
+                    var parameter = method.Parameters[0];
+                    if (HasProblematicTopLevelProperty(parameter.Type, parameter.Name))
+                    {
+                        var location = parameter.Locations.Length != 0 ?
+                            parameter.Locations[0] :
+                            Location.None;
+
+                        symbolAnalysisContext.ReportDiagnostic(
+                            Diagnostic.Create(
+                                DiagnosticDescriptors.MVC1004_ParameterNameCollidesWithTopLevelProperty,
+                                location,
+                                parameter.Type.Name,
+                                parameter.Name));
+                    }
+                }
+            }, SymbolKind.Method);
+        }
+
+        private bool HasProblematicTopLevelProperty(ITypeSymbol type, string name)
+        {
+            while (type != null)
+            {
+                foreach (var member in type.GetMembers())
+                {
+                    if (member.DeclaredAccessibility == Accessibility.Public &&
+                        !member.IsStatic &&
+                        member.Kind == SymbolKind.Property &&
+                        string.Equals(name, member.Name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+
+                type = type.BaseType;
+            }
+
+            return false;
+        }
+
+        private readonly struct SymbolCache
+        {
+            public SymbolCache(Compilation compilation)
+            {
+                ControllerAttribute = compilation.GetTypeByMetadataName(SymbolNames.ControllerAttribute);
+                IApiBehaviorMetadata = compilation.GetTypeByMetadataName(SymbolNames.IApiBehaviorMetadata);
+                NonControllerAttribute = compilation.GetTypeByMetadataName(SymbolNames.ControllerAttribute);
+                NonActionAttribute = compilation.GetTypeByMetadataName(SymbolNames.NonActionAttribute);
+
+                var disposable = compilation.GetSpecialType(SpecialType.System_IDisposable);
+                var members = disposable.GetMembers(nameof(IDisposable.Dispose));
+                IDisposableDispose = members.Length == 1 ? (IMethodSymbol)members[0] : null;
+            }
+
+            public INamedTypeSymbol ControllerAttribute { get; }
+            public INamedTypeSymbol IApiBehaviorMetadata { get; }
+            public INamedTypeSymbol NonControllerAttribute { get; }
+            public INamedTypeSymbol NonActionAttribute { get; }
+            public IMethodSymbol IDisposableDispose { get; }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Analyzers/TopLevelParameterNameAnalyzer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Analyzers/TopLevelParameterNameAnalyzer.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Mvc.Analyzers
                     return;
                 }
 
-                if (!MvcFacts.IsController(method.ContainingType, symbolCache.ControllerAttribute, symbolCache.NonControllerAttribute) &&
+                if (!MvcFacts.IsController(method.ContainingType, symbolCache.ControllerAttribute, symbolCache.NonControllerAttribute) ||
                     !MvcFacts.IsControllerAction(method, symbolCache.NonActionAttribute, symbolCache.IDisposableDispose))
                 {
                     return;
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.Mvc.Analyzers
                 foreach (var member in type.GetMembers())
                 {
                     if (member.DeclaredAccessibility != Accessibility.Public ||
-                        member.IsStatic &&
+                        member.IsStatic ||
                         member.Kind != SymbolKind.Property)
                     {
                         continue;

--- a/src/Microsoft.AspNetCore.Mvc.Api.Analyzers/ApiControllerFacts.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Api.Analyzers/ApiControllerFacts.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.AspNetCore.Mvc.Analyzers;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers

--- a/src/Microsoft.AspNetCore.Mvc.Api.Analyzers/Microsoft.AspNetCore.Mvc.Api.Analyzers.csproj
+++ b/src/Microsoft.AspNetCore.Mvc.Api.Analyzers/Microsoft.AspNetCore.Mvc.Api.Analyzers.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <Compile Include="..\Microsoft.AspNetCore.Mvc.Analyzers\CodeAnalysisExtensions.cs" />
+    <Compile Include="..\Microsoft.AspNetCore.Mvc.Analyzers\MvcFacts.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/DiagnosticsAreReturned_ForControllerActionsWithParametersThatMatchProperties.cs
+++ b/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/DiagnosticsAreReturned_ForControllerActionsWithParametersThatMatchProperties.cs
@@ -1,0 +1,13 @@
+﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+{
+    public class DiagnosticsAreReturned_ForControllerActionsWithParametersThatMatchProperties : Controller
+    {
+        [HttpPost]
+        public IActionResult EditPerson(DiagnosticsAreReturned_ForControllerActionsWithParametersThatMatchPropertiesModel /*MM*/model) => null;
+    }
+
+    public class DiagnosticsAreReturned_ForControllerActionsWithParametersThatMatchPropertiesModel
+    {
+        public string Model { get; }
+    }
+}

--- a/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/DiagnosticsAreReturned_ForModelBoundParameters.cs
+++ b/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/DiagnosticsAreReturned_ForModelBoundParameters.cs
@@ -1,0 +1,17 @@
+﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+{
+    public class DiagnosticsAreReturned_ForModelBoundParameters : Controller
+    {
+        [HttpPost]
+        public IActionResult EditPerson(
+            [FromBody] DiagnosticsAreReturned_ForModelBoundParametersModel model,
+            [FromQuery] DiagnosticsAreReturned_ForModelBoundParametersModel /*MM*/value) => null;
+    }
+
+    public class DiagnosticsAreReturned_ForModelBoundParametersModel
+    {
+        public string Model { get; }
+
+        public string Value { get; }
+    }
+}

--- a/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/DiagnosticsAreReturned_IfModelNameProviderIsUsedToModifyParameterName.cs
+++ b/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/DiagnosticsAreReturned_IfModelNameProviderIsUsedToModifyParameterName.cs
@@ -1,0 +1,15 @@
+﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+{
+    public class DiagnosticsAreReturned_IfModelNameProviderIsUsedToModifyParameterName : Controller
+    {
+        [HttpPost]
+        public IActionResult Edit([ModelBinder(Name = "model")] DiagnosticsAreReturned_IfModelNameProviderIsUsedToModifyParameterNameModel /*MM*/parameter) => null;
+    }
+
+    public class DiagnosticsAreReturned_IfModelNameProviderIsUsedToModifyParameterNameModel
+    {
+        public string Model { get; }
+
+        public string Value { get; }
+    }
+}

--- a/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_IgnoresFields.cs
+++ b/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_IgnoresFields.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+{
+    public class IsProblematicParameter_IgnoresFields
+    {
+        public string model;
+
+        public void ActionMethod(IsProblematicParameter_IgnoresFields model) { }
+    }
+}

--- a/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_IgnoresMethods.cs
+++ b/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_IgnoresMethods.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+{
+    public class IsProblematicParameter_IgnoresMethods
+    {
+        public string Item() => null;
+
+        public void ActionMethod(IsProblematicParameter_IgnoresMethods item) { }
+    }
+}

--- a/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_IgnoresNonPublicProperties.cs
+++ b/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_IgnoresNonPublicProperties.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+{
+    public class IsProblematicParameter_IgnoresNonPublicProperties
+    {
+        protected string Model { get; set; }
+
+        public void ActionMethod(IsProblematicParameter_IgnoresNonPublicProperties model) { }
+    }
+}

--- a/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_IgnoresStaticProperties.cs
+++ b/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_IgnoresStaticProperties.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+{
+    public class IsProblematicParameter_IgnoresStaticProperties
+    {
+        public static string Model { get; set; }
+
+        public void ActionMethod(IsProblematicParameter_IgnoresStaticProperties model) { }
+    }
+}

--- a/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsFalse_ForFromBodyParameter.cs
+++ b/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsFalse_ForFromBodyParameter.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+{
+    public class IsProblematicParameter_ReturnsFalse_ForFromBodyParameter
+    {
+        public string Model { get; set; }
+
+        public void ActionMethod([FromBody] IsProblematicParameter_ReturnsFalse_ForFromBodyParameter model) { }
+    }
+}

--- a/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsFalse_IfModelBinderAttributeIsUsedToRenameParameter.cs
+++ b/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsFalse_IfModelBinderAttributeIsUsedToRenameParameter.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+{
+    public class IsProblematicParameter_ReturnsFalse_IfModelBinderAttributeIsUsedToRenameParameter
+    {
+        public string Model { get; set; }
+
+        public void ActionMethod([FromRoute(Name = "id")] IsProblematicParameter_ReturnsFalse_IfModelBinderAttributeIsUsedToRenameParameter model) { }
+    }
+}

--- a/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsFalse_IfModelBinderAttributeIsUsedToRenameProperty.cs
+++ b/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsFalse_IfModelBinderAttributeIsUsedToRenameProperty.cs
@@ -1,0 +1,10 @@
+﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+{
+    public class IsProblematicParameter_ReturnsFalse_IfModelBinderAttributeIsUsedToRenameProperty
+    {
+        [FromQuery(Name = "different")]
+        public string Model { get; set; }
+
+        public void ActionMethod([Bind(Prefix = nameof(Model))] IsProblematicParameter_ReturnsFalse_IfModelBinderAttributeIsUsedToRenameProperty different) { }
+    }
+}

--- a/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsTrue_IfParameterNameIsTheSameAsModelProperty.cs
+++ b/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsTrue_IfParameterNameIsTheSameAsModelProperty.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+{
+    public class IsProblematicParameter_ReturnsTrue_IfParameterNameIsTheSameAsModelProperty
+    {
+        public string Model { get; set; }
+
+        public void ActionMethod(IsProblematicParameter_ReturnsTrue_IfParameterNameIsTheSameAsModelProperty model) { }
+    }
+}

--- a/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsTrue_IfParameterNameWithBinderAttributeIsTheSameNameAsModelProperty.cs
+++ b/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsTrue_IfParameterNameWithBinderAttributeIsTheSameNameAsModelProperty.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+{
+    public class IsProblematicParameter_ReturnsTrue_IfParameterNameWithBinderAttributeIsTheSameNameAsModelProperty
+    {
+        public string Model { get; set; }
+
+        public void ActionMethod([Bind(Prefix = "model")] IsProblematicParameter_ReturnsTrue_IfParameterNameWithBinderAttributeIsTheSameNameAsModelProperty different) { }
+    }
+}

--- a/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsTrue_IfPropertyWithModelBindingAttributeHasSameNameAsParameter.cs
+++ b/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/IsProblematicParameter_ReturnsTrue_IfPropertyWithModelBindingAttributeHasSameNameAsParameter.cs
@@ -1,0 +1,10 @@
+﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+{
+    public class IsProblematicParameter_ReturnsTrue_IfPropertyWithModelBindingAttributeHasSameNameAsParameter
+    {
+        [ModelBinder(typeof(object), Name = "model")]
+        public string Different { get; set; }
+
+        public void ActionMethod(IsProblematicParameter_ReturnsTrue_IfPropertyWithModelBindingAttributeHasSameNameAsParameter model) { }
+    }
+}

--- a/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/NoDiagnosticsAreReturnedForApiControllers.cs
+++ b/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/NoDiagnosticsAreReturnedForApiControllers.cs
@@ -1,0 +1,14 @@
+﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+{
+    [ApiController]
+    public class NoDiagnosticsAreReturnedForApiControllers : Controller
+    {
+        [HttpPost]
+        public IActionResult EditPerson(NoDiagnosticsAreReturnedForApiControllersModel model) => null;
+    }
+
+    public class NoDiagnosticsAreReturnedForApiControllersModel
+    {
+        public string Model { get; }
+    }
+}

--- a/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/NoDiagnosticsAreReturnedForNonActions.cs
+++ b/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/NoDiagnosticsAreReturnedForNonActions.cs
@@ -1,0 +1,13 @@
+﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+{
+    public class NoDiagnosticsAreReturnedForNonActions : Controller
+    {
+        [NonAction]
+        public IActionResult EditPerson(NoDiagnosticsAreReturnedForNonActionsModel model) => null;
+    }
+
+    public class NoDiagnosticsAreReturnedForNonActionsModel
+    {
+        public string Model { get; }
+    }
+}

--- a/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/NoDiagnosticsAreReturnedIfParameterIsRenamedUsingBindingAttribute.cs
+++ b/test/Mvc.Analyzers.Test/TestFiles/TopLevelParameterNameAnalyzerTest/NoDiagnosticsAreReturnedIfParameterIsRenamedUsingBindingAttribute.cs
@@ -1,0 +1,13 @@
+﻿namespace Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles
+{
+    public class NoDiagnosticsAreReturnedIfParameterIsRenamedUsingBindingAttribute : Controller
+    {
+        [HttpPost]
+        public IActionResult EditPerson([FromForm(Name = "")] NoDiagnosticsAreReturnedIfParameterIsRenamedUsingBindingAttributeModel model) => null;
+    }
+
+    public class NoDiagnosticsAreReturnedIfParameterIsRenamedUsingBindingAttributeModel
+    {
+        public string Model { get; }
+    }
+}

--- a/test/Mvc.Analyzers.Test/TopLevelParameterNameAnalyzerTest.cs
+++ b/test/Mvc.Analyzers.Test/TopLevelParameterNameAnalyzerTest.cs
@@ -36,6 +36,10 @@ namespace Microsoft.AspNetCore.Mvc.Analyzers
             => RunNoDiagnosticsAreReturned();
 
         [Fact]
+        public Task NoDiagnosticsAreReturnedForNonActions()
+            => RunNoDiagnosticsAreReturned();
+
+        [Fact]
         public async Task IsProblematicParameter_ReturnsTrue_IfParameterNameIsTheSameAsModelProperty()
         {
             var result = await IsProblematicParameterTest();
@@ -72,6 +76,34 @@ namespace Microsoft.AspNetCore.Mvc.Analyzers
 
         [Fact]
         public async Task IsProblematicParameter_ReturnsFalse_ForFromBodyParameter()
+        {
+            var result = await IsProblematicParameterTest();
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task IsProblematicParameter_IgnoresStaticProperties()
+        {
+            var result = await IsProblematicParameterTest();
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task IsProblematicParameter_IgnoresFields()
+        {
+            var result = await IsProblematicParameterTest();
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task IsProblematicParameter_IgnoresMethods()
+        {
+            var result = await IsProblematicParameterTest();
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task IsProblematicParameter_IgnoresNonPublicProperties()
         {
             var result = await IsProblematicParameterTest();
             Assert.False(result);

--- a/test/Mvc.Analyzers.Test/TopLevelParameterNameAnalyzerTest.cs
+++ b/test/Mvc.Analyzers.Test/TopLevelParameterNameAnalyzerTest.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Analyzer.Testing;
+using Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers
+{
+    public class TopLevelParameterNameAnalyzerTest
+    {
+        private MvcDiagnosticAnalyzerRunner Runner { get; } = new MvcDiagnosticAnalyzerRunner(new TopLevelParameterNameAnalyzer());
+
+        [Fact]
+        public Task DiagnosticsAreReturned_ForControllerActionsWithParametersThatMatchProperties()
+            => RunTest(nameof(DiagnosticsAreReturned_ForControllerActionsWithParametersThatMatchPropertiesModel), "model");
+
+        [Fact]
+        public Task NoDiagnosticsAreReturnedForApiControllers()
+            => RunNoDiagnosticsAreReturned();
+
+        private async Task RunNoDiagnosticsAreReturned([CallerMemberName] string testMethod = "")
+        {
+            // Arrange
+            var testSource = MvcTestSource.Read(GetType().Name, testMethod);
+            var expectedLocation = testSource.DefaultMarkerLocation;
+
+            // Act
+            var result = await Runner.GetDiagnosticsAsync(testSource.Source);
+
+            // Assert
+            Assert.Empty(result);
+        }
+
+        private async Task RunTest(string typeName, string parameterName, [CallerMemberName] string testMethod = "")
+        {
+            // Arrange
+            var descriptor = DiagnosticDescriptors.MVC1004_ParameterNameCollidesWithTopLevelProperty;
+            var testSource = MvcTestSource.Read(GetType().Name, testMethod);
+            var expectedLocation = testSource.DefaultMarkerLocation;
+
+            // Act
+            var result = await Runner.GetDiagnosticsAsync(testSource.Source);
+
+            // Assert
+            Assert.Collection(
+                result,
+                diagnostic =>
+                {
+                    Assert.Equal(descriptor.Id, diagnostic.Id);
+                    Assert.Same(descriptor, diagnostic.Descriptor);
+                    AnalyzerAssert.DiagnosticLocation(expectedLocation, diagnostic.Location);
+                    Assert.Equal(string.Format(descriptor.MessageFormat.ToString(), typeName, parameterName), diagnostic.GetMessage());
+                });
+        }
+    }
+}

--- a/test/Mvc.Analyzers.Test/TopLevelParameterNameAnalyzerTest.cs
+++ b/test/Mvc.Analyzers.Test/TopLevelParameterNameAnalyzerTest.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Analyzer.Testing;
 using Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles;
+using Microsoft.CodeAnalysis;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.Analyzers
@@ -18,8 +20,79 @@ namespace Microsoft.AspNetCore.Mvc.Analyzers
             => RunTest(nameof(DiagnosticsAreReturned_ForControllerActionsWithParametersThatMatchPropertiesModel), "model");
 
         [Fact]
+        public Task DiagnosticsAreReturned_ForModelBoundParameters()
+            => RunTest(nameof(DiagnosticsAreReturned_ForModelBoundParametersModel), "value");
+
+        [Fact]
+        public Task DiagnosticsAreReturned_IfModelNameProviderIsUsedToModifyParameterName()
+            => RunTest(nameof(DiagnosticsAreReturned_IfModelNameProviderIsUsedToModifyParameterNameModel), "parameter");
+
+        [Fact]
         public Task NoDiagnosticsAreReturnedForApiControllers()
             => RunNoDiagnosticsAreReturned();
+
+        [Fact]
+        public Task NoDiagnosticsAreReturnedIfParameterIsRenamedUsingBindingAttribute()
+            => RunNoDiagnosticsAreReturned();
+
+        [Fact]
+        public async Task IsProblematicParameter_ReturnsTrue_IfParameterNameIsTheSameAsModelProperty()
+        {
+            var result = await IsProblematicParameterTest();
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task IsProblematicParameter_ReturnsTrue_IfParameterNameWithBinderAttributeIsTheSameNameAsModelProperty()
+        {
+            var result = await IsProblematicParameterTest();
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task IsProblematicParameter_ReturnsTrue_IfPropertyWithModelBindingAttributeHasSameNameAsParameter()
+        {
+            var result = await IsProblematicParameterTest();
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task IsProblematicParameter_ReturnsFalse_IfModelBinderAttributeIsUsedToRenameParameter()
+        {
+            var result = await IsProblematicParameterTest();
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task IsProblematicParameter_ReturnsFalse_IfModelBinderAttributeIsUsedToRenameProperty()
+        {
+            var result = await IsProblematicParameterTest();
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task IsProblematicParameter_ReturnsFalse_ForFromBodyParameter()
+        {
+            var result = await IsProblematicParameterTest();
+            Assert.False(result);
+        }
+
+        private async Task<bool> IsProblematicParameterTest([CallerMemberName] string testMethod = "")
+        {
+            var testSource = MvcTestSource.Read(GetType().Name, testMethod);
+            var project = DiagnosticProject.Create(GetType().Assembly, new[] { testSource.Source });
+
+            var compilation = await project.GetCompilationAsync();
+
+            var modelType = compilation.GetTypeByMetadataName($"Microsoft.AspNetCore.Mvc.Analyzers.TopLevelParameterNameAnalyzerTestFiles.{testMethod}");
+            var method = (IMethodSymbol)modelType.GetMembers("ActionMethod").First();
+            var parameter = method.Parameters[0];
+
+            var symbolCache = new TopLevelParameterNameAnalyzer.SymbolCache(compilation);
+
+            var result = TopLevelParameterNameAnalyzer.IsProblematicParameter(symbolCache, parameter);
+            return result;
+        }
 
         private async Task RunNoDiagnosticsAreReturned([CallerMemberName] string testMethod = "")
         {

--- a/test/Mvc.Api.Analyzers.Test/MvcFactsTest.cs
+++ b/test/Mvc.Api.Analyzers.Test/MvcFactsTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Analyzer.Testing;
+using Microsoft.AspNetCore.Mvc.Analyzers;
 using Microsoft.CodeAnalysis;
 using Xunit;
 


### PR DESCRIPTION
…the same name as a top level property

Fixes #7753