### PR TITLE
Fix #8451

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/DefaultActionDescriptorCollectionProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/DefaultActionDescriptorCollectionProvider.cs
@@ -33,11 +33,12 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
 
             _actionDescriptorChangeProviders = actionDescriptorChangeProviders.ToArray();
 
+            _lock = new object();
+
+            // IMPORTANT: this needs to be the last thing we do in the constructor. Change notifications can happen immediately!
             ChangeToken.OnChange(
                 GetCompositeChangeToken,
                 UpdateCollection);
-
-            _lock = new object();
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcEndpointDataSource.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Internal/MvcEndpointDataSource.cs
@@ -58,6 +58,8 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
             ConventionalEndpointInfos = new List<MvcEndpointInfo>();
 
+            // IMPORTANT: this needs to be the last thing we do in the constructor. Change notifications can happen immediately!
+            //
             // It's possible for someone to override the collection provider without providing
             // change notifications. If that's the case we won't process changes.
             if (actions is ActionDescriptorCollectionProvider collectionProviderWithChangeToken)


### PR DESCRIPTION
Change tokens can call into your code IMMEDIATELY when you subscribe. I
reviewed our other usage of ChangeToken.OnChange in MVC and everything
looks good.