### PR TITLE
Ignore line ending diff in unit tests

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RazorPagesWithBasePathTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RazorPagesWithBasePathTest.cs
@@ -330,7 +330,7 @@ Hello from page";
             var response = await Client.GetStringAsync("/Accounts/PageWithLinks");
 
             // Assert
-            Assert.Equal(expected, response.Trim());
+            Assert.Equal(expected, response.Trim(), ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -346,7 +346,7 @@ Hello from page";
             var response = await Client.GetStringAsync("/Accounts/RelativeLinks");
 
             // Assert
-            Assert.Equal(expected, response.Trim());
+            Assert.Equal(expected, response.Trim(), ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -369,7 +369,7 @@ Hello from /Pages/Shared/";
             var response = await Client.GetStringAsync("/Accounts/Manage/RenderPartials");
 
             // Assert
-            Assert.Equal(expected, response.Trim());
+            Assert.Equal(expected, response.Trim(), ignoreLineEndingDifferences: true);
         }
 
         [Fact]


### PR DESCRIPTION
Fix unit tests that fail because of line ending differences.

```
  [xUnit.net 00:00:37.85]     Microsoft.AspNetCore.Mvc.FunctionalTests.RazorPagesWithBasePathTest.PagesInAreas_CanGenerateLinksToControllersAndPages [FAIL]
  Failed   Microsoft.AspNetCore.Mvc.FunctionalTests.RazorPagesWithBasePathTest.PagesInAreas_CanGenerateLinksToControllersAndPages
  Error Message:
   Assert.Equal() Failure
                                   ↓ (pos 62)
  Expected: ・・・Link inside area</a>\r\n<a href="/Products/List/old/20">Link to・・・
  Actual:   ・・・Link inside area</a>\n<a href="/Products/List/old/20">Link to ・・・
                                   ↑ (pos 62)
  Stack Trace:
     at Microsoft.AspNetCore.Mvc.FunctionalTests.RazorPagesWithBasePathTest.PagesInAreas_CanGenerateLinksToControllersAndPages() in C:\GitHub\Mvc\test\Microsoft.AspNetCore.Mvc.FunctionalTests\RazorPagesWithBasePathTest.cs:line 333
  --- End of stack trace from previous location where exception was thrown ---
  [xUnit.net 00:00:44.25]     Microsoft.AspNetCore.Mvc.FunctionalTests.RazorPagesWithBasePathTest.PagesInAreas_CanGenerateRelativeLinks [FAIL]
  Failed   Microsoft.AspNetCore.Mvc.FunctionalTests.RazorPagesWithBasePathTest.PagesInAreas_CanGenerateRelativeLinks
  Error Message:
   Assert.Equal() Failure
                                   ↓ (pos 64)
  Expected: ・・・Parent directory</a>\r\n<a href="/Accounts/Manage/RenderPartial・・・
  Actual:   ・・・Parent directory</a>\n<a href="/Accounts/Manage/RenderPartials・・・
                                   ↑ (pos 64)
  Stack Trace:
     at Microsoft.AspNetCore.Mvc.FunctionalTests.RazorPagesWithBasePathTest.PagesInAreas_CanGenerateRelativeLinks() in C:\GitHub\Mvc\test\Microsoft.AspNetCore.Mvc.FunctionalTests\RazorPagesWithBasePathTest.cs:line 349
  --- End of stack trace from previous location where exception was thrown ---
  [xUnit.net 00:00:45.70]     Microsoft.AspNetCore.Mvc.FunctionalTests.RazorPagesWithBasePathTest.PagesInAreas_CanDiscoverViewsFromAreaAndSharedDirectories [FAIL]
  Failed   Microsoft.AspNetCore.Mvc.FunctionalTests.RazorPagesWithBasePathTest.PagesInAreas_CanDiscoverViewsFromAreaAndSharedDirectories
  Error Message:
   Assert.Equal() Failure
                                   ↓ (pos 23)
  Expected: ・・・out in /Views/Shared\r\nPartial in /Areas/Accounts/Pages/Manage・・・
  Actual:   ・・・out in /Views/Shared\nPartial in /Areas/Accounts/Pages/Manage/・・・
                                   ↑ (pos 23)
  Stack Trace:
     at Microsoft.AspNetCore.Mvc.FunctionalTests.RazorPagesWithBasePathTest.PagesInAreas_CanDiscoverViewsFromAreaAndSharedDirectories() in C:\GitHub\Mvc\test\Microsoft.AspNetCore.Mvc.FunctionalTests\RazorPagesWithBasePathTest.cs:line 372
  --- End of stack trace from previous location where exception was thrown ---

  Total tests: 11938. Passed: 11934. Failed: 3. Skipped: 1.
  Test Run Failed.
  Test execution time: 1.8642 Minutes
```