### PR TITLE
Use StatusCodes constants instead of literals in the ProducesResponseType code fix

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Api.Analyzers/AddResponseTypeAttributeCodeFixAction.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Api.Analyzers/AddResponseTypeAttributeCodeFixAction.cs
@@ -73,7 +73,14 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
 
             if (root is CompilationUnitSyntax compilationUnit && addUsingDirective)
             {
-                root = compilationUnit.AddUsings(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("Microsoft.AspNetCore.Http")));
+                const string @namespace = "Microsoft.AspNetCore.Http";
+
+                var declaredUsings = new HashSet<string>(compilationUnit.Usings.Select(x => x.Name.ToString()));
+
+                if (!declaredUsings.Contains(@namespace))
+                {
+                    root = compilationUnit.AddUsings(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(@namespace)));
+                }
             }
 
             return document.WithSyntaxRoot(root);

--- a/src/Microsoft.AspNetCore.Mvc.Api.Analyzers/ApiSymbolNames.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Api.Analyzers/ApiSymbolNames.cs
@@ -32,5 +32,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
         public const string ProducesDefaultResponseTypeAttribute = "Microsoft.AspNetCore.Mvc.ProducesDefaultResponseTypeAttribute";
 
         public const string ProducesResponseTypeAttribute = "Microsoft.AspNetCore.Mvc.ProducesResponseTypeAttribute";
+
+        public const string HttpStatusCodes = "Microsoft.AspNetCore.Http.StatusCodes";
     }
 }

--- a/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsFullyQualifiedProducesResponseType.Output.cs
+++ b/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsFullyQualifiedProducesResponseType.Output.cs
@@ -17,9 +17,9 @@ namespace TestApp._OUTPUT_
 {
     public class CodeFixAddsFullyQualifiedProducesResponseType : BaseController
     {
-        [Microsoft.AspNetCore.Mvc.ProducesResponseType(202)]
-        [Microsoft.AspNetCore.Mvc.ProducesResponseType(400)]
-        [Microsoft.AspNetCore.Mvc.ProducesResponseType(404)]
+        [Microsoft.AspNetCore.Mvc.ProducesResponseType(Microsoft.AspNetCore.Http.StatusCodes.Status202Accepted)]
+        [Microsoft.AspNetCore.Mvc.ProducesResponseType(Microsoft.AspNetCore.Http.StatusCodes.Status400BadRequest)]
+        [Microsoft.AspNetCore.Mvc.ProducesResponseType(Microsoft.AspNetCore.Http.StatusCodes.Status404NotFound)]
         [Microsoft.AspNetCore.Mvc.ProducesDefaultResponseType]
         public object GetItem(int id)
         {

--- a/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsFullyQualifiedProducesResponseType.Output.cs
+++ b/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsFullyQualifiedProducesResponseType.Output.cs
@@ -1,4 +1,5 @@
-﻿
+﻿using Microsoft.AspNetCore.Http;
+
 [assembly: Microsoft.AspNetCore.Mvc.ApiConventionType(typeof(Microsoft.AspNetCore.Mvc.DefaultApiConventions))]
 
 namespace TestApp._OUTPUT_
@@ -17,9 +18,9 @@ namespace TestApp._OUTPUT_
 {
     public class CodeFixAddsFullyQualifiedProducesResponseType : BaseController
     {
-        [Microsoft.AspNetCore.Mvc.ProducesResponseType(Microsoft.AspNetCore.Http.StatusCodes.Status202Accepted)]
-        [Microsoft.AspNetCore.Mvc.ProducesResponseType(Microsoft.AspNetCore.Http.StatusCodes.Status400BadRequest)]
-        [Microsoft.AspNetCore.Mvc.ProducesResponseType(Microsoft.AspNetCore.Http.StatusCodes.Status404NotFound)]
+        [Microsoft.AspNetCore.Mvc.ProducesResponseType(StatusCodes.Status202Accepted)]
+        [Microsoft.AspNetCore.Mvc.ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [Microsoft.AspNetCore.Mvc.ProducesResponseType(StatusCodes.Status404NotFound)]
         [Microsoft.AspNetCore.Mvc.ProducesDefaultResponseType]
         public object GetItem(int id)
         {

--- a/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsMissingStatusCodes.Input.cs
+++ b/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsMissingStatusCodes.Input.cs
@@ -1,10 +1,12 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._INPUT_
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._INPUT_
 {
     [ApiController]
     [Route("[controller]/[action]")]
     public class CodeFixAddsMissingStatusCodes : ControllerBase
     {
-        [ProducesResponseType(404)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public IActionResult GetItem(int id)
         {
             if (id == 0)

--- a/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsMissingStatusCodes.Output.cs
+++ b/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsMissingStatusCodes.Output.cs
@@ -6,7 +6,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
     [Route("[controller]/[action]")]
     public class CodeFixAddsMissingStatusCodes : ControllerBase
     {
-        [ProducesResponseType(404)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesDefaultResponseType]

--- a/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsMissingStatusCodes.Output.cs
+++ b/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsMissingStatusCodes.Output.cs
@@ -5,8 +5,8 @@
     public class CodeFixAddsMissingStatusCodes : ControllerBase
     {
         [ProducesResponseType(404)]
-        [ProducesResponseType(200)]
-        [ProducesResponseType(400)]
+        [ProducesResponseType(Http.StatusCodes.Status200OK)]
+        [ProducesResponseType(Http.StatusCodes.Status400BadRequest)]
         [ProducesDefaultResponseType]
         public IActionResult GetItem(int id)
         {

--- a/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsMissingStatusCodes.Output.cs
+++ b/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsMissingStatusCodes.Output.cs
@@ -1,12 +1,14 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
 {
     [ApiController]
     [Route("[controller]/[action]")]
     public class CodeFixAddsMissingStatusCodes : ControllerBase
     {
         [ProducesResponseType(404)]
-        [ProducesResponseType(Http.StatusCodes.Status200OK)]
-        [ProducesResponseType(Http.StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesDefaultResponseType]
         public IActionResult GetItem(int id)
         {

--- a/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodes.Output.cs
+++ b/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodes.Output.cs
@@ -4,8 +4,8 @@
     [Route("[controller]/[action]")]
     public class CodeFixAddsStatusCodesController : ControllerBase
     {
-        [ProducesResponseType(200)]
-        [ProducesResponseType(404)]
+        [ProducesResponseType(Http.StatusCodes.Status200OK)]
+        [ProducesResponseType(Http.StatusCodes.Status404NotFound)]
         [ProducesDefaultResponseType]
         public IActionResult GetItem(int id)
         {

--- a/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodes.Output.cs
+++ b/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodes.Output.cs
@@ -1,11 +1,13 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
 {
     [ApiController]
     [Route("[controller]/[action]")]
     public class CodeFixAddsStatusCodesController : ControllerBase
     {
-        [ProducesResponseType(Http.StatusCodes.Status200OK)]
-        [ProducesResponseType(Http.StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesDefaultResponseType]
         public IActionResult GetItem(int id)
         {

--- a/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsSuccessStatusCode.Output.cs
+++ b/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsSuccessStatusCode.Output.cs
@@ -8,9 +8,9 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
     [Route("[controller]/[action]")]
     public class CodeFixAddsSuccessStatusCode : ControllerBase
     {
-        [ProducesResponseType(201)]
-        [ProducesResponseType(400)]
-        [ProducesResponseType(404)]
+        [ProducesResponseType(Http.StatusCodes.Status201Created)]
+        [ProducesResponseType(Http.StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(Http.StatusCodes.Status404NotFound)]
         [ProducesDefaultResponseType]
         public ActionResult<object> GetItem(string id)
         {

--- a/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsSuccessStatusCode.Output.cs
+++ b/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsSuccessStatusCode.Output.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 
 [assembly: ApiConventionType(typeof(DefaultApiConventions))]
 
@@ -8,9 +9,9 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
     [Route("[controller]/[action]")]
     public class CodeFixAddsSuccessStatusCode : ControllerBase
     {
-        [ProducesResponseType(Http.StatusCodes.Status201Created)]
-        [ProducesResponseType(Http.StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(Http.StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesDefaultResponseType]
         public ActionResult<object> GetItem(string id)
         {

--- a/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWithConventionAddsMissingStatusCodes.Output.cs
+++ b/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWithConventionAddsMissingStatusCodes.Output.cs
@@ -8,8 +8,8 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
     [Route("[controller]/[action]")]
     public class CodeFixWithConventionAddsMissingStatusCodes : ControllerBase
     {
-        [ProducesResponseType(202)]
-        [ProducesResponseType(404)]
+        [ProducesResponseType(Http.StatusCodes.Status202Accepted)]
+        [ProducesResponseType(Http.StatusCodes.Status404NotFound)]
         [ProducesDefaultResponseType]
         public ActionResult<string> GetItem(int id)
         {

--- a/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWithConventionAddsMissingStatusCodes.Output.cs
+++ b/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWithConventionAddsMissingStatusCodes.Output.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 
 [assembly: ApiConventionType(typeof(DefaultApiConventions))]
 
@@ -8,8 +9,8 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
     [Route("[controller]/[action]")]
     public class CodeFixWithConventionAddsMissingStatusCodes : ControllerBase
     {
-        [ProducesResponseType(Http.StatusCodes.Status202Accepted)]
-        [ProducesResponseType(Http.StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status202Accepted)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesDefaultResponseType]
         public ActionResult<string> GetItem(int id)
         {

--- a/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWithConventionMethodAddsMissingStatusCodes.Output.cs
+++ b/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWithConventionMethodAddsMissingStatusCodes.Output.cs
@@ -4,8 +4,8 @@
     [Route("[controller]/[action]")]
     public class CodeFixWithConventionMethodAddsMissingStatusCodes : ControllerBase
     {
-        [ProducesResponseType(202)]
-        [ProducesResponseType(404)]
+        [ProducesResponseType(Http.StatusCodes.Status202Accepted)]
+        [ProducesResponseType(Http.StatusCodes.Status404NotFound)]
         [ProducesDefaultResponseType]
         public ActionResult<string> GetItem(int id)
         {

--- a/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWithConventionMethodAddsMissingStatusCodes.Output.cs
+++ b/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWithConventionMethodAddsMissingStatusCodes.Output.cs
@@ -1,11 +1,13 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
 {
     [ApiController]
     [Route("[controller]/[action]")]
     public class CodeFixWithConventionMethodAddsMissingStatusCodes : ControllerBase
     {
-        [ProducesResponseType(Http.StatusCodes.Status202Accepted)]
-        [ProducesResponseType(Http.StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status202Accepted)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesDefaultResponseType]
         public ActionResult<string> GetItem(int id)
         {


### PR DESCRIPTION
I'm a fan of using the constants. What do you think? @pranavkm?