### PR TITLE
Redesign the ViewEngine to be async

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Microsoft.AspNetCore.Mvc.ViewFeatures.csproj
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Microsoft.AspNetCore.Mvc.ViewFeatures.csproj
@@ -11,6 +11,9 @@ Microsoft.AspNetCore.Mvc.ViewComponent</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;aspnetcoremvc</PackageTags>
+    <Version>2.1.3.1</Version>
+    <AssemblyVersion>2.1.3.1</AssemblyVersion>
+    <FileVersion>2.1.3.1</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/HtmlHelperDisplayExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/HtmlHelperDisplayExtensions.cs
@@ -482,6 +482,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
                 additionalViewData: null);
         }
 
+
         /// <summary>
         /// Returns HTML markup for the current model, using a display template and specified additional view data. The
         /// template is found using the model's <see cref="ModelBinding.ModelMetadata"/>.

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/HtmlHelperDisplayExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/HtmlHelperDisplayExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq.Expressions;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
 
 namespace Microsoft.AspNetCore.Mvc.Rendering
@@ -44,6 +45,40 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             }
 
             return htmlHelper.Display(expression, templateName: null, htmlFieldName: null, additionalViewData: null);
+        }
+
+        /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using a display template. The template is found
+        /// using the <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="expression">
+        /// Expression name, relative to the current model. May identify a single property or an
+        /// <see cref="object"/> that contains the properties to display.
+        /// </param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> display template includes markup for each property in the
+        /// <paramref name="expression"/>'s value.
+        /// </para>
+        /// <para>
+        /// Example <paramref name="expression"/>s include <c>string.Empty</c> which identifies the current model and
+        /// <c>"prop"</c> which identifies the current model's "prop" property.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>DisplayTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> DisplayAsync(this IHtmlHelper htmlHelper, string expression)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            return htmlHelper.DisplayAsync(expression, templateName: null, htmlFieldName: null, additionalViewData: null);
         }
 
         /// <summary>
@@ -94,6 +129,53 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using a display template and specified
+        /// additional view data. The template is found using the <paramref name="expression"/>'s
+        /// <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="expression">
+        /// Expression name, relative to the current model. May identify a single property or an
+        /// <see cref="object"/> that contains the properties to display.
+        /// </param>
+        /// <param name="additionalViewData">
+        /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{String, Object}"/>
+        /// that can contain additional view data that will be merged into the
+        /// <see cref="ViewFeatures.ViewDataDictionary{TModel}"/> instance created for the template.
+        /// </param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> display template includes markup for each property in the
+        /// <paramref name="expression"/>'s value.
+        /// </para>
+        /// <para>
+        /// Example <paramref name="expression"/>s include <c>string.Empty</c> which identifies the current model and
+        /// <c>"prop"</c> which identifies the current model's "prop" property.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>DisplayTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> DisplayAsync(
+            this IHtmlHelper htmlHelper,
+            string expression,
+            object additionalViewData)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            return htmlHelper.DisplayAsync(
+                expression,
+                templateName: null,
+                htmlFieldName: null,
+                additionalViewData: additionalViewData);
+        }
+
+        /// <summary>
         /// Returns HTML markup for the <paramref name="expression"/>, using a display template. The template is found
         /// using the <paramref name="templateName"/> or the <paramref name="expression"/>'s
         /// <see cref="ModelBinding.ModelMetadata"/>.
@@ -130,6 +212,45 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             }
 
             return htmlHelper.Display(expression, templateName, htmlFieldName: null, additionalViewData: null);
+        }
+
+        /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using a display template. The template is found
+        /// using the <paramref name="templateName"/> or the <paramref name="expression"/>'s
+        /// <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="expression">
+        /// Expression name, relative to the current model. May identify a single property or an
+        /// <see cref="object"/> that contains the properties to display.
+        /// </param>
+        /// <param name="templateName">The name of the template used to create the HTML markup.</param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> display template includes markup for each property in the
+        /// <paramref name="expression"/>'s value.
+        /// </para>
+        /// <para>
+        /// Example <paramref name="expression"/>s include <c>string.Empty</c> which identifies the current model and
+        /// <c>"prop"</c> which identifies the current model's "prop" property.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>DisplayTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> DisplayAsync(
+            this IHtmlHelper htmlHelper,
+            string expression,
+            string templateName)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            return htmlHelper.DisplayAsync(expression, templateName, htmlFieldName: null, additionalViewData: null);
         }
 
         /// <summary>
@@ -175,6 +296,55 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             }
 
             return htmlHelper.Display(
+                expression,
+                templateName,
+                htmlFieldName: null,
+                additionalViewData: additionalViewData);
+        }
+
+        /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using a display template and specified
+        /// additional view data. The template is found using the <paramref name="templateName"/> or the
+        /// <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="expression">
+        /// Expression name, relative to the current model. May identify a single property or an
+        /// <see cref="object"/> that contains the properties to display.
+        /// </param>
+        /// <param name="templateName">The name of the template used to create the HTML markup.</param>
+        /// <param name="additionalViewData">
+        /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{String, Object}"/>
+        /// that can contain additional view data that will be merged into the
+        /// <see cref="ViewFeatures.ViewDataDictionary{TModel}"/> instance created for the template.
+        /// </param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> display template includes markup for each property in the
+        /// <paramref name="expression"/>'s value.
+        /// </para>
+        /// <para>
+        /// Example <paramref name="expression"/>s include <c>string.Empty</c> which identifies the current model and
+        /// <c>"prop"</c> which identifies the current model's "prop" property.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>DisplayTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> DisplayAsync(
+            this IHtmlHelper htmlHelper,
+            string expression,
+            string templateName,
+            object additionalViewData)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            return htmlHelper.DisplayAsync(
                 expression,
                 templateName,
                 htmlFieldName: null,
@@ -226,6 +396,50 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using a display template and specified HTML
+        /// field name. The template is found using the <paramref name="templateName"/> or the
+        /// <paramref name="expression"/>'s<see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="expression">
+        /// Expression name, relative to the current model. May identify a single property or an
+        /// <see cref="object"/> that contains the properties to display.
+        /// </param>
+        /// <param name="templateName">The name of the template used to create the HTML markup.</param>
+        /// <param name="htmlFieldName">
+        /// A <see cref="string"/> used to disambiguate the names of HTML elements that are created for
+        /// properties that have the same name.
+        /// </param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> display template includes markup for each property in the
+        /// <paramref name="expression"/>'s value.
+        /// </para>
+        /// <para>
+        /// Example <paramref name="expression"/>s include <c>string.Empty</c> which identifies the current model and
+        /// <c>"prop"</c> which identifies the current model's "prop" property.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>DisplayTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> DisplayAsync(
+            this IHtmlHelper htmlHelper,
+            string expression,
+            string templateName,
+            string htmlFieldName)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            return htmlHelper.DisplayAsync(expression, templateName, htmlFieldName, additionalViewData: null);
+        }
+
+        /// <summary>
         /// Returns HTML markup for the <paramref name="expression"/>, using a display template. The template is found
         /// using the <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
@@ -259,6 +473,46 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             }
 
             return htmlHelper.DisplayFor(
+                expression,
+                templateName: null,
+                htmlFieldName: null,
+                additionalViewData: null);
+        }
+
+        /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using a display template. The template is found
+        /// using the <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
+        /// <param name="expression">An expression to be evaluated against the current model.</param>
+        /// <typeparam name="TModel">The type of the model.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> display template includes markup for each property in the
+        /// <paramref name="expression"/> result.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>DisplayTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> DisplayForAsync<TModel, TResult>(
+            this IHtmlHelper<TModel> htmlHelper,
+            Expression<Func<TModel, TResult>> expression)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            if (expression == null)
+            {
+                throw new ArgumentNullException(nameof(expression));
+            }
+
+            return htmlHelper.DisplayForAsync(
                 expression,
                 templateName: null,
                 htmlFieldName: null,
@@ -313,6 +567,53 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using a display template and specified
+        /// additional view data. The template is found using the <paramref name="expression"/>'s
+        /// <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
+        /// <param name="expression">An expression to be evaluated against the current model.</param>
+        /// <param name="additionalViewData">
+        /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{String, Object}"/>
+        /// that can contain additional view data that will be merged into the
+        /// <see cref="ViewFeatures.ViewDataDictionary{TModel}"/> instance created for the template.
+        /// </param>
+        /// <typeparam name="TModel">The type of the model.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> display template includes markup for each property in the
+        /// <paramref name="expression"/> result.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>DisplayTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> DisplayForAsync<TModel, TResult>(
+            this IHtmlHelper<TModel> htmlHelper,
+            Expression<Func<TModel, TResult>> expression,
+            object additionalViewData)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            if (expression == null)
+            {
+                throw new ArgumentNullException(nameof(expression));
+            }
+
+            return htmlHelper.DisplayForAsync(
+                expression,
+                templateName: null,
+                htmlFieldName: null,
+                additionalViewData: additionalViewData);
+        }
+
+        /// <summary>
         /// Returns HTML markup for the <paramref name="expression"/>, using a display template. The template is found
         /// using the <paramref name="templateName"/> or the <paramref name="expression"/>'s
         /// <see cref="ModelBinding.ModelMetadata"/>.
@@ -349,6 +650,49 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             }
 
             return htmlHelper.DisplayFor(
+                expression,
+                templateName,
+                htmlFieldName: null,
+                additionalViewData: null);
+        }
+
+        /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using a display template. The template is found
+        /// using the <paramref name="templateName"/> or the <paramref name="expression"/>'s
+        /// <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
+        /// <param name="expression">An expression to be evaluated against the current model.</param>
+        /// <param name="templateName">The name of the template used to create the HTML markup.</param>
+        /// <typeparam name="TModel">The type of the model.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> display template includes markup for each property in the
+        /// <paramref name="expression"/> result.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>DisplayTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> DisplayForAsync<TModel, TResult>(
+            this IHtmlHelper<TModel> htmlHelper,
+            Expression<Func<TModel, TResult>> expression,
+            string templateName)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            if (expression == null)
+            {
+                throw new ArgumentNullException(nameof(expression));
+            }
+
+            return htmlHelper.DisplayForAsync(
                 expression,
                 templateName,
                 htmlFieldName: null,
@@ -398,6 +742,55 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             }
 
             return htmlHelper.DisplayFor(
+                expression,
+                templateName,
+                htmlFieldName: null,
+                additionalViewData: additionalViewData);
+        }
+
+        /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using a display template and specified
+        /// additional view data. The template is found using the <paramref name="templateName"/> or the
+        /// <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
+        /// <param name="expression">An expression to be evaluated against the current model.</param>
+        /// <param name="templateName">The name of the template used to create the HTML markup.</param>
+        /// <param name="additionalViewData">
+        /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{String, Object}"/>
+        /// that can contain additional view data that will be merged into the
+        /// <see cref="ViewFeatures.ViewDataDictionary{TModel}"/> instance created for the template.
+        /// </param>
+        /// <typeparam name="TModel">The type of the model.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> display template includes markup for each property in the
+        /// <paramref name="expression"/> result.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>DisplayTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> DisplayForAsync<TModel, TResult>(
+            this IHtmlHelper<TModel> htmlHelper,
+            Expression<Func<TModel, TResult>> expression,
+            string templateName,
+            object additionalViewData)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            if (expression == null)
+            {
+                throw new ArgumentNullException(nameof(expression));
+            }
+
+            return htmlHelper.DisplayForAsync(
                 expression,
                 templateName,
                 htmlFieldName: null,
@@ -453,6 +846,54 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using a display template and specified HTML
+        /// field name. The template is found using the <paramref name="templateName"/> or the
+        /// <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
+        /// <param name="expression">An expression to be evaluated against the current model.</param>
+        /// <param name="templateName">The name of the template used to create the HTML markup.</param>
+        /// <param name="htmlFieldName">
+        /// A <see cref="string"/> used to disambiguate the names of HTML elements that are created for properties
+        /// that have the same name.
+        /// </param>
+        /// <typeparam name="TModel">The type of the model.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> display template includes markup for each property in the
+        /// <paramref name="expression"/> result.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>DisplayTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> DisplayForAsync<TModel, TResult>(
+            this IHtmlHelper<TModel> htmlHelper,
+            Expression<Func<TModel, TResult>> expression,
+            string templateName,
+            string htmlFieldName)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            if (expression == null)
+            {
+                throw new ArgumentNullException(nameof(expression));
+            }
+
+            return htmlHelper.DisplayForAsync(
+                expression,
+                templateName: templateName,
+                htmlFieldName: htmlFieldName,
+                additionalViewData: null);
+        }
+
+        /// <summary>
         /// Returns HTML markup for the current model, using a display template. The template is found using the
         /// model's <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
@@ -482,6 +923,35 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
                 additionalViewData: null);
         }
 
+        /// <summary>
+        /// Returns HTML markup for the current model, using a display template. The template is found using the
+        /// model's <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> display template includes markup for each property in the
+        /// current model.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>DisplayTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> DisplayForModelAsync(this IHtmlHelper htmlHelper)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            return htmlHelper.DisplayAsync(
+                expression: null,
+                templateName: null,
+                htmlFieldName: null,
+                additionalViewData: null);
+        }
 
         /// <summary>
         /// Returns HTML markup for the current model, using a display template and specified additional view data. The
@@ -519,6 +989,41 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
+        /// Returns HTML markup for the current model, using a display template and specified additional view data. The
+        /// template is found using the model's <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="additionalViewData">
+        /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{String, Object}"/>
+        /// that can contain additional view data that will be merged into the
+        /// <see cref="ViewFeatures.ViewDataDictionary{TModel}"/> instance created for the template.
+        /// </param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> display template includes markup for each property in the
+        /// current model.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>DisplayTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> DisplayForModelAsync(this IHtmlHelper htmlHelper, object additionalViewData)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            return htmlHelper.DisplayAsync(
+                expression: null,
+                templateName: null,
+                htmlFieldName: null,
+                additionalViewData: additionalViewData);
+        }
+
+        /// <summary>
         /// Returns HTML markup for the current model, using a display template. The template is found using the
         /// <paramref name="templateName"/> or the model's <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
@@ -543,6 +1048,37 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             }
 
             return htmlHelper.Display(
+                expression: null,
+                templateName: templateName,
+                htmlFieldName: null,
+                additionalViewData: null);
+        }
+
+        /// <summary>
+        /// Returns HTML markup for the current model, using a display template. The template is found using the
+        /// <paramref name="templateName"/> or the model's <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="templateName">The name of the template used to create the HTML markup.</param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> display template includes markup for each property in the
+        /// current model.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>DisplayTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> DisplayForModelAsync(this IHtmlHelper htmlHelper, string templateName)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            return htmlHelper.DisplayAsync(
                 expression: null,
                 templateName: templateName,
                 htmlFieldName: null,
@@ -583,6 +1119,46 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             }
 
             return htmlHelper.Display(
+                expression: null,
+                templateName: templateName,
+                htmlFieldName: null,
+                additionalViewData: additionalViewData);
+        }
+
+        /// <summary>
+        /// Returns HTML markup for the current model, using a display template and specified additional view data. The
+        /// template is found using the <paramref name="templateName"/> or the model's
+        /// <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="templateName">The name of the template used to create the HTML markup.</param>
+        /// <param name="additionalViewData">
+        /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{String, Object}"/>
+        /// that can contain additional view data that will be merged into the
+        /// <see cref="ViewFeatures.ViewDataDictionary{TModel}"/> instance created for the template.
+        /// </param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> display template includes markup for each property in the
+        /// current model.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>DisplayTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> DisplayForModelAsync(
+            this IHtmlHelper htmlHelper,
+            string templateName,
+            object additionalViewData)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            return htmlHelper.DisplayAsync(
                 expression: null,
                 templateName: templateName,
                 htmlFieldName: null,
@@ -629,6 +1205,45 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
+        /// Returns HTML markup for the current model, using a display template and specified HTML field name. The
+        /// template is found using the <paramref name="templateName"/> or the model's
+        /// <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="templateName">The name of the template used to create the HTML markup.</param>
+        /// <param name="htmlFieldName">
+        /// A <see cref="string"/> used to disambiguate the names of HTML elements that are created for
+        /// properties that have the same name.
+        /// </param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> display template includes markup for each property in the
+        /// current model.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>DisplayTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> DisplayForModelAsync(
+            this IHtmlHelper htmlHelper,
+            string templateName,
+            string htmlFieldName)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            return htmlHelper.DisplayAsync(
+                expression: null,
+                templateName: templateName,
+                htmlFieldName: htmlFieldName,
+                additionalViewData: null);
+        }
+
+        /// <summary>
         /// Returns HTML markup for the current model, using a display template, specified HTML field name, and
         /// additional view data. The template is found using the <paramref name="templateName"/> or the model's
         /// <see cref="ModelBinding.ModelMetadata"/>.
@@ -667,6 +1282,51 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             }
 
             return htmlHelper.Display(
+                expression: null,
+                templateName: templateName,
+                htmlFieldName: htmlFieldName,
+                additionalViewData: additionalViewData);
+        }
+
+        /// <summary>
+        /// Returns HTML markup for the current model, using a display template, specified HTML field name, and
+        /// additional view data. The template is found using the <paramref name="templateName"/> or the model's
+        /// <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="templateName">The name of the template used to create the HTML markup.</param>
+        /// <param name="htmlFieldName">
+        /// A <see cref="string"/> used to disambiguate the names of HTML elements that are created for
+        /// properties that have the same name.
+        /// </param>
+        /// <param name="additionalViewData">
+        /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{String, Object}"/>
+        /// that can contain additional view data that will be merged into the
+        /// <see cref="ViewFeatures.ViewDataDictionary{TModel}"/> instance created for the template.
+        /// </param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> display template includes markup for each property in the
+        /// current model.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>DisplayTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> DisplayForModelAsync(
+            this IHtmlHelper htmlHelper,
+            string templateName,
+            string htmlFieldName,
+            object additionalViewData)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            return htmlHelper.DisplayAsync(
                 expression: null,
                 templateName: templateName,
                 htmlFieldName: htmlFieldName,

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/HtmlHelperEditorExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/HtmlHelperEditorExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq.Expressions;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
 
 namespace Microsoft.AspNetCore.Mvc.Rendering
@@ -44,6 +45,40 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             }
 
             return htmlHelper.Editor(expression, templateName: null, htmlFieldName: null, additionalViewData: null);
+        }
+
+        /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using an editor template. The template is found
+        /// using the <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="expression">
+        /// Expression name, relative to the current model. May identify a single property or an
+        /// <see cref="object"/> that contains the properties to edit.
+        /// </param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element(s).</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> editor template includes &lt;label&gt; and &lt;input&gt;
+        /// elements for each property in the <paramref name="expression"/>'s value.
+        /// </para>
+        /// <para>
+        /// Example <paramref name="expression"/>s include <c>string.Empty</c> which identifies the current model and
+        /// <c>"prop"</c> which identifies the current model's "prop" property.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>EditorTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> EditorAsync(this IHtmlHelper htmlHelper, string expression)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            return htmlHelper.EditorAsync(expression, templateName: null, htmlFieldName: null, additionalViewData: null);
         }
 
         /// <summary>
@@ -94,6 +129,53 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using an editor template and specified
+        /// additional view data. The template is found using the <paramref name="expression"/>'s
+        /// <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="expression">
+        /// Expression name, relative to the current model. May identify a single property or an
+        /// <see cref="object"/> that contains the properties to edit.
+        /// </param>
+        /// <param name="additionalViewData">
+        /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{String, Object}"/>
+        /// that can contain additional view data that will be merged into the
+        /// <see cref="ViewFeatures.ViewDataDictionary{TModel}"/> instance created for the template.
+        /// </param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element(s).</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> editor template includes &lt;label&gt; and &lt;input&gt;
+        /// elements for each property in the <paramref name="expression"/>'s value.
+        /// </para>
+        /// <para>
+        /// Example <paramref name="expression"/>s include <c>string.Empty</c> which identifies the current model and
+        /// <c>"prop"</c> which identifies the current model's "prop" property.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>EditorTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> EditorAsync(
+            this IHtmlHelper htmlHelper,
+            string expression,
+            object additionalViewData)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            return htmlHelper.EditorAsync(
+                expression,
+                templateName: null,
+                htmlFieldName: null,
+                additionalViewData: additionalViewData);
+        }
+
+        /// <summary>
         /// Returns HTML markup for the <paramref name="expression"/>, using an editor template. The template is found
         /// using the <paramref name="templateName"/> or the <paramref name="expression"/>'s
         /// <see cref="ModelBinding.ModelMetadata"/>.
@@ -127,6 +209,42 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             }
 
             return htmlHelper.Editor(expression, templateName, htmlFieldName: null, additionalViewData: null);
+        }
+
+        /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using an editor template. The template is found
+        /// using the <paramref name="templateName"/> or the <paramref name="expression"/>'s
+        /// <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="expression">
+        /// Expression name, relative to the current model. May identify a single property or an
+        /// <see cref="object"/> that contains the properties to edit.
+        /// </param>
+        /// <param name="templateName">The name of the template used to create the HTML markup.</param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element(s).</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> editor template includes &lt;label&gt; and &lt;input&gt;
+        /// elements for each property in the <paramref name="expression"/>'s value.
+        /// </para>
+        /// <para>
+        /// Example <paramref name="expression"/>s include <c>string.Empty</c> which identifies the current model and
+        /// <c>"prop"</c> which identifies the current model's "prop" property.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>EditorTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> EditorAsync(this IHtmlHelper htmlHelper, string expression, string templateName)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            return htmlHelper.EditorAsync(expression, templateName, htmlFieldName: null, additionalViewData: null);
         }
 
         /// <summary>
@@ -172,6 +290,55 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             }
 
             return htmlHelper.Editor(
+                expression,
+                templateName,
+                htmlFieldName: null,
+                additionalViewData: additionalViewData);
+        }
+
+        /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using an editor template and specified
+        /// additional view data. The template is found using the <paramref name="templateName"/> or the
+        /// <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="expression">
+        /// Expression name, relative to the current model. May identify a single property or an
+        /// <see cref="object"/> that contains the properties to edit.
+        /// </param>
+        /// <param name="templateName">The name of the template used to create the HTML markup.</param>
+        /// <param name="additionalViewData">
+        /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{String, Object}"/>
+        /// that can contain additional view data that will be merged into the
+        /// <see cref="ViewFeatures.ViewDataDictionary{TModel}"/> instance created for the template.
+        /// </param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element(s).</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> editor template includes &lt;label&gt; and &lt;input&gt;
+        /// elements for each property in the <paramref name="expression"/>'s value.
+        /// </para>
+        /// <para>
+        /// Example <paramref name="expression"/>s include <c>string.Empty</c> which identifies the current model and
+        /// <c>"prop"</c> which identifies the current model's "prop" property.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>EditorTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> EditorAsync(
+            this IHtmlHelper htmlHelper,
+            string expression,
+            string templateName,
+            object additionalViewData)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            return htmlHelper.EditorAsync(
                 expression,
                 templateName,
                 htmlFieldName: null,
@@ -223,6 +390,50 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using an editor template and specified HTML
+        /// field name. The template is found using the <paramref name="templateName"/> or the
+        /// <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="expression">
+        /// Expression name, relative to the current model. May identify a single property or an
+        /// <see cref="object"/> that contains the properties to edit.
+        /// </param>
+        /// <param name="templateName">The name of the template used to create the HTML markup.</param>
+        /// <param name="htmlFieldName">
+        /// A <see cref="string"/> used to disambiguate the names of HTML elements that are created for
+        /// properties that have the same name.
+        /// </param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element(s).</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> editor template includes &lt;label&gt; and &lt;input&gt;
+        /// elements for each property in the <paramref name="expression"/>'s value.
+        /// </para>
+        /// <para>
+        /// Example <paramref name="expression"/>s include <c>string.Empty</c> which identifies the current model and
+        /// <c>"prop"</c> which identifies the current model's "prop" property.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>EditorTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> EditorAsync(
+            this IHtmlHelper htmlHelper,
+            string expression,
+            string templateName,
+            string htmlFieldName)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            return htmlHelper.EditorAsync(expression, templateName, htmlFieldName, additionalViewData: null);
+        }
+
+        /// <summary>
         /// Returns HTML markup for the <paramref name="expression"/>, using an editor template. The template is found
         /// using the <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
@@ -256,6 +467,42 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             }
 
             return htmlHelper.EditorFor(expression, templateName: null, htmlFieldName: null, additionalViewData: null);
+        }
+
+        /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using an editor template. The template is found
+        /// using the <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
+        /// <param name="expression">An expression to be evaluated against the current model.</param>
+        /// <typeparam name="TModel">The type of the model.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element(s).</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> editor template includes &lt;label&gt; and &lt;input&gt;
+        /// elements for each property in the <paramref name="expression"/> result.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>EditorTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> EditorForAsync<TModel, TResult>(
+            this IHtmlHelper<TModel> htmlHelper,
+            Expression<Func<TModel, TResult>> expression)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            if (expression == null)
+            {
+                throw new ArgumentNullException(nameof(expression));
+            }
+
+            return htmlHelper.EditorForAsync(expression, templateName: null, htmlFieldName: null, additionalViewData: null);
         }
 
         /// <summary>
@@ -306,6 +553,53 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using an editor template and specified
+        /// additional view data. The template is found using the <paramref name="expression"/>'s
+        /// <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
+        /// <param name="expression">An expression to be evaluated against the current model.</param>
+        /// <param name="additionalViewData">
+        /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{String, Object}"/>
+        /// that can contain additional view data that will be merged into the
+        /// <see cref="ViewFeatures.ViewDataDictionary{TModel}"/> instance created for the template.
+        /// </param>
+        /// <typeparam name="TModel">The type of the model.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element(s).</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> editor template includes &lt;label&gt; and &lt;input&gt;
+        /// elements for each property in the <paramref name="expression"/> result.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>EditorTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> EditorForAsync<TModel, TResult>(
+            this IHtmlHelper<TModel> htmlHelper,
+            Expression<Func<TModel, TResult>> expression,
+            object additionalViewData)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            if (expression == null)
+            {
+                throw new ArgumentNullException(nameof(expression));
+            }
+
+            return htmlHelper.EditorForAsync(
+                expression,
+                templateName: null,
+                htmlFieldName: null,
+                additionalViewData: additionalViewData);
+        }
+
+        /// <summary>
         /// Returns HTML markup for the <paramref name="expression"/>, using an editor template. The template is found
         /// using the <paramref name="templateName"/> or the <paramref name="expression"/>'s
         /// <see cref="ModelBinding.ModelMetadata"/>.
@@ -342,6 +636,45 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             }
 
             return htmlHelper.EditorFor(expression, templateName, htmlFieldName: null, additionalViewData: null);
+        }
+
+        /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using an editor template. The template is found
+        /// using the <paramref name="templateName"/> or the <paramref name="expression"/>'s
+        /// <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
+        /// <param name="expression">An expression to be evaluated against the current model.</param>
+        /// <param name="templateName">The name of the template that is used to create the HTML markup.</param>
+        /// <typeparam name="TModel">The type of the model.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element(s).</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> editor template includes &lt;label&gt; and &lt;input&gt;
+        /// elements for each property in the <paramref name="expression"/> result.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>EditorTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> EditorForAsync<TModel, TResult>(
+            this IHtmlHelper<TModel> htmlHelper,
+            Expression<Func<TModel, TResult>> expression,
+            string templateName)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            if (expression == null)
+            {
+                throw new ArgumentNullException(nameof(expression));
+            }
+
+            return htmlHelper.EditorForAsync(expression, templateName, htmlFieldName: null, additionalViewData: null);
         }
 
         /// <summary>
@@ -394,6 +727,55 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using an editor template and specified
+        /// additional view data. The template is found using the <paramref name="templateName"/> or the
+        /// <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
+        /// <param name="expression">An expression to be evaluated against the current model.</param>
+        /// <param name="templateName">The name of the template that is used to create the HTML markup.</param>
+        /// <param name="additionalViewData">
+        /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{String, Object}"/>
+        /// that can contain additional view data that will be merged into the
+        /// <see cref="ViewFeatures.ViewDataDictionary{TModel}"/> instance created for the template.
+        /// </param>
+        /// <typeparam name="TModel">The type of the model.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element(s).</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> editor template includes &lt;label&gt; and &lt;input&gt;
+        /// elements for each property in the <paramref name="expression"/> result.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>EditorTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> EditorForAsync<TModel, TResult>(
+            this IHtmlHelper<TModel> htmlHelper,
+            Expression<Func<TModel, TResult>> expression,
+            string templateName,
+            object additionalViewData)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            if (expression == null)
+            {
+                throw new ArgumentNullException(nameof(expression));
+            }
+
+            return htmlHelper.EditorForAsync(
+                expression,
+                templateName,
+                htmlFieldName: null,
+                additionalViewData: additionalViewData);
+        }
+
+        /// <summary>
         /// Returns HTML markup for the <paramref name="expression"/>, using an editor template and specified HTML
         /// field name. The template is found using the <paramref name="templateName"/> or the
         /// <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
@@ -438,6 +820,50 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using an editor template and specified HTML
+        /// field name. The template is found using the <paramref name="templateName"/> or the
+        /// <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
+        /// <param name="expression">An expression to be evaluated against the current model.</param>
+        /// <param name="templateName">The name of the template that is used to create the HTML markup.</param>
+        /// <param name="htmlFieldName">
+        /// A <see cref="string"/> used to disambiguate the names of HTML elements that are created for properties
+        /// that have the same name.
+        /// </param>
+        /// <typeparam name="TModel">The type of the model.</typeparam>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element(s).</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> editor template includes &lt;label&gt; and &lt;input&gt;
+        /// elements for each property in the <paramref name="expression"/> result.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>EditorTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> EditorForAsync<TModel, TResult>(
+            this IHtmlHelper<TModel> htmlHelper,
+            Expression<Func<TModel, TResult>> expression,
+            string templateName,
+            string htmlFieldName)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            if (expression == null)
+            {
+                throw new ArgumentNullException(nameof(expression));
+            }
+
+            return htmlHelper.EditorForAsync(expression, templateName, htmlFieldName, additionalViewData: null);
+        }
+
+        /// <summary>
         /// Returns HTML markup for the current model, using an editor template. The template is found using the
         /// model's <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
@@ -461,6 +887,36 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             }
 
             return htmlHelper.Editor(
+                expression: null,
+                templateName: null,
+                htmlFieldName: null,
+                additionalViewData: null);
+        }
+
+        /// <summary>
+        /// Returns HTML markup for the current model, using an editor template. The template is found using the
+        /// model's <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element(s).</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> editor template includes &lt;label&gt; and &lt;input&gt;
+        /// elements for each property in the current model.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>EditorTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> EditorForModelAsync(this IHtmlHelper htmlHelper)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            return htmlHelper.EditorAsync(
                 expression: null,
                 templateName: null,
                 htmlFieldName: null,
@@ -503,6 +959,41 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
+        /// Returns HTML markup for the current model, using an editor template and specified additional view data. The
+        /// template is found using the model's <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="additionalViewData">
+        /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{String, Object}"/>
+        /// that can contain additional view data that will be merged into the
+        /// <see cref="ViewFeatures.ViewDataDictionary{TModel}"/> instance created for the template.
+        /// </param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element(s).</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> editor template includes &lt;label&gt; and &lt;input&gt;
+        /// elements for each property in the current model.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>EditorTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> EditorForModelAsync(this IHtmlHelper htmlHelper, object additionalViewData)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            return htmlHelper.EditorAsync(
+                expression: null,
+                templateName: null,
+                htmlFieldName: null,
+                additionalViewData: additionalViewData);
+        }
+
+        /// <summary>
         /// Returns HTML markup for the current model, using an editor template. The template is found using the
         /// <paramref name="templateName"/> or the model's <see cref="ModelBinding.ModelMetadata"/>.
         /// </summary>
@@ -527,6 +1018,37 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             }
 
             return htmlHelper.Editor(
+                expression: null,
+                templateName: templateName,
+                htmlFieldName: null,
+                additionalViewData: null);
+        }
+
+        /// <summary>
+        /// Returns HTML markup for the current model, using an editor template. The template is found using the
+        /// <paramref name="templateName"/> or the model's <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="templateName">The name of the template used to create the HTML markup.</param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element(s).</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> editor template includes &lt;label&gt; and &lt;input&gt;
+        /// elements for each property in the current model.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>EditorTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> EditorForModelAsync(this IHtmlHelper htmlHelper, string templateName)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            return htmlHelper.EditorAsync(
                 expression: null,
                 templateName: templateName,
                 htmlFieldName: null,
@@ -567,6 +1089,46 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             }
 
             return htmlHelper.Editor(
+                expression: null,
+                templateName: templateName,
+                htmlFieldName: null,
+                additionalViewData: additionalViewData);
+        }
+
+        /// <summary>
+        /// Returns HTML markup for the current model, using an editor template and specified additional view data. The
+        /// template is found using the <paramref name="templateName"/> or the model's
+        /// <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="templateName">The name of the template used to create the HTML markup.</param>
+        /// <param name="additionalViewData">
+        /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{String, Object}"/>
+        /// that can contain additional view data that will be merged into the
+        /// <see cref="ViewFeatures.ViewDataDictionary{TModel}"/> instance created for the template.
+        /// </param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element(s).</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> editor template includes &lt;label&gt; and &lt;input&gt;
+        /// elements for each property in the current model.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>EditorTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> EditorForModelAsync(
+            this IHtmlHelper htmlHelper,
+            string templateName,
+            object additionalViewData)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            return htmlHelper.EditorAsync(
                 expression: null,
                 templateName: templateName,
                 htmlFieldName: null,
@@ -613,6 +1175,45 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         }
 
         /// <summary>
+        /// Returns HTML markup for the current model, using an editor template and specified HTML field name. The
+        /// template is found using the <paramref name="templateName"/> or the model's
+        /// <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="templateName">The name of the template used to create the HTML markup.</param>
+        /// <param name="htmlFieldName">
+        /// A <see cref="string"/> used to disambiguate the names of HTML elements that are created for
+        /// properties that have the same name.
+        /// </param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element(s).</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> editor template includes &lt;label&gt; and &lt;input&gt;
+        /// elements for each property in the current model.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>EditorTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> EditorForModelAsync(
+            this IHtmlHelper htmlHelper,
+            string templateName,
+            string htmlFieldName)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            return htmlHelper.EditorAsync(
+                expression: null,
+                templateName: templateName,
+                htmlFieldName: htmlFieldName,
+                additionalViewData: null);
+        }
+
+        /// <summary>
         /// Returns HTML markup for the current model, using an editor template, specified HTML field name, and
         /// additional view data. The template is found using the <paramref name="templateName"/> or the model's
         /// <see cref="ModelBinding.ModelMetadata"/>.
@@ -651,6 +1252,51 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             }
 
             return htmlHelper.Editor(
+                expression: null,
+                templateName: templateName,
+                htmlFieldName: htmlFieldName,
+                additionalViewData: additionalViewData);
+        }
+
+        /// <summary>
+        /// Returns HTML markup for the current model, using an editor template, specified HTML field name, and
+        /// additional view data. The template is found using the <paramref name="templateName"/> or the model's
+        /// <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
+        /// <param name="templateName">The name of the template used to create the HTML markup.</param>
+        /// <param name="htmlFieldName">
+        /// A <see cref="string"/> used to disambiguate the names of HTML elements that are created for
+        /// properties that have the same name.
+        /// </param>
+        /// <param name="additionalViewData">
+        /// An anonymous <see cref="object"/> or <see cref="System.Collections.Generic.IDictionary{String, Object}"/>
+        /// that can contain additional view data that will be merged into the
+        /// <see cref="ViewFeatures.ViewDataDictionary{TModel}"/> instance created for the template.
+        /// </param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element(s).</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> editor template includes &lt;label&gt; and &lt;input&gt;
+        /// elements for each property in the current model.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>EditorTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        public static Task<IHtmlContent> EditorForModelAsync(
+            this IHtmlHelper htmlHelper,
+            string templateName,
+            string htmlFieldName,
+            object additionalViewData)
+        {
+            if (htmlHelper == null)
+            {
+                throw new ArgumentNullException(nameof(htmlHelper));
+            }
+
+            return htmlHelper.EditorAsync(
                 expression: null,
                 templateName: templateName,
                 htmlFieldName: htmlFieldName,

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/IHtmlHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/IHtmlHelper.cs
@@ -235,6 +235,46 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
             object additionalViewData);
 
         /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using a display template, specified HTML field
+        /// name, and additional view data. The template is found using the <paramref name="templateName"/> or the
+        /// <paramref name="expression"/>'s <see cref="ModelMetadata"/>.
+        /// </summary>
+        /// <param name="expression">
+        /// Expression name, relative to the current model. May identify a single property or an
+        /// <see cref="object"/> that contains the properties to display.
+        /// </param>
+        /// <param name="templateName">The name of the template used to create the HTML markup.</param>
+        /// <param name="htmlFieldName">
+        /// A <see cref="string"/> used to disambiguate the names of HTML elements that are created for
+        /// properties that have the same name.
+        /// </param>
+        /// <param name="additionalViewData">
+        /// An anonymous <see cref="object"/> or <see cref="IDictionary{String, Object}"/> that can contain additional
+        /// view data that will be merged into the <see cref="ViewDataDictionary{TModel}"/> instance created for the
+        /// template.
+        /// </param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> display template includes markup for each property in the
+        /// <paramref name="expression"/>'s value.
+        /// </para>
+        /// <para>
+        /// Example <paramref name="expression"/>s include <c>string.Empty</c> which identifies the current model and
+        /// <c>"prop"</c> which identifies the current model's "prop" property.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>DisplayTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        Task<IHtmlContent> DisplayAsync(
+            string expression,
+            string templateName,
+            string htmlFieldName,
+            object additionalViewData);
+
+        /// <summary>
         /// Returns the display name for the specified <paramref name="expression"/>.
         /// </summary>
         /// <param name="expression">Expression name, relative to the current model.</param>
@@ -321,6 +361,42 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </para>
         /// </remarks>
         IHtmlContent Editor(string expression, string templateName, string htmlFieldName, object additionalViewData);
+
+        /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using an editor template, specified HTML field
+        /// name, and additional view data. The template is found using the <paramref name="templateName"/> or the
+        /// <paramref name="expression"/>'s <see cref="ModelMetadata"/>.
+        /// </summary>
+        /// <param name="expression">
+        /// Expression name, relative to the current model. May identify a single property or an
+        /// <see cref="object"/> that contains the properties to edit.
+        /// </param>
+        /// <param name="templateName">The name of the template used to create the HTML markup.</param>
+        /// <param name="htmlFieldName">
+        /// A <see cref="string"/> used to disambiguate the names of HTML elements that are created for
+        /// properties that have the same name.
+        /// </param>
+        /// <param name="additionalViewData">
+        /// An anonymous <see cref="object"/> or <see cref="IDictionary{String, Object}"/> that can contain additional
+        /// view data that will be merged into the <see cref="ViewDataDictionary{TModel}"/> instance created for the
+        /// template.
+        /// </param>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element(s).</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> editor template includes &lt;label&gt; and &lt;input&gt;
+        /// elements for each property in the <paramref name="expression"/>'s value.
+        /// </para>
+        /// <para>
+        /// Example <paramref name="expression"/>s include <c>string.Empty</c> which identifies the current model and
+        /// <c>"prop"</c> which identifies the current model's "prop" property.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>EditorTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        Task<IHtmlContent> EditorAsync(string expression, string templateName, string htmlFieldName, object additionalViewData);
 
         /// <summary>
         /// Converts the <paramref name="value"/> to an HTML-encoded <see cref="string"/>.

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/IHtmlHelperOfT.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Rendering/IHtmlHelperOfT.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
@@ -74,6 +75,40 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </para>
         /// </remarks>
         IHtmlContent DisplayFor<TResult>(
+            Expression<Func<TModel, TResult>> expression,
+            string templateName,
+            string htmlFieldName,
+            object additionalViewData);
+
+        /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using a display template, specified HTML field
+        /// name, and additional view data. The template is found using the <paramref name="templateName"/> or the
+        /// <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="expression">An expression to be evaluated against the current model.</param>
+        /// <param name="templateName">The name of the template used to create the HTML markup.</param>
+        /// <param name="htmlFieldName">
+        /// A <see cref="string"/> used to disambiguate the names of HTML elements that are created for properties
+        /// that have the same name.
+        /// </param>
+        /// <param name="additionalViewData">
+        /// An anonymous <see cref="object"/> or <see cref="IDictionary{String, Object}"/> that can contain additional
+        /// view data that will be merged into the <see cref="ViewDataDictionary{TModel}"/> instance created for the
+        /// template.
+        /// </param>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the created HTML.</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> display template includes markup for each property in the
+        /// <paramref name="expression"/> result.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>DisplayTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        Task<IHtmlContent> DisplayForAsync<TResult>(
             Expression<Func<TModel, TResult>> expression,
             string templateName,
             string htmlFieldName,
@@ -174,6 +209,40 @@ namespace Microsoft.AspNetCore.Mvc.Rendering
         /// </para>
         /// </remarks>
         IHtmlContent EditorFor<TResult>(
+            Expression<Func<TModel, TResult>> expression,
+            string templateName,
+            string htmlFieldName,
+            object additionalViewData);
+
+        /// <summary>
+        /// Returns HTML markup for the <paramref name="expression"/>, using an editor template, specified HTML field
+        /// name, and additional view data. The template is found using the <paramref name="templateName"/> or the
+        /// <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
+        /// </summary>
+        /// <param name="expression">An expression to be evaluated against the current model.</param>
+        /// <param name="templateName">The name of the template that is used to create the HTML markup.</param>
+        /// <param name="htmlFieldName">
+        /// A <see cref="string"/> used to disambiguate the names of HTML elements that are created for properties
+        /// that have the same name.
+        /// </param>
+        /// <param name="additionalViewData">
+        /// An anonymous <see cref="object"/> or <see cref="IDictionary{String, Object}"/> that can contain additional
+        /// view data that will be merged into the <see cref="ViewDataDictionary{TModel}"/> instance created for the
+        /// template.
+        /// </param>
+        /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>
+        /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element(s).</returns>
+        /// <remarks>
+        /// <para>
+        /// For example the default <see cref="object"/> editor template includes &lt;label&gt; and &lt;input&gt;
+        /// elements for each property in the <paramref name="expression"/> result.
+        /// </para>
+        /// <para>
+        /// Custom templates are found under a <c>EditorTemplates</c> folder. The folder name is case-sensitive on
+        /// case-sensitive file systems.
+        /// </para>
+        /// </remarks>
+        Task<IHtmlContent> EditorForAsync<TResult>(
             Expression<Func<TModel, TResult>> expression,
             string templateName,
             string htmlFieldName,

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/HtmlHelper.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/HtmlHelper.cs
@@ -327,6 +327,22 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         }
 
         /// <inheritdoc />
+        public Task<IHtmlContent> DisplayAsync(
+            string expression,
+            string templateName,
+            string htmlFieldName,
+            object additionalViewData)
+        {
+            var metadata = ExpressionMetadataProvider.FromStringExpression(expression, ViewData, MetadataProvider);
+
+            return GenerateDisplayAsync(
+                metadata,
+                htmlFieldName ?? ExpressionHelper.GetExpressionText(expression),
+                templateName,
+                additionalViewData);
+        }
+
+        /// <inheritdoc />
         public string DisplayName(string expression)
         {
             var modelExplorer = ExpressionMetadataProvider.FromStringExpression(expression, ViewData, MetadataProvider);
@@ -365,6 +381,22 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             var modelExplorer = ExpressionMetadataProvider.FromStringExpression(expression, ViewData, MetadataProvider);
 
             return GenerateEditor(
+                modelExplorer,
+                htmlFieldName ?? ExpressionHelper.GetExpressionText(expression),
+                templateName,
+                additionalViewData);
+        }
+
+        /// <inheritdoc />
+        public Task<IHtmlContent> EditorAsync(
+            string expression,
+            string templateName,
+            string htmlFieldName,
+            object additionalViewData)
+        {
+            var modelExplorer = ExpressionMetadataProvider.FromStringExpression(expression, ViewData, MetadataProvider);
+
+            return GenerateEditorAsync(
                 modelExplorer,
                 htmlFieldName ?? ExpressionHelper.GetExpressionText(expression),
                 templateName,
@@ -501,6 +533,26 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 additionalViewData: additionalViewData);
 
             return templateBuilder.Build();
+        }
+
+        protected virtual Task<IHtmlContent> GenerateDisplayAsync(
+            ModelExplorer modelExplorer,
+            string htmlFieldName,
+            string templateName,
+            object additionalViewData)
+        {
+            var templateBuilder = new TemplateBuilder(
+                _viewEngine,
+                _bufferScope,
+                ViewContext,
+                ViewData,
+                modelExplorer,
+                htmlFieldName,
+                templateName,
+                readOnly: true,
+                additionalViewData: additionalViewData);
+
+            return templateBuilder.BuildAsync();
         }
 
         protected virtual async Task RenderPartialCoreAsync(
@@ -821,6 +873,26 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 additionalViewData: additionalViewData);
 
             return templateBuilder.Build();
+        }
+
+        protected virtual Task<IHtmlContent> GenerateEditorAsync(
+            ModelExplorer modelExplorer,
+            string htmlFieldName,
+            string templateName,
+            object additionalViewData)
+        {
+            var templateBuilder = new TemplateBuilder(
+                _viewEngine,
+                _bufferScope,
+                ViewContext,
+                ViewData,
+                modelExplorer,
+                htmlFieldName,
+                templateName,
+                readOnly: false,
+                additionalViewData: additionalViewData);
+
+            return templateBuilder.BuildAsync();
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/HtmlHelperOfT.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/HtmlHelperOfT.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Text.Encodings.Web;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -152,6 +153,26 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         }
 
         /// <inheritdoc />
+        public Task<IHtmlContent> DisplayForAsync<TResult>(
+            Expression<Func<TModel, TResult>> expression,
+            string templateName,
+            string htmlFieldName,
+            object additionalViewData)
+        {
+            if (expression == null)
+            {
+                throw new ArgumentNullException(nameof(expression));
+            }
+
+            var modelExplorer = GetModelExplorer(expression);
+            return GenerateDisplayAsync(
+                modelExplorer,
+                htmlFieldName ?? GetExpressionName(expression),
+                templateName,
+                additionalViewData);
+        }
+
+        /// <inheritdoc />
         public string DisplayNameFor<TResult>(Expression<Func<TModel, TResult>> expression)
         {
             if (expression == null)
@@ -211,6 +232,26 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 
             var modelExplorer = GetModelExplorer(expression);
             return GenerateEditor(
+                modelExplorer,
+                htmlFieldName ?? GetExpressionName(expression),
+                templateName,
+                additionalViewData);
+        }
+
+        /// <inheritdoc />
+        public Task<IHtmlContent> EditorForAsync<TResult>(
+            Expression<Func<TModel, TResult>> expression,
+            string templateName,
+            string htmlFieldName,
+            object additionalViewData)
+        {
+            if (expression == null)
+            {
+                throw new ArgumentNullException(nameof(expression));
+            }
+
+            var modelExplorer = GetModelExplorer(expression);
+            return GenerateEditorAsync(
                 modelExplorer,
                 htmlFieldName ?? GetExpressionName(expression),
                 templateName,

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/TemplateBuilder.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/TemplateBuilder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -77,6 +78,10 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
 
         public IHtmlContent Build()
         {
+            return BuildAsync().GetAwaiter().GetResult();
+        }
+        public async Task<IHtmlContent> BuildAsync()
+        {
             if (_metadata.ConvertEmptyStringToNull && string.Empty.Equals(_model))
             {
                 _model = null;
@@ -96,8 +101,8 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             // though _model may have been reset to null. Otherwise we might lose track of the model type /property.
             viewData.ModelExplorer = _modelExplorer.GetExplorerForModel(_model);
 
-            var formatString = _readOnly ? 
-                viewData.ModelMetadata.DisplayFormatString : 
+            var formatString = _readOnly ?
+                viewData.ModelMetadata.DisplayFormatString :
                 viewData.ModelMetadata.EditFormatString;
 
             var formattedModelValue = _model;
@@ -157,7 +162,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
                 _templateName,
                 _readOnly);
 
-            return templateRenderer.Render();
+            return await templateRenderer.RenderAsync();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/TemplateRenderer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/ViewFeatures/TemplateRenderer.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -115,6 +116,10 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
 
         public IHtmlContent Render()
         {
+            return RenderAsync().GetAwaiter().GetResult();
+        }
+        public async Task<IHtmlContent> RenderAsync()
+        {
             var defaultActions = GetDefaultActions();
             var modeViewPath = _readOnly ? DisplayTemplateViewPath : EditorTemplateViewPath;
 
@@ -138,7 +143,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
                         {
                             var viewContext = new ViewContext(_viewContext, viewEngineResult.View, _viewData, writer);
                             var renderTask = viewEngineResult.View.RenderAsync(viewContext);
-                            renderTask.GetAwaiter().GetResult();
+                            await renderTask;
                             return viewBuffer;
                         }
                     }
@@ -153,6 +158,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
             throw new InvalidOperationException(
                 Resources.FormatTemplateHelpers_NoTemplate(_viewData.ModelExplorer.ModelType.FullName));
         }
+
 
         private Dictionary<string, Func<IHtmlHelper, IHtmlContent>> GetDefaultActions()
         {

--- a/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Internal/DefaultEditorTemplatesTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.ViewFeatures.Test/Internal/DefaultEditorTemplatesTest.cs
@@ -1462,6 +1462,15 @@ Environment.NewLine;
                 throw new NotImplementedException();
             }
 
+            public Task<IHtmlContent> DisplayAsync(
+                string expression,
+                string templateName,
+                string htmlFieldName,
+                object additionalViewData)
+            {
+                throw new NotImplementedException();
+            }
+
             public string DisplayName(string expression)
             {
                 throw new NotImplementedException();
@@ -1488,6 +1497,15 @@ Environment.NewLine;
                 object additionalViewData)
             {
                 return _innerHelper.Editor(expression, templateName, htmlFieldName, additionalViewData);
+            }
+
+            public Task<IHtmlContent> EditorAsync(
+                string expression,
+                string templateName,
+                string htmlFieldName,
+                object additionalViewData)
+            {
+                return _innerHelper.EditorAsync(expression, templateName, htmlFieldName, additionalViewData);
             }
 
             public string Encode(string value)

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <VersionPrefix>2.1.2</VersionPrefix>
+    <VersionPrefix>2.1.3</VersionPrefix>
     <VersionSuffix>rtm</VersionSuffix>
     <BuildNumber Condition="'$(BuildNumber)' == ''">t000</BuildNumber>
     <FeatureBranchVersionPrefix Condition="'$(FeatureBranchVersionPrefix)' == ''">a-</FeatureBranchVersionPrefix>
@@ -10,7 +10,7 @@
     <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(FeatureBranchVersionSuffix)' != ''">$(FeatureBranchVersionPrefix)$(VersionSuffix)-$([System.Text.RegularExpressions.Regex]::Replace('$(FeatureBranchVersionSuffix)', '[^\w-]', '-'))</VersionSuffix>
     <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
 
-    <ExperimentalVersionPrefix>0.1.2</ExperimentalVersionPrefix>
+    <ExperimentalVersionPrefix>0.1.3</ExperimentalVersionPrefix>
     <ExperimentalVersionSuffix>rtm</ExperimentalVersionSuffix>
 
     <ExperimentalPackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(ExperimentalVersionSuffix)' == 'rtm' ">$(ExperimentalVersionPrefix)</ExperimentalPackageVersion>


### PR DESCRIPTION
Hi,
Regarding issue #7416 , I believe this covers most of it.
As far as I've noticed, the only remaining Sync parts of the view engine are two default display actions, CollectionTemplate and ObjectTemplate, as I didn't want to pull in a bigger update (which actually contains code change, except for adding Async methods).
This also can be easily resolved by changing the GetDefaultActions to Async (it's private anyway), and updating both collections of _defaultDisplayActions and _defaultEditorActions to a Func returning a Task. I could create another pull request for this as well if needed.
Hope this can be merged and pushed into the 2.2 release.

Thanks guys,
Effy