### PR TITLE
Use content-type specified by ProducesAttribute if no formatter supports it

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ApiExplorer/ApiResponseTypeProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ApiExplorer/ApiResponseTypeProvider.cs
@@ -152,6 +152,8 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
 
                 foreach (var contentType in contentTypes)
                 {
+                    var isSupportedContentType = false;
+
                     foreach (var responseTypeMetadataProvider in responseTypeMetadataProviders)
                     {
                         var formatterSupportedContentTypes = responseTypeMetadataProvider.GetSupportedContentTypes(
@@ -163,6 +165,8 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                             continue;
                         }
 
+                        isSupportedContentType = true;
+
                         foreach (var formatterSupportedContentType in formatterSupportedContentTypes)
                         {
                             apiResponse.ApiResponseFormats.Add(new ApiResponseFormat
@@ -171,6 +175,15 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                                 MediaType = formatterSupportedContentType,
                             });
                         }
+                    }
+
+                    if (!isSupportedContentType && contentType != null)
+                    {
+                        // No output formatter was found that supports this content type. Add the user specified content type as-is to the result.
+                        apiResponse.ApiResponseFormats.Add(new ApiResponseFormat
+                        {
+                            MediaType = contentType,
+                        });
                     }
                 }
             }

--- a/test/Microsoft.AspNetCore.Mvc.ApiExplorer.Test/ApiResponseTypeProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ApiExplorer.Test/ApiResponseTypeProviderTest.cs
@@ -45,7 +45,11 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                     Assert.False(responseType.IsDefaultResponse);
                     Assert.Collection(
                         responseType.ApiResponseFormats,
-                        format => Assert.Equal("application/json", format.MediaType));
+                        format =>
+                        {
+                            Assert.Equal("application/json", format.MediaType);
+                            Assert.IsType<TestOutputFormatter>(format.Formatter);
+                        });
                 },
                 responseType =>
                 {
@@ -106,7 +110,11 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                     Assert.False(responseType.IsDefaultResponse);
                     Assert.Collection(
                         responseType.ApiResponseFormats,
-                        format => Assert.Equal("application/json", format.MediaType));
+                        format =>
+                        {
+                            Assert.Equal("application/json", format.MediaType);
+                            Assert.IsType<TestOutputFormatter>(format.Formatter);
+                        });
                 },
                 responseType =>
                 {
@@ -115,7 +123,11 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                     Assert.False(responseType.IsDefaultResponse);
                     Assert.Collection(
                         responseType.ApiResponseFormats,
-                        format => Assert.Equal("application/json", format.MediaType));
+                        format =>
+                        {
+                            Assert.Equal("application/json", format.MediaType);
+                            Assert.IsType<TestOutputFormatter>(format.Formatter);
+                        });
                 },
                 responseType =>
                 {
@@ -156,7 +168,11 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                    Assert.False(responseType.IsDefaultResponse);
                    Assert.Collection(
                         responseType.ApiResponseFormats,
-                        format => Assert.Equal("application/json", format.MediaType));
+                        format =>
+                        {
+                            Assert.Equal("application/json", format.MediaType);
+                            Assert.IsType<TestOutputFormatter>(format.Formatter);
+                        });
                },
                responseType =>
                {
@@ -660,6 +676,36 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                     Assert.Collection(
                         responseType.ApiResponseFormats,
                         format => Assert.Equal("application/json", format.MediaType));
+                });
+        }
+
+        [Fact]
+        public void GetApiResponseTypes_UsesContentTypeWithoutWildCard_WhenNoFormatterSupportsIt()
+        {
+            // Arrange
+            var actionDescriptor = GetControllerActionDescriptor(typeof(TestController), nameof(TestController.GetUser));
+            actionDescriptor.FilterDescriptors.Add(new FilterDescriptor(new ProducesAttribute("application/pdf"), FilterScope.Action));
+
+            var provider = GetProvider();
+
+            // Act
+            var result = provider.GetApiResponseTypes(actionDescriptor);
+
+            // Assert
+            Assert.Collection(
+                result.OrderBy(r => r.StatusCode),
+                responseType =>
+                {
+                    Assert.Equal(200, responseType.StatusCode);
+                    Assert.Equal(typeof(DerivedModel), responseType.Type);
+                    Assert.False(responseType.IsDefaultResponse);
+                    Assert.Collection(
+                        responseType.ApiResponseFormats,
+                        format =>
+                        {
+                            Assert.Equal("application/pdf", format.MediaType);
+                            Assert.Null(format.Formatter);
+                        });
                 });
         }
 

--- a/test/WebSites/ApiExplorerWebSite/Controllers/ApiExplorerApiController.cs
+++ b/test/WebSites/ApiExplorerWebSite/Controllers/ApiExplorerApiController.cs
@@ -1,8 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Mvc;
+using System.IO;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 
 namespace ApiExplorerWebSite
 {
@@ -27,5 +28,8 @@ namespace ApiExplorerWebSite
         public void ActionWithFormFileCollectionParameter(IFormFileCollection formFile)
         {
         }
+
+        [Produces("application/pdf", Type = typeof(Stream))]
+        public IActionResult ProducesWithUnsupportedContentType() => null;
     }
 }


### PR DESCRIPTION
This allows users to use `ProducesAttribute` to specify the content-type
for action results such as FileStreamResult where the result determines the content type
and the specified value is informational.

Fixes https://github.com/aspnet/Mvc/issues/5701