### PR TITLE
Add .NET Core App 2.1 and 2.2 versions of GetDocumentInsider

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -7,7 +7,7 @@
       is not otherwise referenced. They avoid unnecessary changes to the Universe build graph or to product
       dependencies. Do not use these properties elsewhere.
     -->
-  
+
     <AngleSharpPackageVersion>0.9.9</AngleSharpPackageVersion>
     <BenchmarkDotNetPackageVersion>0.10.13</BenchmarkDotNetPackageVersion>
     <BenchmarksOnlyMicrosoftEntityFrameworkCoreDesignPackageVersion>2.1.1</BenchmarksOnlyMicrosoftEntityFrameworkCoreDesignPackageVersion>
@@ -54,7 +54,8 @@
     <MicrosoftAspNetCoreServerKestrelPackageVersion>2.2.0-preview2-35143</MicrosoftAspNetCoreServerKestrelPackageVersion>
     <MicrosoftAspNetCoreSessionPackageVersion>2.2.0-preview2-35143</MicrosoftAspNetCoreSessionPackageVersion>
     <MicrosoftAspNetCoreStaticFilesPackageVersion>2.2.0-preview2-35143</MicrosoftAspNetCoreStaticFilesPackageVersion>
-    <MicrosoftAspNetCoreTestHost20PackageVersion>2.0.0</MicrosoftAspNetCoreTestHost20PackageVersion>
+    <MicrosoftAspNetCoreTestHost20PackageVersion>2.0.3</MicrosoftAspNetCoreTestHost20PackageVersion>
+    <MicrosoftAspNetCoreTestHost21PackageVersion>2.1.1</MicrosoftAspNetCoreTestHost21PackageVersion>
     <MicrosoftAspNetCoreTestHostPackageVersion>2.2.0-preview2-35143</MicrosoftAspNetCoreTestHostPackageVersion>
     <MicrosoftAspNetCoreTestingPackageVersion>2.2.0-preview2-35143</MicrosoftAspNetCoreTestingPackageVersion>
     <MicrosoftAspNetCoreWebUtilitiesPackageVersion>2.2.0-preview2-35143</MicrosoftAspNetCoreWebUtilitiesPackageVersion>

--- a/src/GetDocumentInsider/Commands/GetDocumentCommand.cs
+++ b/src/GetDocumentInsider/Commands/GetDocumentCommand.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETCOREAPP2_1 || NETCOREAPP2_2
 using System.Runtime.Loader;
 #endif
 using Microsoft.DotNet.Cli.CommandLine;
@@ -82,7 +82,7 @@ namespace Microsoft.Extensions.ApiDescription.Client.Commands
                 }
             }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETCOREAPP2_1 || NETCOREAPP2_2
             AssemblyLoadContext.Default.Resolving += (loadContext, assemblyName) =>
             {
                 var name = assemblyName.Name;

--- a/src/GetDocumentInsider/GetDocumentInsider.csproj
+++ b/src/GetDocumentInsider/GetDocumentInsider.csproj
@@ -5,14 +5,22 @@
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
     <RootNamespace>Microsoft.Extensions.ApiDescription.Client</RootNamespace>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreTestHost20PackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreTestHost21PackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreTestHostPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/dotnet-getdocument/Commands/InvokeCommand.cs
+++ b/src/dotnet-getdocument/Commands/InvokeCommand.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Extensions.ApiDescription.Client.Commands
 
         private CommandOption _configuration;
         private CommandOption _framework;
-        private CommandOption _msbuildprojectextensionspath;
+        private CommandOption _MSBuildProjectExtensionsPath;
         private CommandOption _output;
         private CommandOption _project;
         private CommandOption _runtime;
@@ -33,7 +33,7 @@ namespace Microsoft.Extensions.ApiDescription.Client.Commands
             _framework = options.Framework;
             _configuration = options.Configuration;
             _runtime = options.Runtime;
-            _msbuildprojectextensionspath = options.MSBuildProjectExtensionsPath;
+            _MSBuildProjectExtensionsPath = options.MSBuildProjectExtensionsPath;
 
             _output = command.Option("--output <Path>", Resources.OutputDescription);
             command.VersionOption("--version", ProductInfo.GetVersion);
@@ -52,7 +52,7 @@ namespace Microsoft.Extensions.ApiDescription.Client.Commands
 
             var project = Project.FromFile(
                 projectFile,
-                _msbuildprojectextensionspath.Value(),
+                _MSBuildProjectExtensionsPath.Value(),
                 _framework.Value(),
                 _configuration.Value(),
                 _runtime.Value());
@@ -89,14 +89,21 @@ namespace Microsoft.Extensions.ApiDescription.Client.Commands
                         break;
 
                     case ".NETCoreApp":
-                        executable = "dotnet";
-                        toolsDirectory = Path.Combine(thisPath, "netcoreapp2.0");
-
                         if (targetFramework.Version < new Version(2, 0))
                         {
                             throw new CommandException(
                                 Resources.FormatNETCoreApp1Project(project.Name, targetFramework.Version));
                         }
+
+                        var targetFrameworkPath = project.TargetFramework;
+                        if (targetFramework.Version > new Version(2, 2))
+                        {
+                            // No current support for more recent target frameworks than 2.2.
+                            targetFrameworkPath = "netcoreapp2.2";
+                        }
+
+                        executable = "dotnet";
+                        toolsDirectory = Path.Combine(thisPath, targetFrameworkPath);
 
                         args.Add("exec");
                         args.Add("--depsFile");

--- a/src/dotnet-getdocument/dotnet-getdocument.csproj
+++ b/src/dotnet-getdocument/dotnet-getdocument.csproj
@@ -56,6 +56,8 @@
       <_Temporary Include="../GetDocumentInsider/GetDocumentInsider.csproj" Properties="TargetFramework=net461" />
       <_Temporary Include="../GetDocumentInsider/GetDocumentInsider.csproj" Properties="TargetFramework=net461;Platform=x86" />
       <_Temporary Include="../GetDocumentInsider/GetDocumentInsider.csproj" Properties="TargetFramework=netcoreapp2.0" />
+      <_Temporary Include="../GetDocumentInsider/GetDocumentInsider.csproj" Properties="TargetFramework=netcoreapp2.1" />
+      <_Temporary Include="../GetDocumentInsider/GetDocumentInsider.csproj" Properties="TargetFramework=netcoreapp2.2" />
     </ItemGroup>
 
     <MSBuild Projects="../GetDocumentInsider/GetDocumentInsider.csproj" RemoveProperties="RuntimeIdentifier;TargetFramework" Targets="Restore" />
@@ -74,7 +76,9 @@
         id=$(PackageId);
         InsiderNet461Output=..\GetDocumentInsider\bin\$(Configuration)\net461\publish\*;
         InsiderNet461X86Output=..\GetDocumentInsider\bin\x86\$(Configuration)\net461\publish\*;
-        InsiderNetCoreOutput=..\GetDocumentInsider\bin\$(Configuration)\netcoreapp2.0\publish\*;
+        InsiderNetCore20Output=..\GetDocumentInsider\bin\$(Configuration)\netcoreapp2.0\publish\*;
+        InsiderNetCore21Output=..\GetDocumentInsider\bin\$(Configuration)\netcoreapp2.1\publish\*;
+        InsiderNetCore22Output=..\GetDocumentInsider\bin\$(Configuration)\netcoreapp2.2\publish\*;
         licenseUrl=$(PackageLicenseUrl);
         Output=$(PublishDir)**\*;
         OutputShims=$(IntermediateOutputPath)shims\**\*;

--- a/src/dotnet-getdocument/dotnet-getdocument.nuspec
+++ b/src/dotnet-getdocument/dotnet-getdocument.nuspec
@@ -20,7 +20,9 @@
   <files>
     <file src="$InsiderNet461Output$" target="tools\$targetFramework$\any\net461" />
     <file src="$InsiderNet461X86Output$" target="tools\$targetFramework$\any\net461-x86" />
-    <file src="$InsiderNetCoreOutput$" target="tools\$targetFramework$\any\netcoreapp2.0" />
+    <file src="$InsiderNetCore20Output$" target="tools\$targetFramework$\any\netcoreapp2.0" />
+    <file src="$InsiderNetCore21Output$" target="tools\$targetFramework$\any\netcoreapp2.1" />
+    <file src="$InsiderNetCore22Output$" target="tools\$targetFramework$\any\netcoreapp2.2" />
     <file src="$Output$" target="tools\$targetFramework$\any" />
     <!-- file src="$OutputShims$" target="tools\$targetFramework$\any\shims" / -->
     <file src="$SettingsFile$" target="tools\$targetFramework$\any" />


### PR DESCRIPTION
- should make tool more compatible with various web sites

nit: fix casing of `_MSBuildProjectExtensionsPath` field