### PR TITLE
No HttpContext to route constraints in MvcEndpointDataSource

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.Mvc.Performance/MvcEndpointDatasourceBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.Mvc.Performance/MvcEndpointDatasourceBenchmark.cs
@@ -110,8 +110,7 @@ namespace Microsoft.AspNetCore.Mvc.Performance
         {
             var dataSource = new MvcEndpointDataSource(
                 actionDescriptorCollectionProvider,
-                new MvcEndpointInvokerFactory(new ActionInvokerFactory(Array.Empty<IActionInvokerProvider>())),
-                new MockServiceProvider());
+                new MvcEndpointInvokerFactory(new ActionInvokerFactory(Array.Empty<IActionInvokerProvider>())));
 
             return dataSource;
         }
@@ -124,14 +123,6 @@ namespace Microsoft.AspNetCore.Mvc.Performance
             }
 
             public ActionDescriptorCollection ActionDescriptors { get; }
-        }
-
-        private class MockServiceProvider : IServiceProvider
-        {
-            public object GetService(Type serviceType)
-            {
-                throw new NotImplementedException();
-            }
         }
 
         private class MockParameterPolicyFactory : ParameterPolicyFactory

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcEndpointDataSource.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcEndpointDataSource.cs
@@ -23,7 +23,6 @@ namespace Microsoft.AspNetCore.Mvc.Internal
     {
         private readonly IActionDescriptorCollectionProvider _actions;
         private readonly MvcEndpointInvokerFactory _invokerFactory;
-        private readonly DefaultHttpContext _httpContextInstance;
 
         // The following are protected by this lock for WRITES only. This pattern is similar
         // to DefaultActionDescriptorChangeProvider - see comments there for details on
@@ -35,8 +34,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
         public MvcEndpointDataSource(
             IActionDescriptorCollectionProvider actions,
-            MvcEndpointInvokerFactory invokerFactory,
-            IServiceProvider serviceProvider)
+            MvcEndpointInvokerFactory invokerFactory)
         {
             if (actions == null)
             {
@@ -48,14 +46,8 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                 throw new ArgumentNullException(nameof(invokerFactory));
             }
 
-            if (serviceProvider == null)
-            {
-                throw new ArgumentNullException(nameof(serviceProvider));
-            }
-
             _actions = actions;
             _invokerFactory = invokerFactory;
-            _httpContextInstance = new DefaultHttpContext() { RequestServices = serviceProvider };
 
             ConventionalEndpointInfos = new List<MvcEndpointInfo>();
 
@@ -358,7 +350,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
                     {
                         foreach (var constraint in constraints)
                         {
-                            if (!constraint.Match(_httpContextInstance, NullRouter.Instance, routeKey, new RouteValueDictionary(action.RouteValues), RouteDirection.IncomingRequest))
+                            if (!constraint.Match(httpContext: null, NullRouter.Instance, routeKey, new RouteValueDictionary(action.RouteValues), RouteDirection.IncomingRequest))
                             {
                                 // Did not match constraint
                                 return false;

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/MvcEndpointDataSourceTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Internal/MvcEndpointDataSourceTests.cs
@@ -711,8 +711,7 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
             var dataSource = new MvcEndpointDataSource(
                 actionDescriptorCollectionProvider,
-                mvcEndpointInvokerFactory ?? new MvcEndpointInvokerFactory(new ActionInvokerFactory(Array.Empty<IActionInvokerProvider>())),
-                services.BuildServiceProvider());
+                mvcEndpointInvokerFactory ?? new MvcEndpointInvokerFactory(new ActionInvokerFactory(Array.Empty<IActionInvokerProvider>())));
 
             return dataSource;
         }


### PR DESCRIPTION
No longer needed. `exists` constraint gets services from its constructor and argument null exceptions have been removed.