### PR TITLE
Remove [Obsolete] action result code

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/LocalRedirectResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/LocalRedirectResult.cs
@@ -105,42 +105,5 @@ namespace Microsoft.AspNetCore.Mvc
             var executor = context.HttpContext.RequestServices.GetRequiredService<IActionResultExecutor<LocalRedirectResult>>();
             return executor.ExecuteAsync(context, this);
         }
-
-#pragma warning disable CS0809
-        [Obsolete("This implementation will be removed in a future release, use ExecuteResultAsync.")]
-        public override void ExecuteResult(ActionContext context)
-        {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            var services = context.HttpContext.RequestServices;
-            var urlHelperFactory = services.GetRequiredService<IUrlHelperFactory>();
-            var logger = services.GetRequiredService<ILogger<LocalRedirectResult>>();
-
-            var urlHelper = UrlHelper ?? urlHelperFactory.GetUrlHelper(context);
-
-            // IsLocalUrl is called to handle  Urls starting with '~/'.
-            if (!urlHelper.IsLocalUrl(Url))
-            {
-                throw new InvalidOperationException(Resources.UrlNotLocal);
-            }
-
-            var destinationUrl = urlHelper.Content(Url);
-            logger.LocalRedirectResultExecuting(destinationUrl);
-
-            if (PreserveMethod)
-            {
-                context.HttpContext.Response.StatusCode = Permanent ?
-                    StatusCodes.Status308PermanentRedirect : StatusCodes.Status307TemporaryRedirect;
-                context.HttpContext.Response.Headers[HeaderNames.Location] = destinationUrl;
-            }
-            else
-            {
-                context.HttpContext.Response.Redirect(destinationUrl, Permanent);
-            }
-        }
-#pragma warning restore CS0809
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/RedirectResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RedirectResult.cs
@@ -115,42 +115,5 @@ namespace Microsoft.AspNetCore.Mvc
             var executor = context.HttpContext.RequestServices.GetRequiredService<IActionResultExecutor<RedirectResult>>();
             return executor.ExecuteAsync(context, this);
         }
-
-#pragma warning disable CS0809
-        [Obsolete("This implementation will be removed in a future release, use ExecuteResultAsync.")]
-        public override void ExecuteResult(ActionContext context)
-        {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            var services = context.HttpContext.RequestServices;
-            var urlHelperFactory = services.GetRequiredService<IUrlHelperFactory>();
-            var logger = services.GetRequiredService<ILogger<RedirectResult>>();
-
-            var urlHelper = UrlHelper ?? urlHelperFactory.GetUrlHelper(context);
-
-            // IsLocalUrl is called to handle URLs starting with '~/'.
-            var destinationUrl = Url;
-            if (urlHelper.IsLocalUrl(destinationUrl))
-            {
-                destinationUrl = urlHelper.Content(Url);
-            }
-
-            logger.RedirectResultExecuting(destinationUrl);
-
-            if (PreserveMethod)
-            {
-                context.HttpContext.Response.StatusCode = Permanent ?
-                    StatusCodes.Status308PermanentRedirect : StatusCodes.Status307TemporaryRedirect;
-                context.HttpContext.Response.Headers[HeaderNames.Location] = destinationUrl;
-            }
-            else
-            {
-                context.HttpContext.Response.Redirect(destinationUrl, Permanent);
-            }
-        }
-#pragma warning restore CS0809
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/RedirectToActionResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RedirectToActionResult.cs
@@ -182,47 +182,5 @@ namespace Microsoft.AspNetCore.Mvc
             var executor = context.HttpContext.RequestServices.GetRequiredService<IActionResultExecutor<RedirectToActionResult>>();
             return executor.ExecuteAsync(context, this);
         }
-
-#pragma warning disable CS0809
-        [Obsolete("This implementation will be removed in a future release, use ExecuteResultAsync.")]
-        public override void ExecuteResult(ActionContext context)
-        {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            var services = context.HttpContext.RequestServices;
-            var urlHelperFactory = services.GetRequiredService<IUrlHelperFactory>();
-            var logger = services.GetRequiredService<ILogger<RedirectToActionResultExecutor>>();
-
-            var urlHelper = UrlHelper ?? urlHelperFactory.GetUrlHelper(context);
-
-            var destinationUrl = urlHelper.Action(
-                ActionName,
-                ControllerName,
-                RouteValues,
-                protocol: null,
-                host: null,
-                fragment: Fragment);
-            if (string.IsNullOrEmpty(destinationUrl))
-            {
-                throw new InvalidOperationException(Resources.NoRoutesMatched);
-            }
-
-            logger.RedirectToActionResultExecuting(destinationUrl);
-
-            if (PreserveMethod)
-            {
-                context.HttpContext.Response.StatusCode = Permanent ?
-                    StatusCodes.Status308PermanentRedirect : StatusCodes.Status307TemporaryRedirect;
-                context.HttpContext.Response.Headers[HeaderNames.Location] = destinationUrl;
-            }
-            else
-            {
-                context.HttpContext.Response.Redirect(destinationUrl, Permanent);
-            }
-        }
-#pragma warning restore CS0809
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/RedirectToPageResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RedirectToPageResult.cs
@@ -221,47 +221,5 @@ namespace Microsoft.AspNetCore.Mvc
             var executor = context.HttpContext.RequestServices.GetRequiredService<IActionResultExecutor<RedirectToPageResult>>();
             return executor.ExecuteAsync(context, this);
         }
-
-#pragma warning disable CS0809
-        [Obsolete("This implementation will be removed in a future release, use ExecuteResultAsync.")]
-        public override void ExecuteResult(ActionContext context)
-        {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            var services = context.HttpContext.RequestServices;
-            var urlHelperFactory = services.GetRequiredService<IUrlHelperFactory>();
-            var logger = services.GetRequiredService<ILogger<RedirectToPageResult>>();
-
-            var urlHelper = UrlHelper ?? urlHelperFactory.GetUrlHelper(context);
-            var destinationUrl = urlHelper.Page(
-                PageName,
-                PageHandler,
-                RouteValues,
-                Protocol,
-                Host,
-                fragment: Fragment);
-
-            if (string.IsNullOrEmpty(destinationUrl))
-            {
-                throw new InvalidOperationException(Resources.FormatNoRoutesMatchedForPage(PageName));
-            }
-
-            logger.RedirectToPageResultExecuting(PageName);
-
-            if (PreserveMethod)
-            {
-                context.HttpContext.Response.StatusCode = Permanent ?
-                    StatusCodes.Status308PermanentRedirect : StatusCodes.Status307TemporaryRedirect;
-                context.HttpContext.Response.Headers[HeaderNames.Location] = destinationUrl;
-            }
-            else
-            {
-                context.HttpContext.Response.Redirect(destinationUrl, Permanent);
-            }
-        }
-#pragma warning restore CS0809
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Core/RedirectToRouteResult.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/RedirectToRouteResult.cs
@@ -174,46 +174,5 @@ namespace Microsoft.AspNetCore.Mvc
             var executor = context.HttpContext.RequestServices.GetRequiredService<IActionResultExecutor<RedirectToRouteResult>>();
             return executor.ExecuteAsync(context, this);
         }
-
-#pragma warning disable CS0809
-        [Obsolete("This implementation will be removed in a future release, use ExecuteResultAsync.")]
-        public override void ExecuteResult(ActionContext context)
-        {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            var services = context.HttpContext.RequestServices;
-            var urlHelperFactory = services.GetRequiredService<IUrlHelperFactory>();
-            var logger = services.GetRequiredService<ILogger<RedirectToRouteResult>>();
-
-            var urlHelper = UrlHelper ?? urlHelperFactory.GetUrlHelper(context);
-
-            var destinationUrl = urlHelper.RouteUrl(
-                RouteName,
-                RouteValues,
-                protocol: null,
-                host: null,
-                fragment: Fragment);
-            if (string.IsNullOrEmpty(destinationUrl))
-            {
-                throw new InvalidOperationException(Resources.NoRoutesMatched);
-            }
-
-            logger.RedirectToRouteResultExecuting(destinationUrl, RouteName);
-
-            if (PreserveMethod)
-            {
-                context.HttpContext.Response.StatusCode = Permanent ?
-                    StatusCodes.Status308PermanentRedirect : StatusCodes.Status307TemporaryRedirect;
-                context.HttpContext.Response.Headers[HeaderNames.Location] = destinationUrl;
-            }
-            else
-            {
-                context.HttpContext.Response.Redirect(destinationUrl, Permanent);
-            }
-        }
-#pragma warning restore CS0809
     }
 }


### PR DESCRIPTION
Related to Open issue: 

  #https://github.com/aspnet/Mvc/issues/6880

Removed obsolete override 'ActionResult.ExecuteResult' methods.

RedirectResult
LocalRedirectResult
RedirectToActionResult
RedirectToPageResult
RedirectToRouteResult