### PR TITLE
Allow RazorPage with Poco model to work

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/PageActionInvoker.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/PageActionInvoker.cs
@@ -72,8 +72,6 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
         // Internal for testing
         internal PageActionInvokerCacheEntry CacheEntry { get; }
 
-        private bool HasPageModel => _actionDescriptor.HandlerTypeInfo != _actionDescriptor.PageTypeInfo;
-
         // Internal for testing
         internal PageContext PageContext => _pageContext;
 
@@ -137,17 +135,21 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
 
         private object CreateInstance()
         {
-            if (HasPageModel)
+            if (_actionDescriptor.ModelTypeInfo != _actionDescriptor.PageTypeInfo)
             {
-                // Since this is a PageModel, we need to activate it, and then run a handler method on the model.
+                // The page has a model. Initialize it.
                 _pageModel = CacheEntry.ModelFactory(_pageContext);
                 _pageContext.ViewData.Model = _pageModel;
+            }
 
+            if (_actionDescriptor.HandlerTypeInfo == _actionDescriptor.ModelTypeInfo)
+            {
+                // The page model is the handler.
                 return _pageModel;
             }
             else
             {
-                // Since this is a Page without a PageModel, we need to create the Page before running a handler method.
+                // The page is the handler. We need to create the Page before running a handler method.
                 _viewContext = new ViewContext(
                     _pageContext,
                     NullView.Instance,

--- a/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/PageActionInvokerTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.RazorPages.Test/Internal/PageActionInvokerTest.cs
@@ -263,13 +263,14 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Internal
             // Assert
             var page = Assert.IsType<TestPage>(instance);
             Assert.IsType<ViewDataDictionary<PocoModel>>(page.PageContext.ViewData);
-            Assert.Null(page.PageContext.ViewData.Model);
+            Assert.NotNull(page.PageContext.ViewData.Model);
+            Assert.IsType<PocoModel>(page.PageContext.ViewData.Model);
 
             var pageResult = Assert.IsType<PageResult>(result);
             Assert.Same(page, pageResult.Page);
-            Assert.Null(pageResult.Model);
+            Assert.NotNull(pageResult.Model);
+            Assert.IsType<PocoModel>(pageResult.Model);
             Assert.Same(page.ViewContext.ViewData, pageResult.ViewData);
-
         }
 
         [Fact]


### PR DESCRIPTION
`PageActionInvoker.HasPageModel` incorrectly checks to see if the handler type is not the page type to determine if the page has a model. This misses a scenario where a Page has a model, but [is not the handler](https://github.com/aspnet/Mvc/blob/release/2.2/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/DefaultPageApplicationModelProvider.cs#L97-L106). 

`PageActionInvokerProvider` does this correctly verifying is the model is not the page: https://github.com/aspnet/Mvc/blob/release/2.2/src/Microsoft.AspNetCore.Mvc.RazorPages/Internal/PageActionInvokerProvider.cs#L191-L195 and I've copied the check in this fix.