### PR TITLE
Remove redundant null check

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/PhysicalFileResultExecutor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Infrastructure/PhysicalFileResultExecutor.cs
@@ -110,20 +110,13 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
         }
 
         protected virtual Stream GetFileStream(string path)
-        {
-            if (path == null)
-            {
-                throw new ArgumentNullException(nameof(path));
-            }
-
-            return new FileStream(
-                    path,
-                    FileMode.Open,
-                    FileAccess.Read,
-                    FileShare.ReadWrite,
-                    BufferSize,
-                    FileOptions.Asynchronous | FileOptions.SequentialScan);
-        }
+            => new FileStream(
+                path,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.ReadWrite,
+                BufferSize,
+                FileOptions.Asynchronous | FileOptions.SequentialScan);
 
         protected virtual FileMetadata GetFileInfo(string path)
         {


### PR DESCRIPTION
new FileStream() will throw with path == null (https://github.com/dotnet/corefx/blob/0bfc4f3cf62f6fc29162ad5b1b89acc14124a375/src/Common/src/CoreLib/System/IO/FileStream.cs#L184)