### PR TITLE
Find `IDocumentProvider` using a more-laborious process

### DIFF
--- a/src/GetDocumentInsider/Properties/Resources.Designer.cs
+++ b/src/GetDocumentInsider/Properties/Resources.Designer.cs
@@ -220,6 +220,20 @@ namespace Microsoft.Extensions.ApiDescription.Tool
         internal static string FormatMissingEntryPoint(object p0)
             => string.Format(CultureInfo.CurrentCulture, GetString("MissingEntryPoint"), p0);
 
+        /// <summary>
+        /// Unable to find service type '{0}' in loaded assemblies.
+        /// </summary>
+        internal static string ServiceNotFound
+        {
+            get => GetString("ServiceNotFound");
+        }
+
+        /// <summary>
+        /// Unable to find service type '{0}' in loaded assemblies.
+        /// </summary>
+        internal static string FormatServiceNotFound(object p0)
+            => string.Format(CultureInfo.CurrentCulture, GetString("ServiceNotFound"), p0);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/GetDocumentInsider/Resources.resx
+++ b/src/GetDocumentInsider/Resources.resx
@@ -162,4 +162,7 @@
   <data name="MissingEntryPoint" xml:space="preserve">
     <value>Assembly '{0}' does not contain an entry point.</value>
   </data>
+  <data name="ServiceNotFound" xml:space="preserve">
+    <value>Unable to find service type '{0}' in loaded assemblies.</value>
+  </data>
 </root>

--- a/src/dotnet-getdocument/Properties/Resources.Designer.cs
+++ b/src/dotnet-getdocument/Properties/Resources.Designer.cs
@@ -305,7 +305,7 @@ namespace Microsoft.Extensions.ApiDescription.Tool
             => GetString("OutputDescription");
 
         /// <summary>
-        /// Unable to retrieve '{0}' project metadata. Ensure '{1}' is set.
+        /// Unable to retrieve '{0}' project metadata. Ensure '$({1})' is set.
         /// </summary>
         internal static string GetMetadataValueFailed
         {
@@ -313,7 +313,7 @@ namespace Microsoft.Extensions.ApiDescription.Tool
         }
 
         /// <summary>
-        /// Unable to retrieve '{0}' project metadata. Ensure '{1}' is set.
+        /// Unable to retrieve '{0}' project metadata. Ensure '$({1})' is set.
         /// </summary>
         internal static string FormatGetMetadataValueFailed(object p0, object p1)
             => string.Format(CultureInfo.CurrentCulture, GetString("GetMetadataValueFailed"), p0, p1);


### PR DESCRIPTION
- `Type.GetType(string)` requires an assembly-qualified name and we don't know the assembly

nit:
- reflect recent change to `dotnet-getdocument`'s `Resources.resx` file in its designer file