### PR TITLE
Micro performance improvement in ModelState.IsValid

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelStateDictionary.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Abstractions/ModelBinding/ModelStateDictionary.cs
@@ -147,7 +147,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         {
             get
             {
-                return ValidationState == ModelValidationState.Valid || ValidationState == ModelValidationState.Skipped;
+                var state = ValidationState;
+                return state == ModelValidationState.Valid || state == ModelValidationState.Skipped;
             }
         }
 


### PR DESCRIPTION
# Overview
Currently, `ModelState.IsValid` calls `GetValidity` method twice. However `GetValidity` method is recursive method which is a little heavy, so we shouldn't call it twice. This pull-request resolves this problem using local variable cache.


# Risk
Low. Only use local variable.