### PR TITLE
Support status code methods, constructors and object initializers in analyzer and code fix

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Api.Analyzers/SymbolApiResponseMetadataProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Api.Analyzers/SymbolApiResponseMetadataProvider.cs
@@ -382,6 +382,21 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
                 return true;
             }
 
+            if (expression is MemberAccessExpressionSyntax memberAccess)
+            {
+                var symbolInfo = semanticModel.GetSymbolInfo(memberAccess, cancellationToken);
+
+                if (symbolInfo.Symbol is IFieldSymbol field && field.HasConstantValue && field.ConstantValue is int constantStatusCode)
+                {
+                    // Covers the 'return StatusCode(StatusCodes.Status200OK)' case.
+                    statusCode = constantStatusCode;
+                    return true;
+                }
+
+                statusCode = default;
+                return false;
+            }
+
             if (expression is IdentifierNameSyntax identifier)
             {
                 var symbolInfo = semanticModel.GetSymbolInfo(identifier, cancellationToken);

--- a/src/Microsoft.AspNetCore.Mvc.Api.Analyzers/SymbolApiResponseMetadataProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Api.Analyzers/SymbolApiResponseMetadataProvider.cs
@@ -276,14 +276,133 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
 
                 return new ActualApiResponseMetadata(returnStatementSyntax, statusCode.Value);
             }
-            else if (!symbolCache.IActionResult.IsAssignableFrom(statementReturnType))
+
+            if (!symbolCache.IActionResult.IsAssignableFrom(statementReturnType))
             {
                 // Return expression does not have a DefaultStatusCodeAttribute and it is not
                 // an instance of IActionResult. Must be returning the "model".
                 return new ActualApiResponseMetadata(returnStatementSyntax);
             }
 
+            if (returnExpression is InvocationExpressionSyntax invocation)
+            {
+                // Covers the 'return StatusCode(200)' case.
+                if (TryGetParameterStatusCode(semanticModel, invocation.Expression, invocation.ArgumentList, cancellationToken, out var statusCode))
+                {
+                    return new ActualApiResponseMetadata(returnStatementSyntax, statusCode);
+                }
+
+                return null;
+            }
+
+            if (returnExpression is ObjectCreationExpressionSyntax creation)
+            {
+                // Covers the 'return new ObjectResult(...) { StatusCode = 200 }' case.
+                if (TryGetInitializerStatusCode(semanticModel, creation.Initializer, cancellationToken, out var statusCode))
+                {
+                    return new ActualApiResponseMetadata(returnStatementSyntax, statusCode);
+                }
+
+                // Covers the 'return new StatusCodeResult(200) case.
+                if (TryGetParameterStatusCode(semanticModel, creation, creation.ArgumentList, cancellationToken, out statusCode))
+                {
+                    return new ActualApiResponseMetadata(returnStatementSyntax, statusCode);
+                }
+            }
+
             return null;
+        }
+
+        private static bool TryGetInitializerStatusCode(
+            SemanticModel semanticModel,
+            InitializerExpressionSyntax initializer,
+            CancellationToken cancellationToken,
+            out int statusCode)
+        {
+            if (initializer == null)
+            {
+                statusCode = default;
+                return false;
+            }
+
+            foreach (var assignment in initializer.Expressions.OfType<AssignmentExpressionSyntax>())
+            {
+                if (assignment.Left is IdentifierNameSyntax identifier)
+                {
+                    var symbolInfo = semanticModel.GetSymbolInfo(identifier, cancellationToken);
+
+                    if (symbolInfo.Symbol is IPropertySymbol property && property.Name.Equals("StatusCode"))
+                    {
+                        return TryGetExpressionStatusCode(semanticModel, assignment.Right, cancellationToken, out statusCode);
+                    }
+                }
+            }
+
+            statusCode = default;
+            return false;
+        }
+
+        private static bool TryGetParameterStatusCode(
+            SemanticModel semanticModel,
+            ExpressionSyntax expression,
+            BaseArgumentListSyntax argumentList,
+            CancellationToken cancellationToken,
+            out int statusCode)
+        {
+            var symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
+
+            if (symbolInfo.Symbol is IMethodSymbol method)
+            {
+                var statusCodeParameter = method.Parameters.FirstOrDefault(parameter =>
+                    parameter.Type.SpecialType == SpecialType.System_Int32 &&
+                    parameter.Name.Equals("statusCode"));
+
+                if (statusCodeParameter != null)
+                {
+                    var argument = argumentList.Arguments[statusCodeParameter.Ordinal];
+
+                    return TryGetExpressionStatusCode(semanticModel, argument.Expression, cancellationToken, out statusCode);
+                }
+            }
+
+            statusCode = default;
+            return false;
+        }
+
+        private static bool TryGetExpressionStatusCode(
+            SemanticModel semanticModel,
+            ExpressionSyntax expression,
+            CancellationToken cancellationToken,
+            out int statusCode)
+        {
+            if (expression is LiteralExpressionSyntax literal && literal.Token.Value is int literalStatusCode)
+            {
+                // Covers the 'return StatusCode(200)' case.
+                statusCode = literalStatusCode;
+                return true;
+            }
+
+            if (expression is IdentifierNameSyntax identifier)
+            {
+                var symbolInfo = semanticModel.GetSymbolInfo(identifier, cancellationToken);
+
+                if (symbolInfo.Symbol is IFieldSymbol field && field.HasConstantValue && field.ConstantValue is int constantStatusCode)
+                {
+                    // Covers the 'return StatusCode(StatusCode)' case, where 'StatusCode' is a constant field.
+                    statusCode = constantStatusCode;
+                    return true;
+                }
+
+                if (symbolInfo.Symbol is ILocalSymbol local && local.HasConstantValue && local.ConstantValue is int localStatusCode)
+                {
+                    // Covers the 'return StatusCode(statusCode)' case, where 'statusCode' is a local constant.
+                    statusCode = localStatusCode;
+                    return true;
+                }
+            }
+
+            statusCode = default;
+            return false;
         }
 
         private static bool ShouldDescendIntoChildren(SyntaxNode syntaxNode)

--- a/src/Microsoft.AspNetCore.Mvc.Api.Analyzers/SymbolApiResponseMetadataProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Api.Analyzers/SymbolApiResponseMetadataProvider.cs
@@ -382,28 +382,14 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
                 return true;
             }
 
-            if (expression is MemberAccessExpressionSyntax memberAccess)
+            if (expression is IdentifierNameSyntax || expression is MemberAccessExpressionSyntax)
             {
-                var symbolInfo = semanticModel.GetSymbolInfo(memberAccess, cancellationToken);
+                var symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
 
                 if (symbolInfo.Symbol is IFieldSymbol field && field.HasConstantValue && field.ConstantValue is int constantStatusCode)
                 {
                     // Covers the 'return StatusCode(StatusCodes.Status200OK)' case.
-                    statusCode = constantStatusCode;
-                    return true;
-                }
-
-                statusCode = default;
-                return false;
-            }
-
-            if (expression is IdentifierNameSyntax identifier)
-            {
-                var symbolInfo = semanticModel.GetSymbolInfo(identifier, cancellationToken);
-
-                if (symbolInfo.Symbol is IFieldSymbol field && field.HasConstantValue && field.ConstantValue is int constantStatusCode)
-                {
-                    // Covers the 'return StatusCode(StatusCode)' case, where 'StatusCode' is a constant field.
+                    // It also covers the 'return StatusCode(StatusCode)' case, where 'StatusCode' is a constant field.
                     statusCode = constantStatusCode;
                     return true;
                 }

--- a/test/Mvc.Api.Analyzers.Test/AddResponseTypeAttributeCodeFixProviderIntegrationTest.cs
+++ b/test/Mvc.Api.Analyzers.Test/AddResponseTypeAttributeCodeFixProviderIntegrationTest.cs
@@ -33,6 +33,18 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
         [Fact]
         public Task CodeFixAddsFullyQualifiedProducesResponseType() => RunTest();
 
+        [Fact]
+        public Task CodeFixAddsNumericLiteralForNonExistingStatusCodeConstants() => RunTest();
+
+        [Fact]
+        public Task CodeFixAddsStatusCodesFromMethodParameters() => RunTest();
+
+        [Fact]
+        public Task CodeFixAddsStatusCodesFromConstructorParameters() => RunTest();
+
+        [Fact]
+        public Task CodeFixAddsStatusCodesFromObjectInitializer() => RunTest();
+
         private async Task RunTest([CallerMemberName] string testMethod = "")
         {
             // Arrange

--- a/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsNumericLiteralForNonExistingStatusCodeConstants.Input.cs
+++ b/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsNumericLiteralForNonExistingStatusCodeConstants.Input.cs
@@ -1,0 +1,17 @@
+﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._INPUT_
+{
+    [ApiController]
+    [Route("[controller]/[action]")]
+    public class CodeFixAddsNumericLiteralForNonExistingStatusCodeConstantsController : ControllerBase
+    {
+        public IActionResult GetItem(int id)
+        {
+            if (id == 0)
+            {
+                return StatusCode(345);
+            }
+
+            return Ok(new object());
+        }
+    }
+}

--- a/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsNumericLiteralForNonExistingStatusCodeConstants.Output.cs
+++ b/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsNumericLiteralForNonExistingStatusCodeConstants.Output.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
+{
+    [ApiController]
+    [Route("[controller]/[action]")]
+    public class CodeFixAddsNumericLiteralForNonExistingStatusCodeConstantsController : ControllerBase
+    {
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(345)]
+        [ProducesDefaultResponseType]
+        public IActionResult GetItem(int id)
+        {
+            if (id == 0)
+            {
+                return StatusCode(345);
+            }
+
+            return Ok(new object());
+        }
+    }
+}

--- a/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromConstructorParameters.Input.cs
+++ b/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromConstructorParameters.Input.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._INPUT_
+{
+    [ApiController]
+    [Route("[controller]/[action]")]
+    public class CodeFixAddsStatusCodesFromConstructorParametersController : ControllerBase
+    {
+        private const int FieldStatusCode = 201;
+
+        public IActionResult GetItem(int id)
+        {
+            if (id == 0)
+            {
+                return new StatusCodeResult(422);
+            }
+            
+            if (id == 1)
+            {
+                return new StatusCodeResult(StatusCodes.Status202Accepted);
+            }
+            
+            if (id == 2)
+            {
+                const int localStatusCode = 204;
+                
+                return new StatusCodeResult(localStatusCode);
+            }
+            
+            if (id == 3)
+            {
+                return new StatusCodeResult(FieldStatusCode);
+            }
+
+            return Ok(new object());
+        }
+    }
+}

--- a/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromConstructorParameters.Output.cs
+++ b/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromConstructorParameters.Output.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
+{
+    [ApiController]
+    [Route("[controller]/[action]")]
+    public class CodeFixAddsStatusCodesFromConstructorParametersController : ControllerBase
+    {
+        private const int FieldStatusCode = 201;
+
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status202Accepted)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
+        [ProducesDefaultResponseType]
+        public IActionResult GetItem(int id)
+        {
+            if (id == 0)
+            {
+                return new StatusCodeResult(422);
+            }
+            
+            if (id == 1)
+            {
+                return new StatusCodeResult(StatusCodes.Status202Accepted);
+            }
+            
+            if (id == 2)
+            {
+                const int localStatusCode = 204;
+                
+                return new StatusCodeResult(localStatusCode);
+            }
+            
+            if (id == 3)
+            {
+                return new StatusCodeResult(FieldStatusCode);
+            }
+
+            return Ok(new object());
+        }
+    }
+}

--- a/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromMethodParameters.Input.cs
+++ b/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromMethodParameters.Input.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._INPUT_
+{
+    [ApiController]
+    [Route("[controller]/[action]")]
+    public class CodeFixAddsStatusCodesFromMethodParametersController : ControllerBase
+    {
+        private const int FieldStatusCode = 201;
+        
+        public IActionResult GetItem(int id)
+        {
+            if (id == 0)
+            {
+                return StatusCode(422);
+            }
+            
+            if (id == 1)
+            {
+                return StatusCode(StatusCodes.Status202Accepted);
+            }
+            
+            if (id == 2)
+            {
+                const int localStatusCode = 204;
+                
+                return StatusCode(localStatusCode);
+            }
+            
+            if (id == 3)
+            {
+                return StatusCode(FieldStatusCode);
+            }
+
+            return Ok(new object());
+        }
+    }
+}

--- a/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromMethodParameters.Output.cs
+++ b/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromMethodParameters.Output.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
+{
+    [ApiController]
+    [Route("[controller]/[action]")]
+    public class CodeFixAddsStatusCodesFromMethodParametersController : ControllerBase
+    {
+        private const int FieldStatusCode = 201;
+
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status202Accepted)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
+        [ProducesDefaultResponseType]
+        public IActionResult GetItem(int id)
+        {
+            if (id == 0)
+            {
+                return StatusCode(422);
+            }
+            
+            if (id == 1)
+            {
+                return StatusCode(StatusCodes.Status202Accepted);
+            }
+            
+            if (id == 2)
+            {
+                const int localStatusCode = 204;
+                
+                return StatusCode(localStatusCode);
+            }
+            
+            if (id == 3)
+            {
+                return StatusCode(FieldStatusCode);
+            }
+
+            return Ok(new object());
+        }
+    }
+}

--- a/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromObjectInitializer.Input.cs
+++ b/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromObjectInitializer.Input.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._INPUT_
+{
+    [ApiController]
+    [Route("[controller]/[action]")]
+    public class CodeFixAddsStatusCodesFromObjectInitializerController : ControllerBase
+    {
+        private const int FieldStatusCode = 201;
+
+        public IActionResult GetItem(int id)
+        {
+            if (id == 0)
+            {
+                return new ObjectResult(new object())
+                {
+                    StatusCode = 422
+                };
+            }
+            
+            if (id == 1)
+            {
+                return new ObjectResult(new object())
+                {
+                    StatusCode = StatusCodes.Status202Accepted
+                };
+            }
+            
+            if (id == 2)
+            {
+                const int localStatusCode = 204;
+                
+                return new ObjectResult(new object())
+                {
+                    StatusCode = localStatusCode
+                };
+            }
+            
+            if (id == 3)
+            {
+                return new ObjectResult(new object())
+                {
+                    StatusCode = FieldStatusCode
+                };
+            }
+
+            return Ok(new object());
+        }
+    }
+}

--- a/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromObjectInitializer.Output.cs
+++ b/test/Mvc.Api.Analyzers.Test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixAddsStatusCodesFromObjectInitializer.Output.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
+{
+    [ApiController]
+    [Route("[controller]/[action]")]
+    public class CodeFixAddsStatusCodesFromObjectInitializerController : ControllerBase
+    {
+        private const int FieldStatusCode = 201;
+
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status202Accepted)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
+        [ProducesDefaultResponseType]
+        public IActionResult GetItem(int id)
+        {
+            if (id == 0)
+            {
+                return new ObjectResult(new object())
+                {
+                    StatusCode = 422
+                };
+            }
+            
+            if (id == 1)
+            {
+                return new ObjectResult(new object())
+                {
+                    StatusCode = StatusCodes.Status202Accepted
+                };
+            }
+            
+            if (id == 2)
+            {
+                const int localStatusCode = 204;
+                
+                return new ObjectResult(new object())
+                {
+                    StatusCode = localStatusCode
+                };
+            }
+            
+            if (id == 3)
+            {
+                return new ObjectResult(new object())
+                {
+                    StatusCode = FieldStatusCode
+                };
+            }
+
+            return Ok(new object());
+        }
+    }
+}


### PR DESCRIPTION
The analyzer should now flag and offer a code fix for the following cases:

| Case | Example |
| ---- | ------- |
| Method call with numeric literal argument | `StatusCode(200)` |
| Method call with field constant argument | `StatusCode(FieldConstant)` |
| Method call with local constant argument | `StatusCode(localConstant)` |
| Method call with member access constant argument | `StatusCode(StatusCodes.Status200OK)` |
| Result constructor with numeric literal argument | `new StatusCodeResult(200)` |
| Result constructor with field constant argument | `new StatusCodeResult(FieldConstant)` |
| Result constructor with local constant argument | `new StatusCodeResult(localConstant)` |
| Result constructor with member access constant argument | `new StatusCodeResult(StatusCodes.Status200OK)` |
| Object initializer with numeric literal assignment | `new ObjectResult(...) { StatusCode = 200 }` |
| Object initializer with field constant assignment | `new ObjectResult(...) { StatusCode = FieldConstant }` |
| Object initializer with local constant assignment | `new ObjectResult(...) { StatusCode = localConstant }` |
| Object initializer with member access constant assignment | `new ObjectResult(...) { StatusCode = StatusCodes.Status200OK }` |

There should be unit tests for all these cases.

// @pranavkm 