### PR TITLE
Remove LinkGenerationTemplate

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/Routing/ControllerLinkGeneratorExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Routing/ControllerLinkGeneratorExtensions.cs
@@ -13,11 +13,6 @@ namespace Microsoft.AspNetCore.Routing
     /// </summary>
     public static class ControllerLinkGeneratorExtensions
     {
-        private static readonly LinkGenerationTemplateOptions _templateOptions = new LinkGenerationTemplateOptions()
-        {
-            UseAmbientValues = true,
-        };
-
         /// <summary>
         /// Generates a URI with an absolute path based on the provided values.
         /// </summary>
@@ -222,41 +217,6 @@ namespace Microsoft.AspNetCore.Routing
 
             var address = CreateAddress(httpContext: null, action, controller, values);
             return generator.GetUriByAddress<RouteValuesAddress>(address, address.ExplicitValues, scheme, host, pathBase, fragment, options);
-        }
-
-        /// <summary>
-        /// Gets a <see cref="LinkGenerationTemplate"/> based on the provided <paramref name="action"/>, <paramref name="controller"/>, and <paramref name="values"/>.
-        /// </summary>
-        /// <param name="generator">The <see cref="LinkGenerator"/>.</param>
-        /// <param name="action">The action name. Used to resolve endpoints.</param>
-        /// <param name="controller">The controller name. Used to resolve endpoints.</param>
-        /// <param name="values">The route values. Optional. Used to resolve endpoints and expand parameters in the route template.</param>
-        /// <returns>
-        /// A <see cref="LinkGenerationTemplate"/> if one or more endpoints matching the address can be found, otherwise <c>null</c>.
-        /// </returns>
-        public static LinkGenerationTemplate GetTemplateByAction(
-            this LinkGenerator generator,
-            string action,
-            string controller,
-            object values = default)
-        {
-            if (generator == null)
-            {
-                throw new ArgumentNullException(nameof(generator));
-            }
-
-            if (action == null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
-
-            if (controller == null)
-            {
-                throw new ArgumentNullException(nameof(controller));
-            }
-
-            var address = CreateAddress(httpContext: null, action, controller, values);
-            return generator.GetTemplateByAddress<RouteValuesAddress>(address, _templateOptions);
         }
 
         private static RouteValuesAddress CreateAddress(HttpContext httpContext, string action, string controller, object values)

--- a/src/Microsoft.AspNetCore.Mvc.Core/Routing/PageLinkGeneratorExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/Routing/PageLinkGeneratorExtensions.cs
@@ -13,11 +13,6 @@ namespace Microsoft.AspNetCore.Routing
     /// </summary>
     public static class PageLinkGeneratorExtensions
     {
-        private static readonly LinkGenerationTemplateOptions _templateOptions = new LinkGenerationTemplateOptions()
-        {
-            UseAmbientValues = true,
-        };
-
         /// <summary>
         /// Generates a URI with an absolute path based on the provided values.
         /// </summary>
@@ -214,36 +209,6 @@ namespace Microsoft.AspNetCore.Routing
 
             var address = CreateAddress(httpContext: null, page, handler, values);
             return generator.GetUriByAddress<RouteValuesAddress>(address, address.ExplicitValues, scheme, host, pathBase, fragment, options);
-        }
-
-        /// <summary>
-        /// Gets a <see cref="LinkGenerationTemplate"/> based on the provided <paramref name="page"/>, <paramref name="handler"/>, and <paramref name="values"/>.
-        /// </summary>
-        /// <param name="generator">The <see cref="LinkGenerator"/>.</param>
-        /// <param name="page">The page name. Used to resolve endpoints.</param>
-        /// <param name="handler">The page handler name. Optional.</param>
-        /// <param name="values">The route values. Optional. Used to resolve endpoints and expand parameters in the route template.</param>
-        /// <returns>
-        /// A <see cref="LinkGenerationTemplate"/> if one or more endpoints matching the address can be found, otherwise <c>null</c>.
-        /// </returns>
-        public static LinkGenerationTemplate GetTemplateByPage(
-            this LinkGenerator generator,
-            string page,
-            string handler = default,
-            object values = default)
-        {
-            if (generator == null)
-            {
-                throw new ArgumentNullException(nameof(generator));
-            }
-
-            if (page == null)
-            {
-                throw new ArgumentNullException(nameof(page));
-            }
-
-            var address = CreateAddress(httpContext: null, page, handler, values);
-            return generator.GetTemplateByAddress<RouteValuesAddress>(address, _templateOptions);
         }
 
         private static RouteValuesAddress CreateAddress(HttpContext httpContext, string page, string handler, object values)

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Routing/ControllerLinkGeneratorExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Routing/ControllerLinkGeneratorExtensionsTest.cs
@@ -168,27 +168,6 @@ namespace Microsoft.AspNetCore.Routing
             Assert.Equal("http://example.com/Foo/Bar%3Fencodeme%3F/Home/Index/?query=some%3Fquery#Fragment?", uri);
         }
 
-        [Fact]
-        public void GetTemplateByAction_CreatesTemplate()
-        {
-            // Arrange
-            var endpoint1 = CreateEndpoint(
-                "Home/Index/{id}",
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
-            var endpoint2 = CreateEndpoint(
-                "Home/Index/{id?}",
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
-
-            var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
-
-            // Act
-            var template = linkGenerator.GetTemplateByAction(action: "Index", controller: "Home");
-
-            // Assert
-            Assert.NotNull(template);
-            Assert.Equal("/Home/Index/17", template.GetPath(new { id = 17 }));
-        }
-
         private RouteEndpoint CreateEndpoint(
             string template,
             object defaults = null,

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Routing/PageLinkGeneratorExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Routing/PageLinkGeneratorExtensionsTest.cs
@@ -166,29 +166,6 @@ namespace Microsoft.AspNetCore.Routing
             Assert.Equal("http://example.com/Foo/Bar%3Fencodeme%3F/Admin/ManageUsers/?query=some%3Fquery#Fragment?", uri);
         }
 
-        [Fact]
-        public void GetTemplateByAction_CreatesTemplate()
-        {
-            // Arrange
-            var endpoint1 = CreateEndpoint(
-                "About/{id}",
-                defaults: new { page = "/About", },
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { page = "/About", })) });
-            var endpoint2 = CreateEndpoint(
-                "Admin/ManageUsers",
-                defaults: new { page = "/Admin/ManageUsers", },
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { page = "/Admin/ManageUsers", })) });
-
-            var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
-
-            // Act
-            var template = linkGenerator.GetTemplateByPage(page: "/About");
-
-            // Assert
-            Assert.NotNull(template);
-            Assert.Equal("/About/17", template.GetPath(new { id = 17 }));
-        }
-
         private RouteEndpoint CreateEndpoint(
             string template,
             object defaults = null,


### PR DESCRIPTION
This doesn't really accomplish our goals for 2.2 - I don't have a clear
scenario where I would tell a developer to use this VS something else.
Will reevaluate in 3.0