### PR TITLE
Reduce IList interface calls

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/PagedBufferedTextWriter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/PagedBufferedTextWriter.cs
@@ -37,7 +37,8 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             }
 
             var pages = _charBuffer.Pages;
-            for (var i = 0; i < pages.Count; i++)
+            var count = pages.Count;
+            for (var i = 0; i < count; i++)
             {
                 var page = pages[i];
                 var pageLength = Math.Min(length, page.Length);

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/PagedCharBuffer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/PagedCharBuffer.cs
@@ -11,7 +11,6 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
     {
         public const int PageSize = 1024;
         private int _charIndex;
-        private List<char[]> _pages = new List<char[]>();
 
         public PagedCharBuffer(ICharBufferSource bufferSource)
         {
@@ -20,14 +19,15 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
 
         public ICharBufferSource BufferSource { get; }
 
-        public IList<char[]> Pages => _pages;
+        // Strongly typed rather than IList for performance
+        public List<char[]> Pages { get; } = new List<char[]>(); 
 
         public int Length
         {
             get
             {
                 var length = _charIndex;
-                var pages = _pages;
+                var pages = Pages;
                 var fullPages = pages.Count - 1;
                 for (var i = 0; i < fullPages; i++)
                 {
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
         /// </summary>
         public void Clear()
         {
-            var pages = _pages;
+            var pages = Pages;
             for (var i = pages.Count - 1; i > 0; i--)
             {
                 var page = pages[i];
@@ -139,7 +139,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             try
             {
                 page = BufferSource.Rent(PageSize);
-                _pages.Add(page);
+                Pages.Add(page);
             }
             catch when (page != null)
             {
@@ -152,7 +152,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
 
         public void Dispose()
         {
-            var pages = _pages;
+            var pages = Pages;
             var count = pages.Count;
             for (var i = 0; i < count; i++)
             {

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Internal/PagedCharBufferTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Internal/PagedCharBufferTest.cs
@@ -469,14 +469,14 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
 
             // Assert - 1
             Assert.Equal(0, buffer.Length);
-            Assert.Equal(1, buffer.Pages.Count);
+            Assert.Single(buffer.Pages);
 
             // Act - 2
             buffer.Append("efgh");
 
             // Assert - 2
             Assert.Equal(4, buffer.Length);
-            Assert.Equal(1, buffer.Pages.Count);
+            Assert.Single(buffer.Pages);
             Assert.Equal(new[] { 'e', 'f', 'g', 'h' }, buffer.Pages[0].Take(buffer.Length));
         }
     }


### PR DESCRIPTION
When internal to class refer directly to concrete type.

Cache `.Count` in local rather than calling it repeatedly as a loop condition.

10 requests

Previous

![image](https://user-images.githubusercontent.com/1142958/44761799-683cc280-ab3c-11e8-9022-71dae291dbcc.png)

Post

![image](https://user-images.githubusercontent.com/1142958/44761806-75f24800-ab3c-11e8-90d0-8e92b791da37.png)

Resolves https://github.com/aspnet/Mvc/issues/8354