### PR TITLE
Zero cost(ish) diagnositcs when disabled

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionInvoker.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionInvoker.cs
@@ -27,12 +27,12 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
         internal ControllerActionInvoker(
             ILogger logger,
-            DiagnosticSource diagnosticSource,
+            DiagnosticListener diagnosticListener,
             IActionResultTypeMapper mapper,
             ControllerContext controllerContext,
             ControllerActionInvokerCacheEntry cacheEntry,
             IFilterMetadata[] filters)
-            : base(diagnosticSource, logger, mapper, controllerContext, filters, controllerContext.ValueProviderFactories)
+            : base(diagnosticListener, logger, mapper, controllerContext, filters, controllerContext.ValueProviderFactories)
         {
             if (cacheEntry == null)
             {
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                         var filter = (IAsyncActionFilter)state;
                         var actionExecutingContext = _actionExecutingContext;
 
-                        _diagnosticSource.BeforeOnActionExecution(actionExecutingContext, filter);
+                        _diagnosticListener.BeforeOnActionExecution(actionExecutingContext, filter);
                         _logger.BeforeExecutingMethodOnFilter(
                             MvcCoreLoggerExtensions.ActionFilter,
                             nameof(IAsyncActionFilter.OnActionExecutionAsync),
@@ -153,7 +153,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                             };
                         }
 
-                        _diagnosticSource.AfterOnActionExecution(_actionExecutedContext, filter);
+                        _diagnosticListener.AfterOnActionExecution(_actionExecutedContext, filter);
                         _logger.AfterExecutingMethodOnFilter(
                             MvcCoreLoggerExtensions.ActionFilter,
                             nameof(IAsyncActionFilter.OnActionExecutionAsync),
@@ -170,7 +170,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                         var filter = (IActionFilter)state;
                         var actionExecutingContext = _actionExecutingContext;
 
-                        _diagnosticSource.BeforeOnActionExecuting(actionExecutingContext, filter);
+                        _diagnosticListener.BeforeOnActionExecuting(actionExecutingContext, filter);
                         _logger.BeforeExecutingMethodOnFilter(
                             MvcCoreLoggerExtensions.ActionFilter,
                             nameof(IActionFilter.OnActionExecuting),
@@ -178,7 +178,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
                         filter.OnActionExecuting(actionExecutingContext);
 
-                        _diagnosticSource.AfterOnActionExecuting(actionExecutingContext, filter);
+                        _diagnosticListener.AfterOnActionExecuting(actionExecutingContext, filter);
                         _logger.AfterExecutingMethodOnFilter(
                             MvcCoreLoggerExtensions.ActionFilter,
                             nameof(IActionFilter.OnActionExecuting),
@@ -220,7 +220,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                         var filter = (IActionFilter)state;
                         var actionExecutedContext = _actionExecutedContext;
 
-                        _diagnosticSource.BeforeOnActionExecuted(actionExecutedContext, filter);
+                        _diagnosticListener.BeforeOnActionExecuted(actionExecutedContext, filter);
                         _logger.BeforeExecutingMethodOnFilter(
                             MvcCoreLoggerExtensions.ActionFilter,
                             nameof(IActionFilter.OnActionExecuted),
@@ -228,7 +228,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
                         filter.OnActionExecuted(actionExecutedContext);
 
-                        _diagnosticSource.AfterOnActionExecuted(actionExecutedContext, filter);
+                        _diagnosticListener.AfterOnActionExecuted(actionExecutedContext, filter);
                         _logger.AfterExecutingMethodOnFilter(
                             MvcCoreLoggerExtensions.ActionFilter,
                             nameof(IActionFilter.OnActionExecuted),
@@ -336,13 +336,13 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             var actionMethodExecutor = _cacheEntry.ActionMethodExecutor;
             var orderedArguments = PrepareArguments(arguments, objectMethodExecutor);
 
-            var diagnosticSource = _diagnosticSource;
+            var diagnosticListener = _diagnosticListener;
             var logger = _logger;
 
             IActionResult result = null;
             try
             {
-                diagnosticSource.BeforeActionMethod(
+                diagnosticListener.BeforeActionMethod(
                     controllerContext,
                     arguments,
                     controller);
@@ -363,7 +363,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             }
             finally
             {
-                diagnosticSource.AfterActionMethod(
+                diagnosticListener.AfterActionMethod(
                     controllerContext,
                     arguments,
                     controllerContext,

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionInvokerProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ControllerActionInvokerProvider.cs
@@ -20,21 +20,21 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         private readonly IReadOnlyList<IValueProviderFactory> _valueProviderFactories;
         private readonly int _maxModelValidationErrors;
         private readonly ILogger _logger;
-        private readonly DiagnosticSource _diagnosticSource;
+        private readonly DiagnosticListener _diagnosticListener;
         private readonly IActionResultTypeMapper _mapper;
 
         public ControllerActionInvokerProvider(
             ControllerActionInvokerCache controllerActionInvokerCache,
             IOptions<MvcOptions> optionsAccessor,
             ILoggerFactory loggerFactory,
-            DiagnosticSource diagnosticSource,
+            DiagnosticListener diagnosticListener,
             IActionResultTypeMapper mapper)
         {
             _controllerActionInvokerCache = controllerActionInvokerCache;
             _valueProviderFactories = optionsAccessor.Value.ValueProviderFactories.ToArray();
             _maxModelValidationErrors = optionsAccessor.Value.MaxModelValidationErrors;
             _logger = loggerFactory.CreateLogger<ControllerActionInvoker>();
-            _diagnosticSource = diagnosticSource;
+            _diagnosticListener = diagnosticListener;
             _mapper = mapper;
         }
 
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
                 var invoker = new ControllerActionInvoker(
                     _logger,
-                    _diagnosticSource,
+                    _diagnosticListener,
                     _mapper,
                     controllerContext,
                     cacheResult.cacheEntry,

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcAttributeRouteHandler.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcAttributeRouteHandler.cs
@@ -18,21 +18,21 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         private readonly IActionInvokerFactory _actionInvokerFactory;
         private readonly IActionSelector _actionSelector;
         private readonly ILogger _logger;
-        private DiagnosticSource _diagnosticSource;
+        private DiagnosticListener _diagnosticListener;
 
         public MvcAttributeRouteHandler(
             IActionInvokerFactory actionInvokerFactory,
             IActionSelector actionSelector,
-            DiagnosticSource diagnosticSource,
+            DiagnosticListener diagnosticListener,
             ILoggerFactory loggerFactory)
-            : this(actionInvokerFactory, actionSelector, diagnosticSource, loggerFactory, actionContextAccessor: null)
+            : this(actionInvokerFactory, actionSelector, diagnosticListener, loggerFactory, actionContextAccessor: null)
         {
         }
 
         public MvcAttributeRouteHandler(
             IActionInvokerFactory actionInvokerFactory,
             IActionSelector actionSelector,
-            DiagnosticSource diagnosticSource,
+            DiagnosticListener diagnosticListener,
             ILoggerFactory loggerFactory,
             IActionContextAccessor actionContextAccessor)
         {
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
             _actionInvokerFactory = actionInvokerFactory;
             _actionSelector = actionSelector;
-            _diagnosticSource = diagnosticSource;
+            _diagnosticListener = diagnosticListener;
             _logger = loggerFactory.CreateLogger<MvcAttributeRouteHandler>();
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcCoreDiagnosticSourceExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcCoreDiagnosticSourceExtensions.cs
@@ -16,55 +16,82 @@ namespace Microsoft.AspNetCore.Mvc.Internal
     public static class MvcCoreDiagnosticSourceExtensions
     {
         public static void BeforeAction(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ActionDescriptor actionDescriptor,
             HttpContext httpContext,
             RouteData routeData)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(actionDescriptor != null);
             Debug.Assert(httpContext != null);
             Debug.Assert(routeData != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeAction"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeActionImpl(diagnosticListener, actionDescriptor, httpContext, routeData);
+            }
+        }
+
+        private static void BeforeActionImpl(DiagnosticListener diagnosticListener, ActionDescriptor actionDescriptor, HttpContext httpContext, RouteData routeData)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeAction"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.BeforeAction",
                     new { actionDescriptor, httpContext = httpContext, routeData = routeData });
             }
         }
 
         public static void AfterAction(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ActionDescriptor actionDescriptor,
             HttpContext httpContext,
             RouteData routeData)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(actionDescriptor != null);
             Debug.Assert(httpContext != null);
             Debug.Assert(routeData != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterAction"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterActionImpl(diagnosticListener, actionDescriptor, httpContext, routeData);
+            }
+        }
+
+        private static void AfterActionImpl(DiagnosticListener diagnosticListener, ActionDescriptor actionDescriptor, HttpContext httpContext, RouteData routeData)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterAction"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.AfterAction",
                     new { actionDescriptor, httpContext = httpContext, routeData = routeData });
             }
         }
 
         public static void BeforeOnAuthorizationAsync(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             AuthorizationFilterContext authorizationContext,
             IAsyncAuthorizationFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(authorizationContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnAuthorization"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeOnAuthorizationAsyncImpl(diagnosticListener, authorizationContext, filter);
+            }
+        }
+
+        private static void BeforeOnAuthorizationAsyncImpl(DiagnosticListener diagnosticListener, AuthorizationFilterContext authorizationContext, IAsyncAuthorizationFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnAuthorization"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.BeforeOnAuthorization",
                     new
                     {
@@ -76,17 +103,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void AfterOnAuthorizationAsync(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             AuthorizationFilterContext authorizationContext,
             IAsyncAuthorizationFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(authorizationContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnAuthorization"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterOnAuthorizationAsyncImpl(diagnosticListener, authorizationContext, filter);
+            }
+        }
+
+        private static void AfterOnAuthorizationAsyncImpl(DiagnosticListener diagnosticListener, AuthorizationFilterContext authorizationContext, IAsyncAuthorizationFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnAuthorization"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.AfterOnAuthorization",
                     new
                     {
@@ -98,17 +134,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void BeforeOnAuthorization(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             AuthorizationFilterContext authorizationContext,
             IAuthorizationFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(authorizationContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnAuthorization"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeOnAuthorizationImpl(diagnosticListener, authorizationContext, filter);
+            }
+        }
+
+        private static void BeforeOnAuthorizationImpl(DiagnosticListener diagnosticListener, AuthorizationFilterContext authorizationContext, IAuthorizationFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnAuthorization"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.BeforeOnAuthorization",
                     new
                     {
@@ -120,17 +165,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void AfterOnAuthorization(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             AuthorizationFilterContext authorizationContext,
             IAuthorizationFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(authorizationContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnAuthorization"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterOnAuthorizationImpl(diagnosticListener, authorizationContext, filter);
+            }
+        }
+
+        private static void AfterOnAuthorizationImpl(DiagnosticListener diagnosticListener, AuthorizationFilterContext authorizationContext, IAuthorizationFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnAuthorization"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.AfterOnAuthorization",
                     new
                     {
@@ -142,17 +196,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void BeforeOnResourceExecution(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ResourceExecutingContext resourceExecutingContext,
             IAsyncResourceFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(resourceExecutingContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnResourceExecution"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeOnResourceExecutionImpl(diagnosticListener, resourceExecutingContext, filter);
+            }
+        }
+
+        private static void BeforeOnResourceExecutionImpl(DiagnosticListener diagnosticListener, ResourceExecutingContext resourceExecutingContext, IAsyncResourceFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnResourceExecution"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.BeforeOnResourceExecution",
                     new
                     {
@@ -164,17 +227,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void AfterOnResourceExecution(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ResourceExecutedContext resourceExecutedContext,
             IAsyncResourceFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(resourceExecutedContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnResourceExecution"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterOnResourceExecutionImpl(diagnosticListener, resourceExecutedContext, filter);
+            }
+        }
+
+        private static void AfterOnResourceExecutionImpl(DiagnosticListener diagnosticListener, ResourceExecutedContext resourceExecutedContext, IAsyncResourceFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnResourceExecution"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.AfterOnResourceExecution",
                     new
                     {
@@ -186,17 +258,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void BeforeOnResourceExecuting(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ResourceExecutingContext resourceExecutingContext,
             IResourceFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(resourceExecutingContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnResourceExecuting"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeOnResourceExecutingImpl(diagnosticListener, resourceExecutingContext, filter);
+            }
+        }
+
+        private static void BeforeOnResourceExecutingImpl(DiagnosticListener diagnosticListener, ResourceExecutingContext resourceExecutingContext, IResourceFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnResourceExecuting"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.BeforeOnResourceExecuting",
                     new
                     {
@@ -208,17 +289,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void AfterOnResourceExecuting(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ResourceExecutingContext resourceExecutingContext,
             IResourceFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(resourceExecutingContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnResourceExecuting"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterOnResourceExecutingImpl(diagnosticListener, resourceExecutingContext, filter);
+            }
+        }
+
+        private static void AfterOnResourceExecutingImpl(DiagnosticListener diagnosticListener, ResourceExecutingContext resourceExecutingContext, IResourceFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnResourceExecuting"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.AfterOnResourceExecuting",
                     new
                     {
@@ -230,17 +320,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void BeforeOnResourceExecuted(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ResourceExecutedContext resourceExecutedContext,
             IResourceFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(resourceExecutedContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnResourceExecuted"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeOnResourceExecutedImpl(diagnosticListener, resourceExecutedContext, filter);
+            }
+        }
+
+        private static void BeforeOnResourceExecutedImpl(DiagnosticListener diagnosticListener, ResourceExecutedContext resourceExecutedContext, IResourceFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnResourceExecuted"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.BeforeOnResourceExecuted",
                     new
                     {
@@ -252,17 +351,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void AfterOnResourceExecuted(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ResourceExecutedContext resourceExecutedContext,
             IResourceFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(resourceExecutedContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnResourceExecuted"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterOnResourceExecutedImpl(diagnosticListener, resourceExecutedContext, filter);
+            }
+        }
+
+        private static void AfterOnResourceExecutedImpl(DiagnosticListener diagnosticListener, ResourceExecutedContext resourceExecutedContext, IResourceFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnResourceExecuted"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.AfterOnResourceExecuted",
                     new
                     {
@@ -274,17 +382,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void BeforeOnExceptionAsync(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ExceptionContext exceptionContext,
             IAsyncExceptionFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(exceptionContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnException"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeOnExceptionAsyncImpl(diagnosticListener, exceptionContext, filter);
+            }
+        }
+
+        private static void BeforeOnExceptionAsyncImpl(DiagnosticListener diagnosticListener, ExceptionContext exceptionContext, IAsyncExceptionFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnException"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.BeforeOnException",
                     new
                     {
@@ -296,17 +413,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void AfterOnExceptionAsync(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ExceptionContext exceptionContext,
             IAsyncExceptionFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(exceptionContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnException"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterOnExceptionAsyncImpl(diagnosticListener, exceptionContext, filter);
+            }
+        }
+
+        private static void AfterOnExceptionAsyncImpl(DiagnosticListener diagnosticListener, ExceptionContext exceptionContext, IAsyncExceptionFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnException"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.AfterOnException",
                     new
                     {
@@ -318,17 +444,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void BeforeOnException(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ExceptionContext exceptionContext,
             IExceptionFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(exceptionContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnException"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeOnExceptionImpl(diagnosticListener, exceptionContext, filter);
+            }
+        }
+
+        private static void BeforeOnExceptionImpl(DiagnosticListener diagnosticListener, ExceptionContext exceptionContext, IExceptionFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnException"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.BeforeOnException",
                     new
                     {
@@ -340,17 +475,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void AfterOnException(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ExceptionContext exceptionContext,
             IExceptionFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(exceptionContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnException"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterOnExceptionImpl(diagnosticListener, exceptionContext, filter);
+            }
+        }
+
+        private static void AfterOnExceptionImpl(DiagnosticListener diagnosticListener, ExceptionContext exceptionContext, IExceptionFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnException"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.AfterOnException",
                     new
                     {
@@ -362,17 +506,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void BeforeOnActionExecution(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ActionExecutingContext actionExecutingContext,
             IAsyncActionFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(actionExecutingContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnActionExecution"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeOnActionExecutionImpl(diagnosticListener, actionExecutingContext, filter);
+            }
+        }
+
+        private static void BeforeOnActionExecutionImpl(DiagnosticListener diagnosticListener, ActionExecutingContext actionExecutingContext, IAsyncActionFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnActionExecution"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.BeforeOnActionExecution",
                     new
                     {
@@ -384,17 +537,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void AfterOnActionExecution(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ActionExecutedContext actionExecutedContext,
             IAsyncActionFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(actionExecutedContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnActionExecution"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterOnActionExecutionImpl(diagnosticListener, actionExecutedContext, filter);
+            }
+        }
+
+        private static void AfterOnActionExecutionImpl(DiagnosticListener diagnosticListener, ActionExecutedContext actionExecutedContext, IAsyncActionFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnActionExecution"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.AfterOnActionExecution",
                     new
                     {
@@ -406,17 +568,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void BeforeOnActionExecuting(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ActionExecutingContext actionExecutingContext,
             IActionFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(actionExecutingContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnActionExecuting"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeOnActionExecutingImpl(diagnosticListener, actionExecutingContext, filter);
+            }
+        }
+
+        private static void BeforeOnActionExecutingImpl(DiagnosticListener diagnosticListener, ActionExecutingContext actionExecutingContext, IActionFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnActionExecuting"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.BeforeOnActionExecuting",
                     new
                     {
@@ -428,17 +599,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void AfterOnActionExecuting(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ActionExecutingContext actionExecutingContext,
             IActionFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(actionExecutingContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnActionExecuting"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterOnActionExecutingImpl(diagnosticListener, actionExecutingContext, filter);
+            }
+        }
+
+        private static void AfterOnActionExecutingImpl(DiagnosticListener diagnosticListener, ActionExecutingContext actionExecutingContext, IActionFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnActionExecuting"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.AfterOnActionExecuting",
                     new
                     {
@@ -450,17 +630,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void BeforeOnActionExecuted(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ActionExecutedContext actionExecutedContext,
             IActionFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(actionExecutedContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnActionExecuted"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeOnActionExecutedImpl(diagnosticListener, actionExecutedContext, filter);
+            }
+        }
+
+        private static void BeforeOnActionExecutedImpl(DiagnosticListener diagnosticListener, ActionExecutedContext actionExecutedContext, IActionFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnActionExecuted"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.BeforeOnActionExecuted",
                     new
                     {
@@ -472,17 +661,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void AfterOnActionExecuted(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ActionExecutedContext actionExecutedContext,
             IActionFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(actionExecutedContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnActionExecuted"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterOnActionExecutedImpl(diagnosticListener, actionExecutedContext, filter);
+            }
+        }
+
+        private static void AfterOnActionExecutedImpl(DiagnosticListener diagnosticListener, ActionExecutedContext actionExecutedContext, IActionFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnActionExecuted"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.AfterOnActionExecuted",
                     new
                     {
@@ -494,19 +692,28 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void BeforeActionMethod(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ActionContext actionContext,
             IDictionary<string, object> actionArguments,
             object controller)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(actionContext != null);
             Debug.Assert(actionArguments != null);
             Debug.Assert(controller != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeActionMethod"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeActionMethodImpl(diagnosticListener, actionContext, actionArguments, controller);
+            }
+        }
+
+        private static void BeforeActionMethodImpl(DiagnosticListener diagnosticListener, ActionContext actionContext, IDictionary<string, object> actionArguments, object controller)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeActionMethod"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.BeforeActionMethod",
                     new
                     {
@@ -518,20 +725,29 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void AfterActionMethod(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ActionContext actionContext,
             IDictionary<string, object> actionArguments,
             object controller,
             IActionResult result)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(actionContext != null);
             Debug.Assert(actionArguments != null);
             Debug.Assert(controller != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterActionMethod"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterActionMethodImpl(diagnosticListener, actionContext, actionArguments, controller, result);
+            }
+        }
+
+        private static void AfterActionMethodImpl(DiagnosticListener diagnosticListener, ActionContext actionContext, IDictionary<string, object> actionArguments, object controller, IActionResult result)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterActionMethod"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.AfterActionMethod",
                     new
                     {
@@ -544,17 +760,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void BeforeOnResultExecution(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ResultExecutingContext resultExecutingContext,
             IAsyncResultFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(resultExecutingContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnResultExecution"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeOnResultExecutionImpl(diagnosticListener, resultExecutingContext, filter);
+            }
+        }
+
+        private static void BeforeOnResultExecutionImpl(DiagnosticListener diagnosticListener, ResultExecutingContext resultExecutingContext, IAsyncResultFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnResultExecution"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.BeforeOnResultExecution",
                     new
                     {
@@ -566,17 +791,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void AfterOnResultExecution(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ResultExecutedContext resultExecutedContext,
             IAsyncResultFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(resultExecutedContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnResultExecution"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterOnResultExecutionImpl(diagnosticListener, resultExecutedContext, filter);
+            }
+        }
+
+        private static void AfterOnResultExecutionImpl(DiagnosticListener diagnosticListener, ResultExecutedContext resultExecutedContext, IAsyncResultFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnResultExecution"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.AfterOnResultExecution",
                     new
                     {
@@ -588,17 +822,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void BeforeOnResultExecuting(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ResultExecutingContext resultExecutingContext,
             IResultFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(resultExecutingContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnResultExecuting"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeOnResultExecutingImpl(diagnosticListener, resultExecutingContext, filter);
+            }
+        }
+
+        private static void BeforeOnResultExecutingImpl(DiagnosticListener diagnosticListener, ResultExecutingContext resultExecutingContext, IResultFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnResultExecuting"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.BeforeOnResultExecuting",
                     new
                     {
@@ -610,17 +853,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void AfterOnResultExecuting(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ResultExecutingContext resultExecutingContext,
             IResultFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(resultExecutingContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnResultExecuting"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterOnResultExecutingImpl(diagnosticListener, resultExecutingContext, filter);
+            }
+        }
+
+        private static void AfterOnResultExecutingImpl(DiagnosticListener diagnosticListener, ResultExecutingContext resultExecutingContext, IResultFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnResultExecuting"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.AfterOnResultExecuting",
                     new
                     {
@@ -632,17 +884,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void BeforeOnResultExecuted(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ResultExecutedContext resultExecutedContext,
             IResultFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(resultExecutedContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnResultExecuted"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeOnResultExecutedImpl(diagnosticListener, resultExecutedContext, filter);
+            }
+        }
+
+        private static void BeforeOnResultExecutedImpl(DiagnosticListener diagnosticListener, ResultExecutedContext resultExecutedContext, IResultFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnResultExecuted"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.BeforeOnResultExecuted",
                     new
                     {
@@ -654,17 +915,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void AfterOnResultExecuted(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ResultExecutedContext resultExecutedContext,
             IResultFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(resultExecutedContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnResultExecuted"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterOnResultExecutedImpl(diagnosticListener, resultExecutedContext, filter);
+            }
+        }
+
+        private static void AfterOnResultExecutedImpl(DiagnosticListener diagnosticListener, ResultExecutedContext resultExecutedContext, IResultFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnResultExecuted"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.AfterOnResultExecuted",
                     new
                     {
@@ -676,34 +946,52 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void BeforeActionResult(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ActionContext actionContext,
             IActionResult result)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(actionContext != null);
             Debug.Assert(result != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeActionResult"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeActionResultImpl(diagnosticListener, actionContext, result);
+            }
+        }
+
+        private static void BeforeActionResultImpl(DiagnosticListener diagnosticListener, ActionContext actionContext, IActionResult result)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeActionResult"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.BeforeActionResult",
                     new { actionContext = actionContext, result = result });
             }
         }
 
         public static void AfterActionResult(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ActionContext actionContext,
             IActionResult result)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(actionContext != null);
             Debug.Assert(result != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterActionResult"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterActionResultImpl(diagnosticListener, actionContext, result);
+            }
+        }
+
+        private static void AfterActionResultImpl(DiagnosticListener diagnosticListener, ActionContext actionContext, IActionResult result)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterActionResult"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.AfterActionResult",
                     new { actionContext = actionContext, result = result });
             }

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcRouteHandler.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcRouteHandler.cs
@@ -17,21 +17,21 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         private readonly IActionInvokerFactory _actionInvokerFactory;
         private readonly IActionSelector _actionSelector;
         private readonly ILogger _logger;
-        private readonly DiagnosticSource _diagnosticSource;
+        private readonly DiagnosticListener _diagnosticListener;
 
         public MvcRouteHandler(
             IActionInvokerFactory actionInvokerFactory,
             IActionSelector actionSelector,
-            DiagnosticSource diagnosticSource,
+            DiagnosticListener diagnosticListener,
             ILoggerFactory loggerFactory)
-            : this(actionInvokerFactory, actionSelector, diagnosticSource, loggerFactory, actionContextAccessor: null)
+            : this(actionInvokerFactory, actionSelector, diagnosticListener, loggerFactory, actionContextAccessor: null)
         {
         }
 
         public MvcRouteHandler(
             IActionInvokerFactory actionInvokerFactory,
             IActionSelector actionSelector,
-            DiagnosticSource diagnosticSource,
+            DiagnosticListener diagnosticListener,
             ILoggerFactory loggerFactory,
             IActionContextAccessor actionContextAccessor)
         {
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
             _actionInvokerFactory = actionInvokerFactory;
             _actionSelector = actionSelector;
-            _diagnosticSource = diagnosticSource;
+            _diagnosticListener = diagnosticListener;
             _logger = loggerFactory.CreateLogger<MvcRouteHandler>();
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/ResourceInvoker.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/ResourceInvoker.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 {
     public abstract class ResourceInvoker
     {
-        protected readonly DiagnosticSource _diagnosticSource;
+        protected readonly DiagnosticListener _diagnosticListener;
         protected readonly ILogger _logger;
         protected readonly IActionResultTypeMapper _mapper;
         protected readonly ActionContext _actionContext;
@@ -38,14 +38,14 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         protected object _instance;
 
         public ResourceInvoker(
-            DiagnosticSource diagnosticSource,
+            DiagnosticListener diagnosticListener,
             ILogger logger,
             IActionResultTypeMapper mapper,
             ActionContext actionContext,
             IFilterMetadata[] filters,
             IList<IValueProviderFactory> valueProviderFactories)
         {
-            _diagnosticSource = diagnosticSource ?? throw new ArgumentNullException(nameof(diagnosticSource));
+            _diagnosticListener = diagnosticListener ?? throw new ArgumentNullException(nameof(diagnosticListener));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
             _actionContext = actionContext ?? throw new ArgumentNullException(nameof(actionContext));
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         {
             try
             {
-                _diagnosticSource.BeforeAction(
+                _diagnosticListener.BeforeAction(
                     _actionContext.ActionDescriptor,
                     _actionContext.HttpContext,
                     _actionContext.RouteData);
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             }
             finally
             {
-                _diagnosticSource.AfterAction(
+                _diagnosticListener.AfterAction(
                     _actionContext.ActionDescriptor,
                     _actionContext.HttpContext,
                     _actionContext.RouteData);
@@ -130,7 +130,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         {
             var actionContext = _actionContext;
 
-            _diagnosticSource.BeforeActionResult(actionContext, result);
+            _diagnosticListener.BeforeActionResult(actionContext, result);
             _logger.BeforeExecutingActionResult(result);
 
             try
@@ -139,7 +139,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             }
             finally
             {
-                _diagnosticSource.AfterActionResult(actionContext, result);
+                _diagnosticListener.AfterActionResult(actionContext, result);
                 _logger.AfterExecutingActionResult(result);
             }
         }
@@ -196,7 +196,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                         var filter = (IAsyncAuthorizationFilter)state;
                         var authorizationContext = _authorizationContext;
 
-                        _diagnosticSource.BeforeOnAuthorizationAsync(authorizationContext, filter);
+                        _diagnosticListener.BeforeOnAuthorizationAsync(authorizationContext, filter);
                         _logger.BeforeExecutingMethodOnFilter(
                             FilterTypeConstants.AuthorizationFilter,
                             nameof(IAsyncAuthorizationFilter.OnAuthorizationAsync),
@@ -220,7 +220,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                         var filter = (IAsyncAuthorizationFilter)state;
                         var authorizationContext = _authorizationContext;
 
-                        _diagnosticSource.AfterOnAuthorizationAsync(authorizationContext, filter);
+                        _diagnosticListener.AfterOnAuthorizationAsync(authorizationContext, filter);
                         _logger.AfterExecutingMethodOnFilter(
                             FilterTypeConstants.AuthorizationFilter,
                             nameof(IAsyncAuthorizationFilter.OnAuthorizationAsync),
@@ -242,7 +242,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                         var filter = (IAuthorizationFilter)state;
                         var authorizationContext = _authorizationContext;
 
-                        _diagnosticSource.BeforeOnAuthorization(authorizationContext, filter);
+                        _diagnosticListener.BeforeOnAuthorization(authorizationContext, filter);
                         _logger.BeforeExecutingMethodOnFilter(
                             FilterTypeConstants.AuthorizationFilter,
                             nameof(IAuthorizationFilter.OnAuthorization),
@@ -250,7 +250,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
                         filter.OnAuthorization(authorizationContext);
 
-                        _diagnosticSource.AfterOnAuthorization(authorizationContext, filter);
+                        _diagnosticListener.AfterOnAuthorization(authorizationContext, filter);
                         _logger.AfterExecutingMethodOnFilter(
                             FilterTypeConstants.AuthorizationFilter,
                             nameof(IAuthorizationFilter.OnAuthorization),
@@ -333,7 +333,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                         var filter = (IAsyncResourceFilter)state;
                         var resourceExecutingContext = _resourceExecutingContext;
 
-                        _diagnosticSource.BeforeOnResourceExecution(resourceExecutingContext, filter);
+                        _diagnosticListener.BeforeOnResourceExecution(resourceExecutingContext, filter);
                         _logger.BeforeExecutingMethodOnFilter(
                             FilterTypeConstants.ResourceFilter,
                             nameof(IAsyncResourceFilter.OnResourceExecutionAsync),
@@ -364,7 +364,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                                 Result = _resourceExecutingContext.Result,
                             };
 
-                            _diagnosticSource.AfterOnResourceExecution(_resourceExecutedContext, filter);
+                            _diagnosticListener.AfterOnResourceExecution(_resourceExecutedContext, filter);
                             _logger.AfterExecutingMethodOnFilter(
                                 FilterTypeConstants.ResourceFilter,
                                 nameof(IAsyncResourceFilter.OnResourceExecutionAsync),
@@ -388,7 +388,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                         var filter = (IResourceFilter)state;
                         var resourceExecutingContext = _resourceExecutingContext;
 
-                        _diagnosticSource.BeforeOnResourceExecuting(resourceExecutingContext, filter);
+                        _diagnosticListener.BeforeOnResourceExecuting(resourceExecutingContext, filter);
                         _logger.BeforeExecutingMethodOnFilter(
                             FilterTypeConstants.ResourceFilter,
                             nameof(IResourceFilter.OnResourceExecuting),
@@ -396,7 +396,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
                         filter.OnResourceExecuting(resourceExecutingContext);
 
-                        _diagnosticSource.AfterOnResourceExecuting(resourceExecutingContext, filter);
+                        _diagnosticListener.AfterOnResourceExecuting(resourceExecutingContext, filter);
                         _logger.AfterExecutingMethodOnFilter(
                             FilterTypeConstants.ResourceFilter,
                             nameof(IResourceFilter.OnResourceExecuting),
@@ -432,7 +432,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                         var filter = (IResourceFilter)state;
                         var resourceExecutedContext = _resourceExecutedContext;
 
-                        _diagnosticSource.BeforeOnResourceExecuted(resourceExecutedContext, filter);
+                        _diagnosticListener.BeforeOnResourceExecuted(resourceExecutedContext, filter);
                         _logger.BeforeExecutingMethodOnFilter(
                             FilterTypeConstants.ResourceFilter,
                             nameof(IResourceFilter.OnResourceExecuted),
@@ -440,7 +440,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
                         filter.OnResourceExecuted(resourceExecutedContext);
 
-                        _diagnosticSource.AfterOnResourceExecuted(resourceExecutedContext, filter);
+                        _diagnosticListener.AfterOnResourceExecuted(resourceExecutedContext, filter);
                         _logger.AfterExecutingMethodOnFilter(
                             FilterTypeConstants.ResourceFilter,
                             nameof(IResourceFilter.OnResourceExecuted),
@@ -528,7 +528,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                         // we'll call the filter. Otherwise there's nothing to do.
                         if (exceptionContext?.Exception != null && !exceptionContext.ExceptionHandled)
                         {
-                            _diagnosticSource.BeforeOnExceptionAsync(exceptionContext, filter);
+                            _diagnosticListener.BeforeOnExceptionAsync(exceptionContext, filter);
                             _logger.BeforeExecutingMethodOnFilter(
                                 FilterTypeConstants.ExceptionFilter,
                                 nameof(IAsyncExceptionFilter.OnExceptionAsync),
@@ -555,7 +555,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                         var filter = (IAsyncExceptionFilter)state;
                         var exceptionContext = _exceptionContext;
 
-                        _diagnosticSource.AfterOnExceptionAsync(exceptionContext, filter);
+                        _diagnosticListener.AfterOnExceptionAsync(exceptionContext, filter);
                         _logger.AfterExecutingMethodOnFilter(
                             FilterTypeConstants.ExceptionFilter,
                             nameof(IAsyncExceptionFilter.OnExceptionAsync),
@@ -595,7 +595,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                         // we'll call the filter. Otherwise there's nothing to do.
                         if (exceptionContext?.Exception != null && !exceptionContext.ExceptionHandled)
                         {
-                            _diagnosticSource.BeforeOnException(exceptionContext, filter);
+                            _diagnosticListener.BeforeOnException(exceptionContext, filter);
                             _logger.BeforeExecutingMethodOnFilter(
                                 FilterTypeConstants.ExceptionFilter,
                                 nameof(IExceptionFilter.OnException),
@@ -603,7 +603,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
                             filter.OnException(exceptionContext);
 
-                            _diagnosticSource.AfterOnException(exceptionContext, filter);
+                            _diagnosticListener.AfterOnException(exceptionContext, filter);
                             _logger.AfterExecutingMethodOnFilter(
                                 FilterTypeConstants.ExceptionFilter,
                                 nameof(IExceptionFilter.OnException),
@@ -905,7 +905,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                         var filter = (TFilterAsync)state;
                         var resultExecutingContext = _resultExecutingContext;
 
-                        _diagnosticSource.BeforeOnResultExecution(resultExecutingContext, filter);
+                        _diagnosticListener.BeforeOnResultExecution(resultExecutingContext, filter);
                         _logger.BeforeExecutingMethodOnFilter(
                             resultFilterKind,
                             nameof(IAsyncResultFilter.OnResultExecutionAsync),
@@ -945,7 +945,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                             };
                         }
 
-                        _diagnosticSource.AfterOnResultExecution(_resultExecutedContext, filter);
+                        _diagnosticListener.AfterOnResultExecution(_resultExecutedContext, filter);
                         _logger.AfterExecutingMethodOnFilter(
                             resultFilterKind,
                             nameof(IAsyncResultFilter.OnResultExecutionAsync),
@@ -962,7 +962,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                         var filter = (TFilter)state;
                         var resultExecutingContext = _resultExecutingContext;
 
-                        _diagnosticSource.BeforeOnResultExecuting(resultExecutingContext, filter);
+                        _diagnosticListener.BeforeOnResultExecuting(resultExecutingContext, filter);
                         _logger.BeforeExecutingMethodOnFilter(
                             resultFilterKind,
                             nameof(IResultFilter.OnResultExecuting),
@@ -970,7 +970,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
                         filter.OnResultExecuting(resultExecutingContext);
 
-                        _diagnosticSource.AfterOnResultExecuting(resultExecutingContext, filter);
+                        _diagnosticListener.AfterOnResultExecuting(resultExecutingContext, filter);
                         _logger.AfterExecutingMethodOnFilter(
                             resultFilterKind,
                             nameof(IResultFilter.OnResultExecuting),
@@ -1012,7 +1012,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                         var filter = (TFilter)state;
                         var resultExecutedContext = _resultExecutedContext;
 
-                        _diagnosticSource.BeforeOnResultExecuted(resultExecutedContext, filter);
+                        _diagnosticListener.BeforeOnResultExecuted(resultExecutedContext, filter);
                         _logger.BeforeExecutingMethodOnFilter(
                             resultFilterKind,
                             nameof(IResultFilter.OnResultExecuted),
@@ -1020,7 +1020,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
                         filter.OnResultExecuted(resultExecutedContext);
 
-                        _diagnosticSource.AfterOnResultExecuted(resultExecutedContext, filter);
+                        _diagnosticListener.AfterOnResultExecuted(resultExecutedContext, filter);
                         _logger.AfterExecutingMethodOnFilter(
                             resultFilterKind,
                             nameof(IResultFilter.OnResultExecuted),

--- a/src/Microsoft.AspNetCore.Mvc.Razor/DependencyInjection/MvcRazorMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/DependencyInjection/MvcRazorMvcCoreBuilderExtensions.cs
@@ -171,9 +171,9 @@ namespace Microsoft.Extensions.DependencyInjection
                 var optionsAccessor = s.GetRequiredService<IOptions<RazorViewEngineOptions>>();
                 var razorFileSystem = s.GetRequiredService<RazorProjectFileSystem>();
                 var loggerFactory = s.GetRequiredService<ILoggerFactory>();
-                var diagnosticSource = s.GetRequiredService<DiagnosticSource>();
+                var diagnosticListener = s.GetRequiredService<DiagnosticListener>();
 
-                var viewEngine = new RazorViewEngine(pageFactory, pageActivator, htmlEncoder, optionsAccessor, razorFileSystem, loggerFactory, diagnosticSource);
+                var viewEngine = new RazorViewEngine(pageFactory, pageActivator, htmlEncoder, optionsAccessor, razorFileSystem, loggerFactory, diagnosticListener);
                 return viewEngine;
             });
             services.TryAddSingleton<IViewCompilerProvider, RazorViewCompilerProvider>();

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/MvcRazorDiagnosticSourceExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/MvcRazorDiagnosticSourceExtensions.cs
@@ -9,13 +9,25 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
     public static class MvcRazorDiagnosticSourceExtensions
     {
         public static void BeforeViewPage(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             IRazorPage page,
             ViewContext viewContext)
         {
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.Razor.BeforeViewPage"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeViewPageImpl(diagnosticListener, page, viewContext);
+            }
+        }
+
+        private static void BeforeViewPageImpl(
+            this DiagnosticListener diagnosticListener,
+            IRazorPage page,
+            ViewContext viewContext)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.Razor.BeforeViewPage"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.Razor.BeforeViewPage",
                     new
                     {
@@ -28,13 +40,25 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
         }
 
         public static void AfterViewPage(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             IRazorPage page,
             ViewContext viewContext)
         {
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.Razor.AfterViewPage"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterViewPageImpl(diagnosticListener, page, viewContext);
+            }
+        }
+
+        private static void AfterViewPageImpl(
+            this DiagnosticListener diagnosticListener,
+            IRazorPage page,
+            ViewContext viewContext)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.Razor.AfterViewPage"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.Razor.AfterViewPage",
                     new
                     {

--- a/src/Microsoft.AspNetCore.Mvc.Razor/Internal/RazorPagePropertyActivator.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/Internal/RazorPagePropertyActivator.cs
@@ -108,7 +108,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal
             {
                 valueAccessor = valueAccessors.JsonHelperAccessor;
             }
-            else if (property.PropertyType == typeof(DiagnosticSource))
+            else if (property.PropertyType == typeof(DiagnosticListener))
             {
                 valueAccessor = valueAccessors.DiagnosticSourceAccessor;
             }

--- a/src/Microsoft.AspNetCore.Mvc.Razor/RazorPage.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/RazorPage.cs
@@ -273,7 +273,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             }
         }
 
-        public override void BeginContext(int position, int length, bool isLiteral)
+        protected override void BeginContextImpl(int position, int length, bool isLiteral)
         {
             const string BeginContextEvent = "Microsoft.AspNetCore.Mvc.Razor.BeginInstrumentationContext";
 
@@ -292,7 +292,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             }
         }
 
-        public override void EndContext()
+        protected override void EndContextImpl()
         {
             const string EndContextEvent = "Microsoft.AspNetCore.Mvc.Razor.EndInstrumentationContext";
 

--- a/src/Microsoft.AspNetCore.Mvc.Razor/RazorPageActivator.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/RazorPageActivator.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             IModelMetadataProvider metadataProvider,
             IUrlHelperFactory urlHelperFactory,
             IJsonHelper jsonHelper,
-            DiagnosticSource diagnosticSource,
+            DiagnosticListener diagnosticListener,
             HtmlEncoder htmlEncoder,
             IModelExpressionProvider modelExpressionProvider)
         {
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             {
                 UrlHelperAccessor = context => urlHelperFactory.GetUrlHelper(context),
                 JsonHelperAccessor = context => jsonHelper,
-                DiagnosticSourceAccessor = context => diagnosticSource,
+                DiagnosticSourceAccessor = context => diagnosticListener,
                 HtmlEncoderAccessor = context => htmlEncoder,
                 ModelExpressionProviderAccessor = context => modelExpressionProvider,
             };

--- a/src/Microsoft.AspNetCore.Mvc.Razor/RazorPageBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/RazorPageBase.cs
@@ -83,10 +83,10 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         public IDictionary<string, RenderAsyncDelegate> PreviousSectionWriters { get; set; }
 
         /// <summary>
-        /// Gets or sets a <see cref="System.Diagnostics.DiagnosticSource"/> instance used to instrument the page execution.
+        /// Gets or sets a <see cref="System.Diagnostics.DiagnosticListener"/> instance used to instrument the page execution.
         /// </summary>
         [RazorInject]
-        public DiagnosticSource DiagnosticSource { get; set; }
+        public DiagnosticListener DiagnosticSource { get; set; }
 
         /// <summary>
         /// Gets the <see cref="System.Text.Encodings.Web.HtmlEncoder"/> to use when this <see cref="RazorPage"/>
@@ -673,9 +673,29 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             EndContext();
         }
 
-        public abstract void BeginContext(int position, int length, bool isLiteral);
+        public void BeginContext(int position, int length, bool isLiteral)
+        {
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (DiagnosticSource?.IsEnabled() == true)
+            {
+                // Virtual (non-inline) call only when Diagnositcs is enabled
+                BeginContextImpl(position, length, isLiteral);
+            }
+        }
 
-        public abstract void EndContext();
+        protected abstract void BeginContextImpl(int position, int length, bool isLiteral);
+
+        public void EndContext()
+        {
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (DiagnosticSource?.IsEnabled() == true)
+            {
+                // Virtual (non-inline) call only when Diagnositcs is enabled
+                EndContextImpl();
+            }
+        }
+
+        protected abstract void EndContextImpl();
 
         private bool IsBoolFalseOrNullValue(string prefix, object value)
         {

--- a/src/Microsoft.AspNetCore.Mvc.Razor/RazorView.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/RazorView.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         private readonly IRazorViewEngine _viewEngine;
         private readonly IRazorPageActivator _pageActivator;
         private readonly HtmlEncoder _htmlEncoder;
-        private readonly DiagnosticSource _diagnosticSource;
+        private readonly DiagnosticListener _diagnosticListener;
         private IViewBufferScope _bufferScope;
 
         /// <summary>
@@ -36,14 +36,14 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         /// </param>
         /// <param name="razorPage">The <see cref="IRazorPage"/> instance to execute.</param>
         /// <param name="htmlEncoder">The HTML encoder.</param>
-        /// <param name="diagnosticSource">The <see cref="DiagnosticSource"/>.</param>
+        /// <param name="diagnosticListener">The <see cref="DiagnosticListener"/>.</param>
         public RazorView(
             IRazorViewEngine viewEngine,
             IRazorPageActivator pageActivator,
             IReadOnlyList<IRazorPage> viewStartPages,
             IRazorPage razorPage,
             HtmlEncoder htmlEncoder,
-            DiagnosticSource diagnosticSource)
+            DiagnosticListener diagnosticListener)
         {
             if (viewEngine == null)
             {
@@ -70,9 +70,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor
                 throw new ArgumentNullException(nameof(htmlEncoder));
             }
 
-            if (diagnosticSource == null)
+            if (diagnosticListener == null)
             {
-                throw new ArgumentNullException(nameof(diagnosticSource));
+                throw new ArgumentNullException(nameof(diagnosticListener));
             }
 
             _viewEngine = viewEngine;
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             ViewStartPages = viewStartPages;
             RazorPage = razorPage;
             _htmlEncoder = htmlEncoder;
-            _diagnosticSource = diagnosticSource;
+            _diagnosticListener = diagnosticListener;
         }
 
         /// <inheritdoc />
@@ -171,7 +171,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
 
             OnAfterPageActivated?.Invoke(page, context);
 
-            _diagnosticSource.BeforeViewPage(page, context);
+            _diagnosticListener.BeforeViewPage(page, context);
 
             try
             {
@@ -179,7 +179,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             }
             finally
             {
-                _diagnosticSource.AfterViewPage(page, context);
+                _diagnosticListener.AfterViewPage(page, context);
             }
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Razor/RazorViewEngine.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/RazorViewEngine.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         private readonly ILogger _logger;
         private readonly RazorViewEngineOptions _options;
         private readonly RazorProject _razorFileSystem;
-        private readonly DiagnosticSource _diagnosticSource;
+        private readonly DiagnosticListener _diagnosticListener;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RazorViewEngine" />.
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             IOptions<RazorViewEngineOptions> optionsAccessor,
             RazorProject razorProject,
             ILoggerFactory loggerFactory,
-            DiagnosticSource diagnosticSource)
+            DiagnosticListener diagnosticListener)
         {
             _options = optionsAccessor.Value;
 
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             _htmlEncoder = htmlEncoder;
             _logger = loggerFactory.CreateLogger<RazorViewEngine>();
             _razorFileSystem = razorProject;
-            _diagnosticSource = diagnosticSource;
+            _diagnosticListener = diagnosticListener;
             ViewLookupCache = new MemoryCache(new MemoryCacheOptions());
         }
 
@@ -94,9 +94,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             IOptions<RazorViewEngineOptions> optionsAccessor,
             RazorProjectFileSystem razorFileSystem,
             ILoggerFactory loggerFactory,
-            DiagnosticSource diagnosticSource)
+            DiagnosticListener diagnosticListener)
 #pragma warning disable CS0618 // Type or member is obsolete
-            : this (pageFactory, pageActivator, htmlEncoder, optionsAccessor, (RazorProject)razorFileSystem, loggerFactory, diagnosticSource)
+            : this (pageFactory, pageActivator, htmlEncoder, optionsAccessor, (RazorProject)razorFileSystem, loggerFactory, diagnosticListener)
 #pragma warning restore CS0618 // Type or member is obsolete
         {
         }
@@ -499,7 +499,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
                 viewStarts[i] = viewStartItem.PageFactory();
             }
 
-            var view = new RazorView(this, _pageActivator, viewStarts, page, _htmlEncoder, _diagnosticSource);
+            var view = new RazorView(this, _pageActivator, viewStarts, page, _htmlEncoder, _diagnosticListener);
             return ViewEngineResult.Found(viewName, view);
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Razor/breakingchanges.netcore.json
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/breakingchanges.netcore.json
@@ -1,0 +1,62 @@
+[
+  {
+    "TypeId": "public class Microsoft.AspNetCore.Mvc.Razor.RazorPageActivator : Microsoft.AspNetCore.Mvc.Razor.IRazorPageActivator",
+    "MemberId": "public .ctor(Microsoft.AspNetCore.Mvc.ModelBinding.IModelMetadataProvider metadataProvider, Microsoft.AspNetCore.Mvc.Routing.IUrlHelperFactory urlHelperFactory, Microsoft.AspNetCore.Mvc.Rendering.IJsonHelper jsonHelper, System.Diagnostics.DiagnosticSource diagnosticSource, System.Text.Encodings.Web.HtmlEncoder htmlEncoder, Microsoft.AspNetCore.Mvc.ViewFeatures.IModelExpressionProvider modelExpressionProvider)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.AspNetCore.Mvc.Razor.RazorViewEngine : Microsoft.AspNetCore.Mvc.Razor.IRazorViewEngine",
+    "MemberId": "public .ctor(Microsoft.AspNetCore.Mvc.Razor.IRazorPageFactoryProvider pageFactory, Microsoft.AspNetCore.Mvc.Razor.IRazorPageActivator pageActivator, System.Text.Encodings.Web.HtmlEncoder htmlEncoder, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Mvc.Razor.RazorViewEngineOptions> optionsAccessor, Microsoft.AspNetCore.Razor.Language.RazorProject razorProject, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, System.Diagnostics.DiagnosticSource diagnosticSource)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.AspNetCore.Mvc.Razor.RazorViewEngine : Microsoft.AspNetCore.Mvc.Razor.IRazorViewEngine",
+    "MemberId": "public .ctor(Microsoft.AspNetCore.Mvc.Razor.IRazorPageFactoryProvider pageFactory, Microsoft.AspNetCore.Mvc.Razor.IRazorPageActivator pageActivator, System.Text.Encodings.Web.HtmlEncoder htmlEncoder, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Mvc.Razor.RazorViewEngineOptions> optionsAccessor, Microsoft.AspNetCore.Razor.Language.RazorProjectFileSystem razorFileSystem, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, System.Diagnostics.DiagnosticSource diagnosticSource)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.AspNetCore.Mvc.Razor.RazorView : Microsoft.AspNetCore.Mvc.ViewEngines.IView",
+    "MemberId": "public .ctor(Microsoft.AspNetCore.Mvc.Razor.IRazorViewEngine viewEngine, Microsoft.AspNetCore.Mvc.Razor.IRazorPageActivator pageActivator, System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Mvc.Razor.IRazorPage> viewStartPages, Microsoft.AspNetCore.Mvc.Razor.IRazorPage razorPage, System.Text.Encodings.Web.HtmlEncoder htmlEncoder, System.Diagnostics.DiagnosticSource diagnosticSource)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public abstract class Microsoft.AspNetCore.Mvc.Razor.RazorPageBase : Microsoft.AspNetCore.Mvc.Razor.IRazorPage",
+    "MemberId": "public abstract System.Void BeginContext(System.Int32 position, System.Int32 length, System.Boolean isLiteral)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public abstract class Microsoft.AspNetCore.Mvc.Razor.RazorPageBase : Microsoft.AspNetCore.Mvc.Razor.IRazorPage",
+    "MemberId": "public abstract System.Void EndContext()",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public abstract class Microsoft.AspNetCore.Mvc.Razor.RazorPageBase : Microsoft.AspNetCore.Mvc.Razor.IRazorPage",
+    "MemberId": "public System.Diagnostics.DiagnosticSource get_DiagnosticSource()",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public abstract class Microsoft.AspNetCore.Mvc.Razor.RazorPageBase : Microsoft.AspNetCore.Mvc.Razor.IRazorPage",
+    "MemberId": "public System.Void set_DiagnosticSource(System.Diagnostics.DiagnosticSource value)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public abstract class Microsoft.AspNetCore.Mvc.Razor.RazorPage : Microsoft.AspNetCore.Mvc.Razor.RazorPageBase",
+    "MemberId": "public override System.Void BeginContext(System.Int32 position, System.Int32 length, System.Boolean isLiteral)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public abstract class Microsoft.AspNetCore.Mvc.Razor.RazorPage : Microsoft.AspNetCore.Mvc.Razor.RazorPageBase",
+    "MemberId": "public override System.Void EndContext()",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public abstract class Microsoft.AspNetCore.Mvc.Razor.RazorPageBase : Microsoft.AspNetCore.Mvc.Razor.IRazorPage",
+    "MemberId": "protected abstract System.Void BeginContextImpl(System.Int32 position, System.Int32 length, System.Boolean isLiteral)",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public abstract class Microsoft.AspNetCore.Mvc.Razor.RazorPageBase : Microsoft.AspNetCore.Mvc.Razor.IRazorPage",
+    "MemberId": "protected abstract System.Void EndContextImpl()",
+    "Kind": "Addition"
+  }
+]

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Infrastructure/DefaultPageFactoryProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Infrastructure/DefaultPageFactoryProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
             IModelMetadataProvider metadataProvider,
             IUrlHelperFactory urlHelperFactory,
             IJsonHelper jsonHelper,
-            DiagnosticSource diagnosticSource,
+            DiagnosticListener diagnosticListener,
             HtmlEncoder htmlEncoder,
             IModelExpressionProvider modelExpressionProvider)
         {
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
             {
                 UrlHelperAccessor = context => urlHelperFactory.GetUrlHelper(context),
                 JsonHelperAccessor = context => jsonHelper,
-                DiagnosticSourceAccessor = context => diagnosticSource,
+                DiagnosticSourceAccessor = context => diagnosticListener,
                 HtmlEncoderAccessor = context => htmlEncoder,
                 ModelExpressionProviderAccessor = context => modelExpressionProvider,
             };

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Infrastructure/PageResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Infrastructure/PageResultExecutor.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
     {
         private readonly IRazorViewEngine _razorViewEngine;
         private readonly IRazorPageActivator _razorPageActivator;
-        private readonly DiagnosticSource _diagnosticSource;
+        private readonly DiagnosticListener _diagnosticListener;
         private readonly HtmlEncoder _htmlEncoder;
 
         /// <summary>
@@ -30,21 +30,21 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
         /// <param name="compositeViewEngine">The <see cref="ICompositeViewEngine"/>.</param>
         /// <param name="razorViewEngine">The <see cref="IRazorViewEngine"/>.</param>
         /// <param name="razorPageActivator">The <see cref="IRazorPageActivator"/>.</param>
-        /// <param name="diagnosticSource">The <see cref="DiagnosticSource"/>.</param>
+        /// <param name="diagnosticListener">The <see cref="DiagnosticListener"/>.</param>
         /// <param name="htmlEncoder">The <see cref="HtmlEncoder"/>.</param>
         public PageResultExecutor(
             IHttpResponseStreamWriterFactory writerFactory,
             ICompositeViewEngine compositeViewEngine,
             IRazorViewEngine razorViewEngine,
             IRazorPageActivator razorPageActivator,
-            DiagnosticSource diagnosticSource,
+            DiagnosticListener diagnosticListener,
             HtmlEncoder htmlEncoder)
-            : base(writerFactory, compositeViewEngine, diagnosticSource)
+            : base(writerFactory, compositeViewEngine, diagnosticListener)
         {
             _razorViewEngine = razorViewEngine;
             _htmlEncoder = htmlEncoder;
             _razorPageActivator = razorPageActivator;
-            _diagnosticSource = diagnosticSource;
+            _diagnosticListener = diagnosticListener;
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
                 viewStarts,
                 pageAdapter,
                 _htmlEncoder,
-                _diagnosticSource)
+                _diagnosticListener)
             {
                 OnAfterPageActivated = (page, currentViewContext) =>
                 {

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/MvcRazorPagesDiagnosticSourceExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/MvcRazorPagesDiagnosticSourceExtensions.cs
@@ -11,21 +11,30 @@ namespace Microsoft.AspNetCore.Mvc.Internal
     public static class MvcRazorPagesDiagnosticSourceExtensions
     {
         public static void BeforeHandlerMethod(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ActionContext actionContext,
             HandlerMethodDescriptor handlerMethodDescriptor,
             IDictionary<string, object> arguments,
             object instance)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(actionContext != null);
             Debug.Assert(handlerMethodDescriptor != null);
             Debug.Assert(arguments != null);
             Debug.Assert(instance != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeHandlerMethod"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeHandlerMethodImpl(diagnosticListener, actionContext, handlerMethodDescriptor, arguments, instance);
+            }
+        }
+
+        private static void BeforeHandlerMethodImpl(DiagnosticListener diagnosticListener, ActionContext actionContext, HandlerMethodDescriptor handlerMethodDescriptor, IDictionary<string, object> arguments, object instance)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeHandlerMethod"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.BeforeHandlerMethod",
                     new
                     {
@@ -38,22 +47,31 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void AfterHandlerMethod(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ActionContext actionContext,
             HandlerMethodDescriptor handlerMethodDescriptor,
             IDictionary<string, object> arguments,
             object instance,
             IActionResult result)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(actionContext != null);
             Debug.Assert(handlerMethodDescriptor != null);
             Debug.Assert(arguments != null);
             Debug.Assert(instance != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterHandlerMethod"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterHandlerMethodImpl(diagnosticListener, actionContext, handlerMethodDescriptor, arguments, instance, result);
+            }
+        }
+
+        private static void AfterHandlerMethodImpl(DiagnosticListener diagnosticListener, ActionContext actionContext, HandlerMethodDescriptor handlerMethodDescriptor, IDictionary<string, object> arguments, object instance, IActionResult result)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterHandlerMethod"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.AfterHandlerMethod",
                     new
                     {
@@ -65,19 +83,28 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                     });
             }
         }
-        
+
         public static void BeforeOnPageHandlerExecution(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             PageHandlerExecutingContext handlerExecutionContext,
             IAsyncPageFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(handlerExecutionContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnPageHandlerExecution"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeOnPageHandlerExecutionImpl(diagnosticListener, handlerExecutionContext, filter);
+            }
+        }
+
+        private static void BeforeOnPageHandlerExecutionImpl(DiagnosticListener diagnosticListener, PageHandlerExecutingContext handlerExecutionContext, IAsyncPageFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnPageHandlerExecution"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.BeforeOnPageHandlerExecution",
                     new
                     {
@@ -89,17 +116,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void AfterOnPageHandlerExecution(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             PageHandlerExecutedContext handlerExecutedContext,
             IAsyncPageFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(handlerExecutedContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnPageHandlerExecution"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterOnPageHandlerExecutionImpl(diagnosticListener, handlerExecutedContext, filter);
+            }
+        }
+
+        private static void AfterOnPageHandlerExecutionImpl(DiagnosticListener diagnosticListener, PageHandlerExecutedContext handlerExecutedContext, IAsyncPageFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnPageHandlerExecution"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.AfterOnPageHandlerExecution",
                     new
                     {
@@ -111,17 +147,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void BeforeOnPageHandlerExecuting(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             PageHandlerExecutingContext handlerExecutingContext,
             IPageFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(handlerExecutingContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnPageHandlerExecuting"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeOnPageHandlerExecutingImpl(diagnosticListener, handlerExecutingContext, filter);
+            }
+        }
+
+        private static void BeforeOnPageHandlerExecutingImpl(DiagnosticListener diagnosticListener, PageHandlerExecutingContext handlerExecutingContext, IPageFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnPageHandlerExecuting"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.BeforeOnPageHandlerExecuting",
                     new
                     {
@@ -133,17 +178,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void AfterOnPageHandlerExecuting(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             PageHandlerExecutingContext handlerExecutingContext,
             IPageFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(handlerExecutingContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnPageHandlerExecuting"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterOnPageHandlerExecutingImpl(diagnosticListener, handlerExecutingContext, filter);
+            }
+        }
+
+        private static void AfterOnPageHandlerExecutingImpl(DiagnosticListener diagnosticListener, PageHandlerExecutingContext handlerExecutingContext, IPageFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnPageHandlerExecuting"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.AfterOnPageHandlerExecuting",
                     new
                     {
@@ -155,17 +209,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void BeforeOnPageHandlerExecuted(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             PageHandlerExecutedContext handlerExecutedContext,
             IPageFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(handlerExecutedContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnPageHandlerExecuted"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeOnPageHandlerExecutedImpl(diagnosticListener, handlerExecutedContext, filter);
+            }
+        }
+
+        private static void BeforeOnPageHandlerExecutedImpl(DiagnosticListener diagnosticListener, PageHandlerExecutedContext handlerExecutedContext, IPageFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnPageHandlerExecuted"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.BeforeOnPageHandlerExecuted",
                     new
                     {
@@ -177,17 +240,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void AfterOnPageHandlerExecuted(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             PageHandlerExecutedContext handlerExecutedContext,
             IPageFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(handlerExecutedContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnPageHandlerExecuted"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterOnPageHandlerExecutedImpl(diagnosticListener, handlerExecutedContext, filter);
+            }
+        }
+
+        private static void AfterOnPageHandlerExecutedImpl(DiagnosticListener diagnosticListener, PageHandlerExecutedContext handlerExecutedContext, IPageFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnPageHandlerExecuted"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.AfterOnPageHandlerExecuted",
                     new
                     {
@@ -199,17 +271,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void BeforeOnPageHandlerSelection(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             PageHandlerSelectedContext handlerSelectedContext,
             IAsyncPageFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(handlerSelectedContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnPageHandlerSelection"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeOnPageHandlerSelectionImpl(diagnosticListener, handlerSelectedContext, filter);
+            }
+        }
+
+        private static void BeforeOnPageHandlerSelectionImpl(DiagnosticListener diagnosticListener, PageHandlerSelectedContext handlerSelectedContext, IAsyncPageFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnPageHandlerSelection"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.BeforeOnPageHandlerSelection",
                     new
                     {
@@ -221,17 +302,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void AfterOnPageHandlerSelection(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             PageHandlerSelectedContext handlerSelectedContext,
             IAsyncPageFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(handlerSelectedContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnPageHandlerSelection"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterOnPageHandlerSelectionImpl(diagnosticListener, handlerSelectedContext, filter);
+            }
+        }
+
+        private static void AfterOnPageHandlerSelectionImpl(DiagnosticListener diagnosticListener, PageHandlerSelectedContext handlerSelectedContext, IAsyncPageFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnPageHandlerSelection"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.AfterOnPageHandlerSelection",
                     new
                     {
@@ -243,17 +333,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void BeforeOnPageHandlerSelected(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             PageHandlerSelectedContext handlerSelectedContext,
             IPageFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(handlerSelectedContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnPageHandlerSelected"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeOnPageHandlerSelectedImpl(diagnosticListener, handlerSelectedContext, filter);
+            }
+        }
+
+        private static void BeforeOnPageHandlerSelectedImpl(DiagnosticListener diagnosticListener, PageHandlerSelectedContext handlerSelectedContext, IPageFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeOnPageHandlerSelected"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.BeforeOnPageHandlerSelected",
                     new
                     {
@@ -265,17 +364,26 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         }
 
         public static void AfterOnPageHandlerSelected(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             PageHandlerSelectedContext handlerSelectedContext,
             IPageFilter filter)
         {
-            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(diagnosticListener != null);
             Debug.Assert(handlerSelectedContext != null);
             Debug.Assert(filter != null);
 
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnPageHandlerSelected"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterOnPageHandlerSelectedImpl(diagnosticListener, handlerSelectedContext, filter);
+            }
+        }
+
+        private static void AfterOnPageHandlerSelectedImpl(DiagnosticListener diagnosticListener, PageHandlerSelectedContext handlerSelectedContext, IPageFilter filter)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterOnPageHandlerSelected"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.AfterOnPageHandlerSelected",
                     new
                     {

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/PageActionInvoker.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/PageActionInvoker.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 
         public PageActionInvoker(
             IPageHandlerMethodSelector handlerMethodSelector,
-            DiagnosticSource diagnosticSource,
+            DiagnosticListener diagnosticListener,
             ILogger logger,
             IActionResultTypeMapper mapper,
             PageContext pageContext,
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             ITempDataDictionaryFactory tempDataFactory,
             HtmlHelperOptions htmlHelperOptions)
             : base(
-                  diagnosticSource,
+                  diagnosticListener,
                   logger,
                   mapper,
                   pageContext,
@@ -258,7 +258,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 
                 Debug.Assert(executor != null, "We should always find a executor for a handler");
 
-                _diagnosticSource.BeforeHandlerMethod(_pageContext, handler, _arguments, _instance);
+                _diagnosticListener.BeforeHandlerMethod(_pageContext, handler, _arguments, _instance);
                 _logger.ExecutingHandlerMethod(_pageContext, handler, arguments);
 
                 try
@@ -268,7 +268,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                 }
                 finally
                 {
-                    _diagnosticSource.AfterHandlerMethod(_pageContext, handler, _arguments, _instance, _result);
+                    _diagnosticListener.AfterHandlerMethod(_pageContext, handler, _arguments, _instance, _result);
                 }
             }
 
@@ -350,7 +350,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                         var filter = (IAsyncPageFilter)state;
                         var handlerSelectedContext = _handlerSelectedContext;
 
-                        _diagnosticSource.BeforeOnPageHandlerSelection(handlerSelectedContext, filter);
+                        _diagnosticListener.BeforeOnPageHandlerSelection(handlerSelectedContext, filter);
                         _logger.BeforeExecutingMethodOnFilter(
                             PageLoggerExtensions.PageFilter,
                             nameof(IAsyncPageFilter.OnPageHandlerSelectionAsync),
@@ -373,7 +373,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 
                         var filter = (IAsyncPageFilter)state;
 
-                        _diagnosticSource.AfterOnPageHandlerSelection(_handlerSelectedContext, filter);
+                        _diagnosticListener.AfterOnPageHandlerSelection(_handlerSelectedContext, filter);
                         _logger.AfterExecutingMethodOnFilter(
                             PageLoggerExtensions.PageFilter,
                             nameof(IAsyncPageFilter.OnPageHandlerSelectionAsync),
@@ -390,7 +390,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                         var filter = (IPageFilter)state;
                         var handlerSelectedContext = _handlerSelectedContext;
 
-                        _diagnosticSource.BeforeOnPageHandlerSelected(handlerSelectedContext, filter);
+                        _diagnosticListener.BeforeOnPageHandlerSelected(handlerSelectedContext, filter);
                         _logger.BeforeExecutingMethodOnFilter(
                             PageLoggerExtensions.PageFilter,
                             nameof(IPageFilter.OnPageHandlerSelected),
@@ -398,7 +398,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 
                         filter.OnPageHandlerSelected(handlerSelectedContext);
 
-                        _diagnosticSource.AfterOnPageHandlerSelected(handlerSelectedContext, filter);
+                        _diagnosticListener.AfterOnPageHandlerSelected(handlerSelectedContext, filter);
 
                         goto case State.PageSelectHandlerNext;
                     }
@@ -461,7 +461,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                         var filter = (IAsyncPageFilter)state;
                         var handlerExecutingContext = _handlerExecutingContext;
 
-                        _diagnosticSource.BeforeOnPageHandlerExecution(handlerExecutingContext, filter);
+                        _diagnosticListener.BeforeOnPageHandlerExecution(handlerExecutingContext, filter);
                         _logger.BeforeExecutingMethodOnFilter(
                             PageLoggerExtensions.PageFilter,
                             nameof(IAsyncPageFilter.OnPageHandlerExecutionAsync),
@@ -500,7 +500,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                             };
                         }
 
-                        _diagnosticSource.AfterOnPageHandlerExecution(_handlerExecutedContext, filter);
+                        _diagnosticListener.AfterOnPageHandlerExecution(_handlerExecutedContext, filter);
                         _logger.AfterExecutingMethodOnFilter(
                            PageLoggerExtensions.PageFilter,
                            nameof(IAsyncPageFilter.OnPageHandlerExecutionAsync),
@@ -517,7 +517,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                         var filter = (IPageFilter)state;
                         var handlerExecutingContext = _handlerExecutingContext;
 
-                        _diagnosticSource.BeforeOnPageHandlerExecuting(handlerExecutingContext, filter);
+                        _diagnosticListener.BeforeOnPageHandlerExecuting(handlerExecutingContext, filter);
                         _logger.BeforeExecutingMethodOnFilter(
                            PageLoggerExtensions.PageFilter,
                            nameof(IPageFilter.OnPageHandlerExecuting),
@@ -525,7 +525,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 
                         filter.OnPageHandlerExecuting(handlerExecutingContext);
 
-                        _diagnosticSource.AfterOnPageHandlerExecuting(handlerExecutingContext, filter);
+                        _diagnosticListener.AfterOnPageHandlerExecuting(handlerExecutingContext, filter);
                         _logger.AfterExecutingMethodOnFilter(
                            PageLoggerExtensions.PageFilter,
                            nameof(IPageFilter.OnPageHandlerExecuting),
@@ -568,7 +568,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
                         var filter = (IPageFilter)state;
                         var handlerExecutedContext = _handlerExecutedContext;
 
-                        _diagnosticSource.BeforeOnPageHandlerExecuted(handlerExecutedContext, filter);
+                        _diagnosticListener.BeforeOnPageHandlerExecuted(handlerExecutedContext, filter);
                         _logger.BeforeExecutingMethodOnFilter(
                            PageLoggerExtensions.PageFilter,
                            nameof(IPageFilter.OnPageHandlerExecuted),
@@ -576,7 +576,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 
                         filter.OnPageHandlerExecuted(handlerExecutedContext);
 
-                        _diagnosticSource.AfterOnPageHandlerExecuted(handlerExecutedContext, filter);
+                        _diagnosticListener.AfterOnPageHandlerExecuted(handlerExecutedContext, filter);
                         _logger.AfterExecutingMethodOnFilter(
                            PageLoggerExtensions.PageFilter,
                            nameof(IPageFilter.OnPageHandlerExecuted),

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/PageActionInvokerProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/PageActionInvokerProvider.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
         private readonly HtmlHelperOptions _htmlHelperOptions;
         private readonly IPageHandlerMethodSelector _selector;
         private readonly RazorProjectFileSystem _razorFileSystem;
-        private readonly DiagnosticSource _diagnosticSource;
+        private readonly DiagnosticListener _diagnosticListener;
         private readonly ILogger<PageActionInvoker> _logger;
         private readonly IActionResultTypeMapper _mapper;
         private volatile InnerCache _currentCache;
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             IOptions<HtmlHelperOptions> htmlHelperOptions,
             IPageHandlerMethodSelector selector,
             RazorProjectFileSystem razorFileSystem,
-            DiagnosticSource diagnosticSource,
+            DiagnosticListener diagnosticListener,
             ILoggerFactory loggerFactory,
             IActionResultTypeMapper mapper)
         {
@@ -79,7 +79,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             _htmlHelperOptions = htmlHelperOptions.Value;
             _selector = selector;
             _razorFileSystem = razorFileSystem;
-            _diagnosticSource = diagnosticSource;
+            _diagnosticListener = diagnosticListener;
             _logger = loggerFactory.CreateLogger<PageActionInvoker>();
             _mapper = mapper;
         }
@@ -159,7 +159,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 
             return new PageActionInvoker(
                 _selector,
-                _diagnosticSource,
+                _diagnosticListener,
                 _logger,
                 _mapper,
                 pageContext,

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/PageBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/PageBase.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages
         }
 
         /// <inheritdoc />
-        public override void BeginContext(int position, int length, bool isLiteral)
+        protected override void BeginContextImpl(int position, int length, bool isLiteral)
         {
             const string BeginContextEvent = "Microsoft.AspNetCore.Mvc.Razor.BeginInstrumentationContext";
 
@@ -129,7 +129,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages
         }
 
         /// <inheritdoc />
-        public override void EndContext()
+        protected override void EndContextImpl()
         {
             const string EndContextEvent = "Microsoft.AspNetCore.Mvc.Razor.EndInstrumentationContext";
 

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/breakingchanges.netcore.json
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/breakingchanges.netcore.json
@@ -1,0 +1,22 @@
+[
+  {
+    "TypeId": "public class Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure.PageResultExecutor : Microsoft.AspNetCore.Mvc.ViewFeatures.ViewExecutor",
+    "MemberId": "public .ctor(Microsoft.AspNetCore.Mvc.Infrastructure.IHttpResponseStreamWriterFactory writerFactory, Microsoft.AspNetCore.Mvc.ViewEngines.ICompositeViewEngine compositeViewEngine, Microsoft.AspNetCore.Mvc.Razor.IRazorViewEngine razorViewEngine, Microsoft.AspNetCore.Mvc.Razor.IRazorPageActivator razorPageActivator, System.Diagnostics.DiagnosticSource diagnosticSource, System.Text.Encodings.Web.HtmlEncoder htmlEncoder)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure.DefaultPageFactoryProvider : Microsoft.AspNetCore.Mvc.RazorPages.IPageFactoryProvider",
+    "MemberId": "public .ctor(Microsoft.AspNetCore.Mvc.RazorPages.IPageActivatorProvider pageActivator, Microsoft.AspNetCore.Mvc.ModelBinding.IModelMetadataProvider metadataProvider, Microsoft.AspNetCore.Mvc.Routing.IUrlHelperFactory urlHelperFactory, Microsoft.AspNetCore.Mvc.Rendering.IJsonHelper jsonHelper, System.Diagnostics.DiagnosticSource diagnosticSource, System.Text.Encodings.Web.HtmlEncoder htmlEncoder, Microsoft.AspNetCore.Mvc.ViewFeatures.IModelExpressionProvider modelExpressionProvider)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public abstract class Microsoft.AspNetCore.Mvc.RazorPages.PageBase : Microsoft.AspNetCore.Mvc.Razor.RazorPageBase",
+    "MemberId": "public override System.Void BeginContext(System.Int32 position, System.Int32 length, System.Boolean isLiteral)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public abstract class Microsoft.AspNetCore.Mvc.RazorPages.PageBase : Microsoft.AspNetCore.Mvc.Razor.RazorPageBase",
+    "MemberId": "public override System.Void EndContext()",
+    "Kind": "Removal"
+  }
+]

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/MvcViewFeaturesDiagnosticSourceExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/MvcViewFeaturesDiagnosticSourceExtensions.cs
@@ -12,13 +12,22 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
     internal static class MvcViewFeaturesDiagnosticSourceExtensions
     {
         public static void BeforeViewComponent(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ViewComponentContext context,
             object viewComponent)
         {
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeViewComponent"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeViewComponentImpl(diagnosticListener, context, viewComponent);
+            }
+        }
+
+        private static void BeforeViewComponentImpl(DiagnosticListener diagnosticListener, ViewComponentContext context, object viewComponent)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeViewComponent"))
+            {
+                diagnosticListener.Write(
                 "Microsoft.AspNetCore.Mvc.BeforeViewComponent",
                 new
                 {
@@ -30,14 +39,23 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
         }
 
         public static void AfterViewComponent(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ViewComponentContext context,
             IViewComponentResult result,
             object viewComponent)
         {
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterViewComponent"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterViewComponentImpl(diagnosticListener, context, result, viewComponent);
+            }
+        }
+
+        private static void AfterViewComponentImpl(DiagnosticListener diagnosticListener, ViewComponentContext context, IViewComponentResult result, object viewComponent)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterViewComponent"))
+            {
+                diagnosticListener.Write(
                 "Microsoft.AspNetCore.Mvc.AfterViewComponent",
                 new
                 {
@@ -50,13 +68,22 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
         }
 
         public static void ViewComponentBeforeViewExecute(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ViewComponentContext context,
             IView view)
         {
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.ViewComponentBeforeViewExecute"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                ViewComponentBeforeViewExecuteImpl(diagnosticListener, context, view);
+            }
+        }
+
+        private static void ViewComponentBeforeViewExecuteImpl(DiagnosticListener diagnosticListener, ViewComponentContext context, IView view)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.ViewComponentBeforeViewExecute"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.ViewComponentBeforeViewExecute",
                     new
                     {
@@ -68,13 +95,22 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
         }
 
         public static void ViewComponentAfterViewExecute(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ViewComponentContext context,
             IView view)
         {
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.ViewComponentAfterViewExecute"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                ViewComponentAfterViewExecuteImpl(diagnosticListener, context, view);
+            }
+        }
+
+        private static void ViewComponentAfterViewExecuteImpl(DiagnosticListener diagnosticListener, ViewComponentContext context, IView view)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.ViewComponentAfterViewExecute"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.ViewComponentAfterViewExecute",
                     new
                     {
@@ -86,42 +122,69 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
         }
 
         public static void BeforeView(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             IView view,
             ViewContext viewContext)
         {
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeView"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                BeforeViewImpl(diagnosticListener, view, viewContext);
+            }
+        }
+
+        private static void BeforeViewImpl(DiagnosticListener diagnosticListener, IView view, ViewContext viewContext)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.BeforeView"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.BeforeView",
                     new { view = view, viewContext = viewContext, });
             }
         }
 
         public static void AfterView(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             IView view,
             ViewContext viewContext)
         {
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.AfterView"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                AfterViewImpl(diagnosticListener, view, viewContext);
+            }
+        }
+
+        private static void AfterViewImpl(DiagnosticListener diagnosticListener, IView view, ViewContext viewContext)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.AfterView"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.AfterView",
                     new { view = view, viewContext = viewContext, });
             }
         }
 
         public static void ViewFound(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ActionContext actionContext,
             bool isMainPage,
             PartialViewResult viewResult,
             string viewName,
             IView view)
         {
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.ViewFound"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                ViewFoundImpl(diagnosticListener, actionContext, isMainPage, viewResult, viewName, view);
+            }
+        }
+
+        private static void ViewFoundImpl(DiagnosticListener diagnosticListener, ActionContext actionContext, bool isMainPage, PartialViewResult viewResult, string viewName, IView view)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.ViewFound"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.ViewFound",
                     new
                     {
@@ -135,16 +198,25 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
         }
 
         public static void ViewNotFound(
-            this DiagnosticSource diagnosticSource,
+            this DiagnosticListener diagnosticListener,
             ActionContext actionContext,
             bool isMainPage,
             PartialViewResult viewResult,
             string viewName,
             IEnumerable<string> searchedLocations)
         {
-            if (diagnosticSource.IsEnabled("Microsoft.AspNetCore.Mvc.ViewNotFound"))
+            // Inlinable fast-path check if Diagnositcs is enabled
+            if (diagnosticListener.IsEnabled())
             {
-                diagnosticSource.Write(
+                ViewNotFoundImpl(diagnosticListener, actionContext, isMainPage, viewResult, viewName, searchedLocations);
+            }
+        }
+
+        private static void ViewNotFoundImpl(DiagnosticListener diagnosticListener, ActionContext actionContext, bool isMainPage, PartialViewResult viewResult, string viewName, IEnumerable<string> searchedLocations)
+        {
+            if (diagnosticListener.IsEnabled("Microsoft.AspNetCore.Mvc.ViewNotFound"))
+            {
+                diagnosticListener.Write(
                     "Microsoft.AspNetCore.Mvc.ViewNotFound",
                     new
                     {

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/DefaultViewComponentInvoker.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/DefaultViewComponentInvoker.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
     {
         private readonly IViewComponentFactory _viewComponentFactory;
         private readonly ViewComponentInvokerCache _viewComponentInvokerCache;
-        private readonly DiagnosticSource _diagnosticSource;
+        private readonly DiagnosticListener _diagnosticListener;
         private readonly ILogger _logger;
 
         /// <summary>
@@ -28,14 +28,14 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
         /// </summary>
         /// <param name="viewComponentFactory">The <see cref="IViewComponentFactory"/>.</param>
         /// <param name="viewComponentInvokerCache">The <see cref="ViewComponentInvokerCache"/>.</param>
-        /// <param name="diagnosticSource">The <see cref="DiagnosticSource"/>.</param>
+        /// <param name="diagnosticListener">The <see cref="DiagnosticListener"/>.</param>
         /// <param name="logger">The <see cref="ILogger"/>.</param>
         public DefaultViewComponentInvoker(
             IViewComponentFactory viewComponentFactory,
 #pragma warning disable PUB0001 // Pubternal type in public API
             ViewComponentInvokerCache viewComponentInvokerCache,
 #pragma warning restore PUB0001
-            DiagnosticSource diagnosticSource,
+            DiagnosticListener diagnosticListener,
             ILogger logger)
         {
             if (viewComponentFactory == null)
@@ -48,9 +48,9 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
                 throw new ArgumentNullException(nameof(viewComponentInvokerCache));
             }
 
-            if (diagnosticSource == null)
+            if (diagnosticListener == null)
             {
-                throw new ArgumentNullException(nameof(diagnosticSource));
+                throw new ArgumentNullException(nameof(diagnosticListener));
             }
 
             if (logger == null)
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
 
             _viewComponentFactory = viewComponentFactory;
             _viewComponentInvokerCache = viewComponentInvokerCache;
-            _diagnosticSource = diagnosticSource;
+            _diagnosticListener = diagnosticListener;
             _logger = logger;
         }
 
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
             {
                 var arguments = PrepareArguments(context.Arguments, executor);
 
-                _diagnosticSource.BeforeViewComponent(context, component);
+                _diagnosticListener.BeforeViewComponent(context, component);
                 _logger.ViewComponentExecuting(context, arguments);
 
                 var stopwatch = ValueStopwatch.StartNew();
@@ -131,7 +131,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
 
                 var viewComponentResult = CoerceToViewComponentResult(resultAsObject);
                 _logger.ViewComponentExecuted(context, stopwatch.GetElapsedTime(), viewComponentResult);
-                _diagnosticSource.AfterViewComponent(context, viewComponentResult, component);
+                _diagnosticListener.AfterViewComponent(context, viewComponentResult, component);
 
                 _viewComponentFactory.ReleaseViewComponent(context, component);
 
@@ -147,7 +147,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
             {
                 var arguments = PrepareArguments(context.Arguments, executor);
 
-                _diagnosticSource.BeforeViewComponent(context, component);
+                _diagnosticListener.BeforeViewComponent(context, component);
                 _logger.ViewComponentExecuting(context, arguments);
 
                 var stopwatch = ValueStopwatch.StartNew();
@@ -164,7 +164,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
 
                 var viewComponentResult = CoerceToViewComponentResult(result);
                 _logger.ViewComponentExecuted(context, stopwatch.GetElapsedTime(), viewComponentResult);
-                _diagnosticSource.AfterViewComponent(context, viewComponentResult, component);
+                _diagnosticListener.AfterViewComponent(context, viewComponentResult, component);
 
                 _viewComponentFactory.ReleaseViewComponent(context, component);
 

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/DefaultViewComponentInvokerFactory.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/DefaultViewComponentInvokerFactory.cs
@@ -13,14 +13,14 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
         private readonly IViewComponentFactory _viewComponentFactory;
         private readonly ViewComponentInvokerCache _viewComponentInvokerCache;
         private readonly ILogger _logger;
-        private readonly DiagnosticSource _diagnosticSource;
+        private readonly DiagnosticListener _diagnosticListener;
 
         public DefaultViewComponentInvokerFactory(
             IViewComponentFactory viewComponentFactory,
 #pragma warning disable PUB0001 // Pubternal type in public API
             ViewComponentInvokerCache viewComponentInvokerCache,
 #pragma warning restore PUB0001
-            DiagnosticSource diagnosticSource,
+            DiagnosticListener diagnosticListener,
             ILoggerFactory loggerFactory)
         {
             if (viewComponentFactory == null)
@@ -33,9 +33,9 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
                 throw new ArgumentNullException(nameof(viewComponentInvokerCache));
             }
 
-            if (diagnosticSource == null)
+            if (diagnosticListener == null)
             {
-                throw new ArgumentNullException(nameof(diagnosticSource));
+                throw new ArgumentNullException(nameof(diagnosticListener));
             }
 
             if (loggerFactory == null)
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
             }
 
             _viewComponentFactory = viewComponentFactory;
-            _diagnosticSource = diagnosticSource;
+            _diagnosticListener = diagnosticListener;
             _viewComponentInvokerCache = viewComponentInvokerCache;
 
             _logger = loggerFactory.CreateLogger<DefaultViewComponentInvoker>();
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
             return new DefaultViewComponentInvoker(
                 _viewComponentFactory,
                 _viewComponentInvokerCache,
-                _diagnosticSource,
+                _diagnosticListener,
                 _logger);
         }
     }

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/ViewViewComponentResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewComponents/ViewViewComponentResult.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
         private const string ViewPathFormat = "Components/{0}/{1}";
         private const string DefaultViewName = "Default";
 
-        private DiagnosticSource _diagnosticSource;
+        private DiagnosticListener _diagnosticListener;
 
         /// <summary>
         /// Gets or sets the view name.
@@ -116,12 +116,12 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
             var view = result.EnsureSuccessful(originalLocations).View;
             using (view as IDisposable)
             {
-                if (_diagnosticSource == null)
+                if (_diagnosticListener == null)
                 {
-                    _diagnosticSource = viewContext.HttpContext.RequestServices.GetRequiredService<DiagnosticSource>();
+                    _diagnosticListener = viewContext.HttpContext.RequestServices.GetRequiredService<DiagnosticListener>();
                 }
 
-                _diagnosticSource.ViewComponentBeforeViewExecute(context, view);
+                _diagnosticListener.ViewComponentBeforeViewExecute(context, view);
 
                 var childViewContext = new ViewContext(
                     viewContext,
@@ -130,7 +130,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
                     context.Writer);
                 await view.RenderAsync(childViewContext);
 
-                _diagnosticSource.ViewComponentAfterViewExecute(context, view);
+                _diagnosticListener.ViewComponentAfterViewExecute(context, view);
             }
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/PartialViewResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/PartialViewResultExecutor.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         /// <param name="writerFactory">The <see cref="IHttpResponseStreamWriterFactory"/>.</param>
         /// <param name="viewEngine">The <see cref="ICompositeViewEngine"/>.</param>
         /// <param name="tempDataFactory">The <see cref="ITempDataDictionaryFactory"/>.</param>
-        /// <param name="diagnosticSource">The <see cref="DiagnosticSource"/>.</param>
+        /// <param name="diagnosticListener">The <see cref="DiagnosticListener"/>.</param>
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
         /// <param name="modelMetadataProvider">The <see cref="IModelMetadataProvider"/>.</param>
         public PartialViewResultExecutor(
@@ -38,10 +38,10 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             IHttpResponseStreamWriterFactory writerFactory,
             ICompositeViewEngine viewEngine,
             ITempDataDictionaryFactory tempDataFactory,
-            DiagnosticSource diagnosticSource,
+            DiagnosticListener diagnosticListener,
             ILoggerFactory loggerFactory,
             IModelMetadataProvider modelMetadataProvider)
-            : base(viewOptions, writerFactory, viewEngine, tempDataFactory, diagnosticSource, modelMetadataProvider)
+            : base(viewOptions, writerFactory, viewEngine, tempDataFactory, diagnosticListener, modelMetadataProvider)
         {
             if (loggerFactory == null)
             {

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ViewExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/ViewExecutor.cs
@@ -32,16 +32,16 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         /// <param name="writerFactory">The <see cref="IHttpResponseStreamWriterFactory"/>.</param>
         /// <param name="viewEngine">The <see cref="ICompositeViewEngine"/>.</param>
         /// <param name="tempDataFactory">The <see cref="ITempDataDictionaryFactory"/>.</param>
-        /// <param name="diagnosticSource">The <see cref="DiagnosticSource"/>.</param>
+        /// <param name="diagnosticListener">The <see cref="DiagnosticSource"/>.</param>
         /// <param name="modelMetadataProvider">The <see cref="IModelMetadataProvider" />.</param>
         public ViewExecutor(
             IOptions<MvcViewOptions> viewOptions,
             IHttpResponseStreamWriterFactory writerFactory,
             ICompositeViewEngine viewEngine,
             ITempDataDictionaryFactory tempDataFactory,
-            DiagnosticSource diagnosticSource,
+            DiagnosticListener diagnosticListener,
             IModelMetadataProvider modelMetadataProvider)
-            : this(writerFactory, viewEngine, diagnosticSource)
+            : this(writerFactory, viewEngine, diagnosticListener)
         {
             if (viewOptions == null)
             {
@@ -53,9 +53,9 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 throw new ArgumentNullException(nameof(tempDataFactory));
             }
 
-            if (diagnosticSource == null)
+            if (diagnosticListener == null)
             {
-                throw new ArgumentNullException(nameof(diagnosticSource));
+                throw new ArgumentNullException(nameof(diagnosticListener));
             }
 
             ViewOptions = viewOptions.Value;
@@ -68,11 +68,11 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         /// </summary>
         /// <param name="writerFactory">The <see cref="IHttpResponseStreamWriterFactory"/>.</param>
         /// <param name="viewEngine">The <see cref="ICompositeViewEngine"/>.</param>
-        /// <param name="diagnosticSource">The <see cref="System.Diagnostics.DiagnosticSource"/>.</param>
+        /// <param name="diagnosticListener">The <see cref="System.Diagnostics.DiagnosticListener"/>.</param>
         protected ViewExecutor(
             IHttpResponseStreamWriterFactory writerFactory,
             ICompositeViewEngine viewEngine,
-            DiagnosticSource diagnosticSource)
+            DiagnosticListener diagnosticListener)
         {
             if (writerFactory == null)
             {
@@ -84,20 +84,20 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 throw new ArgumentNullException(nameof(viewEngine));
             }
 
-            if (diagnosticSource == null)
+            if (diagnosticListener == null)
             {
-                throw new ArgumentNullException(nameof(diagnosticSource));
+                throw new ArgumentNullException(nameof(diagnosticListener));
             }
 
             WriterFactory = writerFactory;
             ViewEngine = viewEngine;
-            DiagnosticSource = diagnosticSource;
+            DiagnosticSource = diagnosticListener;
         }
 
         /// <summary>
         /// Gets the <see cref="DiagnosticSource"/>.
         /// </summary>
-        protected DiagnosticSource DiagnosticSource { get; }
+        protected DiagnosticListener DiagnosticSource { get; }
 
         /// <summary>
         /// Gets the <see cref="ITempDataDictionaryFactory"/>.

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/breakingchanges.netcore.json
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/breakingchanges.netcore.json
@@ -1,0 +1,37 @@
+[
+  {
+    "TypeId": "public class Microsoft.AspNetCore.Mvc.ViewFeatures.ViewExecutor",
+    "MemberId": "protected .ctor(Microsoft.AspNetCore.Mvc.Infrastructure.IHttpResponseStreamWriterFactory writerFactory, Microsoft.AspNetCore.Mvc.ViewEngines.ICompositeViewEngine viewEngine, System.Diagnostics.DiagnosticSource diagnosticSource)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.AspNetCore.Mvc.ViewFeatures.ViewExecutor",
+    "MemberId": "protected System.Diagnostics.DiagnosticSource get_DiagnosticSource()",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.AspNetCore.Mvc.ViewFeatures.ViewExecutor",
+    "MemberId": "public .ctor(Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Mvc.MvcViewOptions> viewOptions, Microsoft.AspNetCore.Mvc.Infrastructure.IHttpResponseStreamWriterFactory writerFactory, Microsoft.AspNetCore.Mvc.ViewEngines.ICompositeViewEngine viewEngine, Microsoft.AspNetCore.Mvc.ViewFeatures.ITempDataDictionaryFactory tempDataFactory, System.Diagnostics.DiagnosticSource diagnosticSource, Microsoft.AspNetCore.Mvc.ModelBinding.IModelMetadataProvider modelMetadataProvider)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.AspNetCore.Mvc.ViewComponents.DefaultViewComponentInvoker : Microsoft.AspNetCore.Mvc.ViewComponents.IViewComponentInvoker",
+    "MemberId": "public .ctor(Microsoft.AspNetCore.Mvc.ViewComponents.IViewComponentFactory viewComponentFactory, Microsoft.AspNetCore.Mvc.ViewFeatures.Internal.ViewComponentInvokerCache viewComponentInvokerCache, System.Diagnostics.DiagnosticSource diagnosticSource, Microsoft.Extensions.Logging.ILogger logger)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.AspNetCore.Mvc.ViewComponents.DefaultViewComponentInvokerFactory : Microsoft.AspNetCore.Mvc.ViewComponents.IViewComponentInvokerFactory",
+    "MemberId": "public .ctor(Microsoft.AspNetCore.Mvc.ViewComponents.IViewComponentFactory viewComponentFactory, Microsoft.AspNetCore.Mvc.ViewFeatures.Internal.ViewComponentInvokerCache viewComponentInvokerCache, System.Diagnostics.DiagnosticSource diagnosticSource, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.AspNetCore.Mvc.ViewFeatures.PartialViewResultExecutor : Microsoft.AspNetCore.Mvc.ViewFeatures.ViewExecutor, Microsoft.AspNetCore.Mvc.Infrastructure.IActionResultExecutor<Microsoft.AspNetCore.Mvc.PartialViewResult>",
+    "MemberId": "public .ctor(Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Mvc.MvcViewOptions> viewOptions, Microsoft.AspNetCore.Mvc.Infrastructure.IHttpResponseStreamWriterFactory writerFactory, Microsoft.AspNetCore.Mvc.ViewEngines.ICompositeViewEngine viewEngine, Microsoft.AspNetCore.Mvc.ViewFeatures.ITempDataDictionaryFactory tempDataFactory, System.Diagnostics.DiagnosticSource diagnosticSource, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, Microsoft.AspNetCore.Mvc.ModelBinding.IModelMetadataProvider modelMetadataProvider)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.AspNetCore.Mvc.ViewFeatures.ViewResultExecutor : Microsoft.AspNetCore.Mvc.ViewFeatures.ViewExecutor, Microsoft.AspNetCore.Mvc.Infrastructure.IActionResultExecutor<Microsoft.AspNetCore.Mvc.ViewResult>",
+    "MemberId": "public .ctor(Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Mvc.MvcViewOptions> viewOptions, Microsoft.AspNetCore.Mvc.Infrastructure.IHttpResponseStreamWriterFactory writerFactory, Microsoft.AspNetCore.Mvc.ViewEngines.ICompositeViewEngine viewEngine, Microsoft.AspNetCore.Mvc.ViewFeatures.ITempDataDictionaryFactory tempDataFactory, System.Diagnostics.DiagnosticSource diagnosticSource, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, Microsoft.AspNetCore.Mvc.ModelBinding.IModelMetadataProvider modelMetadataProvider)",
+    "Kind": "Removal"
+  }
+]

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Builder/MvcApplicationBuilderExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Builder/MvcApplicationBuilderExtensionsTest.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Mvc.Core.Builder
         {
             // Arrange
             var services = new ServiceCollection();
-            services.AddSingleton<DiagnosticSource>(new DiagnosticListener("Microsoft.AspNetCore"));
+            services.AddSingleton<DiagnosticListener>(new DiagnosticListener("Microsoft.AspNetCore"));
             services.AddLogging();
             services.AddMvcCore(o => o.EnableEndpointRouting = false);
             var serviceProvider = services.BuildServiceProvider();
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Mvc.Core.Builder
         {
             // Arrange
             var services = new ServiceCollection();
-            services.AddSingleton<DiagnosticSource>(new DiagnosticListener("Microsoft.AspNetCore"));
+            services.AddSingleton<DiagnosticListener>(new DiagnosticListener("Microsoft.AspNetCore"));
             services.AddLogging();
             services.AddMvcCore(o => o.EnableEndpointRouting = true);
             var serviceProvider = services.BuildServiceProvider();

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/MiddlewareFilterTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/MiddlewareFilterTest.cs
@@ -277,14 +277,14 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
             var actionContext = new ActionContext(httpContext, new RouteData(), actionDescriptor);
 
-            var diagnosticSource = new DiagnosticListener("Microsoft.AspNetCore");
-            diagnosticSource.SubscribeWithAdapter(new TestDiagnosticListener());
+            var diagnosticListener = new DiagnosticListener("Microsoft.AspNetCore");
+            diagnosticListener.SubscribeWithAdapter(new TestDiagnosticListener());
 
             var invoker = new TestControllerActionInvoker(
                 filters,
                 new MockControllerFactory(controller ?? this),
                 new NullLoggerFactory().CreateLogger<ControllerActionInvoker>(),
-                diagnosticSource,
+                diagnosticListener,
                 new ActionResultTypeMapper(),
                 actionContext,
                 new List<IValueProviderFactory>(),
@@ -389,14 +389,14 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 IFilterMetadata[] filters,
                 MockControllerFactory controllerFactory,
                 ILogger logger,
-                DiagnosticSource diagnosticSource,
+                DiagnosticListener diagnosticListener,
                 IActionResultTypeMapper mapper,
                 ActionContext actionContext,
                 IReadOnlyList<IValueProviderFactory> valueProviderFactories,
                 int maxAllowedErrorsInModelState)
                 : base(
                       logger,
-                      diagnosticSource,
+                      diagnosticListener,
                       mapper,
                       CreatControllerContext(actionContext, valueProviderFactories, maxAllowedErrorsInModelState),
                       CreateCacheEntry((ControllerActionDescriptor)actionContext.ActionDescriptor, controllerFactory),

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorPageActivatorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorPageActivatorTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             UrlHelperFactory = new UrlHelperFactory();
         }
 
-        private DiagnosticSource DiagnosticSource { get; }
+        private DiagnosticListener DiagnosticSource { get; }
 
         private HtmlEncoder HtmlEncoder { get; }
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorViewTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Test/RazorViewTest.cs
@@ -112,8 +112,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             var activator = new Mock<IRazorPageActivator>();
 
             var adapter = new TestDiagnosticListener();
-            var diagnosticSource = new DiagnosticListener("Microsoft.AspNetCore.Mvc.Razor");
-            diagnosticSource.SubscribeWithAdapter(adapter);
+            var diagnosticListener = new DiagnosticListener("Microsoft.AspNetCore.Mvc.Razor");
+            diagnosticListener.SubscribeWithAdapter(adapter);
 
             var view = new RazorView(
                 Mock.Of<IRazorViewEngine>(),
@@ -121,7 +121,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
                 new IRazorPage[0],
                 page,
                 new HtmlTestEncoder(),
-                diagnosticSource);
+                diagnosticListener);
 
             var viewContext = CreateViewContext(view);
             var expectedWriter = viewContext.Writer;

--- a/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Infrastructure/DefaultPageFactoryProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Infrastructure/DefaultPageFactoryProviderTest.cs
@@ -294,7 +294,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
             IModelMetadataProvider provider = null,
             IUrlHelperFactory urlHelperFactory = null,
             IJsonHelper jsonHelper = null,
-            DiagnosticSource diagnosticSource = null,
+            DiagnosticListener diagnosticListener = null,
             HtmlEncoder htmlEncoder = null,
             IModelExpressionProvider modelExpressionProvider = null)
         {
@@ -303,7 +303,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
                 provider ?? Mock.Of<IModelMetadataProvider>(),
                 urlHelperFactory ?? Mock.Of<IUrlHelperFactory>(),
                 jsonHelper ?? Mock.Of<IJsonHelper>(),
-                diagnosticSource ?? new DiagnosticListener("Microsoft.AspNetCore.Mvc.RazorPages"),
+                diagnosticListener ?? new DiagnosticListener("Microsoft.AspNetCore.Mvc.RazorPages"),
                 htmlEncoder ?? HtmlEncoder.Default,
                 modelExpressionProvider ?? Mock.Of<IModelExpressionProvider>());
         }
@@ -375,10 +375,10 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
             [RazorInject]
             public IModelExpressionProvider ModelExpressionProviderWithInject { get; set; }
 
-            public DiagnosticSource DiagnosticSourceWithoutInject { get; set; }
+            public DiagnosticListener DiagnosticSourceWithoutInject { get; set; }
 
             [RazorInject]
-            public DiagnosticSource DiagnosticSourceWithInject { get; set; }
+            public DiagnosticListener DiagnosticSourceWithInject { get; set; }
 
             public ILogger LoggerWithoutInject { get; set; }
 

--- a/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/DefaultPageApplicationModelProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/DefaultPageApplicationModelProviderTest.cs
@@ -38,12 +38,12 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 
         private class InvalidPageWithWrongBaseClass : RazorPageBase
         {
-            public override void BeginContext(int position, int length, bool isLiteral)
+            protected override void BeginContextImpl(int position, int length, bool isLiteral)
             {
                 throw new NotImplementedException();
             }
 
-            public override void EndContext()
+            protected override void EndContextImpl()
             {
                 throw new NotImplementedException();
             }

--- a/test/Microsoft.AspNetCore.Mvc.Test/MvcOptionsSetupTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Test/MvcOptionsSetupTest.cs
@@ -265,7 +265,7 @@ namespace Microsoft.AspNetCore.Mvc
         {
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddSingleton(new ApplicationPartManager());
-            serviceCollection.AddSingleton<DiagnosticSource>(new DiagnosticListener("Microsoft.AspNetCore.Mvc"));
+            serviceCollection.AddSingleton<DiagnosticListener>(new DiagnosticListener("Microsoft.AspNetCore.Mvc"));
             serviceCollection.AddMvc();
             serviceCollection
                 .AddSingleton<ObjectPoolProvider, DefaultObjectPoolProvider>()

--- a/test/Microsoft.AspNetCore.Mvc.Test/MvcServiceCollectionExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Test/MvcServiceCollectionExtensionsTest.cs
@@ -265,7 +265,7 @@ namespace Microsoft.AspNetCore.Mvc
 
             services.AddSingleton<IHostingEnvironment>(GetHostingEnvironment());
             services.AddSingleton<ObjectPoolProvider, DefaultObjectPoolProvider>();
-            services.AddSingleton<DiagnosticSource>(new DiagnosticListener("Microsoft.AspNet"));
+            services.AddSingleton<DiagnosticListener>(new DiagnosticListener("Microsoft.AspNet"));
             services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
             services.AddLogging();
             services.AddOptions();

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponentResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponentResultTest.cs
@@ -561,7 +561,7 @@ namespace Microsoft.AspNetCore.Mvc
             }
 
             var services = new ServiceCollection();
-            services.AddSingleton<DiagnosticSource>(diagnosticSource);
+            services.AddSingleton<DiagnosticListener>(diagnosticSource);
             services.AddSingleton<ViewComponentInvokerCache>();
             services.AddSingleton<ExpressionTextCache>();
             services.AddSingleton(Options.Create(new MvcViewOptions()));

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponents/ViewViewComponentResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewComponents/ViewViewComponentResultTest.cs
@@ -355,7 +355,7 @@ namespace Microsoft.AspNetCore.Mvc
             var serviceProvider = new Mock<IServiceProvider>();
             serviceProvider.Setup(p => p.GetService(typeof(ICompositeViewEngine)))
                 .Returns(viewEngine.Object);
-            serviceProvider.Setup(p => p.GetService(typeof(DiagnosticSource)))
+            serviceProvider.Setup(p => p.GetService(typeof(DiagnosticListener)))
                 .Returns(new DiagnosticListener("Test"));
 
             var viewData = new ViewDataDictionary(new EmptyModelMetadataProvider());
@@ -519,7 +519,7 @@ namespace Microsoft.AspNetCore.Mvc
             diagnosticSource.SubscribeWithAdapter(diagnosticListener);
 
             var serviceProvider = new Mock<IServiceProvider>();
-            serviceProvider.Setup(s => s.GetService(typeof(DiagnosticSource))).Returns(diagnosticSource);
+            serviceProvider.Setup(s => s.GetService(typeof(DiagnosticListener))).Returns(diagnosticSource);
 
             var httpContext = new DefaultHttpContext();
             httpContext.RequestServices = serviceProvider.Object;

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/PartialViewResultExecutorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/PartialViewResultExecutorTest.cs
@@ -184,12 +184,12 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         public void FindView_WritesDiagnostic_ViewFound()
         {
             // Arrange
-            var diagnosticSource = new DiagnosticListener("Test");
+            var diagnosticListener = new DiagnosticListener("Test");
             var listener = new TestDiagnosticListener();
-            diagnosticSource.SubscribeWithAdapter(listener);
+            diagnosticListener.SubscribeWithAdapter(listener);
 
             var context = GetActionContext();
-            var executor = GetViewExecutor(diagnosticSource);
+            var executor = GetViewExecutor(diagnosticListener);
 
             var viewName = "myview";
             var viewResult = new PartialViewResult
@@ -217,12 +217,12 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         public void FindView_WritesDiagnostic_ViewNotFound()
         {
             // Arrange
-            var diagnosticSource = new DiagnosticListener("Test");
+            var diagnosticListener = new DiagnosticListener("Test");
             var listener = new TestDiagnosticListener();
-            diagnosticSource.SubscribeWithAdapter(listener);
+            diagnosticListener.SubscribeWithAdapter(listener);
 
             var context = GetActionContext();
-            var executor = GetViewExecutor(diagnosticSource);
+            var executor = GetViewExecutor(diagnosticListener);
 
             var viewName = "myview";
             var viewEngine = new Mock<IViewEngine>(MockBehavior.Strict);
@@ -316,11 +316,11 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             return new ActionContext(new DefaultHttpContext(), routeData, new ControllerActionDescriptor() { ActionName = actionName });
         }
 
-        private PartialViewResultExecutor GetViewExecutor(DiagnosticSource diagnosticSource = null)
+        private PartialViewResultExecutor GetViewExecutor(DiagnosticListener diagnosticListener = null)
         {
-            if (diagnosticSource == null)
+            if (diagnosticListener == null)
             {
-                diagnosticSource = new DiagnosticListener("Test");
+                diagnosticListener = new DiagnosticListener("Test");
             }
 
             var viewEngine = new Mock<IViewEngine>(MockBehavior.Strict);
@@ -341,7 +341,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 new TestHttpResponseStreamWriterFactory(),
                 new CompositeViewEngine(options),
                 new TempDataDictionaryFactory(new SessionStateTempDataProvider()),
-                diagnosticSource,
+                diagnosticListener,
                 NullLoggerFactory.Instance,
                 new EmptyModelMetadataProvider());
 

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/ViewExecutorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/ViewExecutorTest.cs
@@ -235,10 +235,10 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 
             var adapter = new TestDiagnosticListener();
 
-            var diagnosticSource = new DiagnosticListener("Test");
-            diagnosticSource.SubscribeWithAdapter(adapter);
+            var diagnosticListener = new DiagnosticListener("Test");
+            diagnosticListener.SubscribeWithAdapter(adapter);
 
-            var viewExecutor = CreateViewExecutor(diagnosticSource);
+            var viewExecutor = CreateViewExecutor(diagnosticListener);
 
             // Act
             await viewExecutor.ExecuteAsync(
@@ -351,11 +351,11 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             return view.Object;
         }
 
-        private ViewExecutor CreateViewExecutor(DiagnosticListener diagnosticSource = null)
+        private ViewExecutor CreateViewExecutor(DiagnosticListener diagnosticListener = null)
         {
-            if (diagnosticSource == null)
+            if (diagnosticListener == null)
             {
-                diagnosticSource = new DiagnosticListener("Test");
+                diagnosticListener = new DiagnosticListener("Test");
             }
 
             return new ViewExecutor(
@@ -363,7 +363,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 new TestHttpResponseStreamWriterFactory(),
                 new Mock<ICompositeViewEngine>(MockBehavior.Strict).Object,
                 new TempDataDictionaryFactory(new SessionStateTempDataProvider()),
-                diagnosticSource,
+                diagnosticListener,
                 new EmptyModelMetadataProvider());
         }
     }

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/ViewResultExecutorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/ViewFeatures/ViewResultExecutorTest.cs
@@ -180,12 +180,12 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         public void FindView_WritesDiagnostic_ViewFound()
         {
             // Arrange
-            var diagnosticSource = new DiagnosticListener("Test");
+            var diagnosticListener = new DiagnosticListener("Test");
             var listener = new TestDiagnosticListener();
-            diagnosticSource.SubscribeWithAdapter(listener);
+            diagnosticListener.SubscribeWithAdapter(listener);
 
             var context = GetActionContext();
-            var executor = GetViewExecutor(diagnosticSource);
+            var executor = GetViewExecutor(diagnosticListener);
 
             var viewName = "myview";
             var viewResult = new ViewResult
@@ -213,12 +213,12 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         public void FindView_WritesDiagnostic_ViewNotFound()
         {
             // Arrange
-            var diagnosticSource = new DiagnosticListener("Test");
+            var diagnosticListener = new DiagnosticListener("Test");
             var listener = new TestDiagnosticListener();
-            diagnosticSource.SubscribeWithAdapter(listener);
+            diagnosticListener.SubscribeWithAdapter(listener);
 
             var context = GetActionContext();
-            var executor = GetViewExecutor(diagnosticSource);
+            var executor = GetViewExecutor(diagnosticListener);
 
             var viewName = "myview";
             var viewEngine = new Mock<IViewEngine>(MockBehavior.Strict);
@@ -306,11 +306,11 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             return new ActionContext(new DefaultHttpContext(), routeData, new ControllerActionDescriptor() { ActionName = actionName });
         }
 
-        private ViewResultExecutor GetViewExecutor(DiagnosticListener diagnosticSource = null)
+        private ViewResultExecutor GetViewExecutor(DiagnosticListener diagnosticListener = null)
         {
-            if (diagnosticSource == null)
+            if (diagnosticListener == null)
             {
-                diagnosticSource = new DiagnosticListener("Test");
+                diagnosticListener = new DiagnosticListener("Test");
             }
 
             var viewEngine = new Mock<IViewEngine>(MockBehavior.Strict);
@@ -331,7 +331,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 new TestHttpResponseStreamWriterFactory(),
                 new CompositeViewEngine(options),
                 new TempDataDictionaryFactory(new SessionStateTempDataProvider()),
-                diagnosticSource,
+                diagnosticListener,
                 NullLoggerFactory.Instance,
                 new EmptyModelMetadataProvider());
 


### PR DESCRIPTION
Inlinable fast-path check if Diagnositcs is enabled

For 9k requests I'm looking at 45M calls to the non-inlinable `.IsEnabled(string)`

![image](https://user-images.githubusercontent.com/1142958/44751099-29dcde80-ab0f-11e8-930d-a3d3aae3a6e4.png)

And 19M calls each to the non-inlinable `BeginContext`+`EndContext`  

![image](https://user-images.githubusercontent.com/1142958/44751190-6577a880-ab0f-11e8-8815-0bd1dd4cc910.png)

Breaking changes 
* `DiagnosticSource` -> `DiagnosticListener` for inline non-virtual `.IsEnabled()`
* `BeginContext`+`EndContext` abstract -> non-virtual so inlinable (with above check)
* protected `BeginContextImpl`+`EndContextImpl` as the new abstract methods (with non-inlinable virtual `.IsEnabled(string)` call)

Proposing to 3.0 branch (master?) due to breaking changes

/cc @mkArtakMSFT @pranavkm