### PR TITLE
Add missing license headers to src files

### DIFF
--- a/src/GetDocumentInsider/Commands/GetDocumentCommandContext.cs
+++ b/src/GetDocumentInsider/Commands/GetDocumentCommandContext.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.Extensions.ApiDescription.Client.Commands
 {

--- a/src/GetDocumentInsider/Commands/GetDocumentCommandWorker.cs
+++ b/src/GetDocumentInsider/Commands/GetDocumentCommandWorker.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;

--- a/src/GetDocumentInsider/LogWrapper.cs
+++ b/src/GetDocumentInsider/LogWrapper.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.Extensions.ApiDescription.Client
 {

--- a/src/Microsoft.AspNetCore.Mvc.Razor/IModelTypeProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor/IModelTypeProvider.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.AspNetCore.Mvc.Razor
 {

--- a/src/Microsoft.AspNetCore.Mvc.Testing/Handlers/CookieContainerHandler.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Testing/Handlers/CookieContainerHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET  Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Net;

--- a/src/Microsoft.AspNetCore.Mvc.Testing/Handlers/RedirectHandler.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Testing/Handlers/RedirectHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET  Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Microsoft.AspNetCore.Mvc.Testing/WebApplicationFactory.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Testing/WebApplicationFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET  Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Microsoft.AspNetCore.Mvc.Testing/WebApplicationFactoryClientOptions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Testing/WebApplicationFactoryClientOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET  Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Microsoft.AspNetCore.Mvc.Testing/WebApplicationFactoryContentRootAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Testing/WebApplicationFactoryContentRootAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET  Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Microsoft.Extensions.ApiDescription.Client/DownloadFileCore.cs
+++ b/src/Microsoft.Extensions.ApiDescription.Client/DownloadFileCore.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.IO;
 using System.Net.Http;
 using System.Net.Sockets;

--- a/src/Microsoft.Extensions.ApiDescription.Client/GetFileReferenceMetadata.cs
+++ b/src/Microsoft.Extensions.ApiDescription.Client/GetFileReferenceMetadata.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Build.Framework;

--- a/src/Microsoft.Extensions.ApiDescription.Client/GetProjectReferenceMetadata.cs
+++ b/src/Microsoft.Extensions.ApiDescription.Client/GetProjectReferenceMetadata.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Build.Framework;

--- a/src/Microsoft.Extensions.ApiDescription.Client/GetUriReferenceMetadata.cs
+++ b/src/Microsoft.Extensions.ApiDescription.Client/GetUriReferenceMetadata.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Build.Framework;

--- a/src/Microsoft.Extensions.ApiDescription.Client/ILogWrapper.cs
+++ b/src/Microsoft.Extensions.ApiDescription.Client/ILogWrapper.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.Extensions.ApiDescription.Client
 {

--- a/src/Microsoft.Extensions.ApiDescription.Client/LogWrapper.cs
+++ b/src/Microsoft.Extensions.ApiDescription.Client/LogWrapper.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.Extensions.ApiDescription.Client


### PR DESCRIPTION
- #8415
- also correct a typo in Microsoft.AspNetCore.Mvc.Testing files' headers