### PR TITLE
Relayer action discovery infrastructure

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Core/ApplicationModels/ActionAttributeRouteModel.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ApplicationModels/ActionAttributeRouteModel.cs
@@ -3,11 +3,141 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+using Microsoft.AspNetCore.Mvc.Routing;
 
 namespace Microsoft.AspNetCore.Mvc.ApplicationModels
 {
     internal static class ActionAttributeRouteModel
     {
+        public static IEnumerable<SelectorModel> FlattenSelectors(ActionModel actionModel)
+        {
+            // Loop through all attribute routes defined on the controller. 
+            // These perform a cross-product with all of the action-level attribute routes.
+            var controllerSelectors = actionModel.Controller.Selectors
+                .Where(sm => sm.AttributeRouteModel != null)
+                .ToList();
+
+            // We also include metadata and action constraints from the controller
+            // even when there are no routes, or when an action overrides the route template.
+            SelectorModel additionalSelector = null;
+            if (actionModel.Controller.Selectors.Count > 0)
+            {
+                // This logic seems arbitrary but there's a good reason for it.
+                // 
+                // When we build the controller level selectors, any metadata or action constraints
+                // that aren't IRouteTemplateProvider will be included in all selectors. So we 
+                // pick any selector and then grab all of the stuff that isn't IRouteTemplateProvider
+                // then we've found all of the items that aren't routes.
+                //
+                // This is fragile wrt application model customizing the data - but no one has
+                // run into an issue with this and its pretty esoteric.
+                additionalSelector = new SelectorModel(actionModel.Controller.Selectors.First());
+                additionalSelector.AttributeRouteModel = null;
+
+                for (var i = additionalSelector.ActionConstraints.Count - 1; i >= 0; i--)
+                {
+                    if (additionalSelector.ActionConstraints[i] is IRouteTemplateProvider)
+                    {
+                        additionalSelector.ActionConstraints.RemoveAt(i);
+                    }
+                }
+
+                for (var i = additionalSelector.EndpointMetadata.Count - 1; i >= 0; i--)
+                {
+                    if (additionalSelector.EndpointMetadata[i] is IRouteTemplateProvider)
+                    {
+                        additionalSelector.EndpointMetadata.RemoveAt(i);
+                    }
+                }
+            }
+
+            var actionConstraints = new List<IActionConstraintMetadata>();
+
+            foreach (var actionSelector in actionModel.Selectors)
+            {
+                var actionRouteModel = actionSelector.AttributeRouteModel;
+
+                // We check the action to see if the template allows combination behavior
+                // (It doesn't start with / or ~/) so that in the case where we have multiple
+                // [Route] attributes on the controller we don't end up creating multiple
+                if (actionRouteModel != null && actionRouteModel.IsAbsoluteTemplate)
+                {
+                    // We're overriding the routes from the controller, but any *unbound* constraints
+                    // still apply.
+                    var selector = new SelectorModel(actionSelector);
+
+                    selector.AttributeRouteModel = AttributeRouteModel.CombineAttributeRouteModel(
+                        left: null,
+                        right: actionRouteModel);
+
+                    AddActionConstraints(selector, additionalSelector?.ActionConstraints);
+                    AddEndpointMetadata(selector, additionalSelector?.EndpointMetadata);
+
+                    yield return selector;
+                }
+                else if (controllerSelectors.Count > 0)
+                {
+                    for (var i = 0; i < controllerSelectors.Count; i++)
+                    {
+                        var controllerSelector = controllerSelectors[i];
+
+                        // We're using the attribute routes from the controller
+                        var selector = new SelectorModel(actionSelector);
+
+                        selector.AttributeRouteModel = AttributeRouteModel.CombineAttributeRouteModel(
+                            controllerSelector.AttributeRouteModel,
+                            actionRouteModel);
+
+                        AddActionConstraints(selector, controllerSelector.ActionConstraints);
+                        AddEndpointMetadata(selector, controllerSelector.EndpointMetadata);
+
+                        // No need to include the additional selector here because it would duplicate
+                        // data in controllerSelector.
+
+                        yield return selector;
+                    }
+                }
+                else
+                {
+                    // There are no routes on the controller, but any *unbound* constraints
+                    // still apply.
+                    var selector = new SelectorModel(actionSelector);
+
+                    selector.AttributeRouteModel = AttributeRouteModel.CombineAttributeRouteModel(
+                        left: null,
+                        right: actionRouteModel);
+
+                    AddActionConstraints(selector, additionalSelector?.ActionConstraints);
+                    AddEndpointMetadata(selector, additionalSelector?.EndpointMetadata);
+
+                    yield return selector;
+                }
+            }
+        }
+
+        private static void AddActionConstraints(SelectorModel selector, IList<IActionConstraintMetadata> actionConstraints)
+        {
+            if (actionConstraints != null)
+            {
+                for (var i = 0; i < actionConstraints.Count;i++)
+                {
+                    selector.ActionConstraints.Add(actionConstraints[i]);
+                }
+            }
+        }
+
+        private static void AddEndpointMetadata(SelectorModel selector, IList<object> metadata)
+        {
+            if (metadata != null)
+            {
+                for (var i = 0; i < metadata.Count; i++)
+                {
+                    selector.EndpointMetadata.Add(metadata[i]);
+                }
+            }
+        }
+
         public static IEnumerable<(AttributeRouteModel route, SelectorModel actionSelector, SelectorModel controllerSelector)> GetAttributeRoutes(ActionModel actionModel)
         {
             var controllerAttributeRoutes = actionModel.Controller.Selectors

--- a/src/Microsoft.AspNetCore.Mvc.Core/ApplicationModels/ApplicationModelFactory.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ApplicationModels/ApplicationModelFactory.cs
@@ -1,0 +1,364 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+using Microsoft.AspNetCore.Mvc.Core;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Internal;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Mvc.ApplicationModels
+{
+    /// <summary>
+    /// A facade service for creating application models.
+    /// </summary>
+    internal class ApplicationModelFactory
+    {
+        private readonly IApplicationModelProvider[] _applicationModelProviders;
+        private readonly IList<IApplicationModelConvention> _conventions;
+
+        public ApplicationModelFactory(
+            IEnumerable<IApplicationModelProvider> applicationModelProviders,
+            IOptions<MvcOptions> options)
+        {
+            if (applicationModelProviders == null)
+            {
+                throw new ArgumentNullException(nameof(applicationModelProviders));
+            }
+
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            _applicationModelProviders = applicationModelProviders.OrderBy(p => p.Order).ToArray();
+            _conventions = options.Value.Conventions;
+        }
+
+        public ApplicationModel CreateApplicationModel(IEnumerable<TypeInfo> controllerTypes)
+        {
+            if (controllerTypes == null)
+            {
+                throw new ArgumentNullException(nameof(controllerTypes));
+            }
+
+            var context = new ApplicationModelProviderContext(controllerTypes);
+
+            for (var i = 0; i < _applicationModelProviders.Length; i++)
+            {
+                _applicationModelProviders[i].OnProvidersExecuting(context);
+            }
+
+            for (var i = _applicationModelProviders.Length - 1; i >= 0; i--)
+            {
+                _applicationModelProviders[i].OnProvidersExecuted(context);
+            }
+
+            ApplicationModelConventions.ApplyConventions(context.Result, _conventions);
+
+            return context.Result;
+        }
+
+        public static List<TResult> Flatten<TResult>(
+            ApplicationModel application,
+            Func<ApplicationModel, ControllerModel, ActionModel, SelectorModel, TResult> flattener)
+        {
+            var results = new List<TResult>();
+            var errors = new Dictionary<MethodInfo, IList<string>>();
+
+            var actionsByMethod = new Dictionary<MethodInfo, List<(ActionModel, SelectorModel)>>();
+            var actionsByRouteName = new Dictionary<string, List<(ActionModel, SelectorModel)>>(StringComparer.OrdinalIgnoreCase);
+
+            var routeTemplateErrors = new List<string>();
+
+            foreach (var controller in application.Controllers)
+            {
+                foreach (var action in controller.Actions)
+                {
+                    foreach (var selector in ActionAttributeRouteModel.FlattenSelectors(action))
+                    {
+                        // PostProcess attribute routes so we can observe any errors.
+                        ReplaceAttributeRouteTokens(controller, action, selector, routeTemplateErrors);
+
+                        // Add to the data structures we use to find errors.
+                        AddActionToMethodInfoMap(actionsByMethod, action, selector);
+                        AddActionToRouteNameMap(actionsByRouteName, action, selector);
+
+                        var result = flattener(application, controller, action, selector);
+                        Debug.Assert(result != null);
+
+                        results.Add(result);
+                    }
+                }
+            }
+
+            var attributeRoutingConfigurationErrors = new Dictionary<MethodInfo, string>();
+            foreach (var (method, actions) in actionsByMethod)
+            {
+                ValidateActionGroupConfiguration(
+                    method,
+                    actions,
+                    attributeRoutingConfigurationErrors);
+            }
+
+            if (attributeRoutingConfigurationErrors.Any())
+            {
+                var message = CreateAttributeRoutingAggregateErrorMessage(attributeRoutingConfigurationErrors.Values);
+
+                throw new InvalidOperationException(message);
+            }
+
+            var namedRoutedErrors = ValidateNamedAttributeRoutedActions(actionsByRouteName);
+            if (namedRoutedErrors.Any())
+            {
+                var message = CreateAttributeRoutingAggregateErrorMessage(namedRoutedErrors);
+                throw new InvalidOperationException(message);
+            }
+
+            if (routeTemplateErrors.Any())
+            {
+                var message = CreateAttributeRoutingAggregateErrorMessage(routeTemplateErrors);
+                throw new InvalidOperationException(message);
+            }
+
+
+            return results;
+        }
+
+        private static void ReplaceAttributeRouteTokens(
+            ControllerModel controller, 
+            ActionModel action, 
+            SelectorModel selector, 
+            List<string> errors)
+        {
+            if (selector.AttributeRouteModel == null)
+            {
+                return;
+            }
+
+            try
+            {
+                var routeValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { "action", action.ActionName },
+                    { "controller", controller.ControllerName },
+                };
+                
+                foreach (var kvp in action.RouteValues)
+                {
+                    routeValues.TryAdd(kvp.Key, kvp.Value);
+                }
+
+                foreach (var kvp in controller.RouteValues)
+                {
+                    routeValues.TryAdd(kvp.Key, kvp.Value);
+                }
+
+                action.Properties.TryGetValue(typeof(IOutboundParameterTransformer), out var obj);
+                var transformer = obj as IOutboundParameterTransformer;
+
+                selector.AttributeRouteModel.Template = AttributeRouteModel.ReplaceTokens(
+                    selector.AttributeRouteModel.Template,
+                    routeValues,
+                    transformer);
+
+                if (selector.AttributeRouteModel.Name != null)
+                {
+                    selector.AttributeRouteModel.Name = AttributeRouteModel.ReplaceTokens(
+                        selector.AttributeRouteModel.Name,
+                        routeValues,
+                        transformer);
+                }
+            }
+            catch (InvalidOperationException ex)
+            {
+                // Routing will throw an InvalidOperationException here if we can't parse/replace tokens
+                // in the template.
+                var message = Resources.FormatAttributeRoute_IndividualErrorMessage(
+                    action.DisplayName,
+                    Environment.NewLine,
+                    ex.Message);
+
+                errors.Add(message);
+            }
+        }
+
+        private static void AddActionToMethodInfoMap(
+            Dictionary<MethodInfo, List<(ActionModel, SelectorModel)>> actionsByMethod, 
+            ActionModel action,
+            SelectorModel selector)
+        {
+            if (!actionsByMethod.TryGetValue(action.ActionMethod, out var actions))
+            {
+                actions = new List<(ActionModel, SelectorModel)>();
+                actionsByMethod.Add(action.ActionMethod, actions);
+            }
+
+            actions.Add((action, selector));
+        }
+
+        private static void AddActionToRouteNameMap(
+            Dictionary<string, List<(ActionModel action, SelectorModel selector)>> actionsByRouteName,
+            ActionModel action,
+            SelectorModel selector)
+        {
+            var routeName = selector.AttributeRouteModel?.Name;
+            if (selector.AttributeRouteModel?.Name == null)
+            {
+                return;
+            }
+
+            if (!actionsByRouteName.TryGetValue(routeName, out var actions))
+            {
+                actions = new List<(ActionModel, SelectorModel)>();
+                actionsByRouteName.Add(routeName, actions);
+            }
+
+            actions.Add((action, selector));
+        }
+
+        private static List<string> AddErrorNumbers(IEnumerable<string> namedRoutedErrors)
+        {
+            return namedRoutedErrors
+                .Select((error, i) =>
+                    Resources.FormatAttributeRoute_AggregateErrorMessage_ErrorNumber(
+                        i + 1,
+                        Environment.NewLine,
+                        error))
+                .ToList();
+        }
+
+        private static List<string> ValidateNamedAttributeRoutedActions(
+            Dictionary<string, List<(ActionModel action, SelectorModel selector)>> actionsByRouteName)
+        {
+            var namedRouteErrors = new List<string>();
+
+            foreach (var (routeName, actions) in actionsByRouteName)
+            {
+                // We are looking for attribute routed actions that have the same name but
+                // different route templates. We pick the first template of the group and
+                // we compare it against the rest of the templates that have that same name
+                // associated.
+                // The moment we find one that is different we report the whole group to the
+                // user in the error message so that he can see the different actions and the
+                // different templates for a given named attribute route.
+                var template = actions[0].selector.AttributeRouteModel.Template;
+
+                for (var i = 1; i < actions.Count; i++)
+                {
+                    var other = actions[i].selector.AttributeRouteModel.Template;
+
+                    if (!template.Equals(other, StringComparison.OrdinalIgnoreCase))
+                    {
+                        var descriptions = actions.Select(a =>
+                        {
+                            return Resources.FormatAttributeRoute_DuplicateNames_Item(a.action.DisplayName, a.selector.AttributeRouteModel.Template);
+                        });
+
+                        var message = Resources.FormatAttributeRoute_DuplicateNames(routeName, Environment.NewLine, string.Join(Environment.NewLine, descriptions));
+                        namedRouteErrors.Add(message);
+                        break;
+                    }
+                }
+            }
+
+            return namedRouteErrors;
+        }
+
+        private static void ValidateActionGroupConfiguration(
+            MethodInfo method,
+            List<(ActionModel action, SelectorModel selector)> actions,
+            IDictionary<MethodInfo, string> routingConfigurationErrors)
+        {
+            var hasAttributeRoutedActions = false;
+            var hasConventionallyRoutedActions = false;
+
+            for (var i = 0; i < actions.Count; i++)
+            {
+                if (actions[i].selector.AttributeRouteModel == null)
+                {
+                    hasConventionallyRoutedActions = true;
+                }
+                else
+                {
+                    hasAttributeRoutedActions = true;
+                }
+            }
+
+            // Validate that no method result in attribute and non attribute actions at the same time.
+            // By design, mixing attribute and conventionally actions in the same method is not allowed.
+            //
+            // Assuming the controller doesn't specify a route template, this example would not be allowed:
+            //
+            // [HttpGet]
+            // [HttpPost("Foo")]
+            // public void Foo() { }
+            if (hasAttributeRoutedActions && hasConventionallyRoutedActions)
+            {
+                var message = CreateMixedRoutedActionDescriptorsErrorMessage(method, actions);
+                routingConfigurationErrors.Add(method, message);
+            }
+        }
+
+        private static string CreateMixedRoutedActionDescriptorsErrorMessage(
+            MethodInfo method,
+            List<(ActionModel action, SelectorModel selector)> actions)
+        {
+            // Text to show as the attribute route template for conventionally routed actions.
+            var nullTemplate = Resources.AttributeRoute_NullTemplateRepresentation;
+
+            var actionDescriptions = new List<string>();
+            for (var i = 0; i < actions.Count; i++)
+            {
+                var (action, selector) = actions[i];
+                var routeTemplate = selector.AttributeRouteModel?.Template ?? nullTemplate;
+
+                var verbs = selector.ActionConstraints?.OfType<HttpMethodActionConstraint>().FirstOrDefault()?.HttpMethods;
+
+                var formattedVerbs = string.Empty;
+                if (verbs != null)
+                {
+                    formattedVerbs = string.Join(", ", verbs.OrderBy(v => v, StringComparer.OrdinalIgnoreCase));
+                }
+
+                var description = Resources.FormatAttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod_Item(
+                    action.DisplayName,
+                    routeTemplate,
+                    formattedVerbs);
+
+                actionDescriptions.Add(description);
+            }
+
+            // Sample error message:
+            //
+            // A method 'MyApplication.CustomerController.Index' must not define attributed actions and
+            // non attributed actions at the same time:
+            // Action: 'MyApplication.CustomerController.Index' - Route Template: 'Products' - HTTP Verbs: 'PUT'
+            // Action: 'MyApplication.CustomerController.Index' - Route Template: '(none)' - HTTP Verbs: 'POST'
+            //
+            // Use 'AcceptVerbsAttribute' to create a single route that allows multiple HTTP verbs and defines a route,
+            // or set a route template in all attributes that constrain HTTP verbs.
+
+            var formattedMethodInfo = $"{TypeNameHelper.GetTypeDisplayName(method.ReflectedType)}.{method.Name} ({method.ReflectedType.Assembly.GetName().Name})";
+            return Resources.FormatAttributeRoute_MixedAttributeAndConventionallyRoutedActions_ForMethod(
+                    formattedMethodInfo,
+                    Environment.NewLine,
+                    string.Join(Environment.NewLine, actionDescriptions));
+        }
+
+        private static string CreateAttributeRoutingAggregateErrorMessage(IEnumerable<string> individualErrors)
+        {
+            var errorMessages = AddErrorNumbers(individualErrors);
+
+            var message = Resources.FormatAttributeRoute_AggregateErrorMessage(
+                Environment.NewLine,
+                string.Join(Environment.NewLine + Environment.NewLine, errorMessages));
+            return message;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Core/ApplicationModels/InferParameterBindingInfoConvention.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/ApplicationModels/InferParameterBindingInfoConvention.cs
@@ -98,14 +98,14 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
 
         private bool ParameterExistsInAnyRoute(ActionModel action, string parameterName)
         {
-            foreach (var (route, _, _) in ActionAttributeRouteModel.GetAttributeRoutes(action))
+            foreach (var selector in ActionAttributeRouteModel.FlattenSelectors(action))
             {
-                if (route == null)
+                if (selector.AttributeRouteModel == null)
                 {
                     continue;
                 }
 
-                var parsedTemplate = TemplateParser.Parse(route.Template);
+                var parsedTemplate = TemplateParser.Parse(selector.AttributeRouteModel.Template);
                 if (parsedTemplate.GetParameter(parameterName) != null)
                 {
                     return true;

--- a/src/Microsoft.AspNetCore.Mvc.Core/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Core/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Extensions.DependencyInjection
             // Action Discovery
             //
             // These are consumed only when creating action descriptors, then they can be deallocated
-
+            services.TryAddSingleton<ApplicationModelFactory>();
             services.TryAddEnumerable(
                 ServiceDescriptor.Transient<IApplicationModelProvider, DefaultApplicationModelProvider>());
             services.TryAddEnumerable(

--- a/test/Microsoft.AspNetCore.Mvc.Core.Test/Infrastructure/ActionSelectorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Core.Test/Infrastructure/ActionSelectorTest.cs
@@ -1009,8 +1009,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
 
             var provider = new ControllerActionDescriptorProvider(
                 manager,
-                new[] { modelProvider },
-                options);
+                new ApplicationModelFactory(new[] { modelProvider }, options));
 
             return provider;
         }


### PR DESCRIPTION
This change introduces a service facade for creating the application
model, running conventions, validating the result, and flattening the
model.

This is used in the ControllerActionDescriptorProvider and provides the
existing functionality for now. The ControllerActionDescriptorProvider
will process the results and turn each 'flattened' model into a single
action descriptor.

The next change will introduce another consumer of this service, that
turns the 'flattened' model into an EndpointModel so that it can be
exposed via Endpoint Routing's convention system.

---

The main considerations here:

The flattening semantics of application model are pretty complicated :(

The validation that CADP does is actually pretty in depth and might be
really low value... Errors with writing route templates do happen, and
those will be caught by the routing system eventually.... Errors with
duplicate route names are similar... Errors with 'mixed' attribute and
conventional routing are not at all common. I don't think I've ever seen
an issue get filed about this. I did the work to port all of this stuff
forward but I'm not totally sure it's valuable - however, I don't really
want to make an argument for its removal. These are just some random
thoughts to keep in mind if you're reviewing this :+1: