### PR TITLE
Set longRunningTestSeconds for Functional tests

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/xunit.runner.json
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/xunit.runner.json
@@ -1,3 +1,4 @@
 {
-  "shadowCopy": false
+  "shadowCopy": false,
+  "longRunningTestSeconds": 60
 }


### PR DESCRIPTION
We had a test hang on the CI, but without the below change we have no way of knowing which one.

Provides logging to solve aspnet/Coherence-Signed#952.