### PR TITLE
Fast-path async in PagedBufferedTextWriter

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/PagedBufferedTextWriter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/PagedBufferedTextWriter.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -30,7 +31,9 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
 
         public override Task FlushAsync() => FlushAsyncCore();
 
-        // private non-virtual for internal calling
+        // private non-virtual for internal calling.
+        // It first does a fast check to see if async is necessary, we inline this check.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private Task FlushAsyncCore()
         {
             var length = _charBuffer.Length;


### PR DESCRIPTION
`PagedBufferedTextWriter` creates and executes far more async statemachines than it requires.

1 request in the RazorRendering benchmarkapp https://github.com/aspnet/Mvc/pull/8366 currently creates 9,764 FlushAsync statemachines and 8,774 WriteAsync statemachines

![image](https://user-images.githubusercontent.com/1142958/44939983-7e879000-ad81-11e8-9650-95d867849141.png)

Adding the fast-path reduces it to 900 FlushAsync statemachines (all from when FlushAsync is called externally) 

![image](https://user-images.githubusercontent.com/1142958/44940161-d1ae1280-ad82-11e8-977c-603acf15c2c0.png)

Resolves https://github.com/aspnet/Mvc/issues/8370