### PR TITLE
Adds ObjectResult for Forbid Response

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
@@ -2221,10 +2221,11 @@ namespace Microsoft.AspNetCore.Mvc
             => new ChallengeResult(authenticationSchemes, properties);
 
         /// <summary>
-        /// Creates a <see cref="ForbidResult"/> (<see cref="StatusCodes.Status403Forbidden"/> by default).
+        /// Creates a <see cref="ForbidResult"/>.
         /// </summary>
         /// <returns>The created <see cref="ForbidResult"/> for the response.</returns>
         /// <remarks>
+        /// The behavior of this method depends on the <see cref="IAuthenticationService"/> in use.
         /// Some authentication schemes, such as cookies, will convert <see cref="StatusCodes.Status403Forbidden"/> to
         /// a redirect to show a login page.
         /// </remarks>
@@ -2233,25 +2234,12 @@ namespace Microsoft.AspNetCore.Mvc
             => new ForbidResult();
 
         /// <summary>
-        /// Creates a <see cref="ForbidObjectResult"/> (<see cref="StatusCodes.Status403Forbidden"/> by default).
-        /// </summary>
-        /// <param name="value">The content value to format in the entity body.</param>
-        /// <returns>The created <see cref="ForbidObjectResult"/> for the response.</returns>
-        /// <remarks>
-        /// Some authentication schemes, such as cookies, will convert <see cref="StatusCodes.Status403Forbidden"/> to
-        /// a redirect to show a login page.
-        /// </remarks>
-        [NonAction]
-        public virtual ForbidObjectResult Forbid(object value)
-            => new ForbidObjectResult(value);
-
-        /// <summary>
-        /// Creates a <see cref="ForbidResult"/> (<see cref="StatusCodes.Status403Forbidden"/> by default) with the
-        /// specified authentication schemes.
+        /// Creates a <see cref="ForbidResult"/> with the specified authentication schemes.
         /// </summary>
         /// <param name="authenticationSchemes">The authentication schemes to challenge.</param>
         /// <returns>The created <see cref="ForbidResult"/> for the response.</returns>
         /// <remarks>
+        /// The behavior of this method depends on the <see cref="IAuthenticationService"/> in use.
         /// Some authentication schemes, such as cookies, will convert <see cref="StatusCodes.Status403Forbidden"/> to
         /// a redirect to show a login page.
         /// </remarks>
@@ -2260,13 +2248,13 @@ namespace Microsoft.AspNetCore.Mvc
             => new ForbidResult(authenticationSchemes);
 
         /// <summary>
-        /// Creates a <see cref="ForbidResult"/> (<see cref="StatusCodes.Status403Forbidden"/> by default) with the
-        /// specified <paramref name="properties" />.
+        /// Creates a <see cref="ForbidResult"/> with the specified <paramref name="properties" />.
         /// </summary>
         /// <param name="properties"><see cref="AuthenticationProperties"/> used to perform the authentication
         /// challenge.</param>
         /// <returns>The created <see cref="ForbidResult"/> for the response.</returns>
         /// <remarks>
+        /// The behavior of this method depends on the implementation of the <see cref="IAuthenticationService"/> in use. 
         /// Some authentication schemes, such as cookies, will convert <see cref="StatusCodes.Status403Forbidden"/> to 
         /// a redirect to show a login page.
         /// </remarks>
@@ -2283,12 +2271,78 @@ namespace Microsoft.AspNetCore.Mvc
         /// <param name="authenticationSchemes">The authentication schemes to challenge.</param>
         /// <returns>The created <see cref="ForbidResult"/> for the response.</returns>
         /// <remarks>
+        /// The behavior of this method depends on the <see cref="IAuthenticationService"/> in use.
         /// Some authentication schemes, such as cookies, will convert <see cref="StatusCodes.Status403Forbidden"/> to
         /// a redirect to show a login page.
         /// </remarks>
         [NonAction]
         public virtual ForbidResult Forbid(AuthenticationProperties properties, params string[] authenticationSchemes)
             => new ForbidResult(authenticationSchemes, properties);
+
+        /// <summary>
+        /// Creates a <see cref="ForbidObjectResult"/> (<see cref="StatusCodes.Status403Forbidden"/> by default).
+        /// </summary>
+        /// <param name="value">The content value to format in the entity body.</param>
+        /// <returns>The created <see cref="ForbidObjectResult"/> for the response.</returns>
+        /// <remarks>
+        /// The behavior of this method depends on the <see cref="IAuthenticationService"/> in use.
+        /// Some authentication schemes, such as cookies, will convert <see cref="StatusCodes.Status403Forbidden"/> to
+        /// a redirect to show a login page.
+        /// </remarks>
+        [NonAction]
+        public virtual ForbidObjectResult Forbid(object value)
+            => new ForbidObjectResult(value);
+
+        /// <summary>
+        /// Creates a <see cref="ForbidResult"/> (<see cref="StatusCodes.Status403Forbidden"/> by default) with the
+        /// specified authentication schemes.
+        /// </summary>
+        /// <param name="value">The content value to format in the entity body.</param>
+        /// <param name="authenticationSchemes">The authentication schemes to challenge.</param>
+        /// <returns>The created <see cref="ForbidResult"/> for the response.</returns>
+        /// <remarks>
+        /// The behavior of this method depends on the <see cref="IAuthenticationService"/> in use.
+        /// Some authentication schemes, such as cookies, will convert <see cref="StatusCodes.Status403Forbidden"/> to
+        /// a redirect to show a login page.
+        /// </remarks>
+        [NonAction]
+        public virtual ForbidObjectResult Forbid(object value, params string[] authenticationSchemes)
+            => new ForbidObjectResult(value, authenticationSchemes);
+
+        /// <summary>
+        /// Creates a <see cref="ForbidResult"/> (<see cref="StatusCodes.Status403Forbidden"/> by default) with the
+        /// specified <paramref name="properties" />.
+        /// </summary>
+        /// <param name="value">The content value to format in the entity body.</param>
+        /// <param name="properties"><see cref="AuthenticationProperties"/> used to perform the authentication
+        /// challenge.</param>
+        /// <returns>The created <see cref="ForbidResult"/> for the response.</returns>
+        /// <remarks>
+        /// The behavior of this method depends on the <see cref="IAuthenticationService"/> in use.
+        /// Some authentication schemes, such as cookies, will convert <see cref="StatusCodes.Status403Forbidden"/> to 
+        /// a redirect to show a login page.
+        /// </remarks>
+        [NonAction]
+        public virtual ForbidObjectResult Forbid(object value, AuthenticationProperties properties)
+            => new ForbidObjectResult(value, properties);
+
+        /// <summary>
+        /// Creates a <see cref="ForbidResult"/> (<see cref="StatusCodes.Status403Forbidden"/> by default) with the 
+        /// specified authentication schemes and <paramref name="properties" />.
+        /// </summary>
+        /// <param name="value">The content value to format in the entity body.</param>
+        /// <param name="properties"><see cref="AuthenticationProperties"/> used to perform the authentication
+        /// challenge.</param>
+        /// <param name="authenticationSchemes">The authentication schemes to challenge.</param>
+        /// <returns>The created <see cref="ForbidResult"/> for the response.</returns>
+        /// <remarks>
+        /// The behavior of this method depends on the <see cref="IAuthenticationService"/> in use.
+        /// Some authentication schemes, such as cookies, will convert <see cref="StatusCodes.Status403Forbidden"/> to
+        /// a redirect to show a login page.
+        /// </remarks>
+        [NonAction]
+        public virtual ForbidObjectResult Forbid(object value, AuthenticationProperties properties, params string[] authenticationSchemes)
+            => new ForbidObjectResult(value, authenticationSchemes, properties);
 
         /// <summary>
         /// Creates a <see cref="SignInResult"/> with the specified authentication scheme.

--- a/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ControllerBase.cs
@@ -2233,6 +2233,19 @@ namespace Microsoft.AspNetCore.Mvc
             => new ForbidResult();
 
         /// <summary>
+        /// Creates a <see cref="ForbidObjectResult"/> (<see cref="StatusCodes.Status403Forbidden"/> by default).
+        /// </summary>
+        /// <param name="value">The content value to format in the entity body.</param>
+        /// <returns>The created <see cref="ForbidObjectResult"/> for the response.</returns>
+        /// <remarks>
+        /// Some authentication schemes, such as cookies, will convert <see cref="StatusCodes.Status403Forbidden"/> to
+        /// a redirect to show a login page.
+        /// </remarks>
+        [NonAction]
+        public virtual ForbidObjectResult Forbid(object value)
+            => new ForbidObjectResult(value);
+
+        /// <summary>
         /// Creates a <see cref="ForbidResult"/> (<see cref="StatusCodes.Status403Forbidden"/> by default) with the
         /// specified authentication schemes.
         /// </summary>

--- a/src/Microsoft.AspNetCore.Mvc.Core/ForbidObjectResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ForbidObjectResult.cs
@@ -107,6 +107,7 @@ namespace Microsoft.AspNetCore.Mvc
                 throw new ArgumentNullException(nameof(context));
             }
 
+            var executor = context.HttpContext.RequestServices.GetRequiredService<IActionResultExecutor<ForbidObjectResult>>();
             var loggerFactory = context.HttpContext.RequestServices.GetRequiredService<ILoggerFactory>();
             var logger = loggerFactory.CreateLogger<ForbidResult>();
 
@@ -123,6 +124,8 @@ namespace Microsoft.AspNetCore.Mvc
             {
                 await context.HttpContext.ForbidAsync(Properties);
             }
+
+            await executor.ExecuteAsync(context, this);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/ForbidObjectResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ForbidObjectResult.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+
+namespace Microsoft.AspNetCore.Mvc
+{
+    /// <summary>
+    /// An <see cref="ObjectResult"/> that when executed will produce a Forbidden (403) response.
+    /// </summary>
+    [DefaultStatusCode(DefaultStatusCode)]
+    public class ForbidObjectResult : ObjectResult
+    {
+        private const int DefaultStatusCode = StatusCodes.Status403Forbidden;
+
+        /// <summary>
+        /// Creates a new <see cref="ForbidObjectResult"/> instance.
+        /// </summary>
+        public ForbidObjectResult(object value) : base(value)
+        {
+            StatusCode = DefaultStatusCode;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/ForbidObjectResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ForbidObjectResult.cs
@@ -1,13 +1,20 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Mvc
 {
     /// <summary>
-    /// An <see cref="ObjectResult"/> that when executed will produce a Forbidden (403) response.
+    /// An <see cref="ObjectResult"/> that when executed will produce a <see cref="StatusCodes.Status403Forbidden"/> response.
     /// </summary>
     [DefaultStatusCode(DefaultStatusCode)]
     public class ForbidObjectResult : ObjectResult
@@ -15,11 +22,107 @@ namespace Microsoft.AspNetCore.Mvc
         private const int DefaultStatusCode = StatusCodes.Status403Forbidden;
 
         /// <summary>
-        /// Creates a new <see cref="ForbidObjectResult"/> instance.
+        /// Initializes a new instance of <see cref="ForbidObjectResult"/>.
         /// </summary>
-        public ForbidObjectResult(object value) : base(value)
+        /// <param name="value">Response payload.</param>
+        public ForbidObjectResult(object value)
+            : this(value, Array.Empty<string>())
         {
-            StatusCode = DefaultStatusCode;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="ForbidObjectResult"/> with the
+        /// specified authentication scheme.
+        /// </summary>
+        /// <param name="authenticationScheme">The authentication scheme to challenge.</param>
+        /// <param name="value">Response payload.</param>
+        public ForbidObjectResult(object value, string authenticationScheme)
+            : this(value, new[] { authenticationScheme })
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="ForbidObjectResult"/> with the
+        /// specified authentication schemes.
+        /// </summary>
+        /// <param name="authenticationSchemes">The authentication schemes to challenge.</param>
+        /// <param name="value">Response payload.</param>
+        public ForbidObjectResult(object value, IList<string> authenticationSchemes)
+            : this(value, authenticationSchemes, properties: null)
+        {
+        }
+        /// <summary>
+        /// Initializes a new instance of <see cref="ForbidObjectResult"/> with the
+        /// specified <paramref name="properties"/>.
+        /// </summary>
+        /// <param name="properties"><see cref="AuthenticationProperties"/> used to perform the authentication
+        /// challenge.</param>
+        /// <param name="value">Response payload.</param>
+        public ForbidObjectResult(object value, AuthenticationProperties properties)
+            : this(value, Array.Empty<string>(), properties)
+        {
+        }
+        /// <summary>
+        /// Initializes a new instance of <see cref="ForbidObjectResult"/> with the
+        /// specified authentication scheme and <paramref name="properties"/>.
+        /// </summary>
+        /// <param name="authenticationScheme">The authentication schemes to challenge.</param>
+        /// <param name="properties"><see cref="AuthenticationProperties"/> used to perform the authentication
+        /// challenge.</param>
+        /// <param name="value">Response payload.</param>
+        public ForbidObjectResult(object value, string authenticationScheme, AuthenticationProperties properties)
+            : this(value, new[] { authenticationScheme }, properties)
+        {
+        }
+        /// <summary>
+        /// Initializes a new instance of <see cref="ForbidObjectResult"/> with the
+        /// specified authentication schemes and <paramref name="properties"/>.
+        /// </summary>
+        /// <param name="authenticationSchemes">The authentication scheme to challenge.</param>
+        /// <param name="properties"><see cref="AuthenticationProperties"/> used to perform the authentication
+        /// challenge.</param>
+        /// <param name="value">Response payload.</param>
+        public ForbidObjectResult(object value, IList<string> authenticationSchemes, AuthenticationProperties properties)
+            : base(value)
+        {
+            AuthenticationSchemes = authenticationSchemes;
+            Properties = properties;
+        }
+
+        /// <summary>
+        /// Gets or sets the authentication schemes that are challenged.
+        /// </summary>
+        public IList<string> AuthenticationSchemes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="AuthenticationProperties"/> used to perform the authentication challenge.
+        /// </summary>
+        public AuthenticationProperties Properties { get; set; }
+
+        /// <inheritdoc />
+        public override async Task ExecuteResultAsync(ActionContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var loggerFactory = context.HttpContext.RequestServices.GetRequiredService<ILoggerFactory>();
+            var logger = loggerFactory.CreateLogger<ForbidResult>();
+
+            logger.ForbidResultExecuting(AuthenticationSchemes);
+
+            if (AuthenticationSchemes != null && AuthenticationSchemes.Count > 0)
+            {
+                for (var i = 0; i < AuthenticationSchemes.Count; i++)
+                {
+                    await context.HttpContext.ForbidAsync(AuthenticationSchemes[i], Properties);
+                }
+            }
+            else
+            {
+                await context.HttpContext.ForbidAsync(Properties);
+            }
         }
     }
 }


### PR DESCRIPTION
[RFC 7231, in section 6.5.3. 403 Forbidden](https://tools.ietf.org/html/rfc7231#page-59), specifically states:

> A server that wishes to make public why the request has been forbidden can describe that reason in the response payload (if any).

Fixes #8219