### PR TITLE
Allow custom handling of antiforgery failures

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/AntiforgeryValidationFailedResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/AntiforgeryValidationFailedResult.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc.Core.Infrastructure;
+
+namespace Microsoft.AspNetCore.Mvc
+{
+    /// <summary>
+    /// A <see cref="BadRequestResult"/> used for antiforgery validation
+    /// failures. Use <see cref="IAntiforgeryValidationFailedResult"/> to
+    /// match for validation failures inside MVC result filters.
+    /// </summary>
+    public class AntiforgeryValidationFailedResult : BadRequestResult, IAntiforgeryValidationFailedResult
+    { }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/IAntiforgeryValidationFailedResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/IAntiforgeryValidationFailedResult.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Core.Infrastructure
+{
+    /// <summary>
+    /// Represents an <see cref="IActionResult"/> that is used when the
+    /// antiforgery validation failed. This can be matched inside MVC result
+    /// filters to process the validation failure.
+    /// </summary>
+    public interface IAntiforgeryValidationFailedResult : IActionResult
+    { }
+}

--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ValidateAntiforgeryTokenAuthorizationFilter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ValidateAntiforgeryTokenAuthorizationFilter.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Internal
                 catch (AntiforgeryValidationException exception)
                 {
                     _logger.AntiforgeryTokenInvalid(exception.Message, exception);
-                    context.Result = new BadRequestResult();
+                    context.Result = new AntiforgeryValidationFailedResult();
                 }
             }
         }

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/AntiforgeryTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/AntiforgeryTests.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Antiforgery;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests
@@ -174,6 +173,33 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.True(response.Headers.CacheControl.NoCache);
             var pragmaValue = Assert.Single(response.Headers.Pragma.ToArray());
             Assert.Equal("no-cache", pragmaValue.Name);
+        }
+
+        [Fact]
+        public async Task RequestWithoutAntiforgeryToken_SendsBadRequest()
+        {
+            // Arrange
+            var request = new HttpRequestMessage(HttpMethod.Post, "http://localhost/Antiforgery/Login");
+
+            // Act
+            var response = await Client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task RequestWithoutAntiforgeryToken_ExecutesResultFilter()
+        {
+            // Arrange
+            var request = new HttpRequestMessage(HttpMethod.Post, "http://localhost/Antiforgery/LoginWithRedirectResultFilter");
+
+            // Act
+            var response = await Client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+            Assert.Equal("http://example.com/antiforgery-redirect", response.Headers.Location.AbsoluteUri);
         }
     }
 }

--- a/test/WebSites/BasicWebSite/Controllers/AntiforgeryController.cs
+++ b/test/WebSites/BasicWebSite/Controllers/AntiforgeryController.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using BasicWebSite.Filters;
 using BasicWebSite.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -37,6 +38,16 @@ namespace BasicWebSite.Controllers
         public string Login(LoginViewModel model)
         {
             return "OK";
+        }
+
+        // POST: /Antiforgery/LoginWithRedirectResultFilter
+        [HttpPost]
+        [AllowAnonymous]
+        [ValidateAntiForgeryToken]
+        [TypeFilter(typeof(RedirectAntiforgeryValidationFailedResultFilter))]
+        public string LoginWithRedirectResultFilter(LoginViewModel model)
+        {
+            return "Ok";
         }
 
         // GET: /Antiforgery/FlushAsyncLogin

--- a/test/WebSites/BasicWebSite/Filters/RedirectAntiforgeryValidationFailedResultFilter.cs
+++ b/test/WebSites/BasicWebSite/Filters/RedirectAntiforgeryValidationFailedResultFilter.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Core.Infrastructure;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace BasicWebSite.Filters
+{
+    public class RedirectAntiforgeryValidationFailedResultFilter : IAlwaysRunResultFilter
+    {
+        public void OnResultExecuting(ResultExecutingContext context)
+        {
+            if (context.Result is IAntiforgeryValidationFailedResult result)
+            {
+                context.Result = new RedirectResult("http://example.com/antiforgery-redirect");
+            }
+        }
+
+        public void OnResultExecuted(ResultExecutedContext context)
+        { }
+    }
+}


### PR DESCRIPTION
This fixes the problem highlighted in https://github.com/aspnet/AspNetCore/issues/3616 and adds support to allow custom handling of antiforgery validation failures. Right now, the `ValidateAntiforgeryTokenAuthorizationFilter` simply sets a `BadRequestResult` and there is no way to hook into this behavior and do anything else.

This introduces a new `AntiforgeryValidationFailedResult` that extends `BadRequestResult` but allows to be identified explicitly within always-running result filters (they need to be always-running in order to go around the short-circuiting behavior of the MVC filter pipeline).

An example for a filter that intercepts the result is included in the functional test and essentially looks like this:

```
public class RedirectAntiforgeryValidationFailedResultFilter : IAsyncAlwaysRunResultFilter
{
    public Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)
    {
        if (context.Result is AntiforgeryValidationFailedResult result)
        {
            context.Result = new RedirectResult("http://example.com/antiforgery-redirect");
        }

        return next();
    }
}
```

When applied in the pipeline, this filter will intercept the `AntiforgeryValidationFailedResult` and replace it with something else.