### PR TITLE
UrlHelperBase L166-167 declared type of url `out` parameter in TryFastGenerateUrl

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Routing/UrlHelperBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Routing/UrlHelperBase.cs
@@ -162,9 +162,8 @@ namespace Microsoft.AspNetCore.Mvc.Routing
 
             // Perf: In most of the common cases, GenerateUrl is called with a null protocol, host and fragment.
             // In such cases, we might not need to build any URL as the url generated is mostly same as the virtual path available in pathData.
-            // For such common cases, this FastGenerateUrl method saves a string allocation per GenerateUrl call.
-            string url;
-            if (TryFastGenerateUrl(protocol, host, virtualPath, fragment, out url))
+            // For such common cases, this FastGenerateUrl method saves a string allocation per GenerateUrl call.            
+            if (TryFastGenerateUrl(protocol, host, virtualPath, fragment, out string url))
             {
                 return url;
             }


### PR DESCRIPTION
This is a really simple edit, but I was just looking through the `UrlHelperBase` to see where some Ambient Route Values were coming from (like when using  `Url.Action` extension method) when I noticed this line and thought that we weren't getting the full value of using the `out` parameter. 

I couldn't find any other references to the `url` and thought that this might be worth editing to make the line more clear and leverage the use of a typed `out` parameter.