### PR TITLE
Quick fix: Clean up test warnings

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/FileResultTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/FileResultTests.cs
@@ -246,17 +246,21 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal("This is a sample text file", body);
         }
 
+        // Use int for HttpStatusCode data because xUnit cannot serialize a GAC'd enum when running on .NET Framework.
         [Theory]
-        [InlineData("", HttpStatusCode.OK, 26)]
-        [InlineData("bytes = 0-6", HttpStatusCode.PartialContent, 7)]
-        [InlineData("bytes = 17-25", HttpStatusCode.PartialContent, 9)]
-        [InlineData("bytes = 0-50", HttpStatusCode.PartialContent, 26)]
-        [InlineData("0-6", HttpStatusCode.OK, 26)]
-        [InlineData("bytes = ", HttpStatusCode.OK, 26)]
-        [InlineData("bytes = 1-4, 5-11", HttpStatusCode.OK, 26)]
-        [InlineData("bytes = 35-36", HttpStatusCode.RequestedRangeNotSatisfiable, 26)]
-        [InlineData("bytes = -0", HttpStatusCode.RequestedRangeNotSatisfiable, 26)]
-        public async Task FileFromDisk_ReturnsFileWithFileName_DoesNotServeBody_ForHeadRequest_WithLastModifiedAndEtag(string rangeString, HttpStatusCode httpStatusCode, int expectedContentLength)
+        [InlineData("", (int)HttpStatusCode.OK, 26)]
+        [InlineData("bytes = 0-6", (int)HttpStatusCode.PartialContent, 7)]
+        [InlineData("bytes = 17-25", (int)HttpStatusCode.PartialContent, 9)]
+        [InlineData("bytes = 0-50", (int)HttpStatusCode.PartialContent, 26)]
+        [InlineData("0-6", (int)HttpStatusCode.OK, 26)]
+        [InlineData("bytes = ", (int)HttpStatusCode.OK, 26)]
+        [InlineData("bytes = 1-4, 5-11", (int)HttpStatusCode.OK, 26)]
+        [InlineData("bytes = 35-36", (int)HttpStatusCode.RequestedRangeNotSatisfiable, 26)]
+        [InlineData("bytes = -0", (int)HttpStatusCode.RequestedRangeNotSatisfiable, 26)]
+        public async Task FileFromDisk_ReturnsFileWithFileName_DoesNotServeBody_ForHeadRequest_WithLastModifiedAndEtag(
+            string rangeString,
+            int httpStatusCode,
+            int expectedContentLength)
         {
             // Arrange
             var httpRequestMessage = new HttpRequestMessage(HttpMethod.Head, "http://localhost/DownloadFiles/DownloadFromDiskWithFileName_WithLastModifiedAndEtag");
@@ -267,7 +271,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             var response = await Client.SendAsync(httpRequestMessage);
 
             // Assert
-            Assert.Equal(httpStatusCode, response.StatusCode);
+            Assert.Equal(httpStatusCode, (int)response.StatusCode);
 
             Assert.NotNull(response.Content.Headers.ContentType);
             Assert.Equal("text/plain", response.Content.Headers.ContentType.ToString());
@@ -442,17 +446,21 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal("This is sample text from a stream", body);
         }
 
+        // Use int for HttpStatusCode data because xUnit cannot serialize a GAC'd enum when running on .NET Framework.
         [Theory]
-        [InlineData("", HttpStatusCode.OK, 33)]
-        [InlineData("bytes = 0-6", HttpStatusCode.PartialContent, 7)]
-        [InlineData("bytes = 17-25", HttpStatusCode.PartialContent, 9)]
-        [InlineData("bytes = 0-50", HttpStatusCode.PartialContent, 33)]
-        [InlineData("0-6", HttpStatusCode.OK, 33)]
-        [InlineData("bytes = ", HttpStatusCode.OK, 33)]
-        [InlineData("bytes = 1-4, 5-11", HttpStatusCode.OK, 33)]
-        [InlineData("bytes = 35-36", HttpStatusCode.RequestedRangeNotSatisfiable, 33)]
-        [InlineData("bytes = -0", HttpStatusCode.RequestedRangeNotSatisfiable, 33)]
-        public async Task FileFromStream_ReturnsFileWithFileName_DoesNotServeBody_ForHeadRequest(string rangeString, HttpStatusCode httpStatusCode, int expectedContentLength)
+        [InlineData("", (int)HttpStatusCode.OK, 33)]
+        [InlineData("bytes = 0-6", (int)HttpStatusCode.PartialContent, 7)]
+        [InlineData("bytes = 17-25", (int)HttpStatusCode.PartialContent, 9)]
+        [InlineData("bytes = 0-50", (int)HttpStatusCode.PartialContent, 33)]
+        [InlineData("0-6", (int)HttpStatusCode.OK, 33)]
+        [InlineData("bytes = ", (int)HttpStatusCode.OK, 33)]
+        [InlineData("bytes = 1-4, 5-11", (int)HttpStatusCode.OK, 33)]
+        [InlineData("bytes = 35-36", (int)HttpStatusCode.RequestedRangeNotSatisfiable, 33)]
+        [InlineData("bytes = -0", (int)HttpStatusCode.RequestedRangeNotSatisfiable, 33)]
+        public async Task FileFromStream_ReturnsFileWithFileName_DoesNotServeBody_ForHeadRequest(
+            string rangeString,
+            int httpStatusCode,
+            int expectedContentLength)
         {
             // Arrange
             var httpRequestMessage = new HttpRequestMessage(HttpMethod.Head, "http://localhost/DownloadFiles/DownloadFromStreamWithFileName_WithEtag");
@@ -463,7 +471,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             var response = await Client.SendAsync(httpRequestMessage);
 
             // Assert
-            Assert.Equal(httpStatusCode, response.StatusCode);
+            Assert.Equal(httpStatusCode, (int)response.StatusCode);
 
             Assert.NotNull(response.Content.Headers.ContentType);
             Assert.Equal("text/plain", response.Content.Headers.ContentType.ToString());
@@ -616,7 +624,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             var response = await Client.SendAsync(httpRequestMessage);
             var body = await response.Content.ReadAsStringAsync();
 
-            // Assert           
+            // Assert
             Assert.NotNull(response.Content.Headers.ContentType);
             Assert.Equal("text/plain", response.Content.Headers.ContentType.ToString());
             Assert.NotNull(body);
@@ -643,17 +651,21 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal("This is a sample text from a binary array", body);
         }
 
+        // Use int for HttpStatusCode data because xUnit cannot serialize a GAC'd enum when running on .NET Framework.
         [Theory]
-        [InlineData("", HttpStatusCode.OK, 41)]
-        [InlineData("bytes = 0-6", HttpStatusCode.PartialContent, 7)]
-        [InlineData("bytes = 17-25", HttpStatusCode.PartialContent, 9)]
-        [InlineData("bytes = 0-50", HttpStatusCode.PartialContent, 41)]
-        [InlineData("0-6", HttpStatusCode.OK, 41)]
-        [InlineData("bytes = ", HttpStatusCode.OK, 41)]
-        [InlineData("bytes = 1-4, 5-11", HttpStatusCode.OK, 41)]
-        [InlineData("bytes = 45-46", HttpStatusCode.RequestedRangeNotSatisfiable, 41)]
-        [InlineData("bytes = -0", HttpStatusCode.RequestedRangeNotSatisfiable, 41)]
-        public async Task FileFromBinaryData_ReturnsFileWithFileName_DoesNotServeBody_ForHeadRequest(string rangeString, HttpStatusCode httpStatusCode, int expectedContentLength)
+        [InlineData("", (int)HttpStatusCode.OK, 41)]
+        [InlineData("bytes = 0-6", (int)HttpStatusCode.PartialContent, 7)]
+        [InlineData("bytes = 17-25", (int)HttpStatusCode.PartialContent, 9)]
+        [InlineData("bytes = 0-50", (int)HttpStatusCode.PartialContent, 41)]
+        [InlineData("0-6", (int)HttpStatusCode.OK, 41)]
+        [InlineData("bytes = ", (int)HttpStatusCode.OK, 41)]
+        [InlineData("bytes = 1-4, 5-11", (int)HttpStatusCode.OK, 41)]
+        [InlineData("bytes = 45-46", (int)HttpStatusCode.RequestedRangeNotSatisfiable, 41)]
+        [InlineData("bytes = -0", (int)HttpStatusCode.RequestedRangeNotSatisfiable, 41)]
+        public async Task FileFromBinaryData_ReturnsFileWithFileName_DoesNotServeBody_ForHeadRequest(
+            string rangeString,
+            int httpStatusCode,
+            int expectedContentLength)
         {
             // Arrange
             var httpRequestMessage = new HttpRequestMessage(HttpMethod.Head, "http://localhost/DownloadFiles/DownloadFromBinaryDataWithFileName_WithEtag");
@@ -664,7 +676,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             var response = await Client.SendAsync(httpRequestMessage);
 
             // Assert
-            Assert.Equal(httpStatusCode, response.StatusCode);
+            Assert.Equal(httpStatusCode, (int)response.StatusCode);
 
             Assert.NotNull(response.Content.Headers.ContentType);
             Assert.Equal("text/plain", response.Content.Headers.ContentType.ToString());
@@ -842,17 +854,21 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal("attachment; filename=downloadName.txt; filename*=UTF-8''downloadName.txt", contentDisposition);
         }
 
+        // Use int for HttpStatusCode data because xUnit cannot serialize a GAC'd enum when running on .NET Framework.
         [Theory]
-        [InlineData("", HttpStatusCode.OK, 38)]
-        [InlineData("bytes = 0-6", HttpStatusCode.PartialContent, 7)]
-        [InlineData("bytes = 17-25", HttpStatusCode.PartialContent, 9)]
-        [InlineData("bytes = 0-50", HttpStatusCode.PartialContent, 38)]
-        [InlineData("0-6", HttpStatusCode.OK, 38)]
-        [InlineData("bytes = ", HttpStatusCode.OK, 38)]
-        [InlineData("bytes = 1-4, 5-11", HttpStatusCode.OK, 38)]
-        [InlineData("bytes = 45-46", HttpStatusCode.RequestedRangeNotSatisfiable, 38)]
-        [InlineData("bytes = -0", HttpStatusCode.RequestedRangeNotSatisfiable, 38)]
-        public async Task FileFromEmbeddedResources_ReturnsFileWithFileName_DoesNotServeBody_ForHeadRequest(string rangeString, HttpStatusCode httpStatusCode, int expectedContentLength)
+        [InlineData("", (int)HttpStatusCode.OK, 38)]
+        [InlineData("bytes = 0-6", (int)HttpStatusCode.PartialContent, 7)]
+        [InlineData("bytes = 17-25", (int)HttpStatusCode.PartialContent, 9)]
+        [InlineData("bytes = 0-50", (int)HttpStatusCode.PartialContent, 38)]
+        [InlineData("0-6", (int)HttpStatusCode.OK, 38)]
+        [InlineData("bytes = ", (int)HttpStatusCode.OK, 38)]
+        [InlineData("bytes = 1-4, 5-11", (int)HttpStatusCode.OK, 38)]
+        [InlineData("bytes = 45-46", (int)HttpStatusCode.RequestedRangeNotSatisfiable, 38)]
+        [InlineData("bytes = -0", (int)HttpStatusCode.RequestedRangeNotSatisfiable, 38)]
+        public async Task FileFromEmbeddedResources_ReturnsFileWithFileName_DoesNotServeBody_ForHeadRequest(
+            string rangeString,
+            int httpStatusCode,
+            int expectedContentLength)
         {
             // Arrange
             var httpRequestMessage = new HttpRequestMessage(HttpMethod.Head, "http://localhost/EmbeddedFiles/DownloadFileWithFileName");
@@ -863,7 +879,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             var response = await Client.SendAsync(httpRequestMessage);
 
             // Assert
-            Assert.Equal(httpStatusCode, response.StatusCode);
+            Assert.Equal(httpStatusCode, (int)response.StatusCode);
 
             Assert.NotNull(response.Content.Headers.ContentType);
             Assert.Equal("text/plain", response.Content.Headers.ContentType.ToString());

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RoutingEndpointRoutingTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RoutingEndpointRoutingTest.cs
@@ -263,53 +263,6 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
         }
 
-        [Theory]
-        [MemberData(nameof(AttributeRoutedAction_MultipleRouteAttributes_WithMultipleHttpAttributes_RespectsConstraintsData))]
-        public override async Task AttributeRoutedAction_MultipleRouteAttributes_WithMultipleHttpAttributes_RespectsConstraints(
-            string url,
-            string method)
-        {
-            // Arrange
-            var expectedUrl = new Uri(url).AbsolutePath;
-
-            // Act
-            var response = await Client.SendAsync(new HttpRequestMessage(new HttpMethod(method), url));
-
-            // Assert
-            Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
-        }
-
-        // Endpoint routing exposes HTTP 405s for HTTP method mismatches
-        [Theory]
-        [MemberData(nameof(AttributeRoutedAction_RejectsRequestsWithWrongMethods_InRoutesWithoutExtraTemplateSegmentsOnTheActionData))]
-        public override async Task AttributeRoutedAction_RejectsRequestsWithWrongMethods_InRoutesWithoutExtraTemplateSegmentsOnTheAction(
-            string method,
-            string url)
-        {
-            // Arrange
-            var request = new HttpRequestMessage(new HttpMethod(method), $"http://localhost{url}");
-
-            // Assert
-            var response = await Client.SendAsync(request);
-
-            // Assert
-            Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
-        }
-
-        [Theory]
-        [MemberData(nameof(AttributeRouting_MixedAcceptVerbsAndRoute_UnreachableData))]
-        public override async Task AttributeRouting_MixedAcceptVerbsAndRoute_Unreachable(string path, string verb)
-        {
-            // Arrange
-            var request = new HttpRequestMessage(new HttpMethod(verb), "http://localhost" + path);
-
-            // Act
-            var response = await Client.SendAsync(request);
-
-            // Assert
-            Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
-        }
-
         [Fact]
         public async Task ConventionalRoutedAction_ParameterTransformer()
         {
@@ -422,6 +375,12 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal("ConventionalTransformer", result.Controller);
             Assert.Equal("Index", result.Action);
             Assert.Equal("/ConventionalTransformerRoute/conventional-transformer", result.Link);
+        }
+
+        // Endpoint routing exposes HTTP 405s for HTTP method mismatches.
+        protected override void AssertCorsRejectionStatusCode(HttpResponseMessage response)
+        {
+            Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RoutingTestsBase.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/RoutingTestsBase.cs
@@ -8,7 +8,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Routing;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -362,7 +361,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             var response = await Client.SendAsync(request);
 
             // Assert
-            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            AssertCorsRejectionStatusCode(response);
         }
 
         [Theory]
@@ -514,7 +513,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             var response = await Client.SendAsync(new HttpRequestMessage(new HttpMethod(method), url));
 
             // Assert
-            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            AssertCorsRejectionStatusCode(response);
         }
 
         // The url would be /Store/ListProducts with conventional routes
@@ -1295,7 +1294,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal("/", result.Link);
         }
 
-        
+
 
         [Fact]
         public virtual async Task AttributeRoutedAction_InArea_LinkToConventionalRoutedActionInArea()
@@ -1431,7 +1430,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             var response = await Client.SendAsync(request);
 
             // Assert
-            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            AssertCorsRejectionStatusCode(response);
         }
 
         [Theory]
@@ -1474,6 +1473,11 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
         protected static LinkBuilder LinkFrom(string url)
         {
             return new LinkBuilder(url);
+        }
+
+        protected virtual void AssertCorsRejectionStatusCode(HttpResponseMessage response)
+        {
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/WebApiCompatShimBasicTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/WebApiCompatShimBasicTest.cs
@@ -358,10 +358,11 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal("text/json", response.Content.Headers.ContentType.MediaType);
         }
 
+        // Use int for HttpStatusCode data because xUnit cannot serialize a GAC'd enum when running on .NET Framework.
         [Theory]
-        [InlineData("http://localhost/Mvc/Index", HttpStatusCode.OK)]
-        [InlineData("http://localhost/api/Blog/Mvc/Index", HttpStatusCode.NotFound)]
-        public async Task WebApiRouting_AccessMvcController(string url, HttpStatusCode expected)
+        [InlineData("http://localhost/Mvc/Index", (int)HttpStatusCode.OK)]
+        [InlineData("http://localhost/api/Blog/Mvc/Index", (int)HttpStatusCode.NotFound)]
+        public async Task WebApiRouting_AccessMvcController(string url, int expected)
         {
             // Arrange
             var request = new HttpRequestMessage(HttpMethod.Get, url);
@@ -370,13 +371,14 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             var response = await Client.SendAsync(request);
 
             // Assert
-            Assert.Equal(expected, response.StatusCode);
+            Assert.Equal(expected, (int)response.StatusCode);
         }
 
+        // Use int for HttpStatusCode data because xUnit cannot serialize a GAC'd enum when running on .NET Framework.
         [Theory]
-        [InlineData("http://localhost/BasicApi/GenerateUrl", HttpStatusCode.NotFound)]
-        [InlineData("http://localhost/api/Blog/BasicApi/GenerateUrl", HttpStatusCode.OK)]
-        public async Task WebApiRouting_AccessWebApiController(string url, HttpStatusCode expected)
+        [InlineData("http://localhost/BasicApi/GenerateUrl", (int)HttpStatusCode.NotFound)]
+        [InlineData("http://localhost/api/Blog/BasicApi/GenerateUrl", (int)HttpStatusCode.OK)]
+        public async Task WebApiRouting_AccessWebApiController(string url, int expected)
         {
             // Arrange
             var request = new HttpRequestMessage(HttpMethod.Get, url);
@@ -385,7 +387,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             var response = await Client.SendAsync(request);
 
             // Assert
-            Assert.Equal(expected, response.StatusCode);
+            Assert.Equal(expected, (int)response.StatusCode);
         }
 
         [Fact]


### PR DESCRIPTION
- avoid "Skipping test case with duplicate ID" messages
  - xUnit gets confused when `[Theory]`s are overridden
- avoid "falling back to single test case" messages
  - fix inspired by aspnet/SignalR#1820