### PR TITLE
Get builds using Microsoft.Extensions.ApiDescription.Client working e2e

### DIFF
--- a/src/Microsoft.Extensions.ApiDescription.Client/GetFileReferenceMetadata.cs
+++ b/src/Microsoft.Extensions.ApiDescription.Client/GetFileReferenceMetadata.cs
@@ -94,13 +94,6 @@ namespace Microsoft.Extensions.ApiDescription.Client
                 }
 
                 var isTypeScript = codeGenerator.EndsWith(TypeScriptLanguageName, StringComparison.OrdinalIgnoreCase);
-                var targetLanguage = item.GetMetadata("TargetLanguage");
-                if (string.IsNullOrEmpty(targetLanguage))
-                {
-                    targetLanguage = isTypeScript ? TypeScriptLanguageName : CSharpLanguageName;
-                    MetadataSerializer.SetMetadata(newItem, "TargetLanguage", targetLanguage);
-                }
-
                 var @namespace = item.GetMetadata("Namespace");
                 if (string.IsNullOrEmpty(@namespace))
                 {

--- a/src/Microsoft.Extensions.ApiDescription.Client/GetFileReferenceMetadata.cs
+++ b/src/Microsoft.Extensions.ApiDescription.Client/GetFileReferenceMetadata.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Extensions.ApiDescription.Client
         {
             var outputs = new List<ITaskItem>(Inputs.Length);
             var destinations = new HashSet<string>();
+
             foreach (var item in Inputs)
             {
                 var newItem = new TaskItem(item);
@@ -114,6 +115,7 @@ namespace Microsoft.Extensions.ApiDescription.Client
                 }
 
                 // Add metadata which may be used as a property and passed to an inner build.
+                newItem.RemoveMetadata("SerializedMetadata");
                 newItem.SetMetadata("SerializedMetadata", MetadataSerializer.SerializeMetadata(newItem));
             }
 

--- a/src/Microsoft.Extensions.ApiDescription.Client/GetFileReferenceMetadata.cs
+++ b/src/Microsoft.Extensions.ApiDescription.Client/GetFileReferenceMetadata.cs
@@ -15,6 +15,9 @@ namespace Microsoft.Extensions.ApiDescription.Client
     /// </summary>
     public class GetFileReferenceMetadata : Task
     {
+        private const string CSharpLanguageName = "CSharp";
+        private const string TypeScriptLanguageName = "TypeScript";
+
         /// <summary>
         /// Default Namespace metadata value for C# output.
         /// </summary>
@@ -90,11 +93,18 @@ namespace Microsoft.Extensions.ApiDescription.Client
                     MetadataSerializer.SetMetadata(newItem, "ClassName", className);
                 }
 
-                var isTypeScript = codeGenerator.EndsWith("TypeScript", StringComparison.OrdinalIgnoreCase);
+                var isTypeScript = codeGenerator.EndsWith(TypeScriptLanguageName, StringComparison.OrdinalIgnoreCase);
+                var targetLanguage = item.GetMetadata("TargetLanguage");
+                if (string.IsNullOrEmpty(targetLanguage))
+                {
+                    targetLanguage = isTypeScript ? TypeScriptLanguageName : CSharpLanguageName;
+                    MetadataSerializer.SetMetadata(newItem, "TargetLanguage", targetLanguage);
+                }
+
                 var @namespace = item.GetMetadata("Namespace");
                 if (string.IsNullOrEmpty(@namespace))
                 {
-                    @namespace = isTypeScript ? CSharpNamespace : TypeScriptNamespace;
+                    @namespace = isTypeScript ? TypeScriptNamespace : CSharpNamespace;
                     MetadataSerializer.SetMetadata(newItem, "Namespace", @namespace);
                 }
 

--- a/src/Microsoft.Extensions.ApiDescription.Client/GetFileReferenceMetadata.cs
+++ b/src/Microsoft.Extensions.ApiDescription.Client/GetFileReferenceMetadata.cs
@@ -19,21 +19,15 @@ namespace Microsoft.Extensions.ApiDescription.Client
         private const string TypeScriptLanguageName = "TypeScript";
 
         /// <summary>
-        /// Default Namespace metadata value for C# output.
+        /// Default Namespace metadata value.
         /// </summary>
         [Required]
-        public string CSharpNamespace { get; set; }
+        public string Namespace { get; set; }
 
         /// <summary>
         /// Default directory for OutputPath values.
         /// </summary>
         public string OutputDirectory { get; set; }
-
-        /// <summary>
-        /// Default Namespace metadata value for TypeScript output.
-        /// </summary>
-        [Required]
-        public string TypeScriptNamespace { get; set; }
 
         /// <summary>
         /// The ServiceFileReference items to update.
@@ -42,8 +36,8 @@ namespace Microsoft.Extensions.ApiDescription.Client
         public ITaskItem[] Inputs { get; set; }
 
         /// <summary>
-        /// The updated ServiceFileReference items. Will include Namespace and OutputPath metadata. OutputPath metadata
-        /// will contain full paths.
+        /// The updated ServiceFileReference items. Will include ClassName, Namespace and OutputPath metadata.
+        /// OutputPath metadata will contain full paths.
         /// </summary>
         [Output]
         public ITaskItem[] Outputs{ get; set; }
@@ -93,17 +87,16 @@ namespace Microsoft.Extensions.ApiDescription.Client
                     MetadataSerializer.SetMetadata(newItem, "ClassName", className);
                 }
 
-                var isTypeScript = codeGenerator.EndsWith(TypeScriptLanguageName, StringComparison.OrdinalIgnoreCase);
                 var @namespace = item.GetMetadata("Namespace");
                 if (string.IsNullOrEmpty(@namespace))
                 {
-                    @namespace = isTypeScript ? TypeScriptNamespace : CSharpNamespace;
-                    MetadataSerializer.SetMetadata(newItem, "Namespace", @namespace);
+                    MetadataSerializer.SetMetadata(newItem, "Namespace", Namespace);
                 }
 
                 var outputPath = item.GetMetadata("OutputPath");
                 if (string.IsNullOrEmpty(outputPath))
                 {
+                    var isTypeScript = codeGenerator.EndsWith(TypeScriptLanguageName, StringComparison.OrdinalIgnoreCase);
                     outputPath = $"{className}{(isTypeScript ? ".ts" : ".cs")}";
                 }
 

--- a/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.props
+++ b/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.props
@@ -28,10 +28,10 @@
         Condition="'$(ServiceFileReferenceCheckIfNewer)' == ''">true</ServiceFileReferenceCheckIfNewer>
     <ServiceFileReferenceDirectory
         Condition="'$(ServiceFileReferenceDirectory)' != ''">$([MSBuild]::EnsureTrailingSlash('$(ServiceFileReferenceDirectory)'))</ServiceFileReferenceDirectory>
-    <ServiceFileReferenceCSharpNamespace
-        Condition="'$(ServiceFileReferenceCSharpNamespace)' == ''">$(RootNamespace)</ServiceFileReferenceCSharpNamespace>
-    <ServiceFileReferenceTypeScriptNamespace
-        Condition="'$(ServiceFileReferenceTypeScriptNamespace)' == ''">$(RootNamespace)</ServiceFileReferenceTypeScriptNamespace>
+    <ServiceFileReferenceCSharpNamespace Condition="'$(ServiceFileReferenceCSharpNamespace)' == ''" />
+    <ServiceFileReferenceTypeScriptNamespace Condition="'$(ServiceFileReferenceTypeScriptNamespace)' == ''" />
+
+    <DefaultDocumentGeneratorDefaultOptions Condition="'$(DefaultDocumentGeneratorDefaultOptions)' == ''" />
   </PropertyGroup>
 
   <!--

--- a/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.props
+++ b/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.props
@@ -126,8 +126,6 @@
         $(ServiceFileReferenceDirectory).
       -->
       <OutputPath />
-      <!-- Language of the generated file. Calculated based on %(CodeGenerator). -->
-      <TargetLanguage />
     </ServiceFileReference>
   </ItemDefinitionGroup>
 </Project>

--- a/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.props
+++ b/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.props
@@ -40,7 +40,10 @@
   -->
   <ItemDefinitionGroup>
     <ServiceProjectReference>
-      <!-- Name of the API description document generator. -->
+      <!--
+        Name of the API description document generator.  Builds will invoke a target named
+        "%(DocumentGenerator)DocumentGenerator" to do actual document retrieval / generation.
+      -->
       <DocumentGenerator>Default</DocumentGenerator>
 
       <!-- Server project metadata which is likely applicable to all document generators. -->
@@ -107,7 +110,10 @@
     <ServiceFileReference>
       <!-- Name of the class to generate. Defaults to %(Filename)Client but with an uppercase first letter. -->
       <ClassName />
-      <!-- Code generator to use. Required. -->
+      <!--
+        Code generator to use. Required and must end with "CSharp" or "TypeScript" (the currently-supported target
+        languages). Builds will invoke a target named "%(CodeGenerator)CodeGenerator" to do actual code generation.
+      -->
       <CodeGenerator />
       <!--
         Namespace to contain generated class. Default is either $(ServiceFileReferenceCSharpNamespace) or
@@ -120,6 +126,8 @@
         $(ServiceFileReferenceDirectory).
       -->
       <OutputPath />
+      <!-- Language of the generated file. Calculated based on %(CodeGenerator). -->
+      <TargetLanguage />
     </ServiceFileReference>
   </ItemDefinitionGroup>
 </Project>

--- a/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.props
+++ b/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.props
@@ -28,8 +28,6 @@
         Condition="'$(ServiceFileReferenceCheckIfNewer)' == ''">true</ServiceFileReferenceCheckIfNewer>
     <ServiceFileReferenceDirectory
         Condition="'$(ServiceFileReferenceDirectory)' != ''">$([MSBuild]::EnsureTrailingSlash('$(ServiceFileReferenceDirectory)'))</ServiceFileReferenceDirectory>
-    <ServiceFileReferenceCSharpNamespace Condition="'$(ServiceFileReferenceCSharpNamespace)' == ''" />
-    <ServiceFileReferenceTypeScriptNamespace Condition="'$(ServiceFileReferenceTypeScriptNamespace)' == ''" />
 
     <DefaultDocumentGeneratorDefaultOptions Condition="'$(DefaultDocumentGeneratorDefaultOptions)' == ''" />
   </PropertyGroup>
@@ -116,8 +114,7 @@
       -->
       <CodeGenerator />
       <!--
-        Namespace to contain generated class. Default is either $(ServiceFileReferenceCSharpNamespace) or
-        $(ServiceFileReferenceTypeScriptNamespace), depending on target language.
+        Namespace to contain generated class. Default is $(RootNamespace).
       -->
       <Namespace />
       <!--

--- a/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.props
+++ b/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.props
@@ -12,7 +12,10 @@
   <UsingTask TaskName="GetUriReferenceMetadata" AssemblyFile="$(_ApiDescriptionTasksAssemblyPath)" />
   <UsingTask TaskName="Microsoft.Extensions.ApiDescription.Client.DownloadFile" AssemblyFile="$(_ApiDescriptionTasksAssemblyPath)" />
 
-  <!-- Settings users may update as they see fit. -->
+  <!--
+    Settings users may update as they see fit. All $(...Directory) values are interpreted relative to the client
+    project folder, unless already an absolute path.
+  -->
   <PropertyGroup>
     <ServiceProjectReferenceCheckIfNewer
         Condition="'$(ServiceProjectReferenceCheckIfNewer)' == ''">true</ServiceProjectReferenceCheckIfNewer>
@@ -120,7 +123,8 @@
       <!--
         Path to place generated code. Code generator may interpret path as a filename or directory. Default filename or
         folder name is %(ClassName).[cs|ts]. Filenames and relative paths (if explicitly set) are combined with
-        $(ServiceFileReferenceDirectory).
+        $(ServiceFileReferenceDirectory). Final value (depending on $(ServiceFileReferenceDirectory)) is likely to be
+        a path relative to the client project.
       -->
       <OutputPath />
     </ServiceFileReference>

--- a/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.targets
+++ b/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.targets
@@ -297,13 +297,13 @@
     <ItemGroup>
       <TypeScriptCompile Remove="@(ServiceFileReference -> '%(RelativeOutputPath)')" />
       <TypeScriptCompile Include="@(ServiceFileReference -> '%(RelativeOutputPath)')"
-          Condition="'%(ServiceFileReference.TargetLanguage)' == 'TypeScript'">
+          Condition="'%(ServiceFileReference.Extension)' == '.ts'">
         <SourceDocument>%(ServiceFileReference.FullPath)</SourceDocument>
       </TypeScriptCompile>
 
       <Compile Remove="@(ServiceFileReference -> '%(RelativeOutputPath)')" />
       <Compile Include="@(ServiceFileReference -> '%(RelativeOutputPath)')"
-          Condition="'%(ServiceFileReference.TargetLanguage)' != 'TypeScript'">
+          Condition="'%(ServiceFileReference.Extension)' != '.ts'">
         <SourceDocument>%(ServiceFileReference.FullPath)</SourceDocument>
       </Compile>
     </ItemGroup>

--- a/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.targets
+++ b/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.targets
@@ -245,7 +245,6 @@
   <!-- ServiceFileReference support -->
 
   <Target Name="_ServiceFileReferenceGenerator_GetMetadata" Condition="'@(ServiceFileReference)' != ''">
-    <!-- Repeat default namespace checks in case $(RootNamespace) is defined after .props file is imported. -->
     <PropertyGroup>
       <ServiceFileReferenceCSharpNamespace
           Condition="'$(ServiceFileReferenceCSharpNamespace)' == ''">$(RootNamespace)</ServiceFileReferenceCSharpNamespace>

--- a/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.targets
+++ b/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.targets
@@ -165,8 +165,9 @@
       <ServiceFileReference Remove="@(ServiceProjectReference -> '%(DocumentPath)')" />
       <!-- Condition here is temporary. Useful while DefaultDocumentGenerator fails. -->
       <ServiceFileReference Include="@(ServiceProjectReference -> '%(DocumentPath)')"
-          Condition="Exists('%(ServiceProjectReference.DocumentPath)')"
-          SourceProject="%(ServiceProjectReference.FullPath)" />
+          Condition="Exists('%(ServiceProjectReference.DocumentPath)')">
+        <SourceProject>%(ServiceProjectReference.FullPath)</SourceProject>
+      </ServiceFileReference>
     </ItemGroup>
   </Target>
 
@@ -233,8 +234,9 @@
     <!-- _ServiceUriReferenceGenerator_GetMetadata guarantees %(DocumentPath) values are unique. -->
     <ItemGroup>
       <ServiceFileReference Remove="@(ServiceUriReference -> '%(DocumentPath)')" />
-      <ServiceFileReference Include="@(ServiceUriReference -> '%(DocumentPath)')"
-          SourceUri="%(ServiceUriReference.Identity)" />
+      <ServiceFileReference Include="@(ServiceUriReference -> '%(DocumentPath)')">
+        <SourceUri>%(ServiceUriReference.Identity)</SourceUri>
+      </ServiceFileReference>
     </ItemGroup>
   </Target>
 
@@ -263,7 +265,9 @@
 
     <ItemGroup>
       <ServiceFileReference Remove="@(ServiceFileReference)" />
-      <ServiceFileReference Include="@(_Temporary)" />
+      <ServiceFileReference Include="@(_Temporary)">
+        <RelativeOutputPath>$([MSBuild]::MakeRelative($(MSBuildProjectDirectory), %(_Temporary.OutputPath)))</RelativeOutputPath>
+      </ServiceFileReference>
       <_Temporary Remove="@(_Temporary)" />
     </ItemGroup>
   </Target>
@@ -292,9 +296,17 @@
       unique.
     -->
     <ItemGroup>
-      <Compile Remove="@(ServiceFileReference -> '%(OutputPath)')" />
-      <Compile Include="@(ServiceFileReference -> '%(OutputPath)')"
-          SourceDocument="%(ServiceFileReference.FullPath)" />
+      <TypeScriptCompile Remove="@(ServiceFileReference -> '%(RelativeOutputPath)')" />
+      <TypeScriptCompile Include="@(ServiceFileReference -> '%(RelativeOutputPath)')"
+          Condition="'%(ServiceFileReference.TargetLanguage)' == 'TypeScript'">
+        <SourceDocument>%(ServiceFileReference.FullPath)</SourceDocument>
+      </TypeScriptCompile>
+
+      <Compile Remove="@(ServiceFileReference -> '%(RelativeOutputPath)')" />
+      <Compile Include="@(ServiceFileReference -> '%(RelativeOutputPath)')"
+          Condition="'%(ServiceFileReference.TargetLanguage)' != 'TypeScript'">
+        <SourceDocument>%(ServiceFileReference.FullPath)</SourceDocument>
+      </Compile>
     </ItemGroup>
   </Target>
 

--- a/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.targets
+++ b/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.targets
@@ -243,6 +243,13 @@
   <!-- ServiceFileReference support -->
 
   <Target Name="_ServiceFileReferenceGenerator_GetMetadata" Condition="'@(ServiceFileReference)' != ''">
+    <!-- Repeat default namespace checks in case $(RootNamespace) is defined after .props file is imported. -->
+    <PropertyGroup>
+      <ServiceFileReferenceCSharpNamespace
+          Condition="'$(ServiceFileReferenceCSharpNamespace)' == ''">$(RootNamespace)</ServiceFileReferenceCSharpNamespace>
+      <ServiceFileReferenceTypeScriptNamespace
+          Condition="'$(ServiceFileReferenceTypeScriptNamespace)' == ''">$(RootNamespace)</ServiceFileReferenceTypeScriptNamespace>
+    </PropertyGroup>
     <ItemGroup>
       <_Temporary Remove="@(_Temporary)" />
     </ItemGroup>
@@ -273,7 +280,7 @@
   <Target Name="_ServiceFileReferenceGenerator_Core" Inputs="@(ServiceFileReference)" Outputs="%(OutputPath)">
     <MSBuild BuildInParallel="$(BuildInParallel)"
         Projects="$(MSBuildProjectFullPath)"
-        Properties="GeneratorTargetPath=%(ServiceProjectReference.OutputPath);GeneratorTarget=%(CodeGenerator)CodeGenerator;GeneratorMetadata=%(SerializedMetadata);TargetFramework=%(ProjectTargetFramework)"
+        Properties="GeneratorTargetPath=%(ServiceFileReference.OutputPath);GeneratorTarget=%(CodeGenerator)CodeGenerator;GeneratorMetadata=%(SerializedMetadata);TargetFramework=%(ProjectTargetFramework)"
         RemoveProperties="TargetFrameworks;RuntimeIdentifier"
         Targets="_ServiceFileReferenceGenerator_Inner" />
   </Target>

--- a/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.targets
+++ b/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.targets
@@ -154,8 +154,8 @@
   <Target Name="_ServiceProjectReferenceGenerator_Core" Inputs="@(ServiceProjectReference)" Outputs="%(DocumentPath)">
     <MSBuild BuildInParallel="$(BuildInParallel)"
         Projects="$(MSBuildProjectFullPath)"
-        Properties="GeneratorTargetPath=%(ServiceProjectReference.DocumentPath);GeneratorTarget=%(DocumentGenerator)DocumentGenerator;GeneratorMetadata=%(SerializedMetadata);TargetFramework=%(ProjectTargetFramework)"
-        RemoveProperties="TargetFrameworks;RuntimeIdentifier"
+        Properties="GeneratorTargetPath=%(ServiceProjectReference.DocumentPath);GeneratorTarget=%(DocumentGenerator)DocumentGenerator;GeneratorMetadata=%(SerializedMetadata)"
+        RemoveProperties="TargetFrameworks"
         Targets="_ServiceProjectReferenceGenerator_Inner" />
   </Target>
 
@@ -284,8 +284,8 @@
   <Target Name="_ServiceFileReferenceGenerator_Core" Inputs="@(ServiceFileReference)" Outputs="%(OutputPath)">
     <MSBuild BuildInParallel="$(BuildInParallel)"
         Projects="$(MSBuildProjectFullPath)"
-        Properties="GeneratorTargetPath=%(ServiceFileReference.OutputPath);GeneratorTarget=%(CodeGenerator)CodeGenerator;GeneratorMetadata=%(SerializedMetadata);TargetFramework=%(ProjectTargetFramework)"
-        RemoveProperties="TargetFrameworks;RuntimeIdentifier"
+        Properties="GeneratorTargetPath=%(ServiceFileReference.OutputPath);GeneratorTarget=%(CodeGenerator)CodeGenerator;GeneratorMetadata=%(SerializedMetadata)"
+        RemoveProperties="TargetFrameworks"
         Targets="_ServiceFileReferenceGenerator_Inner" />
   </Target>
 

--- a/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.targets
+++ b/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.targets
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project>
-  <!-- Internal settings for Microsoft.Extensions.ApiDescription.Client.targets use. Not intended for customization. -->
+  <!-- Internal settings. Not intended for customization. -->
   <PropertyGroup>
     <ServiceProjectReferenceGeneratorDependsOn>
       _ServiceProjectReferenceGenerator_GetTargetFramework;
@@ -25,8 +25,10 @@
 
   <!-- ServiceProjectReference support -->
 
-  <!-- Metadata setup phase 1: Ensure items have TargetFramework metadata. Call GetTargetFrameworks in the target project. -->
-  <!-- Inputs and outputs cause MSBuild to run target unconditionally and to batch it (run once per project). -->
+  <!--
+    Metadata setup phase 1: Ensure items have TargetFramework metadata. Call GetTargetFrameworks in the target project.
+    Inputs and outputs cause MSBuild to run target unconditionally and to batch it (run once per project).
+  -->
   <Target Name="_ServiceProjectReferenceGenerator_GetTargetFramework"
       Inputs="%(ServiceProjectReference.FullPath)"
       Outputs="&lt;not-a-file !&gt;">
@@ -45,14 +47,17 @@
       <Output TaskParameter="TargetOutputs" ItemName="_Temporary" />
     </MSBuild>
 
-    <!-- Please excuse the mess necessary to extract information from _Temporary and use it in ServiceProjectReference. -->
+    <!--
+      Please excuse the mess necessary to extract information from _Temporary and use it in ServiceProjectReference.
+    -->
     <PropertyGroup>
       <_TargetFrameworks>%(_Temporary.TargetFrameworks)</_TargetFrameworks>
       <_TargetFramework>$(_TargetFrameworks.Split(';')[0])</_TargetFramework>
     </PropertyGroup>
     <ItemGroup>
       <ServiceProjectReference Update="@(ServiceProjectReference)" Condition="'%(FullPath)' == '$(_FullPath)'">
-        <ProjectTargetFramework Condition="'%(ProjectTargetFramework)' == ''">$(_TargetFramework)</ProjectTargetFramework>
+        <ProjectTargetFramework
+            Condition="'%(ProjectTargetFramework)' == ''">$(_TargetFramework)</ProjectTargetFramework>
       </ServiceProjectReference>
       <_Temporary Remove="@(_Temporary)" />
     </ItemGroup>
@@ -64,8 +69,11 @@
     </PropertyGroup>
   </Target>
 
-  <!-- Metadata setup phase 2: Ensure items have ProjectTargetPath metadata. Call GetTargetPath in the target project. -->
-  <!-- Inputs and outputs cause MSBuild to run target unconditionally and batch it (run once per TargetFramework x project combination). -->
+  <!--
+    Metadata setup phase 2: Ensure items have ProjectTargetPath metadata. Call GetTargetPath in the target project.
+    Inputs and outputs cause MSBuild to run target unconditionally and batch it (run once per TargetFramework x
+    project combination).
+  -->
   <Target Name="_ServiceProjectReferenceGenerator_GetProjectTargetPath"
       Inputs="%(ServiceProjectReference.TargetFramework)%(FullPath)')"
       Outputs="&lt;not-a-file !&gt;">
@@ -77,9 +85,6 @@
       <_Temporary Remove="@(_Temporary)" />
     </ItemGroup>
 
-    <Message
-        Importance="high"
-        Text="%0A_ServiceProjectReferenceGenerator_GetProjectTargetPath: '$(_FullPath)' '$(_TargetFramework)'" />
     <MSBuild Projects="$(_FullPath)"
         Properties="TargetFramework=$(_TargetFramework)"
         RebaseOutputs="true"
@@ -94,7 +99,7 @@
     </PropertyGroup>
     <ItemGroup>
       <ServiceProjectReference Update="@(ServiceProjectReference)"
-          Condition="'%(ServiceProjectReference.FullPath)' == '$(_FullPath)' AND '%(ProjectTargetFramework)' == '$(_TargetFramework)'">
+          Condition="'%(FullPath)' == '$(_FullPath)' AND '%(ProjectTargetFramework)' == '$(_TargetFramework)'">
         <ProjectTargetPath>$(_ProjectTargetPath)</ProjectTargetPath>
       </ServiceProjectReference>
       <_Temporary Remove="@(_Temporary)" />
@@ -113,7 +118,8 @@
       <_Temporary Remove="@(_Temporary)" />
     </ItemGroup>
 
-    <GetProjectReferenceMetadata Inputs="@(ServiceProjectReference)" DocumentDirectory="$(ServiceProjectReferenceDirectory)">
+    <GetProjectReferenceMetadata Inputs="@(ServiceProjectReference)"
+        DocumentDirectory="$(ServiceProjectReferenceDirectory)">
       <Output TaskParameter="Outputs" ItemName="_Temporary" />
     </GetProjectReferenceMetadata>
 
@@ -124,9 +130,6 @@
     <ItemGroup>
       <_Temporary Remove="@(_Temporary)" />
     </ItemGroup>
-
-    <Message Importance="high" Text="%0A_ServiceProjectReferenceGenerator_GetMetadata:" />
-    <Message Importance="high" Text="  @(ServiceProjectReference): %(DocumentPath)" />
   </Target>
 
   <Target Name="_ServiceProjectReferenceGenerator_Build"
@@ -145,12 +148,10 @@
     </GetCurrentItems>
   </Target>
 
-  <Target Name="_ServiceProjectReferenceGenerator_Inner" DependsOnTargets="_ServiceProjectReferenceGenerator_GetItems;$(GeneratorTarget)" />
+  <Target Name="_ServiceProjectReferenceGenerator_Inner"
+      DependsOnTargets="_ServiceProjectReferenceGenerator_GetItems;$(GeneratorTarget)" />
 
   <Target Name="_ServiceProjectReferenceGenerator_Core" Inputs="@(ServiceProjectReference)" Outputs="%(DocumentPath)">
-    <Message Importance="high" Text="%0A_ServiceProjectReferenceGenerator_Core:" />
-    <Message Importance="high" Text="  @(ServiceProjectReference): %(DocumentPath)" />
-
     <MSBuild BuildInParallel="$(BuildInParallel)"
         Projects="$(MSBuildProjectFullPath)"
         Properties="GeneratorTargetPath=%(ServiceProjectReference.DocumentPath);GeneratorTarget=%(DocumentGenerator)DocumentGenerator;GeneratorMetadata=%(SerializedMetadata);TargetFramework=%(ProjectTargetFramework)"
@@ -164,8 +165,8 @@
       <ServiceFileReference Remove="@(ServiceProjectReference -> '%(DocumentPath)')" />
       <!-- Condition here is temporary. Useful while DefaultDocumentGenerator fails. -->
       <ServiceFileReference Include="@(ServiceProjectReference -> '%(DocumentPath)')"
-          Condition="Exists('%(DocumentPath)')"
-          SourceProject="%(FullPath)" />
+          Condition="Exists('%(ServiceProjectReference.DocumentPath)')"
+          SourceProject="%(ServiceProjectReference.FullPath)" />
     </ItemGroup>
   </Target>
 
@@ -174,30 +175,36 @@
   <!-- DefaultDocumentGenerator -->
 
   <Target Name="DefaultDocumentGenerator">
-    <Message Importance="high" Text="%0ADefaultDocumentGenerator:" />
-    <Message Importance="high" Text="  @(CurrentServiceProjectReference): %(DocumentPath)" />
-
     <ItemGroup>
       <!-- @(CurrentServiceProjectReference) item group will never contain more than one item. -->
       <CurrentServiceProjectReference Update="@(CurrentServiceProjectReference)">
         <Command>dotnet getdocument --no-build --project %(FullPath) --output %(DocumentPath)</Command>
         <DefaultDocumentGeneratorOptions
             Condition="'%(DefaultDocumentGeneratorOptions)' == ''">$(DefaultDocumentGeneratorDefaultOptions)</DefaultDocumentGeneratorOptions>
+        <ProjectConfiguration
+            Condition="'%(ProjectConfiguration)' == ''">$(Configuration)</ProjectConfiguration>
       </CurrentServiceProjectReference>
-      <CurrentServiceProjectReference Update="@(_Temporary)">
+      <CurrentServiceProjectReference Update="@(CurrentServiceProjectReference)">
         <Command>%(Command) --framework %(ProjectTargetFramework)</Command>
-        <Command Condition="'%(ProjectConfiguration)' == ''">%(Command) --configuration $(Configuration)</Command>
-        <Command Condition="'%(ProjectConfiguration)' != ''">%(Command) --configuration %(ProjectConfiguration)</Command>
+      </CurrentServiceProjectReference>
+      <CurrentServiceProjectReference Update="@(CurrentServiceProjectReference)">
         <Command Condition="'%(Method)' != ''">%(Command) --method %(Method)</Command>
+      </CurrentServiceProjectReference>
+      <CurrentServiceProjectReference Update="@(CurrentServiceProjectReference)">
         <Command Condition="'%(Service)' != ''">%(Command) --service %(Service)</Command>
+      </CurrentServiceProjectReference>
+      <CurrentServiceProjectReference Update="@(CurrentServiceProjectReference)">
         <Command Condition="'%(Uri)' != ''">%(Command) --uri %(Uri)</Command>
-        <Command
-            Condition="'%(DefaultDocumentGeneratorOptions)' != ''">%(Command) %(DefaultDocumentGeneratorOptions)</Command>
+      </CurrentServiceProjectReference>
+      <CurrentServiceProjectReference Update="@(CurrentServiceProjectReference)">
+        <Command>%(Command) --configuration %(ProjectConfiguration) %(DefaultDocumentGeneratorOptions)</Command>
       </CurrentServiceProjectReference>
     </ItemGroup>
 
-    <Message Importance="high" Text="%0A%(CurrentServiceProjectReference.Command)" />
-    <Exec IgnoreExitCode="$([System.IO.File]::Exists('%(DocumentPath)'))" Command="%(CurrentServiceProjectReference.Command)" />
+    <Message Importance="high" Text="%0ADefaultDocumentGenerator:" />
+    <Message Importance="high" Text="  %(CurrentServiceProjectReference.Command)" />
+    <Exec Command="%(CurrentServiceProjectReference.Command)"
+        IgnoreExitCode="$([System.IO.File]::Exists('%(DocumentPath)'))" />
   </Target>
 
   <!-- ServiceUriReference support -->
@@ -226,7 +233,8 @@
     <!-- _ServiceUriReferenceGenerator_GetMetadata guarantees %(DocumentPath) values are unique. -->
     <ItemGroup>
       <ServiceFileReference Remove="@(ServiceUriReference -> '%(DocumentPath)')" />
-      <ServiceFileReference Include="@(ServiceUriReference -> '%(DocumentPath)')" SourceUri="%(Identity)" />
+      <ServiceFileReference Include="@(ServiceUriReference -> '%(DocumentPath)')"
+          SourceUri="%(ServiceUriReference.Identity)" />
     </ItemGroup>
   </Target>
 
@@ -259,12 +267,10 @@
     </GetCurrentItems>
   </Target>
 
-  <Target Name="_ServiceFileReferenceGenerator_Inner" DependsOnTargets="_ServiceFileReferenceGenerator_GetItems;$(GeneratorTarget)" />
+  <Target Name="_ServiceFileReferenceGenerator_Inner"
+      DependsOnTargets="_ServiceFileReferenceGenerator_GetItems;$(GeneratorTarget)" />
 
   <Target Name="_ServiceFileReferenceGenerator_Core" Inputs="@(ServiceFileReference)" Outputs="%(OutputPath)">
-    <Message Importance="high" Text="%0A_ServiceFileReferenceGenerator_Core:" />
-    <Message Importance="high" Text="  @(ServiceFileReference): %(DocumentPath)" />
-
     <MSBuild BuildInParallel="$(BuildInParallel)"
         Projects="$(MSBuildProjectFullPath)"
         Properties="GeneratorTargetPath=%(ServiceProjectReference.OutputPath);GeneratorTarget=%(CodeGenerator)CodeGenerator;GeneratorMetadata=%(SerializedMetadata);TargetFramework=%(ProjectTargetFramework)"
@@ -280,7 +286,8 @@
     -->
     <ItemGroup>
       <Compile Remove="@(ServiceFileReference -> '%(OutputPath)')" />
-      <Compile Include="@(ServiceFileReference -> '%(OutputPath)')" SourceDocument="%(FullPath)" />
+      <Compile Include="@(ServiceFileReference -> '%(OutputPath)')"
+          SourceDocument="%(ServiceFileReference.FullPath)" />
     </ItemGroup>
   </Target>
 

--- a/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.targets
+++ b/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.targets
@@ -245,20 +245,13 @@
   <!-- ServiceFileReference support -->
 
   <Target Name="_ServiceFileReferenceGenerator_GetMetadata" Condition="'@(ServiceFileReference)' != ''">
-    <PropertyGroup>
-      <ServiceFileReferenceCSharpNamespace
-          Condition="'$(ServiceFileReferenceCSharpNamespace)' == ''">$(RootNamespace)</ServiceFileReferenceCSharpNamespace>
-      <ServiceFileReferenceTypeScriptNamespace
-          Condition="'$(ServiceFileReferenceTypeScriptNamespace)' == ''">$(RootNamespace)</ServiceFileReferenceTypeScriptNamespace>
-    </PropertyGroup>
     <ItemGroup>
       <_Temporary Remove="@(_Temporary)" />
     </ItemGroup>
 
     <GetFileReferenceMetadata Inputs="@(ServiceFileReference)"
-        CSharpNamespace="$(ServiceFileReferenceCSharpNamespace)"
-        OutputDirectory="$(ServiceFileReferenceDirectory)"
-        TypeScriptNamespace="$(ServiceFileReferenceTypeScriptNamespace)">
+        Namespace="$(RootNamespace)"
+        OutputDirectory="$(ServiceFileReferenceDirectory)">
       <Output TaskParameter="Outputs" ItemName="_Temporary" />
     </GetFileReferenceMetadata>
 

--- a/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.targets
+++ b/src/Microsoft.Extensions.ApiDescription.Client/build/Microsoft.Extensions.ApiDescription.Client.targets
@@ -250,6 +250,7 @@
     </ItemGroup>
 
     <GetFileReferenceMetadata Inputs="@(ServiceFileReference)"
+        Extension="$(DefaultLanguageSourceExtension)"
         Namespace="$(RootNamespace)"
         OutputDirectory="$(ServiceFileReferenceDirectory)">
       <Output TaskParameter="Outputs" ItemName="_Temporary" />
@@ -257,9 +258,7 @@
 
     <ItemGroup>
       <ServiceFileReference Remove="@(ServiceFileReference)" />
-      <ServiceFileReference Include="@(_Temporary)">
-        <RelativeOutputPath>$([MSBuild]::MakeRelative($(MSBuildProjectDirectory), %(_Temporary.OutputPath)))</RelativeOutputPath>
-      </ServiceFileReference>
+      <ServiceFileReference Include="@(_Temporary)" />
       <_Temporary Remove="@(_Temporary)" />
     </ItemGroup>
   </Target>
@@ -288,17 +287,43 @@
       unique.
     -->
     <ItemGroup>
-      <TypeScriptCompile Remove="@(ServiceFileReference -> '%(RelativeOutputPath)')" />
-      <TypeScriptCompile Include="@(ServiceFileReference -> '%(RelativeOutputPath)')"
-          Condition="'%(ServiceFileReference.Extension)' == '.ts'">
-        <SourceDocument>%(ServiceFileReference.FullPath)</SourceDocument>
+      <_Files Remove="@(_Files)" />
+      <_Files Include="@(ServiceFileReference -> '%(OutputPath)')"
+          Condition="$([System.IO.File]::Exists('%(ServiceFileReference.OutputPath)'))">
+        <OutputPathExtension>$([System.IO.Path]::GetExtension('%(ServiceFileReference.OutputPath)'))</OutputPathExtension>
+      </_Files>
+      <_Directories Remove="@(_Directories)" />
+      <_Directories Include="@(ServiceFileReference -> '%(OutputPath)')"
+          Condition="Exists('%(ServiceFileReference.OutputPath)') AND ! $([System.IO.File]::Exists('%(ServiceFileReference.OutputPath)'))" />
+
+      <!-- If OutputPath is a file, add it directly to relevant items. -->
+      <TypeScriptCompile Remove="@(_Files)" Condition="'%(_Files.OutputPathExtension)' == '.ts'" />
+      <TypeScriptCompile Include="@(_Files)" Condition="'%(_Files.OutputPathExtension)' == '.ts'">
+        <SourceDocument>%(_Files.FullPath)</SourceDocument>
       </TypeScriptCompile>
 
-      <Compile Remove="@(ServiceFileReference -> '%(RelativeOutputPath)')" />
-      <Compile Include="@(ServiceFileReference -> '%(RelativeOutputPath)')"
-          Condition="'%(ServiceFileReference.Extension)' != '.ts'">
+      <Compile Remove="@(_Files)"
+          Condition="'$(DefaultLanguageSourceExtension)' != '.ts' AND '%(_Files.OutputPathExtension)' == '$(DefaultLanguageSourceExtension)'" />
+      <Compile Include="@(_Files)"
+          Condition="'$(DefaultLanguageSourceExtension)' != '.ts' AND '%(_Files.OutputPathExtension)' == '$(DefaultLanguageSourceExtension)'">
         <SourceDocument>%(ServiceFileReference.FullPath)</SourceDocument>
       </Compile>
+
+      <!-- Otherwise, add all descendent files with the expected extension. -->
+      <TypeScriptCompile Remove="@(_Directories -> '%(Identity)/**/*.ts')" />
+      <TypeScriptCompile Include="@(_Directories -> '%(Identity)/**/*.ts')">
+        <SourceDocument>%(_Directories.FullPath)</SourceDocument>
+      </TypeScriptCompile>
+
+      <Compile Remove="@(_Directories -> '%(Identity)/**/*.$(DefaultLanguageSourceExtension)')"
+          Condition="'$(DefaultLanguageSourceExtension)' != '.ts'" />
+      <Compile Include="@(_Directories -> '%(Identity)/**/*.$(DefaultLanguageSourceExtension)')"
+          Condition="'$(DefaultLanguageSourceExtension)' != '.ts'">
+        <SourceDocument>%(_Directories.FullPath)</SourceDocument>
+      </Compile>
+
+      <_Files Remove="@(_Files)" />
+      <_Directories Remove="@(_Directories)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
- follow-ups to 1646345955 and 9d109f5956 aka #8476 and #8477 :
  - fix `%(Command)` updates in `DefaultDocumentGenerator` target
  - correct `@(CurrentServiceFileReference)` items
  - do not add TypeScript files to `@(Compile)`
  - stick with current `$(TargetFramework)` when building `...ReferenceGenerator_Inner` targets
- earlier commits left some smaller bugs and inconsistencies