### PR TITLE
Make ViewBuffer methods more inlinable

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ViewBuffer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ViewBuffer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
@@ -90,6 +91,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
         }
 
         /// <inheritdoc />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IHtmlContentBuilder Append(string unencoded)
         {
             if (unencoded != null)
@@ -103,6 +105,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
         }
 
         /// <inheritdoc />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IHtmlContentBuilder AppendHtml(IHtmlContent content)
         {
             if (content != null)
@@ -114,6 +117,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
         }
 
         /// <inheritdoc />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IHtmlContentBuilder AppendHtml(string encoded)
         {
             if (encoded != null)
@@ -124,12 +128,14 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             return this;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void AppendValue(ViewBufferValue value)
         {
             var page = GetCurrentPage();
             page.Append(value);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private ViewBufferPage GetCurrentPage()
         {
             var currentPage = _currentPage;
@@ -141,6 +147,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             return currentPage;
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private ViewBufferPage AppendNewPage()
         {
             AddPage(new ViewBufferPage(_bufferScope.GetPage(_pageSize)));

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ViewBuffer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ViewBuffer.cs
@@ -91,6 +91,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
         }
 
         /// <inheritdoc />
+        // Very common trival method; nudge it to inline https://github.com/aspnet/Mvc/pull/8339
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IHtmlContentBuilder Append(string unencoded)
         {
@@ -105,6 +106,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
         }
 
         /// <inheritdoc />
+        // Very common trival method; nudge it to inline https://github.com/aspnet/Mvc/pull/8339
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IHtmlContentBuilder AppendHtml(IHtmlContent content)
         {
@@ -117,6 +119,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
         }
 
         /// <inheritdoc />
+        // Very common trival method; nudge it to inline https://github.com/aspnet/Mvc/pull/8339
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IHtmlContentBuilder AppendHtml(string encoded)
         {
@@ -128,6 +131,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             return this;
         }
 
+        // Very common trival method; nudge it to inline https://github.com/aspnet/Mvc/pull/8339
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void AppendValue(ViewBufferValue value)
         {
@@ -135,18 +139,21 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             page.Append(value);
         }
 
+        // Very common trival method; nudge it to inline https://github.com/aspnet/Mvc/pull/8339
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private ViewBufferPage GetCurrentPage()
         {
             var currentPage = _currentPage;
             if (currentPage == null || currentPage.IsFull)
             {
+                // Uncommon slow-path
                 return AppendNewPage();
             }
 
             return currentPage;
         }
 
+        // Slow path for above, don't inline
         [MethodImpl(MethodImplOptions.NoInlining)]
         private ViewBufferPage AppendNewPage()
         {

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ViewBuffer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ViewBuffer.cs
@@ -92,38 +92,35 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
         /// <inheritdoc />
         public IHtmlContentBuilder Append(string unencoded)
         {
-            if (unencoded == null)
+            if (unencoded != null)
             {
-                return this;
+                // Text that needs encoding is the uncommon case in views, which is why it
+                // creates a wrapper and pre-encoded text does not.
+                AppendValue(new ViewBufferValue(new EncodingWrapper(unencoded)));
             }
 
-            // Text that needs encoding is the uncommon case in views, which is why it
-            // creates a wrapper and pre-encoded text does not.
-            AppendValue(new ViewBufferValue(new EncodingWrapper(unencoded)));
             return this;
         }
 
         /// <inheritdoc />
         public IHtmlContentBuilder AppendHtml(IHtmlContent content)
         {
-            if (content == null)
+            if (content != null)
             {
-                return this;
+                AppendValue(new ViewBufferValue(content));
             }
 
-            AppendValue(new ViewBufferValue(content));
             return this;
         }
 
         /// <inheritdoc />
         public IHtmlContentBuilder AppendHtml(string encoded)
         {
-            if (encoded == null)
+            if (encoded != null)
             {
-                return this;
+                AppendValue(new ViewBufferValue(encoded));
             }
 
-            AppendValue(new ViewBufferValue(encoded));
             return this;
         }
 
@@ -135,10 +132,18 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
 
         private ViewBufferPage GetCurrentPage()
         {
-            if (_currentPage == null || _currentPage.IsFull)
+            var currentPage = _currentPage;
+            if (currentPage == null || currentPage.IsFull)
             {
-                AddPage(new ViewBufferPage(_bufferScope.GetPage(_pageSize)));
+                return AppendNewPage();
             }
+
+            return currentPage;
+        }
+
+        private ViewBufferPage AppendNewPage()
+        {
+            AddPage(new ViewBufferPage(_bufferScope.GetPage(_pageSize)));
             return _currentPage;
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ViewBufferPage.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ViewBufferPage.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Runtime.CompilerServices;
+
 namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
 {
     public class ViewBufferPage
@@ -18,6 +20,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
 
         public bool IsFull => Count == Capacity;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(ViewBufferValue value) => Buffer[Count++] = value;
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ViewBufferPage.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ViewBufferPage.cs
@@ -20,6 +20,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
 
         public bool IsFull => Count == Capacity;
 
+        // Very common trival method; nudge it to inline https://github.com/aspnet/Mvc/pull/8339
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(ViewBufferValue value) => Buffer[Count++] = value;
     }


### PR DESCRIPTION
Move the uncommon path out of `GetCurrentPage`

![image](https://user-images.githubusercontent.com/1142958/44697399-7d99ea00-aa73-11e8-9388-1784de22e10d.png)


Resolves https://github.com/aspnet/Mvc/issues/8356