### PR TITLE
[Fixes #8021] Copy the request headers before sending the request on the RedirectHandler

### DIFF
--- a/test/WebSites/BasicWebSite/Controllers/TestingController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/TestingController.cs
@@ -37,6 +37,32 @@ namespace BasicWebSite.Controllers
             return Ok(new RedirectHandlerResponse { Url = value, Body = number.Value });
         }
 
+        [HttpGet("Testing/RedirectHandler/Headers")]
+        public IActionResult RedirectHandlerHeaders()
+        {
+            if (!Request.Headers.TryGetValue("X-Added-Header", out var value))
+            {
+                return Content("No header present");
+            }
+            else
+            {
+                return RedirectToAction(nameof(RedirectHandlerHeadersRedirect));
+            }
+        }
+
+        [HttpGet("Testing/RedirectHandler/Headers/Redirect")]
+        public IActionResult RedirectHandlerHeadersRedirect()
+        {
+            if (Request.Headers.TryGetValue("X-Added-Header", out var value))
+            {
+                return Content("true");
+            }
+            else
+            {
+                return Content("false");
+            }
+        }
+
         [HttpGet("Testing/AntiforgerySimulator/{value}")]
         public IActionResult AntiforgerySimulator([FromRoute]int value)
         {


### PR DESCRIPTION
If another handler modifies the request headers the modified headers get applied on subsequent requests, which is not correct. This change copies the headers before sending the request and uses the original headers for the redirect request instead of the potentially modified ones.