### PR TITLE
Array or List in query string does not get parsed #7712 (#7967)

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ApiBehaviorApplicationModelProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ApiBehaviorApplicationModelProvider.cs
@@ -193,7 +193,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                     var metadata = _modelMetadataProvider.GetMetadataForProperty(
                         controllerModel.ControllerType,
                         property.PropertyInfo.Name);
-                    if (metadata.IsComplexType)
+                    if (metadata.IsComplexType && !metadata.IsCollectionType)
                     {
                         property.BindingInfo.BinderModelName = string.Empty;
                     }
@@ -254,9 +254,9 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         private bool IsComplexTypeParameter(ParameterModel parameter)
         {
             // No need for information from attributes on the parameter. Just use its type.
-            return _modelMetadataProvider
-                .GetMetadataForType(parameter.ParameterInfo.ParameterType)
-                .IsComplexType;
+            var metadata = _modelMetadataProvider
+                .GetMetadataForType(parameter.ParameterInfo.ParameterType);
+            return metadata.IsComplexType && !metadata.IsCollectionType;
         }
     }
 }


### PR DESCRIPTION
- exclude collections when detecting complex types in `ApiBehaviorApplicationModelProvider`
- add test cases

Porting e1af5b8b6d from release/2.2