### PR TITLE
Add additional logging to diagnose flaky cache tag test.

### DIFF
--- a/test/WebSites/HtmlGenerationWebSite/Pages/CacheTagHelper_VaryByCulture.cshtml
+++ b/test/WebSites/HtmlGenerationWebSite/Pages/CacheTagHelper_VaryByCulture.cshtml
@@ -1,4 +1,5 @@
 @page
+@addTagHelper *, HtmlGenerationWebSite
 @using System.Globalization
 @functions
 {
@@ -9,6 +10,6 @@
 <h2 id="culture">@CultureInfo.CurrentCulture</h2>
 <h2 id="ui-culture">@CultureInfo.CurrentUICulture</h2>
 <span id="correlation-id">@CorrelationId</span>
-<cache vary-by-culture="true" vary-by-query="varyByQueryKey">
+<test-cache vary-by-culture="true" vary-by-query="varyByQueryKey">
     <span id="cached-correlation-id">@CorrelationId</span>
-</cache>
+</test-cache>

--- a/test/WebSites/HtmlGenerationWebSite/TestCacheTagHelper.cs
+++ b/test/WebSites/HtmlGenerationWebSite/TestCacheTagHelper.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
+using Microsoft.AspNetCore.Mvc.TagHelpers.Cache;
+using Microsoft.AspNetCore.Mvc.TagHelpers.Internal;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Logging;
+
+namespace HtmlGenerationWebSite
+{
+    // This TagHelper enables us to investigate potential flakiness in the test that uses this tracked by https://github.com/aspnet/Mvc/issues/8281
+    public class TestCacheTagHelper : CacheTagHelper
+    {
+        private readonly ILogger _logger;
+
+        public TestCacheTagHelper(
+            CacheTagHelperMemoryCacheFactory factory,
+            HtmlEncoder htmlEncoder,
+            ILoggerFactory loggerFactory) : base(factory, htmlEncoder)
+        {
+            if (loggerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            _logger = loggerFactory.CreateLogger<TestCacheTagHelper>();
+        }
+
+        public override Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+        {
+            var cacheKey = new CacheTagKey(this, context);
+            if (MemoryCache.TryGetValue(cacheKey, out var _))
+            {
+                _logger.LogInformation("Cache entry exists with key: " + cacheKey.GenerateKey());
+            }
+            else
+            {
+                _logger.LogInformation("Cache entry does NOT exist with key: " + cacheKey.GenerateKey());
+            }
+
+            return base.ProcessAsync(context, output);
+        }
+    }
+}


### PR DESCRIPTION
- Didn't want to add logging directly to product code so made a shim TagHelper that should reflect the same behavior but with more logging.

#8281 

Will merge this up to master if everything looks good (had failures in 2.2 and master).